### PR TITLE
Add GOVUK_APP_DOMAIN_EXTERNAL envvar to Publisher service

### DIFF
--- a/terraform/task-definitions/publisher.json
+++ b/terraform/task-definitions/publisher.json
@@ -13,6 +13,7 @@
       { "name": "FACT_CHECK_SUBJECT_PREFIX", "value": "dev"},
       { "name": "FACT_CHECK_USERNAME", "value": "govuk-fact-check-test@digital.cabinet-office.gov.uk"},
       { "name": "GOVUK_APP_DOMAIN", "value": "test.govuk-internal.digital" },
+      { "name": "GOVUK_APP_DOMAIN_EXTERNAL", "value": "test.govuk.digital" },
       { "name": "GOVUK_APP_NAME", "value": "publisher"},
       { "name": "GOVUK_APP_TYPE", "value": "rack"},
       { "name": "GOVUK_STATSD_PREFIX", "value": "fargate" },


### PR DESCRIPTION
This environment variable is used for external URLs, e.g. when redirecting users to the public Signon URL.

It's essential since Plek falls back to `GOVUK_APP_DOMAIN` when `GOVUK_APP_DOMAIN_EXTERNAL` is not set. This routes users to `signon.<env>.govuk-internal.digital` which of course is inaccessible to end users.