### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+Succint one line description of the PR objectives
+
+Trello
+------
+* Link to Trello card if available
+
+Description
+-----------
+* Describe the objectives that this PR aims to achieve
+* Provide enough context to aid better understanding, for
+  e.g. can refer to previous related PRs 
+* See [doc](https://gds-way.cloudapps.digital/standards/pull-requests.html)
+  for further guidance
+
+Checks/Tests
+------------
+* Provide the different tests that you have performed
+
+Future Work
+-----------
+* Provide a brief description of future work to be done, for e.g.
+  fix hardcoded values 
+


### PR DESCRIPTION
Trello
------
[card](https://trello.com/c/AfiUfhEB/250-add-pr-template-to-govuk-infrastructure-repo)

Description
-----------
* A PR template will help new members know what is the GOV.UK standard for
  commits.
* This has been discussed in the comments of #30

Checks/Tests
------------
* none

Future Work
-----------
* Revise template to make it more useful by taking the feedback of team members