### PR TITLE
Create govuk module to factor out per env config

### DIFF
--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = "eu-west-1"
+  region = "eu-west-1"
 }
 
 module "govuk" {

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -8,51 +8,9 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.69"
   region  = "eu-west-1"
 }
 
-# All services running on GOV.UK run in this single cluster.
-resource "aws_ecs_cluster" "cluster" {
-  name               = "govuk"
-  capacity_providers = ["FARGATE"]
-}
-
-resource "aws_appmesh_mesh" "govuk" {
-  name = "govuk"
-
-  spec {
-    egress_filter {
-      type = "ALLOW_ALL"
-    }
-  }
-}
-
-resource "aws_service_discovery_private_dns_namespace" "govuk_publishing_platform" {
-  name = "mesh.govuk-internal.digital"
-  vpc  = "vpc-9e62bcf8"
-}
-
-module "publisher_service" {
-  appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
-  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
-  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
-  publishing_api_ingress_security_group    = module.publishing_api_service.ingress_security_group
-  source                                   = "../../modules/apps/publisher"
-}
-
-module "content_store_service" {
-  appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
-  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
-  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
-  publishing_api_ingress_security_group    = module.publishing_api_service.ingress_security_group
-  source                                   = "../../modules/apps/content-store"
-}
-
-module "publishing_api_service" {
-  appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
-  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
-  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
-  content_store_ingress_security_group     = module.content_store_service.ingress_security_group
-  source                                   = "../../modules/apps/publishing-api"
+module "govuk" {
+  source = "../../modules/govuk"
 }

--- a/terraform/modules/apps/content-store/main.tf
+++ b/terraform/modules/apps/content-store/main.tf
@@ -1,6 +1,10 @@
-provider "aws" {
-  version = "~> 2.69"
-  region  = "eu-west-1"
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.69"
+    }
+  }
 }
 
 #

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -1,6 +1,10 @@
-provider "aws" {
-  version = "~> 2.69"
-  region  = "eu-west-1"
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.69"
+    }
+  }
 }
 
 #

--- a/terraform/modules/apps/publishing-api/main.tf
+++ b/terraform/modules/apps/publishing-api/main.tf
@@ -1,6 +1,10 @@
-provider "aws" {
-  version = "~> 2.69"
-  region  = "eu-west-1"
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.69"
+    }
+  }
 }
 
 #

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.69"
+    }
+  }
+}
+
+# All services running on GOV.UK run in this single cluster.
+resource "aws_ecs_cluster" "cluster" {
+  name               = "govuk"
+  capacity_providers = ["FARGATE"]
+}
+
+resource "aws_appmesh_mesh" "govuk" {
+  name = "govuk"
+
+  spec {
+    egress_filter {
+      type = "ALLOW_ALL"
+    }
+  }
+}
+
+resource "aws_service_discovery_private_dns_namespace" "govuk_publishing_platform" {
+  name = "mesh.govuk-internal.digital"
+  vpc  = "vpc-9e62bcf8"
+}
+
+module "publisher_service" {
+  appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
+  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  publishing_api_ingress_security_group    = module.publishing_api_service.ingress_security_group
+  source                                   = "../../modules/apps/publisher"
+}
+
+module "content_store_service" {
+  appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
+  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  publishing_api_ingress_security_group    = module.publishing_api_service.ingress_security_group
+  source                                   = "../../modules/apps/content-store"
+}
+
+module "publishing_api_service" {
+  appmesh_mesh_govuk_id                    = aws_appmesh_mesh.govuk.id
+  govuk_publishing_platform_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  govuk_publishing_platform_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  content_store_ingress_security_group     = module.content_store_service.ingress_security_group
+  source                                   = "../../modules/apps/publishing-api"
+}


### PR DESCRIPTION
Push all the resources and module invocations from `deployments/govuk-test` down into a shared module `modules/govuk` which creates all the GOV.UK Publishing resources for a given environment. `deployments/govuk-test` (and later integration, staging, etc.) will just call `modules/govuk` with parameters for settings which vary by environment.

Also clean up the way we define providers. Remove provider definitions from non-root modules, define a minimum provider version in each non-root module and define the provider configuration itself only in root modules — as [recommended in Terraform docs](https://www.terraform.io/docs/configuration/modules.html#providers-within-modules).

This doesn't pull out any of the per-environment settings into module variables (parameters) yet. We'll do that in a subsequent PR.

[Trello card](https://trello.com/c/69WKE6kI/211-implement-initial-structure-for-terraform)

[Design doc](https://docs.google.com/document/d/19s4sYWn3xuPj6QivDh73jnuNMftLdz4yefPAvjT7UIA/edit#)

Tested: we `tf destroy`ed the previous rig and successfully `tf apply`ed this. Cluster and apps came up successfully.

Co-authored-by: Chris Banks <chris.banks@digital.cabinet-office.gov.uk>