### PR TITLE
Frontend DNS record

### DIFF
--- a/terraform/frontend/main.tf
+++ b/terraform/frontend/main.tf
@@ -25,3 +25,22 @@ module "fargate-console" {
   service_name          = "frontend_console"
   container_definitions = file("../task-definitions/frontend_console.json")
 }
+
+# Internal DNS record
+
+data "aws_route53_zone" "internal" {
+  name         = "test.govuk-internal.digital"
+  private_zone = true
+}
+
+resource "aws_route53_record" "internal_service_name" {
+  zone_id = data.aws_route53_zone.internal.zone_id
+  name    = "frontend-ecs.test.govuk-internal.digital"
+  type    = "A"
+
+  alias {
+    name                   = module.infra-fargate.dns_name
+    zone_id                = module.infra-fargate.alb_zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/modules/infra-fargate/main.tf
+++ b/terraform/modules/infra-fargate/main.tf
@@ -108,18 +108,12 @@ resource "aws_ecs_service" "service" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    security_groups = [aws_security_group.service_sg.id, var.govuk_management_access_security_group, var.public_service_sg_id]
+    security_groups = [aws_security_group.service_sg.id, var.govuk_management_access_security_group]
     subnets         = var.private_subnets
   }
 
   load_balancer {
     target_group_arn = aws_lb_target_group.lb_tg.arn
-    container_name   = var.service_name
-    container_port   = var.container_ingress_port
-  }
-
-  load_balancer {
-    target_group_arn = var.public_tg_arn
     container_name   = var.service_name
     container_port   = var.container_ingress_port
   }

--- a/terraform/modules/infra-fargate/variables.tf
+++ b/terraform/modules/infra-fargate/variables.tf
@@ -29,13 +29,3 @@ variable "container_ingress_port" {
   description = "The port which the container will accept connections on"
   type        = number
 }
-
-variable "public_service_sg_id" {
-  description = "The security group to link the public load balancer to the service"
-  type        = string
-}
-
-variable "public_tg_arn" {
-  description = "The target group to link the public load balancer to the service"
-  type        = string
-}


### PR DESCRIPTION
This record will allow us to route traffic to the frontend machine on frontend.pink.test (including quickly switching back to the frontend app on that machine), and also route traffic to the frontend application running in ECS at frontend-ecs.test.

I propose that we use DNS changes where possible to route traffic to services in ECS. However, Frontend is a special case, since 'frontend' is also used for both the frontend machine and application. For example a request for `static.test.govuk-internal.digital/some-resource` will be routed to the 'frontend' machine and then to the static app on that machine.

To route traffic to frontend in ECS, I've created this new DNS record and updated the Frontend 'Backend' in the test account's deployment of Router API to send requests for frontend to this new host.