### PR TITLE
Enable running consoles in ECS Fargate

### DIFF
--- a/terraform/frontend/main.tf
+++ b/terraform/frontend/main.tf
@@ -19,3 +19,9 @@ module "infra-fargate" {
   desired_count          = 1
   container_ingress_port = 3005
 }
+
+module "fargate-console" {
+  source                = "../modules/fargate-console"
+  service_name          = "frontend_console"
+  container_definitions = file("../task-definitions/frontend_console.json")
+}

--- a/terraform/modules/fargate-console/README.md
+++ b/terraform/modules/fargate-console/README.md
@@ -1,0 +1,37 @@
+# Fargate Console
+
+This module provides a way to start a bash session in a running ECS container,
+with the required application code, secrets, and environment variables for
+developers to perform interactive operational and investigative tasks.
+
+Use cases includes:
+
+* Running a Rails console in an AWS environment
+* Running a database console
+* Running a web server without having traffic routed to that server.
+
+See proposal 003 in govuk-replatforming-discovery-2020 for further details
+of the tooling required to make this a good developer experience.
+
+## How it works
+
+Using a GDS CLI command such as `gds govuk console --env test --app frontend`
+people will start a bash session in a running container in ECS.
+
+Behind the scenes this command will start up a container like so:
+
+```shell
+aws ecs run-task --cluster task_runner --task-definition frontend_console \
+--launch-type FARGATE --count 1 --started-by "Harry Potter" \
+--network-configuration '{
+  "awsvpcConfiguration": {
+    "subnets": ["subnet-6dc4370b", "subnet-463bfd0e", "subnet-bfecd0e4"],
+    "securityGroups": ["sg-0b873470482f6232d"],
+    "assignPublicIp": "DISABLED"
+  }
+}'
+```
+
+See the proposal [003 ECS Fargate consoles][] for more details.
+
+[003 ECS Fargate consoles]: https://github.com/alphagov/govuk-replatforming-discovery-2020/blob/c1264ac60409ccbbea95d8126c113ea6511789b0/proposals/003-ecs-fargate-consoles.md

--- a/terraform/modules/fargate-console/main.tf
+++ b/terraform/modules/fargate-console/main.tf
@@ -1,0 +1,21 @@
+data "aws_vpc" "vpc" {
+  id = "vpc-9e62bcf8"
+}
+
+data "aws_iam_role" "task_execution_role" {
+  name = "fargate_task_execution_role"
+}
+
+#
+# ECS Task Definition
+#
+
+resource "aws_ecs_task_definition" "console_definition" {
+  family                   = var.service_name
+  requires_compatibilities = ["FARGATE"]
+  container_definitions    = var.container_definitions
+  network_mode             = "awsvpc"
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = data.aws_iam_role.task_execution_role.arn
+}

--- a/terraform/modules/fargate-console/variables.tf
+++ b/terraform/modules/fargate-console/variables.tf
@@ -1,0 +1,9 @@
+variable "service_name" {
+  description = "Service name of the Fargate service, cluster, task etc."
+  type        = string
+}
+
+variable "container_definitions" {
+  description = "List of container definitions, usually provided as a JSON file"
+  type        = string
+}

--- a/terraform/task-definitions/frontend_console.json
+++ b/terraform/task-definitions/frontend_console.json
@@ -1,0 +1,36 @@
+[
+  {
+    "name": "frontend_console",
+    "image": "govuk/frontend_console:0.0.1",
+    "essential": true,
+    "environment": [
+      { "name": "RAILS_ENV", "value": "production" },
+      { "name": "SECRET_KEY_BASE", "value": "875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2" },
+      { "name": "ASSET_HOST", "value": "www.gov.uk" },
+      { "name": "GOVUK_APP_DOMAIN", "value": "www.gov.uk" },
+      { "name": "GOVUK_WEBSITE_ROOT", "value": "www.gov.uk" },
+      { "name": "WEBSITE_ROOT", "value": "www.gov.uk" },
+      { "name": "PLEK_SERVICE_CONTENT_STORE_URI", "value": "https://www.gov.uk/api" },
+      { "name": "PLEK_SERVICE_STATIC_URI", "value": "https://assets.publishing.service.gov.uk" },
+      { "name": "GOVUK_ASSET_ROOT", "value": "https://assets.digital.cabinet-office.gov.uk" },
+      { "name": "STATSD_PROTOCOL", "value": "tcp" },
+      { "name": "STATSD_HOST", "value": "statsd.test.govuk-internal.digital" },
+      { "name": "GOVUK_STATSD_PREFIX", "value": "fargate" }
+    ],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-create-group": "true",
+            "awslogs-group": "awslogs-fargate",
+            "awslogs-region": "eu-west-1",
+            "awslogs-stream-prefix": "awslogs-frontend-console"
+        }
+    },
+    "portMappings": [
+      {
+        "containerPort": 22,
+        "protocol": "tcp"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This provides the infrastructure necessary to get a developer console up in a container in ECS Fargate.

For example a rails console can be started for the frontend app, as demonstrated in this PR.

See the associated proposal https://github.com/alphagov/govuk-replatforming-discovery-2020/pull/7.

There's [a demo commit](https://github.com/alphagov/frontend/compare/bilbof/ecs-console-dockerfile) on the frontend app repo to show what an app console image might look like.