### PR TITLE
Provision a cluster for manual or ad-hoc tasks

### DIFF
--- a/terraform/task-runner/README.md
+++ b/terraform/task-runner/README.md
@@ -1,0 +1,50 @@
+# Task runner
+
+This project enables developers to run manual and scheduled tasks in ECS.
+
+## Running a rake task
+
+To run a one-off rake task, you must do something like the following:
+
+Create a task definition using the terraform project (e.g. frontend app)
+
+Run the task, with an override for the command:
+
+```sh
+aws ecs run-task --cluster task_runner --task-definition frontend \
+--launch-type FARGATE --count 1 --started-by "Harry Potter" \
+--network-configuration '{
+  "awsvpcConfiguration": {
+    "subnets": ["subnet-6dc4370b", "subnet-463bfd0e", "subnet-bfecd0e4"],
+    "securityGroups": ["sg-0b873470482f6232d"],
+    "assignPublicIp": "DISABLED"
+  }
+}' \
+--overrides '{
+  "containerOverrides": [{
+    "name": "frontend",
+    "command": ["bundle", "exec", "rake", "stats"]
+  }]
+}'
+```
+
+This specifies that we will re-use the task definition created by the frontend
+app. All task definitions must be created in Terraform.
+
+The task_runner cluster is used for grouping together tasks, to make it easy
+to find rake tasks.
+
+The `command` override enables developers to run anything they like within the
+container.
+
+The intent is to expose this interface somehow via a CLI to replace the
+"Run Rake Task" Jenkins job:
+
+```sh
+gds run-task --app frontend --command "bundle exec rake stats"
+```
+
+The [Proposal for running rake tasks in AWS ECS Fargate][] has more details of
+what this command will do.
+
+[Proposal for running rake tasks in AWS ECS Fargate]: https://github.com/alphagov/govuk-replatforming-discovery-2020/pull/6

--- a/terraform/task-runner/main.tf
+++ b/terraform/task-runner/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "s3" {
+    bucket  = "govuk-terraform-test"
+    key     = "projects/rake-task.tfstate"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  version = "~> 2.69"
+  region  = "eu-west-1"
+}
+
+resource "aws_ecs_cluster" "task_runner" {
+  name               = "task_runner"
+  capacity_providers = ["FARGATE"]
+}


### PR DESCRIPTION
This cluster provides the infrastructure needed to run ad-hoc tasks such as rake tasks in AWS ECS Fargate.

An accompanying proposal will be added to [the discovery repo](https://github.com/alphagov/govuk-replatforming-discovery-2020).