### PR TITLE
[spike] Branch deploys to ECS Fargate

### DIFF
--- a/concourse/pipelines/frontend-integration.yml
+++ b/concourse/pipelines/frontend-integration.yml
@@ -1,0 +1,80 @@
+---
+# Deploy pipeline for the frontend app in integration
+definitions:
+
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
+
+resources:
+  - &git-repo
+    icon: github
+    name: govuk-infrastructure
+    source:
+      branch: govuk-cd-frontend
+      uri: https://github.com/alphagov/govuk-infrastructure
+    type: git
+
+  - <<: *git-repo
+    name: frontend
+    source:
+      branch: master
+      uri: https://github.com/alphagov/frontend
+
+  - name: deploy-slack-channel
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/services/((slack_webhook))
+
+jobs:
+  - name: update-pipeline
+    plan:
+    - get: govuk-infrastructure
+      trigger: true
+    - file: govuk-infrastructure/concourse/pipelines/frontend-integration.yml
+      set_pipeline: govuk-cd-frontend
+    serial: true
+
+  - name: deploy-frontend
+    plan:
+    - get: govuk-infrastructure
+    - get: release
+      resource: frontend
+      trigger: true
+    - task: update-task-definition
+      file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+      params:
+        APPLICATION: frontend
+        GOVUK_ENVIRONMENT: test
+    - task: update-ecs-service
+      file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
+      params:
+        APPLICATION: frontend
+        GOVUK_ENVIRONMENT: test
+    serial: true
+    on_failure: &notify-slack-failure
+      put: deploy-slack-channel
+      params:
+        channel: "#govuk-deploy-test"
+        username: 'Concourse deploy pipeline'
+        icon_emoji: ':concourse:'
+        silent: true
+        text: |
+          :red_circle: Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+  - name: smoke-test-frontend
+    plan:
+    - get: govuk-infrastructure
+      passed:
+      - deploy-frontend
+      trigger: true
+    - file: govuk-infrastructure/concourse/tasks/basic-smoke-test.yml
+      params:
+        MESSAGE: Checking the app is not serving HTTP error codes.
+        URL: https://www.gov.uk/
+      task: smoke-test


### PR DESCRIPTION
This spike demonstrates one way to enable developers to deploy branches to a production-like environment (integration).

User needs:
* QA approval
* Test complex interactions between apps
* Experiment with apps in a production-like environment

Proposal:

* We remove integration from the production deployment pipeline
   * Releases automatically go to staging, and then manually or automatically to production
* We maintain a separate integration pipeline for each app hosted in integration
    * Developers can modify the integration pipeline for an app to deploy a branch
    * Integration app pipelines are reset nightly
    * We deploy the latest release of all apps to integration overnight, to reset the apps
* No other changes to integration (e.g. monitoring) are proposed

This spike contains the pipeline for the frontend app in the integration environment.

Workflow to deploy a branch:

1. Developer pulls this repo
2. Developer modifies an app pipeline config, replacing `main` with `my-branch`
3. Developer updates the config for the running pipeline with `fly sp -c pipelines/frontend-integration`
4. Developer runs the pipeline
5. Developer resets the pipeline (we could reset it automatically on a schedule during the day)

Pros:

* Avoids introducing complexity to the production deploy pipeline; this feature would require deploy freezes, protections against deploying branches to prod, creating a new Concourse resource.
* This enables developers to deploy branches without impacting other developers, and crucially without impacting or requiring authorization to modify the main deployment pipeline.
* Integration would become a shared testing environment which would be reset to a clone of staging nightly.
* This enables us to avoid complicating the production deployment pipelines, and draws a line between a testing environment (integration) and the production environments (staging, production).

Cons:

* This change requires that we maintain an additional pipeline for each app we wish to run in integration. It would likely contain duplicated code from the main deploy.yml pipeline.
* Developers cannot deploy branches at the same time (this is not currently possible).
* If app releases are not necessarily deployed to integration, this could mean releases get less exposure to a production-like environment before reaching production.

<img width="756" alt="Screenshot 2020-11-05 at 19 35 35" src="https://user-images.githubusercontent.com/8124374/98288074-34704980-1f9e-11eb-8a2f-6627f959984d.png">

Story: https://trello.com/c/5EN61qZx/231

Other ideas we're looking at:

- improving the local development experience so that it is not
  necessary to deploy branches
- modifying the production deployment pipeline so that it supports
  branch deploys
- creating a separate AWS environment per developer