### PR TITLE
Upgrade Terraform AWS provider to 3.13

### DIFF
--- a/terraform/deployments/apps/test/content-store/main.tf
+++ b/terraform/deployments/apps/test/content-store/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = "~> 3.13"
     }
   }
 }

--- a/terraform/deployments/apps/test/frontend/main.tf
+++ b/terraform/deployments/apps/test/frontend/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = "~> 3.13"
     }
   }
 }

--- a/terraform/deployments/apps/test/publisher/main.tf
+++ b/terraform/deployments/apps/test/publisher/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = "~> 3.13"
     }
   }
 }

--- a/terraform/deployments/apps/test/publishing-api/main.tf
+++ b/terraform/deployments/apps/test/publishing-api/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = "~> 3.13"
     }
   }
 }

--- a/terraform/deployments/apps/test/router/main.tf
+++ b/terraform/deployments/apps/test/router/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = "~> 3.13"
     }
   }
 }

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -5,6 +5,13 @@ terraform {
     region  = "eu-west-1"
     encrypt = true
   }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.13"
+    }
+  }
 }
 
 provider "aws" {

--- a/terraform/deployments/statsd/main.tf
+++ b/terraform/deployments/statsd/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.69"
+  version = "~> 3.13"
   region  = "eu-west-1"
 }
 

--- a/terraform/deployments/task-runner/main.tf
+++ b/terraform/deployments/task-runner/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.69"
+  version = "~> 3.13"
   region  = "eu-west-1"
 }
 

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/apps/content-store/main.tf
+++ b/terraform/modules/apps/content-store/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/apps/content-store/main.tf
+++ b/terraform/modules/apps/content-store/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/apps/frontend/main.tf
+++ b/terraform/modules/apps/frontend/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/apps/frontend/main.tf
+++ b/terraform/modules/apps/frontend/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/apps/publishing-api/main.tf
+++ b/terraform/modules/apps/publishing-api/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/apps/publishing-api/main.tf
+++ b/terraform/modules/apps/publishing-api/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/apps/router/main.tf
+++ b/terraform/modules/apps/router/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/apps/router/main.tf
+++ b/terraform/modules/apps/router/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/task-definition/main.tf
+++ b/terraform/modules/task-definition/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/task-definition/main.tf
+++ b/terraform/modules/task-definition/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/task-definitions/content-store/main.tf
+++ b/terraform/modules/task-definitions/content-store/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/task-definitions/content-store/main.tf
+++ b/terraform/modules/task-definitions/content-store/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/task-definitions/frontend/main.tf
+++ b/terraform/modules/task-definitions/frontend/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/task-definitions/frontend/main.tf
+++ b/terraform/modules/task-definitions/frontend/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/task-definitions/publisher/main.tf
+++ b/terraform/modules/task-definitions/publisher/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/task-definitions/publisher/main.tf
+++ b/terraform/modules/task-definitions/publisher/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/task-definitions/router/main.tf
+++ b/terraform/modules/task-definitions/router/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.69"
+      version = ">= 2.0"
     }
   }
 }

--- a/terraform/modules/task-definitions/router/main.tf
+++ b/terraform/modules/task-definitions/router/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
This upgrade includes a nice ECS addition which should make bringing services up/down more reliable:

- adds wait_for_steady_state attribute to aws_ecs_service

This also follows Terraform's [best practices](https://www.terraform.io/docs/configuration/provider-requirements.html#best-practices-for-provider-versions) for managing provider versions. We now specify a minimum provider version for submodules, where we don't expect to `terraform apply`, and a maximum provider version at the root module.