### PR TITLE
Permit GOV.UK tools Concourse role to assume into test account

### DIFF
--- a/terraform/modules/govuk/ecs_cluster.tf
+++ b/terraform/modules/govuk/ecs_cluster.tf
@@ -128,4 +128,31 @@ resource "aws_iam_role_policy_attachment" "appmesh_envoy_access" {
   policy_arn = "arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess"
 }
 
+#
+# Allow RE Autom8 Concourse role to deploy ECS apps in an account
+#
 
+resource "aws_iam_role" "govuk_concourse_deployer" {
+  name        = "govuk-concourse-deployer"
+  description = "Deploys applications to ECS from Concourse"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Principal": {
+              "AWS": "arn:aws:iam::047969882937:role/cd-govuk-tools-concourse-worker"
+            }
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "concourse_ecs_admin" {
+  role       = aws_iam_role.govuk_concourse_deployer.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
+}


### PR DESCRIPTION
This will allow Concourse jobs to assume a role in the test AWS account and deploy ECS services.

Story: https://trello.com/c/huv5i9DJ/233