### PR TITLE
Attach Publisher's load balancer to its ECS service.

### DIFF
--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -69,6 +69,18 @@ resource "aws_ecs_service" "service" {
   desired_count   = var.desired_count
   launch_type     = "FARGATE"
 
+  health_check_grace_period_seconds = length(var.load_balancers) > 0 ? var.health_check_grace_period_seconds : null
+
+  dynamic "load_balancer" {
+    for_each = var.load_balancers
+    iterator = lb
+    content {
+      target_group_arn = lb.value["target_group_arn"]
+      container_name   = lb.value["container_name"]
+      container_port   = lb.value["container_port"]
+    }
+  }
+
   network_configuration {
     security_groups = concat([aws_security_group.service.id], var.extra_security_groups)
     subnets         = var.subnets

--- a/terraform/modules/app/variables.tf
+++ b/terraform/modules/app/variables.tf
@@ -71,3 +71,15 @@ variable "extra_security_groups" {
   type        = list
   default     = []
 }
+
+variable "load_balancers" {
+  description = "Optional list of maps {target_group_arn, container_name, container_port} for attaching ALB/NLB target groups to the app's ECS service. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#load_balancer"
+  type        = list
+  default     = []
+}
+
+variable "health_check_grace_period_seconds" {
+  description = "Meaningful only if load_balancers is non-empty. See healthCheckGracePeriodSeconds in https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html"
+  type        = number
+  default     = 60
+}

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -67,6 +67,13 @@ module "app" {
   task_role_arn                    = var.task_role_arn
   execution_role_arn               = var.execution_role_arn
   extra_security_groups            = [var.govuk_management_access_sg_id]
+
+  load_balancers = [{
+    target_group_arn = aws_lb_target_group.public.arn
+    container_name   = "publisher"
+    container_port   = 80
+  }]
+
   container_definitions = [
     {
       # TODO: factor out all the remaining hardcoded values (see ../content-store for an example where this has been done)


### PR DESCRIPTION
Add a parameter to `modules/app` to allow attaching ALB/NLB target groups to an app's ECS service. Unfortunately we have to use Terraform's rather clunky "dynamic" construct in order to do this because the AWS provider doesn't have a separate resource type for associating an ECS service with a load balancer (unlike for EC2, where it provides aws_lb_target_group_attachment).

Define the healthcheck grace period on the ECS service if we're attaching one or more load balancers. Parameterise this as well, as we're likely to need to vary it. We have to avoid specifying health_check_grace_period_seconds on the aws_ecs_service resource if there are no load balancers, because otherwise the AWS TF provider complains; hence the ugly ternary conditional there.

[Trello card](https://trello.com/c/69WKE6kI/211)

Tested: `terraform apply` works. Publisher still doesn't serve requests (it gets killed by the healthcheck), but it's closer to working than it was before.