### PR TITLE
Cleanup and fixes for Publisher module

### DIFF
--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -28,6 +28,7 @@ module "govuk" {
   vpc_id                       = "vpc-9e62bcf8"                                            # TODO: hardcoded
   private_subnets              = ["subnet-6dc4370b", "subnet-463bfd0e", "subnet-bfecd0e4"] # TODO: hardcoded
   public_subnets               = ["subnet-6cc4370a", "subnet-ba30f6f2", "subnet-bfe6dae4"] # TODO: hardcoded
+  public_lb_domain_name        = "test.govuk.digital"
   govuk_app_domain_external    = "test.govuk.digital"
   govuk_app_domain_internal    = "test.govuk-internal.digital"
   govuk_website_root           = "test.publishing.service.gov.uk"

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -24,19 +24,19 @@ data "aws_security_group" "redis" {
 }
 
 module "govuk" {
-  source                       = "../../modules/govuk"
-  vpc_id                       = "vpc-9e62bcf8"                                            # TODO: hardcoded
-  private_subnets              = ["subnet-6dc4370b", "subnet-463bfd0e", "subnet-bfecd0e4"] # TODO: hardcoded
-  public_subnets               = ["subnet-6cc4370a", "subnet-ba30f6f2", "subnet-bfe6dae4"] # TODO: hardcoded
-  public_lb_domain_name        = "test.govuk.digital"
-  govuk_app_domain_external    = "test.govuk.digital"
-  govuk_app_domain_internal    = "test.govuk-internal.digital"
-  govuk_website_root           = "test.publishing.service.gov.uk"
-  asset_host                   = "www.gov.uk" # TODO: this looks wrong
-  mongodb_host                 = "mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital"
-  redis_host                   = "pink-backend-redis.0f3erf.ng.0001.euw1.cache.amazonaws.com"
-  statsd_host                  = "statsd.test.govuk-internal.digital"
+  source                        = "../../modules/govuk"
+  vpc_id                        = "vpc-9e62bcf8"                                            # TODO: hardcoded
+  private_subnets               = ["subnet-6dc4370b", "subnet-463bfd0e", "subnet-bfecd0e4"] # TODO: hardcoded
+  public_subnets                = ["subnet-6cc4370a", "subnet-ba30f6f2", "subnet-bfe6dae4"] # TODO: hardcoded
+  public_lb_domain_name         = "test.govuk.digital"
+  govuk_app_domain_external     = "test.govuk.digital"
+  govuk_app_domain_internal     = "test.govuk-internal.digital"
+  govuk_website_root            = "test.publishing.service.gov.uk"
+  asset_host                    = "www.gov.uk" # TODO: this looks wrong
+  mongodb_host                  = "mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital"
+  redis_host                    = "pink-backend-redis.0f3erf.ng.0001.euw1.cache.amazonaws.com"
+  statsd_host                   = "statsd.test.govuk-internal.digital"
   govuk_management_access_sg_id = data.aws_security_group.govuk_management_access.id
-  documentdb_security_group_id = data.aws_security_group.documentdb.id
-  redis_security_group_id      = data.aws_security_group.redis.id
+  documentdb_security_group_id  = data.aws_security_group.documentdb.id
+  redis_security_group_id       = data.aws_security_group.redis.id
 }

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -15,6 +15,10 @@ data "aws_security_group" "documentdb" {
   name = "govuk_shared_documentdb_access"
 }
 
+data "aws_security_group" "govuk_management_access" {
+  name = "govuk_management_access"
+}
+
 data "aws_security_group" "redis" {
   name = "govuk_backend-redis_access"
 }
@@ -31,6 +35,7 @@ module "govuk" {
   mongodb_host                 = "mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital"
   redis_host                   = "pink-backend-redis.0f3erf.ng.0001.euw1.cache.amazonaws.com"
   statsd_host                  = "statsd.test.govuk-internal.digital"
+  govuk_management_access_sg_id = data.aws_security_group.govuk_management_access.id
   documentdb_security_group_id = data.aws_security_group.documentdb.id
   redis_security_group_id      = data.aws_security_group.redis.id
 }

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -256,18 +256,17 @@ resource "aws_security_group" "public_alb" {
 }
 
 data "aws_route53_zone" "public" {
-  name         = var.public_domain_name
-  private_zone = false
+  name         = var.public_lb_domain_name
 }
 
-resource "aws_route53_record" "public_service_record" {
+resource "aws_route53_record" "public_alb" {
   zone_id = data.aws_route53_zone.public.zone_id
-  name    = "${var.service_name}.${var.public_domain_name}"
+  name    = var.service_name
   type    = "A"
 
   alias {
     name                   = aws_lb.public.dns_name
     zone_id                = aws_lb.public.zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 }

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -256,7 +256,7 @@ resource "aws_security_group" "public_alb" {
 }
 
 data "aws_route53_zone" "public" {
-  name         = var.public_lb_domain_name
+  name = var.public_lb_domain_name
 }
 
 resource "aws_route53_record" "public_alb" {

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -66,7 +66,7 @@ module "app" {
   service_discovery_namespace_name = var.service_discovery_namespace_name
   task_role_arn                    = var.task_role_arn
   execution_role_arn               = var.execution_role_arn
-  extra_security_groups            = [var.govuk_management_access_security_group]
+  extra_security_groups            = [var.govuk_management_access_sg_id]
   container_definitions = [
     {
       # TODO: factor out all the remaining hardcoded values (see ../content-store for an example where this has been done)

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -249,16 +249,6 @@ resource "aws_lb_listener_certificate" "publishing_service" {
   certificate_arn = data.aws_acm_certificate.public_lb_alternate.arn
 }
 
-resource "aws_security_group_rule" "public_alb_ingress" {
-  type      = "ingress"
-  from_port = 80
-  to_port   = 80
-  protocol  = "tcp"
-
-  security_group_id        = module.app.security_group_id
-  source_security_group_id = aws_security_group.public_alb.id
-}
-
 resource "aws_security_group" "public_alb" {
   name        = "fargate_${var.service_name}_public_alb"
   vpc_id      = var.vpc_id

--- a/terraform/modules/apps/publisher/variables.tf
+++ b/terraform/modules/apps/publisher/variables.tf
@@ -41,6 +41,11 @@ variable "public_subnets" {
   type        = list
 }
 
+variable "public_lb_domain_name" {
+  description = "Domain in which to create DNS records for the app's Internet-facing load balancer. For example, staging.govuk.digital"
+  type        = string
+}
+
 variable "govuk_management_access_sg_id" {
   description = "ID of security group (defined outside this Terraform repo) for access from jumpboxes etc. This SG is added to all ECS instances."
   type        = string
@@ -52,13 +57,8 @@ variable "desired_count" {
   default     = 1
 }
 
-variable "public_domain_name" {
-  description = "Apex domain for Internet-facing services. For example, staging.publishing.service.gov.uk"
-  type        = string
-  default     = "test.govuk.digital"
-}
-
 variable "mesh_name" {
+  description = "App Mesh mesh name. For example, 'govuk'"
   type = string
 }
 
@@ -67,6 +67,7 @@ variable "asset_host" {
 }
 
 variable "govuk_app_domain_external" {
+  description = "Apex domain for Internet-facing services, as passed to apps for use in redirects etc. For example, staging.publishing.service.gov.uk"
   type = string
 }
 

--- a/terraform/modules/apps/publisher/variables.tf
+++ b/terraform/modules/apps/publisher/variables.tf
@@ -59,7 +59,7 @@ variable "desired_count" {
 
 variable "mesh_name" {
   description = "App Mesh mesh name. For example, 'govuk'"
-  type = string
+  type        = string
 }
 
 variable "asset_host" {
@@ -68,7 +68,7 @@ variable "asset_host" {
 
 variable "govuk_app_domain_external" {
   description = "Apex domain for Internet-facing services, as passed to apps for use in redirects etc. For example, staging.publishing.service.gov.uk"
-  type = string
+  type        = string
 }
 
 variable "govuk_website_root" {

--- a/terraform/modules/apps/publisher/variables.tf
+++ b/terraform/modules/apps/publisher/variables.tf
@@ -41,10 +41,9 @@ variable "public_subnets" {
   type        = list
 }
 
-variable "govuk_management_access_security_group" {
-  description = "Group used to allow access by management systems"
+variable "govuk_management_access_sg_id" {
+  description = "ID of security group (defined outside this Terraform repo) for access from jumpboxes etc. This SG is added to all ECS instances."
   type        = string
-  default     = "sg-0b873470482f6232d"
 }
 
 variable "desired_count" {

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -31,7 +31,9 @@ module "publisher_service" {
   vpc_id                           = var.vpc_id
   private_subnets                  = var.private_subnets
   public_subnets                   = var.public_subnets
+  public_lb_domain_name            = var.public_lb_domain_name
   govuk_management_access_sg_id    = var.govuk_management_access_sg_id
+  # App environment variables
   asset_host                       = var.asset_host
   govuk_app_domain_external        = var.govuk_app_domain_external
   govuk_website_root               = var.govuk_website_root

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -34,12 +34,12 @@ module "publisher_service" {
   public_lb_domain_name            = var.public_lb_domain_name
   govuk_management_access_sg_id    = var.govuk_management_access_sg_id
   # App environment variables
-  asset_host                       = var.asset_host
-  govuk_app_domain_external        = var.govuk_app_domain_external
-  govuk_website_root               = var.govuk_website_root
-  statsd_host                      = var.statsd_host
-  redis_host                       = var.redis_host
-  source                           = "../../modules/apps/publisher"
+  asset_host                = var.asset_host
+  govuk_app_domain_external = var.govuk_app_domain_external
+  govuk_website_root        = var.govuk_website_root
+  statsd_host               = var.statsd_host
+  redis_host                = var.redis_host
+  source                    = "../../modules/apps/publisher"
 }
 
 module "content_store_service" {

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -31,6 +31,7 @@ module "publisher_service" {
   vpc_id                           = var.vpc_id
   private_subnets                  = var.private_subnets
   public_subnets                   = var.public_subnets
+  govuk_management_access_sg_id    = var.govuk_management_access_sg_id
   asset_host                       = var.asset_host
   govuk_app_domain_external        = var.govuk_app_domain_external
   govuk_website_root               = var.govuk_website_root

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -49,11 +49,11 @@ resource "aws_security_group_rule" "publisher_to_any_any" {
 }
 
 resource "aws_security_group_rule" "publisher_from_alb_http" {
-  description = "Publisher receives requests from its public ALB over HTTP"
-  type      = "ingress"
-  from_port = 80
-  to_port   = 80
-  protocol  = "tcp"
+  description              = "Publisher receives requests from its public ALB over HTTP"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
   security_group_id        = module.publisher_service.app_security_group_id
   source_security_group_id = module.publisher_service.alb_security_group_id
 }

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -48,6 +48,16 @@ resource "aws_security_group_rule" "publisher_to_any_any" {
   security_group_id = module.publisher_service.app_security_group_id
 }
 
+resource "aws_security_group_rule" "publisher_from_alb_http" {
+  description = "Publisher receives requests from its public ALB over HTTP"
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+  security_group_id        = module.publisher_service.app_security_group_id
+  source_security_group_id = module.publisher_service.alb_security_group_id
+}
+
 resource "aws_security_group_rule" "publisher_alb_to_publisher_http" {
   description              = "Publisher ALB sends requests to Publisher over HTTP"
   type                     = "egress"

--- a/terraform/modules/govuk/variables.tf
+++ b/terraform/modules/govuk/variables.tf
@@ -24,6 +24,12 @@ variable "public_subnets" {
   type        = list
 }
 
+variable "public_lb_domain_name" {
+  description = "Domain in which to create DNS records for Internet-facing load balancers. For example, staging.govuk.digital"
+  type        = string
+}
+
+
 # TODO: find out how asset_host is actually used and add a description to disambiguate it.
 variable "asset_host" {
   type = string
@@ -39,7 +45,7 @@ variable "mongodb_host" {
 }
 
 variable "redis_host" {
-  description = "Hostname for the shared Redis (which isn't managed by this Terraform repo, at least initially)."
+  description = "Hostname for the shared Redis (defined outside this Terraform repo)."
   type        = string
 }
 
@@ -50,7 +56,7 @@ variable "redis_port" {
 }
 
 variable "redis_security_group_id" {
-  description = "ID of security group for the shared Redis (which isn't managed by this Terraform repo, at least initially)."
+  description = "ID of security group for the shared Redis (defined outside this Terraform repo)."
   type        = string
 }
 

--- a/terraform/modules/govuk/variables.tf
+++ b/terraform/modules/govuk/variables.tf
@@ -29,6 +29,11 @@ variable "asset_host" {
   type = string
 }
 
+variable "govuk_management_access_sg_id" {
+  description = "ID of security group (defined outside this Terraform repo) for access from jumpboxes etc. This SG is added to all ECS instances."
+  type        = string
+}
+
 variable "mongodb_host" {
   type = string
 }


### PR DESCRIPTION
- Avoid hardcoding the `govuk_management_access` security group ID; fetch it by name in the root module and pass it down.
- Move a security group rule for the Publisher ALB from the publisher module into modules/govuk along with all the other security group rules (missed from #27).
- Some minor cleanup of the ALB config for Publisher (details in the commit message) and factor out the domain name.

This introduces a new top-level var `public_lb_domain_name` which looks a bit like a duplicate of `govuk_app_domain_external` as it's currently set to the same thing (`test.govuk.digital`) but I think we'll soon need the ability to vary them separately - see the 0f6951d commit message for more details.

[Trello card](https://trello.com/c/69WKE6kI/211-implement-initial-structure-for-terraform)

Tested: `terraform apply` works and produces expected output.

### Tips for reviewing

This is probably best reviewed commit-by-commit rather than looking at the overall diff, because the mandatory `terraform fmt` makes it hard to see what's going on otherwise.

Please check that my var descriptions are accurate and sufficiently clear.