### PR TITLE
Add draft-content-store

### DIFF
--- a/terraform/modules/apps/content-store/main.tf
+++ b/terraform/modules/apps/content-store/main.tf
@@ -8,22 +8,22 @@ terraform {
 }
 
 data "aws_secretsmanager_secret" "oauth_id" {
-  name = "content_store_app-OAUTH_ID"
+  name = "${var.service_name}_OAUTH_ID"
 }
 data "aws_secretsmanager_secret" "oauth_secret" {
-  name = "content_store_app-OAUTH_SECRET"
+  name = "${var.service_name}_OAUTH_SECRET"
 }
 data "aws_secretsmanager_secret" "publishing_api_bearer_token" {
-  name = "content_store_app-PUBLISHING_API_BEARER_TOKEN" # pragma: allowlist secret
+  name = "${var.service_name}_PUBLISHING_API_BEARER_TOKEN" # pragma: allowlist secret
 }
 data "aws_secretsmanager_secret" "router_api_bearer_token" {
-  name = "content_store_app-ROUTER_API_BEARER_TOKEN" # pragma: allowlist secret
+  name = "${var.service_name}_ROUTER_API_BEARER_TOKEN" # pragma: allowlist secret
 }
 data "aws_secretsmanager_secret" "secret_key_base" {
-  name = "content_store_app-SECRET_KEY_BASE" # pragma: allowlist secret
+  name = "${var.service_name}_SECRET_KEY_BASE" # pragma: allowlist secret
 }
 data "aws_secretsmanager_secret" "sentry_dsn" {
-  name = "content_store_app-SENTRY_DSN"
+  name = "${var.service_name}_SENTRY_DSN"
 }
 
 module "app" {
@@ -57,7 +57,7 @@ module "app" {
         { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
         { "name" : "GOVUK_USER", "value" : "deploy" }, # TODO: clean up?
         { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
-        { "name" : "MONGODB_URI", "value" : "mongodb://${var.mongodb_host}/content_store_production" },
+        { "name" : "MONGODB_URI", "value" : "${var.mongodb_url}" },
         { "name" : "PLEK_SERVICE_PERFORMANCEPLATFORM_BIG_SCREEN_VIEW_URI", "value" : "" },
         { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api.${var.service_discovery_namespace_name}" },
         { "name" : "PLEK_SERVICE_RUMMAGER_URI", "value" : "" },
@@ -78,7 +78,7 @@ module "app" {
           "awslogs-create-group" : "true",
           "awslogs-group" : "awslogs-fargate",
           "awslogs-region" : "eu-west-1", # TODO: hardcoded region
-          "awslogs-stream-prefix" : "awslogs-content-store"
+          "awslogs-stream-prefix" : "awslogs-${var.service_name}",
         }
       },
       "mountPoints" : [],

--- a/terraform/modules/apps/content-store/outputs.tf
+++ b/terraform/modules/apps/content-store/outputs.tf
@@ -1,4 +1,4 @@
 output "app_security_group_id" {
   value       = module.app.security_group_id
-  description = "ID of the security group for Content Store instances."
+  description = "ID of the security group for Content Store (or draft) instances."
 }

--- a/terraform/modules/apps/content-store/variables.tf
+++ b/terraform/modules/apps/content-store/variables.tf
@@ -60,7 +60,7 @@ variable "govuk_website_root" {
   type = string
 }
 
-variable "mongodb_host" {
+variable "mongodb_url" {
   type = string
 }
 

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -57,7 +57,24 @@ module "content_store_service" {
   private_subnets                  = var.private_subnets
   govuk_app_domain_external        = var.govuk_app_domain_external
   govuk_website_root               = var.govuk_website_root
-  mongodb_host                     = var.mongodb_host
+  mongodb_url                      = "mongodb://${var.mongodb_host}/content_store_production"
+  statsd_host                      = var.statsd_host
+  source                           = "../../modules/apps/content-store"
+}
+
+module "draft_content_store_service" {
+  service_name                     = "draft-content-store"
+  mesh_name                        = aws_appmesh_mesh.govuk.id
+  service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  task_role_arn                    = aws_iam_role.task.arn
+  execution_role_arn               = aws_iam_role.execution.arn
+  cluster_id                       = aws_ecs_cluster.cluster.id
+  vpc_id                           = var.vpc_id
+  private_subnets                  = var.private_subnets
+  govuk_app_domain_external        = var.govuk_app_domain_external
+  govuk_website_root               = var.govuk_website_root
+  mongodb_url                      = "mongodb://${var.mongodb_host}/draft_content_store_production"
   statsd_host                      = var.statsd_host
   source                           = "../../modules/apps/content-store"
 }


### PR DESCRIPTION
Following on from #13 and #22 which added content-store, we add the
draft version of content-store in order to build the draft stack of
GOV.UK.

We customize the existing content-store app module so that the
service_name variable can be used to differentiate between draft and non
draft app deployment.

Secrets are renamed and will have to be changed via CLI

Future work:
1. SENTRY_DSN secret is the same across all apps in same environment so
this needs to be fixed throughout the repo.

Ref:
1. [Task Trello Card](https://trello.com/c/AaBscxsV/262-spin-up-draft-content-store)
2. [Parent Trello Card](https://trello.com/c/X4jlkXyE/200-determine-a-minimal-subset-of-apps)