### PR TITLE
Update Terraform READMEs to reflect new structure.

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,13 @@
+# Terraform for GOV.UK Publishing on ECS
+
+## Directory structure
+
+* `deployments`: root modules, from where you can run Terraform commands. These
+  should only call the `govuk` composition module and nothing else.
+* `modules`: non-root modules
+    * `govuk`: composition module for an entire GOV.UK Publishing environment
+    * `app`: reusable module for an app; contains the essential resources which all the apps need.
+    * `apps`: composition modules for each app; calls the app module plus any
+      app-specific resources.
+        * `publisher`: module which creates the Publisher app
+        * ...

--- a/terraform/deployments/govuk-test/README.md
+++ b/terraform/deployments/govuk-test/README.md
@@ -1,4 +1,6 @@
-# GOV.UK Project
+# govuk-test root module
 
-This is the main GOV.UK project for spinning GOV.UK up. It calls all of the
-necessary modules to have a functioning environment up and running.
+This root module configures the GOV.UK Publishing test environment.
+
+The only thing that it should do is pass the settings for the test environment
+to the [`govuk`](../../modules/govuk) composition module.

--- a/terraform/modules/govuk/README.md
+++ b/terraform/modules/govuk/README.md
@@ -1,0 +1,6 @@
+# GOV.UK Publishing composition module
+
+This module represents a complete deployment of GOV.UK Publishing in a single
+environment. It takes takes parameters for configuration items which vary by
+environment and instantiates the modules for each app and other modules
+necessary to bring up a complete environment.


### PR DESCRIPTION
This is really only a temporary update so that the READMEs are at least somewhat pertinent to what's actually going on. We'll very soon want to [generate this documentation using `terraform-docs`](https://trello.com/c/jlCGZ2EB/235-set-up-terraform-docs), at which point the contents of these READMEs will move into the `main.tf`s of their respective directories.

[Trello card](https://trello.com/c/69WKE6kI/211-implement-initial-structure-for-terraform)