### PR TITLE
Use a service mesh for internal networking in ECS

### DIFF
--- a/terraform/content-store/appmesh.tf
+++ b/terraform/content-store/appmesh.tf
@@ -1,0 +1,43 @@
+resource "aws_appmesh_virtual_service" "service" {
+  name      = "${var.service_name}.mesh.govuk-internal.digital"
+  mesh_name = var.appmesh_mesh_govuk_id
+
+  spec {
+    provider {
+      virtual_node {
+        virtual_node_name = aws_appmesh_virtual_node.service.name
+      }
+    }
+  }
+}
+
+resource "aws_appmesh_virtual_node" "service" {
+  name      = var.service_name
+  mesh_name = var.appmesh_mesh_govuk_id
+
+  spec {
+    backend {
+      # The ECS service
+      virtual_service {
+        virtual_service_name = "${var.service_name}.mesh.govuk-internal.digital"
+      }
+    }
+
+    listener {
+      # Incoming traffic to the node
+      port_mapping {
+        port     = var.container_ingress_port
+        protocol = "http"
+      }
+    }
+
+    service_discovery {
+      aws_cloud_map {
+        namespace_name = var.govuk_publishing_platform_namespace_name
+        service_name   = aws_service_discovery_service.service.name
+      }
+    }
+  }
+
+  depends_on = [aws_service_discovery_service.service]
+}

--- a/terraform/content-store/cloudmap.tf
+++ b/terraform/content-store/cloudmap.tf
@@ -1,0 +1,14 @@
+resource "aws_service_discovery_service" "service" {
+  name = var.service_name
+
+  dns_config {
+    namespace_id = var.govuk_publishing_platform_namespace_id
+
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+
+    routing_policy = "WEIGHTED"
+  }
+}

--- a/terraform/content-store/cloudmap.tf
+++ b/terraform/content-store/cloudmap.tf
@@ -5,7 +5,7 @@ resource "aws_service_discovery_service" "service" {
     namespace_id = var.govuk_publishing_platform_namespace_id
 
     dns_records {
-      ttl  = 60
+      ttl  = 10
       type = "A"
     }
 

--- a/terraform/content-store/main.tf
+++ b/terraform/content-store/main.tf
@@ -1,12 +1,3 @@
-terraform {
-  backend "s3" {
-    bucket  = "govuk-terraform-test"
-    key     = "projects/app-content-store.tfstate"
-    region  = "eu-west-1"
-    encrypt = true
-  }
-}
-
 provider "aws" {
   version = "~> 2.69"
   region  = "eu-west-1"
@@ -28,6 +19,10 @@ data "aws_iam_role" "task_execution_role" {
   name = "fargate_task_execution_role"
 }
 
+data "aws_iam_role" "task_role" {
+  name = "fargate_task_role"
+}
+
 data "aws_ecs_cluster" "cluster" {
   cluster_name = "govuk"
 }
@@ -39,26 +34,43 @@ resource "aws_ecs_task_definition" "service" {
   network_mode             = "awsvpc"
   cpu                      = 512
   memory                   = 1024
+  task_role_arn            = data.aws_iam_role.task_role.arn
   execution_role_arn       = data.aws_iam_role.task_execution_role.arn
+
+  proxy_configuration {
+    type           = "APPMESH"
+    container_name = "envoy"
+
+    properties = {
+      AppPorts         = var.container_ingress_port
+      EgressIgnoredIPs = "169.254.170.2,169.254.169.254"
+      IgnoredUID       = "1337"
+      ProxyEgressPort  = 15001
+      ProxyIngressPort = 15000
+    }
+  }
 }
 
 resource "aws_ecs_service" "service" {
-  name                              = var.service_name
-  cluster                           = data.aws_ecs_cluster.cluster.id
-  task_definition                   = aws_ecs_task_definition.service.arn
-  desired_count                     = var.desired_count
-  launch_type                       = "FARGATE"
-  health_check_grace_period_seconds = 300
+  name            = var.service_name
+  cluster         = data.aws_ecs_cluster.cluster.id
+  task_definition = aws_ecs_task_definition.service.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
 
   network_configuration {
-    security_groups = [aws_security_group.service.id, var.govuk_management_access_security_group, data.aws_security_group.service_dependencies.id]
-    subnets         = var.private_subnets
+    security_groups = [
+      aws_security_group.service.id,
+      var.govuk_management_access_security_group,
+      data.aws_security_group.service_dependencies.id,
+      aws_security_group.dependencies.id
+    ]
+    subnets = var.private_subnets
   }
 
-  load_balancer {
-    target_group_arn = aws_lb_target_group.internal_lb_tg.arn
-    container_name   = var.service_name
-    container_port   = var.container_ingress_port
+  service_registries {
+    registry_arn   = aws_service_discovery_service.service.arn
+    container_name = var.service_name
   }
 }
 
@@ -67,110 +79,35 @@ resource "aws_ecs_service" "service" {
 #
 
 resource "aws_security_group" "service" {
-  name        = "fargate_${var.service_name}_alb_access"
+  name        = "fargate_${var.service_name}_ingress"
   vpc_id      = data.aws_vpc.vpc.id
-  description = "Allow the internal ALB for the fargate ${var.service_name} service to access the service"
+  description = "Permit internal services to access the ${var.service_name} ECS service"
 }
 
-#
-# Internal Load balancer
-#
-
-data "aws_acm_certificate" "internal_elb_cert" {
-  domain   = "*.test.govuk-internal.digital"
-  statuses = ["ISSUED"]
-}
-
-resource "aws_lb" "internal_alb" {
-  name               = "fargate-${var.service_name}"
-  internal           = "true"
-  load_balancer_type = "application"
-  security_groups    = [aws_security_group.internal_alb_sg.id]
-  subnets            = var.private_subnets
-}
-
-resource "aws_lb_target_group" "internal_lb_tg" {
-  name        = "${var.service_name}-internal"
-  port        = var.container_ingress_port
-  protocol    = "HTTP"
+resource "aws_security_group" "dependencies" {
+  name        = "fargate_${var.service_name}_app"
   vpc_id      = data.aws_vpc.vpc.id
-  target_type = "ip"
-
-  deregistration_delay = 10
-
-  health_check {
-    path = "/healthcheck"
-  }
-}
-
-resource "aws_lb_listener" "internal_listener" {
-  load_balancer_arn = aws_lb.internal_alb.arn
-  port              = "443"
-  protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = data.aws_acm_certificate.internal_elb_cert.arn
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.internal_lb_tg.arn
-  }
-}
-
-resource "aws_security_group_rule" "internal_alb_ingress" {
-  type      = "ingress"
-  from_port = var.container_ingress_port
-  to_port   = var.container_ingress_port
-  protocol  = "tcp"
-
-  security_group_id        = aws_security_group.service.id
-  source_security_group_id = aws_security_group.internal_alb_sg.id
-}
-
-resource "aws_security_group" "internal_alb_sg" {
-  name        = "fargate_${var.service_name}_elb"
-  vpc_id      = data.aws_vpc.vpc.id
-  description = "ALB ingress and egress security group for ${var.service_name} ECS service"
-
-  ingress {
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    security_groups = [var.govuk_management_access_security_group] # TODO create a security group for talking to content-store ALB.
-  }
+  description = "Allows ingress from ${var.service_name} to its dependencies"
 
   egress {
-    from_port       = var.container_ingress_port
-    to_port         = var.container_ingress_port
-    protocol        = "tcp"
-    security_groups = [aws_security_group.service.id]
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
-#
-# Dependencies
-#
+resource "aws_security_group_rule" "service_ingress" {
+  description = "Allow content-store ingress to publishing-api"
+  type        = "ingress"
+  from_port   = "80"
+  to_port     = "80"
+  protocol    = "tcp"
+
+  security_group_id        = var.publishing_api_ingress_security_group
+  source_security_group_id = aws_security_group.dependencies.id
+}
 
 data "aws_security_group" "service_dependencies" {
   id = "sg-0fa32025e3d7af478" # govuk_content-store_access
-}
-
-#
-# DNS
-#
-
-data "aws_route53_zone" "internal" {
-  name         = var.internal_domain_name
-  private_zone = true
-}
-
-resource "aws_route53_record" "internal_service_record" {
-  zone_id = data.aws_route53_zone.internal.zone_id
-  name    = "${var.service_name}.${var.internal_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = aws_lb.internal_alb.dns_name
-    zone_id                = aws_lb.internal_alb.zone_id
-    evaluate_target_health = false
-  }
 }

--- a/terraform/content-store/outputs.tf
+++ b/terraform/content-store/outputs.tf
@@ -1,0 +1,4 @@
+output "ingress_security_group" {
+  value       = aws_security_group.service.id
+  description = "Add ingress rules to this security group to permit another service to communicate with content-store"
+}

--- a/terraform/content-store/variables.tf
+++ b/terraform/content-store/variables.tf
@@ -19,7 +19,7 @@ variable "govuk_management_access_security_group" {
 variable "container_ingress_port" {
   description = "The port which the container will accept connections on"
   type        = number
-  default     = 3068
+  default     = 80
 }
 
 variable "desired_count" {
@@ -32,4 +32,21 @@ variable "internal_domain_name" {
   description = "The internal root root domain name"
   type        = string
   default     = "test.govuk-internal.digital"
+}
+
+variable "appmesh_mesh_govuk_id" {
+  type    = string
+  default = "govuk"
+}
+
+variable "govuk_publishing_platform_namespace_id" {
+  type = string
+}
+
+variable "govuk_publishing_platform_namespace_name" {
+  type = string
+}
+
+variable "publishing_api_ingress_security_group" {
+  type = string
 }

--- a/terraform/fargate-security/main.tf
+++ b/terraform/fargate-security/main.tf
@@ -101,3 +101,31 @@ resource "aws_iam_role_policy_attachment" "access_secrets_attachment_policy" {
   role       = aws_iam_role.task_execution_role.name
   policy_arn = aws_iam_policy.access_secrets.arn
 }
+
+# Proxy authorization for ECS tasks
+# https://docs.aws.amazon.com/app-mesh/latest/userguide/proxy-authorization.html
+
+resource "aws_iam_role" "task_role" {
+  name        = "fargate_task_role"
+  description = "Allows ECS tasks to call ECS services (like AppMesh)."
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "appmesh_envoy_access" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess"
+}

--- a/terraform/fargate-security/main.tf
+++ b/terraform/fargate-security/main.tf
@@ -129,8 +129,3 @@ resource "aws_iam_role_policy_attachment" "appmesh_envoy_access" {
   role       = aws_iam_role.task_role.name
   policy_arn = "arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess"
 }
-
-resource "aws_iam_role_policy_attachment" "discover_instances" {
-  role       = aws_iam_role.task_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSCloudMapDiscoverInstanceAccess"
-}

--- a/terraform/fargate-security/main.tf
+++ b/terraform/fargate-security/main.tf
@@ -129,3 +129,8 @@ resource "aws_iam_role_policy_attachment" "appmesh_envoy_access" {
   role       = aws_iam_role.task_role.name
   policy_arn = "arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess"
 }
+
+resource "aws_iam_role_policy_attachment" "discover_instances" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCloudMapDiscoverInstanceAccess"
+}

--- a/terraform/govuk/main.tf
+++ b/terraform/govuk/main.tf
@@ -17,3 +17,36 @@ resource "aws_ecs_cluster" "cluster" {
   name               = "govuk"
   capacity_providers = ["FARGATE"]
 }
+
+resource "aws_appmesh_mesh" "govuk" {
+  name = "govuk"
+
+  spec {
+    egress_filter {
+      type = "ALLOW_ALL"
+    }
+  }
+}
+
+resource "aws_service_discovery_http_namespace" "govuk_publishing_platform" {
+  name = "govuk-publishing-platform"
+}
+
+module "publisher_service" {
+  appmesh_mesh_govuk_id = aws_appmesh_mesh.govuk.id
+  govuk_publishing_platform_http_namespace_id = aws_service_discovery_http_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_http_namespace_name = aws_service_discovery_http_namespace.govuk_publishing_platform.name
+  source = "../publisher"
+}
+
+module "publishing_api_service" {
+  appmesh_mesh_govuk_id = aws_appmesh_mesh.govuk.id
+  govuk_publishing_platform_http_namespace_id = aws_service_discovery_http_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_http_namespace_name = aws_service_discovery_http_namespace.govuk_publishing_platform.name
+  source = "../publishing-api"
+}
+
+# TODO: Create a Virtual gateway.
+# https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
+# A virtual gateway allows resources that are outside of your mesh
+# to communicate to resources that are inside of your mesh.

--- a/terraform/govuk/main.tf
+++ b/terraform/govuk/main.tf
@@ -29,7 +29,7 @@ resource "aws_appmesh_mesh" "govuk" {
 }
 
 resource "aws_service_discovery_private_dns_namespace" "govuk_publishing_platform" {
-  name = "govuk.local"
+  name = "mesh.govuk-internal.digital"
   vpc  = "vpc-9e62bcf8"
 }
 

--- a/terraform/govuk/main.tf
+++ b/terraform/govuk/main.tf
@@ -28,23 +28,29 @@ resource "aws_appmesh_mesh" "govuk" {
   }
 }
 
-resource "aws_service_discovery_private_dns_namespace" "govuk_publishing_platform" {
-  name = "govuk.local"
-  vpc  = "vpc-9e62bcf8"
+resource "aws_service_discovery_http_namespace" "govuk_publishing_platform" {
+  name = "govuk-publishing-platform"
 }
+
+# Error: only alphanumeric characters, underscores and hyphens allowed in "name"
+
+# Error: error deleting Service Discovery Service (srv-mo6wycszvyez7fxc):
+# ResourceInUse: Service contains registered instances; delete the instances before deleting the service
+# Error: error deleting Service Discovery Private DNS Namespace (ns-vwoi6tzke55tpjkb): ResourceInUse: Namespace has associated services; delete the services before deleting the namespace
+# Error: Error deleting ECS cluster: ClusterContainsTasksException: The Cluster cannot be deleted while Tasks are active.
 
 module "publisher_service" {
   appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
-  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
-  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  govuk_publishing_platform_namespace_id   = aws_service_discovery_http_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_namespace_name = aws_service_discovery_http_namespace.govuk_publishing_platform.name
   publishing_api_ingress_security_group    = module.publishing_api_service.ingress_security_group
   source                                   = "../publisher"
 }
 
 module "publishing_api_service" {
   appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
-  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
-  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  govuk_publishing_platform_namespace_id   = aws_service_discovery_http_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_namespace_name = aws_service_discovery_http_namespace.govuk_publishing_platform.name
   source                                   = "../publishing-api"
 }
 

--- a/terraform/govuk/main.tf
+++ b/terraform/govuk/main.tf
@@ -28,29 +28,23 @@ resource "aws_appmesh_mesh" "govuk" {
   }
 }
 
-resource "aws_service_discovery_http_namespace" "govuk_publishing_platform" {
-  name = "govuk-publishing-platform"
+resource "aws_service_discovery_private_dns_namespace" "govuk_publishing_platform" {
+  name = "govuk.local"
+  vpc  = "vpc-9e62bcf8"
 }
-
-# Error: only alphanumeric characters, underscores and hyphens allowed in "name"
-
-# Error: error deleting Service Discovery Service (srv-mo6wycszvyez7fxc):
-# ResourceInUse: Service contains registered instances; delete the instances before deleting the service
-# Error: error deleting Service Discovery Private DNS Namespace (ns-vwoi6tzke55tpjkb): ResourceInUse: Namespace has associated services; delete the services before deleting the namespace
-# Error: Error deleting ECS cluster: ClusterContainsTasksException: The Cluster cannot be deleted while Tasks are active.
 
 module "publisher_service" {
   appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
-  govuk_publishing_platform_namespace_id   = aws_service_discovery_http_namespace.govuk_publishing_platform.id
-  govuk_publishing_platform_namespace_name = aws_service_discovery_http_namespace.govuk_publishing_platform.name
+  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
   publishing_api_ingress_security_group    = module.publishing_api_service.ingress_security_group
   source                                   = "../publisher"
 }
 
 module "publishing_api_service" {
   appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
-  govuk_publishing_platform_namespace_id   = aws_service_discovery_http_namespace.govuk_publishing_platform.id
-  govuk_publishing_platform_namespace_name = aws_service_discovery_http_namespace.govuk_publishing_platform.name
+  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
   source                                   = "../publishing-api"
 }
 

--- a/terraform/govuk/main.tf
+++ b/terraform/govuk/main.tf
@@ -28,22 +28,24 @@ resource "aws_appmesh_mesh" "govuk" {
   }
 }
 
-resource "aws_service_discovery_http_namespace" "govuk_publishing_platform" {
-  name = "govuk-publishing-platform"
+resource "aws_service_discovery_private_dns_namespace" "govuk_publishing_platform" {
+  name = "govuk.local"
+  vpc  = "vpc-9e62bcf8"
 }
 
 module "publisher_service" {
-  appmesh_mesh_govuk_id = aws_appmesh_mesh.govuk.id
-  govuk_publishing_platform_http_namespace_id = aws_service_discovery_http_namespace.govuk_publishing_platform.id
-  govuk_publishing_platform_http_namespace_name = aws_service_discovery_http_namespace.govuk_publishing_platform.name
-  source = "../publisher"
+  appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
+  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  publishing_api_ingress_security_group    = module.publishing_api_service.ingress_security_group
+  source                                   = "../publisher"
 }
 
 module "publishing_api_service" {
-  appmesh_mesh_govuk_id = aws_appmesh_mesh.govuk.id
-  govuk_publishing_platform_http_namespace_id = aws_service_discovery_http_namespace.govuk_publishing_platform.id
-  govuk_publishing_platform_http_namespace_name = aws_service_discovery_http_namespace.govuk_publishing_platform.name
-  source = "../publishing-api"
+  appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
+  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  source                                   = "../publishing-api"
 }
 
 # TODO: Create a Virtual gateway.

--- a/terraform/govuk/main.tf
+++ b/terraform/govuk/main.tf
@@ -41,14 +41,18 @@ module "publisher_service" {
   source                                   = "../publisher"
 }
 
+module "content_store_service" {
+  appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
+  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  publishing_api_ingress_security_group    = module.publishing_api_service.ingress_security_group
+  source                                   = "../content-store"
+}
+
 module "publishing_api_service" {
   appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
   govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  content_store_ingress_security_group     = module.content_store_service.ingress_security_group
   source                                   = "../publishing-api"
 }
-
-# TODO: Create a Virtual gateway.
-# https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_gateways.html
-# A virtual gateway allows resources that are outside of your mesh
-# to communicate to resources that are inside of your mesh.

--- a/terraform/publisher/README.md
+++ b/terraform/publisher/README.md
@@ -1,5 +1,7 @@
 # Publisher application
 
-This project module manages the resources required to run the publishing
+This module manages the resources required to run the publishing
 application, including the ECS service and task definitions, the internal
 and external (public) application load balancers, and required security groups.
+
+**Note**: This module is managed by the govuk module. Run terraform from there.

--- a/terraform/publisher/appmesh.tf
+++ b/terraform/publisher/appmesh.tf
@@ -1,17 +1,17 @@
-resource "aws_appmesh_virtual_service" "service" {
+resource "aws_appmesh_virtual_service" "publisher" {
   name      = "${var.service_name}.govuk.local"
   mesh_name = var.appmesh_mesh_govuk_id
 
   spec {
     provider {
       virtual_node {
-        virtual_node_name = aws_appmesh_virtual_node.service.name
+        virtual_node_name = aws_appmesh_virtual_node.publisher.name
       }
     }
   }
 }
 
-resource "aws_appmesh_virtual_node" "service" {
+resource "aws_appmesh_virtual_node" "publisher" {
   name      = var.service_name
   mesh_name = var.appmesh_mesh_govuk_id
 
@@ -26,7 +26,7 @@ resource "aws_appmesh_virtual_node" "service" {
     listener {
       # Incoming traffic to the node
       port_mapping {
-        port     = var.container_ingress_port
+        port     = 3000
         protocol = "http"
       }
     }
@@ -34,10 +34,10 @@ resource "aws_appmesh_virtual_node" "service" {
     service_discovery {
       aws_cloud_map {
         namespace_name = var.govuk_publishing_platform_namespace_name
-        service_name   = aws_service_discovery_service.service.name
+        service_name   = aws_service_discovery_service.publisher.name
       }
     }
   }
 
-  depends_on = [aws_service_discovery_service.service]
+  depends_on = [aws_service_discovery_service.publisher]
 }

--- a/terraform/publisher/appmesh.tf
+++ b/terraform/publisher/appmesh.tf
@@ -1,5 +1,5 @@
 resource "aws_appmesh_virtual_service" "publisher" {
-  name      = "${var.service_name}.govuk.local"
+  name      = "${var.service_name}.govuk-publishing-platform"
   mesh_name = var.appmesh_mesh_govuk_id
 
   spec {
@@ -19,7 +19,7 @@ resource "aws_appmesh_virtual_node" "publisher" {
     backend {
       # The ECS service
       virtual_service {
-        virtual_service_name = "${var.service_name}.govuk.local"
+        virtual_service_name = "${var.service_name}.govuk-publishing-platform"
       }
     }
 

--- a/terraform/publisher/appmesh.tf
+++ b/terraform/publisher/appmesh.tf
@@ -1,5 +1,5 @@
 resource "aws_appmesh_virtual_service" "publisher" {
-  name      = "${var.service_name}.govuk.local"
+  name      = "${var.service_name}.mesh.govuk-internal.digital"
   mesh_name = var.appmesh_mesh_govuk_id
 
   spec {
@@ -19,7 +19,7 @@ resource "aws_appmesh_virtual_node" "publisher" {
     backend {
       # The ECS service
       virtual_service {
-        virtual_service_name = "${var.service_name}.govuk.local"
+        virtual_service_name = "${var.service_name}.mesh.govuk-internal.digital"
       }
     }
 

--- a/terraform/publisher/appmesh.tf
+++ b/terraform/publisher/appmesh.tf
@@ -1,5 +1,5 @@
 resource "aws_appmesh_virtual_service" "publisher" {
-  name      = "${var.service_name}.govuk-publishing-platform"
+  name      = "${var.service_name}.govuk.local"
   mesh_name = var.appmesh_mesh_govuk_id
 
   spec {
@@ -19,7 +19,7 @@ resource "aws_appmesh_virtual_node" "publisher" {
     backend {
       # The ECS service
       virtual_service {
-        virtual_service_name = "${var.service_name}.govuk-publishing-platform"
+        virtual_service_name = "${var.service_name}.govuk.local"
       }
     }
 

--- a/terraform/publisher/cloudmap.tf
+++ b/terraform/publisher/cloudmap.tf
@@ -5,7 +5,7 @@ resource "aws_service_discovery_service" "publisher" {
     namespace_id = var.govuk_publishing_platform_namespace_id
 
     dns_records {
-      ttl  = 60
+      ttl  = 10
       type = "A"
     }
 

--- a/terraform/publisher/cloudmap.tf
+++ b/terraform/publisher/cloudmap.tf
@@ -1,14 +1,4 @@
 resource "aws_service_discovery_service" "publisher" {
   name = var.service_name
-
-  dns_config {
-    namespace_id = var.govuk_publishing_platform_namespace_id
-
-    dns_records {
-      ttl  = 60
-      type = "A"
-    }
-
-    routing_policy = "WEIGHTED"
-  }
+  namespace_id = var.govuk_publishing_platform_namespace_id
 }

--- a/terraform/publisher/cloudmap.tf
+++ b/terraform/publisher/cloudmap.tf
@@ -1,0 +1,4 @@
+resource "aws_service_discovery_service" "publisher" {
+  name = "publisher"
+  namespace_id = var.govuk_publishing_platform_http_namespace_id
+}

--- a/terraform/publisher/cloudmap.tf
+++ b/terraform/publisher/cloudmap.tf
@@ -1,4 +1,14 @@
 resource "aws_service_discovery_service" "publisher" {
-  name = "publisher"
-  namespace_id = var.govuk_publishing_platform_http_namespace_id
+  name = var.service_name
+
+  dns_config {
+    namespace_id = var.govuk_publishing_platform_namespace_id
+
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+
+    routing_policy = "WEIGHTED"
+  }
 }

--- a/terraform/publisher/cloudmap.tf
+++ b/terraform/publisher/cloudmap.tf
@@ -1,4 +1,14 @@
 resource "aws_service_discovery_service" "publisher" {
   name = var.service_name
-  namespace_id = var.govuk_publishing_platform_namespace_id
+
+  dns_config {
+    namespace_id = var.govuk_publishing_platform_namespace_id
+
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+
+    routing_policy = "WEIGHTED"
+  }
 }

--- a/terraform/publisher/main.tf
+++ b/terraform/publisher/main.tf
@@ -84,8 +84,6 @@ resource "aws_ecs_service" "service" {
     aws_lb_listener.public_listener,
     aws_service_discovery_service.publisher
   ]
-
-  depends_on = [aws_service_discovery_service.publisher]
 }
 
 #
@@ -98,7 +96,6 @@ resource "aws_security_group" "service" {
   description = "Allow the public and internal ALBs for the fargate ${var.service_name} service to access the service"
 }
 
-# TODO: Is this is the best way to achieve this, should it instead
 resource "aws_security_group_rule" "service_ingress" {
   description = "Allow publisher ingress to publishing-api"
   type        = "ingress"

--- a/terraform/publisher/variables.tf
+++ b/terraform/publisher/variables.tf
@@ -1,11 +1,20 @@
-#
-# Variables
-#
+variable "appmesh_mesh_govuk_id" {
+  type = string
+  default = "govuk"
+}
 
 variable "service_name" {
   description = "Service name of the Fargate service, cluster, task etc."
   type        = string
   default     = "publisher"
+}
+
+variable "govuk_publishing_platform_http_namespace_id" {
+  type = string
+}
+
+variable "govuk_publishing_platform_http_namespace_name" {
+  type = string
 }
 
 variable "private_subnets" {

--- a/terraform/publisher/variables.tf
+++ b/terraform/publisher/variables.tf
@@ -1,5 +1,5 @@
 variable "appmesh_mesh_govuk_id" {
-  type = string
+  type    = string
   default = "govuk"
 }
 
@@ -9,11 +9,11 @@ variable "service_name" {
   default     = "publisher"
 }
 
-variable "govuk_publishing_platform_http_namespace_id" {
+variable "govuk_publishing_platform_namespace_id" {
   type = string
 }
 
-variable "govuk_publishing_platform_http_namespace_name" {
+variable "govuk_publishing_platform_namespace_name" {
   type = string
 }
 
@@ -45,6 +45,10 @@ variable "desired_count" {
   description = "The desired number of container instances"
   type        = number
   default     = 1
+}
+
+variable "publishing_api_ingress_security_group" {
+  type = string
 }
 
 variable "redis_security_group_id" {

--- a/terraform/publishing-api/appmesh.tf
+++ b/terraform/publishing-api/appmesh.tf
@@ -1,5 +1,5 @@
 resource "aws_appmesh_virtual_service" "service" {
-  name      = "${var.service_name}.govuk.local"
+  name      = "${var.service_name}.govuk-publishing-platform"
   mesh_name = var.appmesh_mesh_govuk_id
 
   spec {
@@ -19,7 +19,7 @@ resource "aws_appmesh_virtual_node" "service" {
     backend {
       # The ECS service
       virtual_service {
-        virtual_service_name = "${var.service_name}.govuk.local"
+        virtual_service_name = "${var.service_name}.govuk-publishing-platform"
       }
     }
 

--- a/terraform/publishing-api/appmesh.tf
+++ b/terraform/publishing-api/appmesh.tf
@@ -1,0 +1,41 @@
+resource "aws_appmesh_virtual_service" "service" {
+  name      = "${var.service_name}.govuk.local"
+  mesh_name = var.appmesh_mesh_govuk_id
+
+  spec {
+    provider {
+      virtual_node {
+        virtual_node_name = aws_appmesh_virtual_node.service.name
+      }
+    }
+  }
+}
+
+resource "aws_appmesh_virtual_node" "service" {
+  name      = var.service_name
+  mesh_name = var.appmesh_mesh_govuk_id
+
+  spec {
+    backend {
+      # The ECS service
+      virtual_service {
+        virtual_service_name = "${var.service_name}-app.govuk.local"
+      }
+    }
+
+    listener {
+      # Incoming traffic to the node
+      port_mapping {
+        port     = 8080
+        protocol = "http"
+      }
+    }
+
+    service_discovery {
+      aws_cloud_map {
+        namespace_name = var.govuk_publishing_platform_http_namespace_name
+        service_name = aws_service_discovery_service.service.name
+      }
+    }
+  }
+}

--- a/terraform/publishing-api/appmesh.tf
+++ b/terraform/publishing-api/appmesh.tf
@@ -1,5 +1,5 @@
 resource "aws_appmesh_virtual_service" "service" {
-  name      = "${var.service_name}.govuk.local"
+  name      = "${var.service_name}.mesh.govuk-internal.digital"
   mesh_name = var.appmesh_mesh_govuk_id
 
   spec {
@@ -19,7 +19,7 @@ resource "aws_appmesh_virtual_node" "service" {
     backend {
       # The ECS service
       virtual_service {
-        virtual_service_name = "${var.service_name}.govuk.local"
+        virtual_service_name = "${var.service_name}.mesh.govuk-internal.digital"
       }
     }
 

--- a/terraform/publishing-api/appmesh.tf
+++ b/terraform/publishing-api/appmesh.tf
@@ -1,5 +1,5 @@
 resource "aws_appmesh_virtual_service" "service" {
-  name      = "${var.service_name}.govuk-publishing-platform"
+  name      = "${var.service_name}.govuk.local"
   mesh_name = var.appmesh_mesh_govuk_id
 
   spec {
@@ -19,7 +19,7 @@ resource "aws_appmesh_virtual_node" "service" {
     backend {
       # The ECS service
       virtual_service {
-        virtual_service_name = "${var.service_name}.govuk-publishing-platform"
+        virtual_service_name = "${var.service_name}.govuk.local"
       }
     }
 

--- a/terraform/publishing-api/cloudmap.tf
+++ b/terraform/publishing-api/cloudmap.tf
@@ -1,4 +1,14 @@
 resource "aws_service_discovery_service" "service" {
   name = var.service_name
-  namespace_id = var.govuk_publishing_platform_namespace_id
+
+  dns_config {
+    namespace_id = var.govuk_publishing_platform_namespace_id
+
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+
+    routing_policy = "WEIGHTED"
+  }
 }

--- a/terraform/publishing-api/cloudmap.tf
+++ b/terraform/publishing-api/cloudmap.tf
@@ -5,7 +5,7 @@ resource "aws_service_discovery_service" "service" {
     namespace_id = var.govuk_publishing_platform_namespace_id
 
     dns_records {
-      ttl  = 60
+      ttl  = 10
       type = "A"
     }
 

--- a/terraform/publishing-api/cloudmap.tf
+++ b/terraform/publishing-api/cloudmap.tf
@@ -1,4 +1,14 @@
 resource "aws_service_discovery_service" "service" {
   name = var.service_name
-  namespace_id = var.govuk_publishing_platform_http_namespace_id
+
+  dns_config {
+    namespace_id = var.govuk_publishing_platform_namespace_id
+
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+
+    routing_policy = "WEIGHTED"
+  }
 }

--- a/terraform/publishing-api/cloudmap.tf
+++ b/terraform/publishing-api/cloudmap.tf
@@ -1,0 +1,4 @@
+resource "aws_service_discovery_service" "service" {
+  name = var.service_name
+  namespace_id = var.govuk_publishing_platform_http_namespace_id
+}

--- a/terraform/publishing-api/cloudmap.tf
+++ b/terraform/publishing-api/cloudmap.tf
@@ -1,14 +1,4 @@
 resource "aws_service_discovery_service" "service" {
   name = var.service_name
-
-  dns_config {
-    namespace_id = var.govuk_publishing_platform_namespace_id
-
-    dns_records {
-      ttl  = 60
-      type = "A"
-    }
-
-    routing_policy = "WEIGHTED"
-  }
+  namespace_id = var.govuk_publishing_platform_namespace_id
 }

--- a/terraform/publishing-api/main.tf
+++ b/terraform/publishing-api/main.tf
@@ -19,6 +19,10 @@ data "aws_iam_role" "task_execution_role" {
   name = "fargate_task_execution_role"
 }
 
+data "aws_iam_role" "task_role" {
+  name = "fargate_task_role"
+}
+
 data "aws_ecs_cluster" "cluster" {
   cluster_name = "govuk"
 }
@@ -31,14 +35,28 @@ resource "aws_ecs_task_definition" "service" {
   cpu                      = 512
   memory                   = 1024
   execution_role_arn       = data.aws_iam_role.task_execution_role.arn
+  task_role_arn            = data.aws_iam_role.task_role.arn
+
+  proxy_configuration {
+    type           = "APPMESH"
+    container_name = "envoy"
+
+    properties = {
+      AppPorts         = var.container_ingress_port
+      EgressIgnoredIPs = "169.254.170.2,169.254.169.254"
+      IgnoredUID       = "1337"
+      ProxyEgressPort  = 15001
+      ProxyIngressPort = 15000
+    }
+  }
 }
 
 resource "aws_ecs_service" "service" {
-  name                              = var.service_name
-  cluster                           = data.aws_ecs_cluster.cluster.id
-  task_definition                   = aws_ecs_task_definition.service.arn
-  desired_count                     = var.desired_count
-  launch_type                       = "FARGATE"
+  name            = var.service_name
+  cluster         = data.aws_ecs_cluster.cluster.id
+  task_definition = aws_ecs_task_definition.service.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
 
   network_configuration {
     security_groups = [aws_security_group.service.id, var.govuk_management_access_security_group, data.aws_security_group.service_dependencies.id]
@@ -46,9 +64,11 @@ resource "aws_ecs_service" "service" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.service.arn
+    registry_arn   = aws_service_discovery_service.service.arn
     container_name = var.service_name
   }
+
+  depends_on = [aws_service_discovery_service.service]
 }
 
 #
@@ -56,9 +76,9 @@ resource "aws_ecs_service" "service" {
 #
 
 resource "aws_security_group" "service" {
-  name        = "fargate_${var.service_name}_alb_access"
+  name        = "fargate_${var.service_name}_ingress"
   vpc_id      = data.aws_vpc.vpc.id
-  description = "Allow the internal ALB for the fargate ${var.service_name} service to access the service"
+  description = "Permit internal services to access the ${var.service_name} ECS service"
 }
 
 #
@@ -66,5 +86,5 @@ resource "aws_security_group" "service" {
 #
 
 data "aws_security_group" "service_dependencies" {
-  id = "sg-05ad7398fc0d7c5b4" # govuk_publishing-api_access
+  id = "sg-05ad7398fc0d7c5b4" # legacy govuk-aws group: govuk_publishing-api_access
 }

--- a/terraform/publishing-api/main.tf
+++ b/terraform/publishing-api/main.tf
@@ -1,12 +1,3 @@
-terraform {
-  backend "s3" {
-    bucket  = "govuk-terraform-test"
-    key     = "projects/app-publishing-api.tfstate"
-    region  = "eu-west-1"
-    encrypt = true
-  }
-}
-
 provider "aws" {
   version = "~> 2.69"
   region  = "eu-west-1"
@@ -48,17 +39,15 @@ resource "aws_ecs_service" "service" {
   task_definition                   = aws_ecs_task_definition.service.arn
   desired_count                     = var.desired_count
   launch_type                       = "FARGATE"
-  health_check_grace_period_seconds = 300
 
   network_configuration {
     security_groups = [aws_security_group.service.id, var.govuk_management_access_security_group, data.aws_security_group.service_dependencies.id]
     subnets         = var.private_subnets
   }
 
-  load_balancer {
-    target_group_arn = aws_lb_target_group.internal_lb_tg.arn
-    container_name   = var.service_name
-    container_port   = var.container_ingress_port
+  service_registries {
+    registry_arn = aws_service_discovery_service.service.arn
+    container_name = var.service_name
   }
 }
 
@@ -73,104 +62,9 @@ resource "aws_security_group" "service" {
 }
 
 #
-# Internal Load balancer
-#
-
-data "aws_acm_certificate" "internal_elb_cert" {
-  domain   = "*.test.govuk-internal.digital"
-  statuses = ["ISSUED"]
-}
-
-resource "aws_lb" "internal_alb" {
-  name               = "fargate-${var.service_name}"
-  internal           = "true"
-  load_balancer_type = "application"
-  security_groups    = [aws_security_group.internal_alb_sg.id]
-  subnets            = var.private_subnets
-}
-
-resource "aws_lb_target_group" "internal_lb_tg" {
-  name        = "${var.service_name}-internal"
-  port        = var.container_ingress_port
-  protocol    = "HTTP"
-  vpc_id      = data.aws_vpc.vpc.id
-  target_type = "ip"
-
-  deregistration_delay = 10
-
-  health_check {
-    path = "/healthcheck"
-  }
-}
-
-resource "aws_lb_listener" "internal_listener" {
-  load_balancer_arn = aws_lb.internal_alb.arn
-  port              = "443"
-  protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = data.aws_acm_certificate.internal_elb_cert.arn
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.internal_lb_tg.arn
-  }
-}
-
-resource "aws_security_group_rule" "internal_alb_ingress" {
-  type      = "ingress"
-  from_port = var.container_ingress_port
-  to_port   = var.container_ingress_port
-  protocol  = "tcp"
-
-  security_group_id        = aws_security_group.service.id
-  source_security_group_id = aws_security_group.internal_alb_sg.id
-}
-
-resource "aws_security_group" "internal_alb_sg" {
-  name        = "fargate_${var.service_name}_elb"
-  vpc_id      = data.aws_vpc.vpc.id
-  description = "ALB ingress and egress security group for ${var.service_name} ECS service"
-
-  ingress {
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    security_groups = [var.govuk_management_access_security_group] # TODO create a security group for talking to publishing-api ALB.
-  }
-
-  egress {
-    from_port       = var.container_ingress_port
-    to_port         = var.container_ingress_port
-    protocol        = "tcp"
-    security_groups = [aws_security_group.service.id]
-  }
-}
-
-#
 # Dependencies
 #
 
 data "aws_security_group" "service_dependencies" {
   id = "sg-05ad7398fc0d7c5b4" # govuk_publishing-api_access
-}
-
-#
-# DNS
-#
-
-data "aws_route53_zone" "internal" {
-  name         = var.internal_domain_name
-  private_zone = true
-}
-
-resource "aws_route53_record" "internal_service_record" {
-  zone_id = data.aws_route53_zone.internal.zone_id
-  name    = "${var.service_name}.${var.internal_domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = aws_lb.internal_alb.dns_name
-    zone_id                = aws_lb.internal_alb.zone_id
-    evaluate_target_health = false
-  }
 }

--- a/terraform/publishing-api/outputs.tf
+++ b/terraform/publishing-api/outputs.tf
@@ -1,0 +1,4 @@
+output "ingress_security_group" {
+  value       = aws_security_group.service.id
+  description = "Add ingress rules to this security group to permit another service to communicate with publishing-api"
+}

--- a/terraform/publishing-api/variables.tf
+++ b/terraform/publishing-api/variables.tf
@@ -46,3 +46,7 @@ variable "govuk_publishing_platform_namespace_id" {
 variable "govuk_publishing_platform_namespace_name" {
   type = string
 }
+
+variable "content_store_ingress_security_group" {
+  type = string
+}

--- a/terraform/publishing-api/variables.tf
+++ b/terraform/publishing-api/variables.tf
@@ -33,3 +33,16 @@ variable "internal_domain_name" {
   type        = string
   default     = "test.govuk-internal.digital"
 }
+
+variable "appmesh_mesh_govuk_id" {
+  type = string
+  default = "govuk"
+}
+
+variable "govuk_publishing_platform_http_namespace_id" {
+  type = string
+}
+
+variable "govuk_publishing_platform_http_namespace_name" {
+  type = string
+}

--- a/terraform/publishing-api/variables.tf
+++ b/terraform/publishing-api/variables.tf
@@ -19,7 +19,7 @@ variable "govuk_management_access_security_group" {
 variable "container_ingress_port" {
   description = "The port which the container will accept connections on"
   type        = number
-  default     = 3093
+  default     = 80
 }
 
 variable "desired_count" {
@@ -35,14 +35,14 @@ variable "internal_domain_name" {
 }
 
 variable "appmesh_mesh_govuk_id" {
-  type = string
+  type    = string
   default = "govuk"
 }
 
-variable "govuk_publishing_platform_http_namespace_id" {
+variable "govuk_publishing_platform_namespace_id" {
   type = string
 }
 
-variable "govuk_publishing_platform_http_namespace_name" {
+variable "govuk_publishing_platform_namespace_name" {
   type = string
 }

--- a/terraform/task-definitions/content-store.json
+++ b/terraform/task-definitions/content-store.json
@@ -4,6 +4,7 @@
     "image": "govuk/content-store:with-content-schemas",
     "essential": true,
     "environment": [
+      { "name": "APPMESH_VIRTUAL_NODE_NAME", "value": "mesh/govuk/virtualNode/content-store" },
       { "name": "DEFAULT_TTL", "value": "1800" },
       { "name": "GOVUK_APP_DOMAIN", "value": "test.govuk-internal.digital" },
       { "name": "GOVUK_APP_DOMAIN_EXTERNAL", "value": "test.govuk.digital" },
@@ -16,9 +17,10 @@
       { "name": "GOVUK_WEBSITE_ROOT", "value": "test.publishing.service.gov.uk" },
       { "name": "MONGODB_URI", "value": "mongodb://mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital/content_store_production" },
       { "name": "PLEK_SERVICE_PERFORMANCEPLATFORM_BIG_SCREEN_VIEW_URI", "value": "" },
+      { "name": "PLEK_SERVICE_PUBLISHING_API_URI", "value": "http://publishing-api.mesh.govuk-internal.digital" },
       { "name": "PLEK_SERVICE_RUMMAGER_URI", "value": "" },
       { "name": "PLEK_SERVICE_SPOTLIGHT_URI", "value": "" },
-      { "name": "PORT", "value": "3068" },
+      { "name": "PORT", "value": "80" },
       { "name": "RAILS_ENV", "value": "production" },
       { "name": "STATSD_PROTOCOL", "value": "tcp" },
       { "name": "STATSD_HOST", "value": "statsd.test.govuk-internal.digital" },
@@ -36,8 +38,8 @@
     "mountPoints": [],
     "portMappings": [
       {
-        "containerPort": 3068,
-        "hostPort": 3068,
+        "containerPort": 80,
+        "hostPort": 80,
         "protocol": "tcp"
       }
     ],
@@ -67,5 +69,24 @@
         "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:content_store_app-SENTRY_DSN-Ixx0fZ"
       }
     ]
+  },
+  {
+    "name": "envoy",
+    "image": "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.15.0.0-prod",
+    "user": "1337",
+    "environment": [
+      { "name": "APPMESH_VIRTUAL_NODE_NAME", "value": "mesh/govuk/virtualNode/content-store" },
+      { "name": "ENVOY_LOG_LEVEL", "value": "debug" }
+    ],
+    "essential": true,
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-create-group": "true",
+            "awslogs-group": "awslogs-fargate",
+            "awslogs-region": "eu-west-1",
+            "awslogs-stream-prefix": "awslogs-content-store-envoy"
+        }
+    }
   }
 ]

--- a/terraform/task-definitions/publisher.json
+++ b/terraform/task-definitions/publisher.json
@@ -23,7 +23,7 @@
       { "name": "GOVUK_USER", "value": "deploy"},
       { "name": "GOVUK_WEBSITE_ROOT", "value": "https://www.gov.uk" },
       { "name": "PLEK_SERVICE_CONTENT_STORE_URI", "value": "https://www.gov.uk/api" },
-      { "name": "PLEK_SERVICE_PUBLISHING_API_URI", "value": "http://publishing-api.govuk.local" },
+      { "name": "PLEK_SERVICE_PUBLISHING_API_URI", "value": "http://publishing-api.govuk-publishing-platform" },
       { "name": "PLEK_SERVICE_STATIC_URI", "value": "https://assets.test.publishing.service.gov.uk" },
       { "name": "RAILS_ENV", "value": "production" },
       { "name": "RAILS_SERVE_STATIC_FILES", "value": "true" },

--- a/terraform/task-definitions/publisher.json
+++ b/terraform/task-definitions/publisher.json
@@ -5,6 +5,7 @@
     "essential": true,
     "environment": [
       { "name": "ASSET_HOST", "value": "www.gov.uk" },
+      { "name": "APPMESH_VIRTUAL_NODE_NAME", "value": "mesh/govuk/virtualNode/publisher" },
       { "name": "BASIC_AUTH_USERNAME", "value": "gds" },
       { "name": "EMAIL_GROUP_BUSINESS", "value": "test-address@digital.cabinet-office.gov.uk" },
       { "name": "EMAIL_GROUP_CITIZEN", "value": "test-address@digital.cabinet-office.gov.uk" },
@@ -49,6 +50,19 @@
         "protocol": "tcp"
       }
     ],
+    "proxyConfiguration": {
+      "type": "APPMESH",
+      "containerName": "envoy",
+      "properties": [
+        { "name": "IgnoredUID", "value": "" },
+        { "name": "IgnoredGID", "value": "" },
+        { "name": "AppPorts", "value": "3000" },
+        { "name": "ProxyIngressPort", "value": "3000" },
+        { "name": "ProxyEgressPort", "value": "8080" },
+        { "name": "EgressIgnoredPorts", "value": "" },
+        { "name": "EgressIgnoredIPs", "value": "" }
+      ]
+    },
     "secrets": [
       {
         "name": "FACT_CHECK_PASSWORD",
@@ -109,6 +123,30 @@
       {
         "name": "MONGODB_URI",
         "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publisher_app-MONGODB_URI-x2sw5T"
+      }
+    ]
+  },
+  {
+    "name": "envoy",
+    "image": "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.15.0.0-prod",
+    "environment": [
+      { "name": "APPMESH_VIRTUAL_NODE_NAME", "value": "mesh/govuk/virtualNode/publisher" },
+      { "name": "ENVOY_LOG_LEVEL", "value": "debug" }
+    ],
+    "essential": true,
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-create-group": "true",
+            "awslogs-group": "awslogs-fargate",
+            "awslogs-region": "eu-west-1",
+            "awslogs-stream-prefix": "awslogs-publisher-envoy"
+        }
+    },
+    "portMappings": [
+      {
+        "containerPort": 8080,
+        "protocol": "tcp"
       }
     ]
   }

--- a/terraform/task-definitions/publisher.json
+++ b/terraform/task-definitions/publisher.json
@@ -23,7 +23,7 @@
       { "name": "GOVUK_USER", "value": "deploy"},
       { "name": "GOVUK_WEBSITE_ROOT", "value": "https://www.gov.uk" },
       { "name": "PLEK_SERVICE_CONTENT_STORE_URI", "value": "https://www.gov.uk/api" },
-      { "name": "PLEK_SERVICE_PUBLISHING_API_URI", "value": "http://publishing-api.govuk.local" },
+      { "name": "PLEK_SERVICE_PUBLISHING_API_URI", "value": "http://publishing-api.mesh.govuk-internal.digital" },
       { "name": "PLEK_SERVICE_STATIC_URI", "value": "https://assets.test.publishing.service.gov.uk" },
       { "name": "RAILS_ENV", "value": "production" },
       { "name": "RAILS_SERVE_STATIC_FILES", "value": "true" },

--- a/terraform/task-definitions/publisher.json
+++ b/terraform/task-definitions/publisher.json
@@ -23,6 +23,7 @@
       { "name": "GOVUK_USER", "value": "deploy"},
       { "name": "GOVUK_WEBSITE_ROOT", "value": "https://www.gov.uk" },
       { "name": "PLEK_SERVICE_CONTENT_STORE_URI", "value": "https://www.gov.uk/api" },
+      { "name": "PLEK_SERVICE_PUBLISHING_API_URI", "value": "http://publishing-api.govuk.local" },
       { "name": "PLEK_SERVICE_STATIC_URI", "value": "https://assets.test.publishing.service.gov.uk" },
       { "name": "RAILS_ENV", "value": "production" },
       { "name": "RAILS_SERVE_STATIC_FILES", "value": "true" },
@@ -33,6 +34,10 @@
       { "name": "STATSD_HOST", "value": "statsd.test.govuk-internal.digital" },
       { "name": "WEBSITE_ROOT", "value": "test.publishing.service.gov.uk" }
     ],
+    "dependsOn": [{
+      "containerName": "envoy",
+      "condition": "START"
+    }],
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
@@ -50,19 +55,6 @@
         "protocol": "tcp"
       }
     ],
-    "proxyConfiguration": {
-      "type": "APPMESH",
-      "containerName": "envoy",
-      "properties": [
-        { "name": "IgnoredUID", "value": "" },
-        { "name": "IgnoredGID", "value": "" },
-        { "name": "AppPorts", "value": "3000" },
-        { "name": "ProxyIngressPort", "value": "3000" },
-        { "name": "ProxyEgressPort", "value": "8080" },
-        { "name": "EgressIgnoredPorts", "value": "" },
-        { "name": "EgressIgnoredIPs", "value": "" }
-      ]
-    },
     "secrets": [
       {
         "name": "FACT_CHECK_PASSWORD",
@@ -129,6 +121,7 @@
   {
     "name": "envoy",
     "image": "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.15.0.0-prod",
+    "user": "1337",
     "environment": [
       { "name": "APPMESH_VIRTUAL_NODE_NAME", "value": "mesh/govuk/virtualNode/publisher" },
       { "name": "ENVOY_LOG_LEVEL", "value": "debug" }
@@ -142,12 +135,6 @@
             "awslogs-region": "eu-west-1",
             "awslogs-stream-prefix": "awslogs-publisher-envoy"
         }
-    },
-    "portMappings": [
-      {
-        "containerPort": 8080,
-        "protocol": "tcp"
-      }
-    ]
+    }
   }
 ]

--- a/terraform/task-definitions/publisher.json
+++ b/terraform/task-definitions/publisher.json
@@ -23,7 +23,7 @@
       { "name": "GOVUK_USER", "value": "deploy"},
       { "name": "GOVUK_WEBSITE_ROOT", "value": "https://www.gov.uk" },
       { "name": "PLEK_SERVICE_CONTENT_STORE_URI", "value": "https://www.gov.uk/api" },
-      { "name": "PLEK_SERVICE_PUBLISHING_API_URI", "value": "http://publishing-api.govuk-publishing-platform" },
+      { "name": "PLEK_SERVICE_PUBLISHING_API_URI", "value": "http://publishing-api.govuk.local" },
       { "name": "PLEK_SERVICE_STATIC_URI", "value": "https://assets.test.publishing.service.gov.uk" },
       { "name": "RAILS_ENV", "value": "production" },
       { "name": "RAILS_SERVE_STATIC_FILES", "value": "true" },

--- a/terraform/task-definitions/publishing-api.json
+++ b/terraform/task-definitions/publishing-api.json
@@ -4,6 +4,7 @@
     "image": "govuk/publishing-api:with-content-schemas",
     "essential": true,
     "environment": [
+      { "name": "APPMESH_VIRTUAL_NODE_NAME", "value": "mesh/govuk/virtualNode/publishing-api" },
       { "name": "CONTENT_API_PROTOTYPE", "value": "yes" },
       { "name": "CONTENT_STORE", "value": "https://content-store.test.publishing.service.gov.uk" },
       { "name": "DRAFT_CONTENT_STORE", "value": "https://draft-content-store.test.publishing.service.gov.uk" },
@@ -49,6 +50,19 @@
         "protocol": "tcp"
       }
     ],
+    "proxyConfiguration": {
+      "type": "APPMESH",
+      "containerName": "envoy",
+      "properties": [
+        { "name": "IgnoredUID", "value": "" },
+        { "name": "IgnoredGID", "value": "" },
+        { "name": "AppPorts", "value": "3000" },
+        { "name": "ProxyIngressPort", "value": "3000" },
+        { "name": "ProxyEgressPort", "value": "8080" },
+        { "name": "EgressIgnoredPorts", "value": "" },
+        { "name": "EgressIgnoredIPs", "value": "" }
+      ]
+    },
     "secrets": [
       {
         "name": "CONTENT_STORE_BEARER_TOKEN",
@@ -89,6 +103,30 @@
       {
         "name": "SENTRY_DSN",
         "valueFrom": "arn:aws:secretsmanager:eu-west-1:430354129336:secret:publishing_api-SENTRY_DSN-pCCOSJ"
+      }
+    ]
+  },
+  {
+    "name": "envoy",
+    "image": "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.15.0.0-prod",
+    "environment": [
+      { "name": "APPMESH_VIRTUAL_NODE_NAME", "value": "mesh/govuk/virtualNode/publishing-api" },
+      { "name": "ENVOY_LOG_LEVEL", "value": "debug" }
+    ],
+    "essential": true,
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-create-group": "true",
+            "awslogs-group": "awslogs-fargate",
+            "awslogs-region": "eu-west-1",
+            "awslogs-stream-prefix": "awslogs-publishing-api-envoy"
+        }
+    },
+    "portMappings": [
+      {
+        "containerPort": 8080,
+        "protocol": "tcp"
       }
     ]
   }

--- a/terraform/task-definitions/publishing-api.json
+++ b/terraform/task-definitions/publishing-api.json
@@ -20,7 +20,7 @@
       { "name": "GOVUK_STATSD_PREFIX", "value": "fargate" },
       { "name": "GOVUK_USER", "value": "deploy" },
       { "name": "GOVUK_WEBSITE_ROOT", "value": "https://www.gov.uk" },
-      { "name": "PORT", "value": "3093" },
+      { "name": "PORT", "value": "80" },
       { "name": "RABBITMQ_HOSTS", "value": "rabbitmq.test.govuk-internal.digital" },
       { "name": "RABBITMQ_USER", "value": "publishing_api" },
       { "name": "RABBITMQ_VHOST", "value": "/" },
@@ -33,6 +33,10 @@
       { "name": "SUPPRESS_DRAFT_STORE_502_ERROR", "value": "" },
       { "name": "UNICORN_WORKER_PROCESSES", "value": "8" }
     ],
+    "dependsOn": [{
+      "containerName": "envoy",
+      "condition": "START"
+    }],
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
@@ -45,24 +49,11 @@
     "mountPoints": [],
     "portMappings": [
       {
-        "containerPort": 3093,
-        "hostPort": 3093,
+        "containerPort": 80,
+        "hostPort": 80,
         "protocol": "tcp"
       }
     ],
-    "proxyConfiguration": {
-      "type": "APPMESH",
-      "containerName": "envoy",
-      "properties": [
-        { "name": "IgnoredUID", "value": "" },
-        { "name": "IgnoredGID", "value": "" },
-        { "name": "AppPorts", "value": "3000" },
-        { "name": "ProxyIngressPort", "value": "3000" },
-        { "name": "ProxyEgressPort", "value": "8080" },
-        { "name": "EgressIgnoredPorts", "value": "" },
-        { "name": "EgressIgnoredIPs", "value": "" }
-      ]
-    },
     "secrets": [
       {
         "name": "CONTENT_STORE_BEARER_TOKEN",
@@ -109,6 +100,7 @@
   {
     "name": "envoy",
     "image": "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.15.0.0-prod",
+    "user": "1337",
     "environment": [
       { "name": "APPMESH_VIRTUAL_NODE_NAME", "value": "mesh/govuk/virtualNode/publishing-api" },
       { "name": "ENVOY_LOG_LEVEL", "value": "debug" }
@@ -122,12 +114,6 @@
             "awslogs-region": "eu-west-1",
             "awslogs-stream-prefix": "awslogs-publishing-api-envoy"
         }
-    },
-    "portMappings": [
-      {
-        "containerPort": 8080,
-        "protocol": "tcp"
-      }
-    ]
+    }
   }
 ]

--- a/terraform/task-definitions/publishing-api.json
+++ b/terraform/task-definitions/publishing-api.json
@@ -6,7 +6,7 @@
     "environment": [
       { "name": "APPMESH_VIRTUAL_NODE_NAME", "value": "mesh/govuk/virtualNode/publishing-api" },
       { "name": "CONTENT_API_PROTOTYPE", "value": "yes" },
-      { "name": "CONTENT_STORE", "value": "https://content-store.test.publishing.service.gov.uk" },
+      { "name": "CONTENT_STORE", "value": "http://content-store.mesh.govuk-internal.digital" },
       { "name": "DRAFT_CONTENT_STORE", "value": "https://draft-content-store.test.publishing.service.gov.uk" },
       { "name": "EVENT_LOG_AWS_ACCESS_ID", "value": "AKIAJE6VSW25CYBUMQJA" },
       { "name": "EVENT_LOG_AWS_BUCKETNAME", "value": "govuk-publishing-api-event-log-test" },
@@ -20,6 +20,7 @@
       { "name": "GOVUK_STATSD_PREFIX", "value": "fargate" },
       { "name": "GOVUK_USER", "value": "deploy" },
       { "name": "GOVUK_WEBSITE_ROOT", "value": "https://www.gov.uk" },
+      { "name": "PLEK_SERVICE_CONTENT_STORE_URI", "value": "http://content-store.mesh.govuk-internal.digital" },
       { "name": "PORT", "value": "80" },
       { "name": "RABBITMQ_HOSTS", "value": "rabbitmq.test.govuk-internal.digital" },
       { "name": "RABBITMQ_USER", "value": "publishing_api" },


### PR DESCRIPTION
We have an opportunity to change how we do internal networking with the move from EC2 to ECS.

This adopts AWS App Mesh (service mesh) and AWS Cloud Map (service discovery) and removes the internal application load balancers (ALBs) for services running in ECS.

Benefits:

- We no longer need to manage the DNS records for services. Instead Cloud Map will create records in Route53 on our behalf, so that we can route requests e.g. to a Content Store ECS service via content-store.mesh.govuk-internal.digital. We still get some control e.g. over the TTL of the created DNS records.
- We no longer run internal ALBs for ECS services
- We get the benefits of running a service mesh managed by AWS. By running AWS-managed images of the [Envoy proxy](https://www.envoyproxy.io/) as a sidecar to our application instances in ECS, our services have consistent ingress/egress logs (similar to the nginx `access.log` we have in EC2). We can introduce gradual/canary deployment strategies using App Mesh. More benefits advertised here: https://aws.amazon.com/app-mesh.

Downsides:

- Service meshes are more complex than application load balancers, and App Mesh is relatively new product (in a few days of testing we hit bugs in the Terraform AWS provider such as https://github.com/terraform-providers/terraform-provider-aws/issues/4853)

An additional change included in this PR: we have begun to adopt a monolithic Terraform module, 'govuk', from which all Terraform commands will be run. This PR moves the Content Store, Publishing API, and Publisher apps to be managed by this module. There are pros and cons to this approach that we hope to discover by trying this out.

One additional minor change is that I've chosen to run all applications on port 80. There's no reason for all services to run on a unique port.

See the individual commit messages for specific details. Take a look at the final commit (adding content store to the mesh) which shows how this changes how we'll run an individual application in practice.

Story: https://trello.com/c/5u69DRCf/165-implement-appmesh-for-ecs-fargate-apps