### PR TITLE
Run db migrations during Publisher deployment

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -153,6 +153,16 @@ jobs:
       params:
         APPLICATION: publisher
         GOVUK_ENVIRONMENT: test
+    - task: fetch-db-migrations-config
+      file: govuk-infrastructure/concourse/tasks/fetch-task-network-config.yml
+      params:
+        APPLICATION: publisher
+        GOVUK_ENVIRONMENT: test
+    - task: run-db-migrations
+      file: govuk-infrastructure/concourse/tasks/run-task.yml
+      params:
+        APPLICATION: publisher
+        COMMAND: "rails db:migrate"
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:

--- a/concourse/tasks/fetch-task-network-config.sh
+++ b/concourse/tasks/fetch-task-network-config.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# This script prepares the network_config for an arbitrary task.
+
+set -eu
+
+root_dir=$(pwd)
+
+# Raise error if env vars not set
+: "${ASSUME_ROLE_ARN:?ASSUME_ROLE_ARN not set}"
+: "${GOVUK_ENVIRONMENT:?GOVUK_ENVIRONMENT not set}"
+: "${AWS_REGION:?AWS_REGION not set}"
+: "${APPLICATION:?APPLICATION not set}"
+
+mkdir -p ~/.aws
+
+cat <<EOF > ~/.aws/config
+[profile default]
+role_arn = $ASSUME_ROLE_ARN
+credential_source = Ec2InstanceMetadata
+EOF
+
+# TODO: Change this to point at govuk module once govuk-test is gone
+cd "src/terraform/deployments/govuk-$GOVUK_ENVIRONMENT"
+
+terraform init
+
+echo "terraform initialized, now getting terraform outputs"
+
+private_subnets=$(terraform output -json private_subnets)
+security_groups=$(terraform output -json $APPLICATION'_security_groups')
+network_config='awsvpcConfiguration={subnets='$private_subnets',securityGroups='$security_groups',assignPublicIp=DISABLED}'
+
+echo $network_config > "$root_dir/terraform-outputs/task_network_config"

--- a/concourse/tasks/fetch-task-network-config.yml
+++ b/concourse/tasks/fetch-task-network-config.yml
@@ -1,0 +1,21 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/terraform
+    tag: terraform-0.13.3
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
+inputs:
+  - name: govuk-infrastructure
+    path: src
+  - name: terraform-outputs
+outputs:
+  - name: terraform-outputs
+params:
+  AWS_REGION: eu-west-1
+  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  APPLICATION:
+  GOVUK_ENVIRONMENT:
+run:
+  path: ./src/concourse/tasks/fetch-task-network-config.sh

--- a/concourse/tasks/run-task.sh
+++ b/concourse/tasks/run-task.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+# This script runs an arbitrary task using an existing task defintion in a
+# new container, using ECS RunTask.
+
+set -eu
+
+root_dir=$(pwd)
+
+# Raise error if env vars not set
+: "${ASSUME_ROLE_ARN:?ASSUME_ROLE_ARN not set}"
+: "${AWS_REGION:?AWS_REGION not set}"
+: "${APPLICATION:?APPLICATION not set}"
+: "${COMMAND:?COMMAND not set}"
+: "${CLUSTER:?COMMAND not set}"
+
+mkdir -p ~/.aws
+
+cat <<EOF > ~/.aws/config
+[profile default]
+role_arn = $ASSUME_ROLE_ARN
+credential_source = Ec2InstanceMetadata
+region = $AWS_REGION
+EOF
+
+task_definition_arn=$(cat terraform-outputs/task_definition_arn)
+network_config=$(cat terraform-outputs/task_network_config)
+
+echo "Starting task..."
+
+task=$(aws ecs run-task --cluster $CLUSTER \
+--task-definition $task_definition_arn --launch-type FARGATE --count 1 \
+--network-configuration $network_config \
+--overrides '{
+  "containerOverrides": [{
+    "name": "'"$APPLICATION"'",
+    "command": ["/bin/bash", "-c", "'"$COMMAND"'"]
+  }]
+}')
+
+task_arn=$(echo $task | jq .tasks[0].taskArn)
+
+echo "waiting for task $task_arn to finish..."
+
+aws ecs wait tasks-stopped --tasks=[$task_arn] --cluster $CLUSTER
+
+echo "task finished."
+
+task_results=$(aws ecs describe-tasks --tasks=[$task_arn] --cluster $CLUSTER)
+echo $task_results
+
+exit_code=$(echo $task_results | jq [.tasks[0].containers[].exitCode] | jq add)
+
+echo "Exiting with code $exit_code"
+
+exit $exit_code

--- a/concourse/tasks/run-task.yml
+++ b/concourse/tasks/run-task.yml
@@ -1,0 +1,20 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/awscli
+    tag: terraform-0.13.3
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
+inputs:
+  - name: govuk-infrastructure
+    path: src
+  - name: terraform-outputs
+params:
+  AWS_REGION: eu-west-1
+  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  APPLICATION:
+  CLUSTER: task_runner
+  COMMAND:
+run:
+  path: ./src/concourse/tasks/run-task.sh

--- a/concourse/tasks/update-task-definition.yml
+++ b/concourse/tasks/update-task-definition.yml
@@ -31,10 +31,15 @@ run:
       echo "Creating a new task definition for $APPLICATION:$BUILD_TAG in ECS"
       echo "================================================="
 
-      cd "src/terraform/deployments/apps/$GOVUK_ENVIRONMENT/$APPLICATION"
+      APP_DIR="src/terraform/deployments/apps/$APPLICATION"
+      cd ${APP_DIR}
 
       terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
 
-      terraform apply -auto-approve -var "image_tag=$BUILD_TAG" -var "assume_role_arn=$ASSUME_ROLE_ARN"
+      terraform apply -var-file=../../variables/$GOVUK_ENVIRONMENT/common.tfvars \
+      -var-file=../../variables/$GOVUK_ENVIRONMENT/apps.tfvars \
+      -var=image_tag=$BUILD_TAG \
+      -var "assume_role_arn=$ASSUME_ROLE_ARN" \
+      -auto-approve
 
       terraform output task_definition_arn > "$root_dir/terraform-outputs/task_definition_arn"

--- a/terraform/deployments/govuk-test/outputs.tf
+++ b/terraform/deployments/govuk-test/outputs.tf
@@ -1,0 +1,7 @@
+output "private_subnets" {
+  value = var.private_subnets
+}
+
+output "publisher_security_groups" {
+  value = module.govuk.publisher_security_groups
+}

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -11,6 +11,10 @@ terraform {
   }
 }
 
+locals {
+  service_security_groups = concat([aws_security_group.service.id], var.extra_security_groups)
+}
+
 resource "aws_ecs_service" "service" {
   name        = var.service_name
   cluster     = var.cluster_id
@@ -29,7 +33,7 @@ resource "aws_ecs_service" "service" {
   }
 
   network_configuration {
-    security_groups = concat([aws_security_group.service.id], var.extra_security_groups)
+    security_groups = local.service_security_groups
     subnets         = var.subnets
   }
 

--- a/terraform/modules/app/outputs.tf
+++ b/terraform/modules/app/outputs.tf
@@ -2,3 +2,8 @@ output "security_group_id" {
   value       = aws_security_group.service.id
   description = "ID of the security group created by the module, containing the app."
 }
+
+output "security_groups" {
+  value       = local.service_security_groups
+  description = "The security groups applied to the ECS Service."
+}

--- a/terraform/modules/apps/publisher/outputs.tf
+++ b/terraform/modules/apps/publisher/outputs.tf
@@ -7,3 +7,8 @@ output "alb_security_group_id" {
   value       = aws_security_group.public_alb.id
   description = "ID of the security group for the Publisher app's Internet-facing load balancer."
 }
+
+output "security_groups" {
+  value       = module.app.security_groups
+  description = "The security groups applied to the ECS Service."
+}

--- a/terraform/modules/govuk/outputs.tf
+++ b/terraform/modules/govuk/outputs.tf
@@ -1,0 +1,4 @@
+output "publisher_security_groups" {
+  value       = module.publisher_service.security_groups
+  description = "The security groups applied to the Publisher ECS Service."
+}


### PR DESCRIPTION
This will run database migrations using a new task Publisher application task definition prior to updating the ECS Service to use the new task definition.

The command 'rails db:migrate' will run in a separate task_runner cluster, and the one-off containers will not be responsible for serving user requests.

This follows the design proposal in [proposal 005].

[proposal 005]: https://github.com/alphagov/govuk-replatforming-discovery-2020/blob/1ceebbb0319ecb3b6be35e3dedea2331638cf5a8/proposals/005-ecs-fargate-deployment.md#database-migrations-will-be-performed-before-new-code-is-deployed

The run-task task is intentionally generic so that it can run arbitrary commands in a container with the same configuration as those serving users.

Additional commits are required to enable db migrations for other apps. I'll put up another PR for these.

Story: https://trello.com/c/jepU0c7G/232