### PR TITLE
Fargate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.terraform

--- a/terraform/frontend/README.md
+++ b/terraform/frontend/README.md
@@ -1,0 +1,13 @@
+# Frontend
+
+Status: `alpha`
+
+The frontend project manages the [frontend application][] service.
+The app pulls an image from DockerHub and uses the infra-fargate module
+to bring up the necessary resources, including the app itself in Fargate,
+the load balancer, and logging for the app.
+
+Additional configuration is defined in the task-definitions/frontend.json file
+which includes the environment variables that the app process is given.
+
+[frontend application]: http://github.com/alphagov/frontend

--- a/terraform/frontend/main.tf
+++ b/terraform/frontend/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  backend "s3" {
+    bucket  = "govuk-terraform-test"
+    key     = "projects/app-frontend.tfstate"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}
+
 provider "aws" {
   version = "~> 2.69"
   region  = "eu-west-1"

--- a/terraform/frontend/main.tf
+++ b/terraform/frontend/main.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  version = "~> 2.69"
+  region  = "eu-west-1"
+}
+
+module "infra-fargate" {
+  source                = "../modules/infra-fargate"
+  service_name          = "frontend"
+  container_definitions = file("../task-definitions/frontend.json")
+  desired_count         = 1
+}

--- a/terraform/modules/infra-fargate/README.md
+++ b/terraform/modules/infra-fargate/README.md
@@ -1,0 +1,1 @@
+# Fargate

--- a/terraform/modules/infra-fargate/README.md
+++ b/terraform/modules/infra-fargate/README.md
@@ -1,1 +1,11 @@
-# Fargate
+# Infra Fargate
+
+Status: `alpha`
+
+The Infra Fargate module is used to bring up an application in ECS Fargate.
+
+The variables `service_name`, `container_definitions`, and `desired_count`
+enable the module to bring up a Fargate cluster, service, and task
+with an application load balancer (ALB) and application logging to CloudWatch.
+
+This does not handle the DNS records required to route traffic to the service.

--- a/terraform/modules/infra-fargate/main.tf
+++ b/terraform/modules/infra-fargate/main.tf
@@ -1,0 +1,32 @@
+resource "aws_ecs_cluster" "cluster" {
+  name               = var.service_name
+  capacity_providers = ["FARGATE"]
+}
+
+resource "aws_ecs_service" "service" {
+  name            = var.service_name
+  cluster         = aws_ecs_cluster.cluster.id
+  task_definition = aws_ecs_task_definition.service.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  ordered_placement_strategy {
+    type  = "binpack"
+    field = "cpu"
+  }
+
+  placement_constraints {
+    type       = "memberOf"
+    expression = "attribute:ecs.availability-zone in [eu-west-1a, eu-west-1b]"
+  }
+}
+
+resource "aws_ecs_task_definition" "service" {
+  family                = var.service_name
+  container_definitions = var.container_definitions
+
+  placement_constraints {
+    type       = "memberOf"
+    expression = "attribute:ecs.availability-zone in [eu-west-1a, eu-west-1b]"
+  }
+}

--- a/terraform/modules/infra-fargate/main.tf
+++ b/terraform/modules/infra-fargate/main.tf
@@ -1,3 +1,7 @@
+data "aws_vpc" "govuk-test" {
+  id = "vpc-9e62bcf8"
+}
+
 resource "aws_ecs_cluster" "cluster" {
   name               = var.service_name
   capacity_providers = ["FARGATE"]
@@ -10,23 +14,16 @@ resource "aws_ecs_service" "service" {
   desired_count   = var.desired_count
   launch_type     = "FARGATE"
 
-  ordered_placement_strategy {
-    type  = "binpack"
-    field = "cpu"
-  }
-
-  placement_constraints {
-    type       = "memberOf"
-    expression = "attribute:ecs.availability-zone in [eu-west-1a, eu-west-1b]"
+  network_configuration {
+    subnets = ["subnet-ba30f6f2"]
   }
 }
 
 resource "aws_ecs_task_definition" "service" {
-  family                = var.service_name
-  container_definitions = var.container_definitions
-
-  placement_constraints {
-    type       = "memberOf"
-    expression = "attribute:ecs.availability-zone in [eu-west-1a, eu-west-1b]"
-  }
+  family                   = var.service_name
+  requires_compatibilities = ["FARGATE"]
+  container_definitions    = var.container_definitions
+  network_mode             = "awsvpc"
+  cpu                      = 1024
+  memory                   = 2048
 }

--- a/terraform/modules/infra-fargate/variables.tf
+++ b/terraform/modules/infra-fargate/variables.tf
@@ -1,0 +1,14 @@
+variable "service_name" {
+  description = "Service name of the Fargate service, cluster, task etc."
+  type        = string
+}
+
+variable "container_definitions" {
+  description = "List of container definitions, usually provided as a JSON file"
+  type        = string
+}
+
+variable "desired_count" {
+  description = "The desired number of container instances"
+  type        = number
+}

--- a/terraform/task-definitions/frontend.json
+++ b/terraform/task-definitions/frontend.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "frontend",
+    "image": "service-first",
+    "cpu": 10,
+    "memory": 512,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ]
+  }
+]

--- a/terraform/task-definitions/frontend.json
+++ b/terraform/task-definitions/frontend.json
@@ -7,14 +7,26 @@
       { "name": "RAILS_ENV", "value": "production" },
       { "name": "SECRET_KEY_BASE", "value": "875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2" },
       { "name": "ASSET_HOST", "value": "www.gov.uk" },
+      { "name": "GOVUK_APP_DOMAIN", "value": "www.gov.uk" },
+      { "name": "GOVUK_WEBSITE_ROOT", "value": "www.gov.uk" },
       { "name": "WEBSITE_ROOT", "value": "www.gov.uk" },
       { "name": "PLEK_SERVICE_CONTENT_STORE_URI", "value": "https://www.gov.uk/api" },
-      { "name": "PLEK_SERVICE_STATIC_URI", "value": "assets.test.publishing.service.gov.uk" }
+      { "name": "PLEK_SERVICE_STATIC_URI", "value": "https://assets.publishing.service.gov.uk" },
+      { "name": "GOVUK_ASSET_ROOT", "value": "https://assets.digital.cabinet-office.gov.uk" }
     ],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-create-group": "true",
+            "awslogs-group": "awslogs-fargate",
+            "awslogs-region": "eu-west-1",
+            "awslogs-stream-prefix": "awslogs-frontend"
+        }
+    },
     "portMappings": [
       {
         "containerPort": 3005,
-        "hostPort": 3005
+        "protocol": "tcp"
       }
     ]
   }

--- a/terraform/task-definitions/frontend.json
+++ b/terraform/task-definitions/frontend.json
@@ -1,14 +1,12 @@
 [
   {
     "name": "frontend",
-    "image": "service-first",
-    "cpu": 10,
-    "memory": 512,
+    "image": "alphagov/frontend:deployed-to-production",
     "essential": true,
     "portMappings": [
       {
-        "containerPort": 80,
-        "hostPort": 80
+        "containerPort": 3005,
+        "hostPort": 3005
       }
     ]
   }

--- a/terraform/task-definitions/frontend.json
+++ b/terraform/task-definitions/frontend.json
@@ -1,8 +1,16 @@
 [
   {
     "name": "frontend",
-    "image": "alphagov/frontend:deployed-to-production",
+    "image": "govuk/frontend:deployed-to-production",
     "essential": true,
+    "environment": [
+      { "name": "RAILS_ENV", "value": "production" },
+      { "name": "SECRET_KEY_BASE", "value": "875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2" },
+      { "name": "ASSET_HOST", "value": "www.gov.uk" },
+      { "name": "WEBSITE_ROOT", "value": "www.gov.uk" },
+      { "name": "PLEK_SERVICE_CONTENT_STORE_URI", "value": "https://www.gov.uk/api" },
+      { "name": "PLEK_SERVICE_STATIC_URI", "value": "assets.test.publishing.service.gov.uk" }
+    ],
     "portMappings": [
       {
         "containerPort": 3005,


### PR DESCRIPTION
The GOV.UK replatforming team are doing a discovery into using AWS ECS Fargate as a replacement for running our apps in EC2 instances.

This Fargate service is serving the homepage in this environment: https://www.test.publishing.service.gov.uk (requires VPN).

This adds a Fargate module and Frontend project. The intent is to see what connecting a frontend app to the rest of the GOV.UK AWS infrastructure will look like.

There are still a few steps to go, including creating a container image for the alphagov/frontend application that we can use in the task definition for the service.

This PR doesn't intend to provide a production ready service, so secrets, logging, DNS records / service migration and so on, are out of scope.