### PR TITLE
Use Secrets Manager for secrets

### DIFF
--- a/terraform/fargate-security/main.tf
+++ b/terraform/fargate-security/main.tf
@@ -65,3 +65,39 @@ resource "aws_iam_role_policy_attachment" "task_exec_policy" {
   role       = aws_iam_role.task_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
+
+
+#
+# Allow apps in ECS Fargate containers to access secrets
+#
+# This allows *all* apps to access *any* secret. We should create a task execution
+# role and policy for each app to permit apps to only access required secrets.
+#
+
+resource "aws_iam_policy" "access_secrets" {
+  name        = "access_secrets"
+  path        = "/accessSecretsPolicy/"
+  description = "Access AWS Secrets Manager secrets policy managed by Terraform"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:eu-west-1:430354129336:secret:*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "access_secrets_attachment_policy" {
+  role       = aws_iam_role.task_execution_role.name
+  policy_arn = aws_iam_policy.access_secrets.arn
+}

--- a/terraform/task-definitions/frontend.json
+++ b/terraform/task-definitions/frontend.json
@@ -5,7 +5,6 @@
     "essential": true,
     "environment": [
       { "name": "RAILS_ENV", "value": "production" },
-      { "name": "SECRET_KEY_BASE", "value": "875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2" },
       { "name": "ASSET_HOST", "value": "www.gov.uk" },
       { "name": "GOVUK_APP_DOMAIN", "value": "www.gov.uk" },
       { "name": "GOVUK_WEBSITE_ROOT", "value": "www.gov.uk" },
@@ -30,6 +29,12 @@
       {
         "containerPort": 3005,
         "protocol": "tcp"
+      }
+    ],
+    "secrets": [
+      {
+        "name": "SECRET_KEY_BASE",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:frontend_app-SECRET_KEY_BASE-Em3aWA"
       }
     ]
   }

--- a/terraform/task-definitions/frontend_console.json
+++ b/terraform/task-definitions/frontend_console.json
@@ -5,7 +5,6 @@
     "essential": true,
     "environment": [
       { "name": "RAILS_ENV", "value": "production" },
-      { "name": "SECRET_KEY_BASE", "value": "875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2" },
       { "name": "ASSET_HOST", "value": "www.gov.uk" },
       { "name": "GOVUK_APP_DOMAIN", "value": "www.gov.uk" },
       { "name": "GOVUK_WEBSITE_ROOT", "value": "www.gov.uk" },
@@ -30,6 +29,12 @@
       {
         "containerPort": 22,
         "protocol": "tcp"
+      }
+    ],
+    "secrets": [
+      {
+        "name": "SECRET_KEY_BASE",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:frontend_app-SECRET_KEY_BASE-Em3aWA"
       }
     ]
   }


### PR DESCRIPTION
This demonstrates how we will provide secrets as environment variables to applications running ECS Fargate.

We can implement more fine grained controls with dedicated task execution roles for each service (read: application) in Fargate once we are finished with our discovery.

Note: I have replaced the demo secret we had as an environment variable.

Proposal for how we will use Secrets Manager: https://github.com/alphagov/govuk-replatforming-discovery-2020/pull/8.