### PR TITLE
Publishing API ECS service

### DIFF
--- a/terraform/govuk/main.tf
+++ b/terraform/govuk/main.tf
@@ -1,3 +1,17 @@
+terraform {
+  backend "s3" {
+    bucket  = "govuk-terraform-test"
+    key     = "projects/govuk.tfstate"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  version = "~> 2.69"
+  region  = "eu-west-1"
+}
+
 # All services running on GOV.UK run in this single cluster.
 resource "aws_ecs_cluster" "cluster" {
   name               = "govuk"

--- a/terraform/publishing-api/README.md
+++ b/terraform/publishing-api/README.md
@@ -1,0 +1,3 @@
+# Publishing API application
+
+This project module manages the resources required to run publishing-api.

--- a/terraform/publishing-api/main.tf
+++ b/terraform/publishing-api/main.tf
@@ -1,0 +1,176 @@
+terraform {
+  backend "s3" {
+    bucket  = "govuk-terraform-test"
+    key     = "projects/app-publishing-api.tfstate"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  version = "~> 2.69"
+  region  = "eu-west-1"
+}
+
+#
+# Data
+#
+
+data "aws_vpc" "vpc" {
+  id = "vpc-9e62bcf8"
+}
+
+#
+# ECS Cluster, Service, Task
+#
+
+data "aws_iam_role" "task_execution_role" {
+  name = "fargate_task_execution_role"
+}
+
+data "aws_ecs_cluster" "cluster" {
+  cluster_name = "govuk"
+}
+
+resource "aws_ecs_task_definition" "service" {
+  family                   = var.service_name
+  requires_compatibilities = ["FARGATE"]
+  container_definitions    = file("../task-definitions/publishing-api.json")
+  network_mode             = "awsvpc"
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = data.aws_iam_role.task_execution_role.arn
+}
+
+resource "aws_ecs_service" "service" {
+  name                              = var.service_name
+  cluster                           = data.aws_ecs_cluster.cluster.id
+  task_definition                   = aws_ecs_task_definition.service.arn
+  desired_count                     = var.desired_count
+  launch_type                       = "FARGATE"
+  health_check_grace_period_seconds = 300
+
+  network_configuration {
+    security_groups = [aws_security_group.service.id, var.govuk_management_access_security_group, data.aws_security_group.service_dependencies.id]
+    subnets         = var.private_subnets
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.internal_lb_tg.arn
+    container_name   = var.service_name
+    container_port   = var.container_ingress_port
+  }
+}
+
+#
+# ECS Service Security groups
+#
+
+resource "aws_security_group" "service" {
+  name        = "fargate_${var.service_name}_alb_access"
+  vpc_id      = data.aws_vpc.vpc.id
+  description = "Allow the internal ALB for the fargate ${var.service_name} service to access the service"
+}
+
+#
+# Internal Load balancer
+#
+
+data "aws_acm_certificate" "internal_elb_cert" {
+  domain   = "*.test.govuk-internal.digital"
+  statuses = ["ISSUED"]
+}
+
+resource "aws_lb" "internal_alb" {
+  name               = "fargate-${var.service_name}"
+  internal           = "true"
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.internal_alb_sg.id]
+  subnets            = var.private_subnets
+}
+
+resource "aws_lb_target_group" "internal_lb_tg" {
+  name        = "${var.service_name}-internal"
+  port        = var.container_ingress_port
+  protocol    = "HTTP"
+  vpc_id      = data.aws_vpc.vpc.id
+  target_type = "ip"
+
+  deregistration_delay = 10
+
+  health_check {
+    path = "/healthcheck"
+  }
+}
+
+resource "aws_lb_listener" "internal_listener" {
+  load_balancer_arn = aws_lb.internal_alb.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = data.aws_acm_certificate.internal_elb_cert.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.internal_lb_tg.arn
+  }
+}
+
+resource "aws_security_group_rule" "internal_alb_ingress" {
+  type      = "ingress"
+  from_port = var.container_ingress_port
+  to_port   = var.container_ingress_port
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.service.id
+  source_security_group_id = aws_security_group.internal_alb_sg.id
+}
+
+resource "aws_security_group" "internal_alb_sg" {
+  name        = "fargate_${var.service_name}_elb"
+  vpc_id      = data.aws_vpc.vpc.id
+  description = "ALB ingress and egress security group for ${var.service_name} ECS service"
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [var.govuk_management_access_security_group] # TODO create a security group for talking to publishing-api ALB.
+  }
+
+  egress {
+    from_port       = var.container_ingress_port
+    to_port         = var.container_ingress_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.service.id]
+  }
+}
+
+#
+# Dependencies
+#
+
+data "aws_security_group" "service_dependencies" {
+  id = "sg-05ad7398fc0d7c5b4" # govuk_publishing-api_access
+}
+
+#
+# DNS
+#
+
+data "aws_route53_zone" "internal" {
+  name         = var.internal_domain_name
+  private_zone = true
+}
+
+resource "aws_route53_record" "internal_service_record" {
+  zone_id = data.aws_route53_zone.internal.zone_id
+  name    = "${var.service_name}.${var.internal_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.internal_alb.dns_name
+    zone_id                = aws_lb.internal_alb.zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/publishing-api/variables.tf
+++ b/terraform/publishing-api/variables.tf
@@ -1,0 +1,35 @@
+variable "service_name" {
+  description = "Service name of the Fargate service, cluster, task etc."
+  type        = string
+  default     = "publishing-api"
+}
+
+variable "private_subnets" {
+  description = "The subnet ids for govuk_private_a, govuk_private_b, and govuk_private_c"
+  type        = list
+  default     = ["subnet-6dc4370b", "subnet-463bfd0e", "subnet-bfecd0e4"]
+}
+
+variable "govuk_management_access_security_group" {
+  description = "Group used to allow access by management systems"
+  type        = string
+  default     = "sg-0b873470482f6232d"
+}
+
+variable "container_ingress_port" {
+  description = "The port which the container will accept connections on"
+  type        = number
+  default     = 3093
+}
+
+variable "desired_count" {
+  description = "The desired number of container instances"
+  type        = number
+  default     = 1
+}
+
+variable "internal_domain_name" {
+  description = "The internal root root domain name"
+  type        = string
+  default     = "test.govuk-internal.digital"
+}

--- a/terraform/task-definitions/publishing-api.json
+++ b/terraform/task-definitions/publishing-api.json
@@ -1,0 +1,95 @@
+[
+  {
+    "name": "publishing-api",
+    "image": "govuk/publishing-api:with-content-schemas",
+    "essential": true,
+    "environment": [
+      { "name": "CONTENT_API_PROTOTYPE", "value": "yes" },
+      { "name": "CONTENT_STORE", "value": "https://content-store.test.publishing.service.gov.uk" },
+      { "name": "DRAFT_CONTENT_STORE", "value": "https://draft-content-store.test.publishing.service.gov.uk" },
+      { "name": "EVENT_LOG_AWS_ACCESS_ID", "value": "AKIAJE6VSW25CYBUMQJA" },
+      { "name": "EVENT_LOG_AWS_BUCKETNAME", "value": "govuk-publishing-api-event-log-test" },
+      { "name": "EVENT_LOG_AWS_USERNAME", "value": "govuk-publishing-api-event-log_user" },
+      { "name": "GOVUK_APP_DOMAIN", "value": "test.govuk-internal.digital" },
+      { "name": "GOVUK_APP_DOMAIN_EXTERNAL", "value": "test.govuk.digital" },
+      { "name": "GOVUK_APP_NAME", "value": "publishing-api" },
+      { "name": "GOVUK_APP_TYPE", "value": "rack" },
+      { "name": "GOVUK_CONTENT_SCHEMAS_PATH", "value": "/govuk-content-schemas" },
+      { "name": "GOVUK_GROUP", "value": "deploy" },
+      { "name": "GOVUK_STATSD_PREFIX", "value": "fargate" },
+      { "name": "GOVUK_USER", "value": "deploy" },
+      { "name": "GOVUK_WEBSITE_ROOT", "value": "https://www.gov.uk" },
+      { "name": "PORT", "value": "3093" },
+      { "name": "RABBITMQ_HOSTS", "value": "rabbitmq.test.govuk-internal.digital" },
+      { "name": "RABBITMQ_USER", "value": "publishing_api" },
+      { "name": "RABBITMQ_VHOST", "value": "/" },
+      { "name": "REDIS_HOST", "value": "pink-backend-redis.0f3erf.ng.0001.euw1.cache.amazonaws.com"},
+      { "name": "REDIS_PORT", "value": "6379"},
+      { "name": "REDIS_URL", "value": "redis://pink-backend-redis.0f3erf.ng.0001.euw1.cache.amazonaws.com:6379"},
+      { "name": "RAILS_ENV", "value": "production" },
+      { "name": "STATSD_PROTOCOL", "value": "tcp" },
+      { "name": "STATSD_HOST", "value": "statsd.test.govuk-internal.digital" },
+      { "name": "SUPPRESS_DRAFT_STORE_502_ERROR", "value": "" },
+      { "name": "UNICORN_WORKER_PROCESSES", "value": "8" }
+    ],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-create-group": "true",
+            "awslogs-group": "awslogs-fargate",
+            "awslogs-region": "eu-west-1",
+            "awslogs-stream-prefix": "awslogs-publishing-api"
+        }
+    },
+    "mountPoints": [],
+    "portMappings": [
+      {
+        "containerPort": 3093,
+        "hostPort": 3093,
+        "protocol": "tcp"
+      }
+    ],
+    "secrets": [
+      {
+        "name": "CONTENT_STORE_BEARER_TOKEN",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-CONTENT_STORE_BEARER_TOKEN-NFDFMS"
+      },
+      {
+        "name": "DATABASE_URL",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-DATABASE_URL-8eTvdm"
+      },
+      {
+        "name": "DRAFT_CONTENT_STORE_BEARER_TOKEN",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-DRAFT_CONTENT_STORE_BEARER_TOKEN-J92NEl"
+      },
+      {
+        "name": "EVENT_LOG_AWS_SECRET_KEY",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-EVENT_LOG_AWS_SECRET_KEY-clLAVu"
+      },
+      {
+        "name": "OAUTH_ID",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-OAUTH_ID-Saqn0P"
+      },
+      {
+        "name": "OAUTH_SECRET",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-OAUTH_SECRET-jLHPvi"
+      },
+      {
+        "name": "RABBITMQ_PASSWORD",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-RABBITMQ_PASSWORD-LBNs2z"
+      },
+      {
+        "name": "ROUTER_API_BEARER_TOKEN",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-ROUTER_API_BEARER_TOKEN-3hNtZy"
+      },
+      {
+        "name": "SECRET_KEY_BASE",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-SECRET_KEY_BASE-tViRPi"
+      },
+      {
+        "name": "SENTRY_DSN",
+        "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-SENTRY_DSN-pCCOSJ"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This adds a module for the Publishing API service, including an application load balancer (ALB) and internal DNS record.

This replaces the current Publishing API running in EC2 by switching out the DNS record for publishing-api.<stack>.<env> to point at the DNS record for the internal ALB.

All published content created in the test environment will go through the ECS-hosted Publishing API following this change.
