### PR TITLE
Add draft-frontend

### DIFF
--- a/terraform/deployments/apps/test/common.tf
+++ b/terraform/deployments/apps/test/common.tf
@@ -10,6 +10,9 @@ locals {
   redis_host                       = "pink-backend-redis.0f3erf.ng.0001.euw1.cache.amazonaws.com"
   redis_port                       = 6379
   asset_host                       = "www.gov.uk" # TODO: this looks wrong
+  assets_url                       = "https://assets.${local.service_discovery_namespace_name}"
+  content_store_url                = "https://content-store.${local.service_discovery_namespace_name}"
+  static_url                       = "https://static.${local.service_discovery_namespace_name}"
 }
 
 data "aws_iam_role" "execution" {

--- a/terraform/deployments/apps/test/frontend/main.tf
+++ b/terraform/deployments/apps/test/frontend/main.tf
@@ -19,9 +19,11 @@ provider "aws" {
 }
 
 module "task_definition" {
-  source = "../../../../modules/task-definitions/frontend"
-
-  asset_host                       = local.asset_host
+  source                           = "../../../../modules/task-definitions/frontend"
+  service_name                     = "frontend"
+  assets_url                       = local.assets_url
+  content_store_url                = local.content_store_url
+  static_url                       = local.static_url
   execution_role_arn               = data.aws_iam_role.execution.arn
   govuk_website_root               = local.govuk_website_root
   image_tag                        = var.image_tag

--- a/terraform/modules/apps/frontend/main.tf
+++ b/terraform/modules/apps/frontend/main.tf
@@ -9,6 +9,7 @@ terraform {
 
 module "task_definition" {
   source                           = "../../task-definitions/frontend"
+  service_name                     = var.service_name
   govuk_website_root               = var.govuk_website_root
   image_tag                        = var.image_tag
   mesh_name                        = var.mesh_name
@@ -17,7 +18,9 @@ module "task_definition" {
   sentry_environment               = var.sentry_environment
   statsd_host                      = var.statsd_host
   service_discovery_namespace_name = var.service_discovery_namespace_name
-  asset_host                       = var.asset_host
+  assets_url                       = var.assets_url
+  content_store_url                = var.content_store_url
+  static_url                       = var.static_url
 }
 
 module "app" {

--- a/terraform/modules/apps/frontend/variables.tf
+++ b/terraform/modules/apps/frontend/variables.tf
@@ -80,6 +80,17 @@ variable "statsd_host" {
   type = string
 }
 
-variable "asset_host" {
-  type = string
+variable "assets_url" {
+  type        = string
+  description = "URL of the Assets service"
+}
+
+variable "content_store_url" {
+  type        = string
+  description = "URL of the Content Store service"
+}
+
+variable "static_url" {
+  type        = string
+  description = "URL of the Static service"
 }

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -24,10 +24,32 @@ module "frontend_service" {
   statsd_host                      = var.statsd_host
   govuk_website_root               = var.govuk_website_root
   govuk_app_domain_external        = var.govuk_app_domain_external
-  source                           = "../../modules/apps/frontend"
-  asset_host                       = var.asset_host
+  assets_url                       = "https://assets.${aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name}"
+  content_store_url                = "https://content-store.${aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name}"
+  static_url                       = "https://static.${aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name}"
   image_tag                        = local.default_image_tag
   sentry_environment               = var.sentry_environment
+  source                           = "../../modules/apps/frontend"
+}
+
+module "draft_frontend_service" {
+  service_name                     = "draft-frontend"
+  mesh_name                        = aws_appmesh_mesh.govuk.id
+  service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  task_role_arn                    = aws_iam_role.task.arn
+  execution_role_arn               = aws_iam_role.execution.arn
+  vpc_id                           = var.vpc_id
+  cluster_id                       = aws_ecs_cluster.cluster.id
+  statsd_host                      = var.statsd_host
+  govuk_website_root               = var.govuk_website_root
+  govuk_app_domain_external        = var.govuk_app_domain_external
+  assets_url                       = "https://draft-assets.${aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name}"
+  content_store_url                = "https://draft-content-store.${aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name}"
+  static_url                       = "https://draft-static.${aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name}"
+  image_tag                        = local.default_image_tag
+  sentry_environment               = var.sentry_environment
+  source                           = "../../modules/apps/frontend"
 }
 
 # TODO: alphabetise

--- a/terraform/modules/task-definitions/frontend/variables.tf
+++ b/terraform/modules/task-definitions/frontend/variables.tf
@@ -31,6 +31,21 @@ variable "service_discovery_namespace_name" {
   type = string
 }
 
-variable "asset_host" {
+variable "service_name" {
   type = string
+}
+
+variable "assets_url" {
+  type        = string
+  description = "URL of the Assets service"
+}
+
+variable "content_store_url" {
+  type        = string
+  description = "URL of the Content Store service"
+}
+
+variable "static_url" {
+  type        = string
+  description = "URL of the Static service"
 }


### PR DESCRIPTION
As part of spinning up the draft GOV.UK, we add the draft version of
frontend.

Some hard-coded parameters are turn into variables to allow reuse of the
frontend module.

Refs:
1. [Task Trello Card](https://trello.com/c/fBB1cgll/264-spin-up-draft-frontend)
2. [Main Trello Card](https://trello.com/c/X4jlkXyE/200-determine-a-minimal-subset-of-apps)
3. #37