### PR TITLE
Adding Docker Hub Authentication Details

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -7,6 +7,8 @@ resource_types:
     source:
       repository: cfcommunity/slack-notification-resource
       tag: latest
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
 
 resources:
   - &git-repo

--- a/concourse/tasks/basic-smoke-test.yml
+++ b/concourse/tasks/basic-smoke-test.yml
@@ -3,6 +3,8 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/curl-ssl
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
 params:
   URL:
   MESSAGE:

--- a/concourse/tasks/deploy-app.yml
+++ b/concourse/tasks/deploy-app.yml
@@ -4,6 +4,8 @@ image_resource:
   source:
     repository: govuk/concourse-deploy
     tag: latest
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
 inputs:
   - name: govuk-infrastructure
     path: src


### PR DESCRIPTION
This is to address the problem of rate limiting that docker hub is
introducing on un-authenticated accounts.