### PR TITLE
Make all apps use same SENTRY_DSN secret

### DIFF
--- a/terraform/modules/apps/content-store/main.tf
+++ b/terraform/modules/apps/content-store/main.tf
@@ -23,7 +23,7 @@ data "aws_secretsmanager_secret" "secret_key_base" {
   name = "${var.service_name}_SECRET_KEY_BASE" # pragma: allowlist secret
 }
 data "aws_secretsmanager_secret" "sentry_dsn" {
-  name = "${var.service_name}_SENTRY_DSN"
+  name = "SENTRY_DSN"
 }
 
 module "app" {

--- a/terraform/modules/apps/frontend/main.tf
+++ b/terraform/modules/apps/frontend/main.tf
@@ -11,6 +11,10 @@ data "aws_secretsmanager_secret" "secret_key_base" {
   name = "frontend_app-SECRET_KEY_BASE"
 }
 
+data "aws_secretsmanager_secret" "sentry_dsn" {
+  name = "SENTRY_DSN"
+}
+
 module "app" {
   source                           = "../../app"
   cpu                              = 512
@@ -65,6 +69,10 @@ module "app" {
         {
           "name" : "SECRET_KEY_BASE",
           "valueFrom" : data.aws_secretsmanager_secret.secret_key_base.arn
+        },
+        {
+          "name" : "SENTRY_DSN",
+          "valueFrom" : data.aws_secretsmanager_secret.sentry_dsn.arn
         }
       ]
     }

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -50,7 +50,7 @@ data "aws_secretsmanager_secret" "secret_key_base" {
   name = "publisher_app-SECRET_KEY_BASE" # pragma: allowlist secret
 }
 data "aws_secretsmanager_secret" "sentry_dsn" {
-  name = "publisher_app-SENTRY_DSN"
+  name = "SENTRY_DSN"
 }
 
 module "app" {

--- a/terraform/modules/apps/publishing-api/main.tf
+++ b/terraform/modules/apps/publishing-api/main.tf
@@ -44,7 +44,7 @@ data "aws_secretsmanager_secret" "secret_key_base" {
 }
 
 data "aws_secretsmanager_secret" "sentry_dsn" {
-  name = "publishing_api_app-SENTRY_DSN"
+  name = "SENTRY_DSN"
 }
 
 

--- a/terraform/modules/apps/router/main.tf
+++ b/terraform/modules/apps/router/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 data "aws_secretsmanager_secret" "sentry_dsn" {
-  name = "router_app-SENTRY_DSN"
+  name = "SENTRY_DSN"
 }
 
 module "app" {


### PR DESCRIPTION
Currently most apps specifiy their own SENTRY_DSN secret but there is
only one SENTRY_DSN per GOV.UK environment.

This PR removes references to per app SENTRY_DSN and make use of a
single SENTRY_DSN.

In addition, we add the SENTRY_DSN to frontend which was missing.

We created the SENTRY_DSN secret already and will delete the redundant
ones after this PR is merged.

Refs:
1. [Trello Card](https://trello.com/c/I5VAhR3W/263-make-all-apps-use-same-sentrydsn)