### PR TITLE
Set app branches from concourse settings file

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -15,7 +15,7 @@ resources:
     icon: github
     name: govuk-infrastructure
     source:
-      branch: main
+      branch: ((govuk-infrastructure-branch))
       uri: https://github.com/alphagov/govuk-infrastructure
     type: git
 

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -22,42 +22,42 @@ resources:
   - <<: *git-repo
     name: frontend
     source:
-      branch: master
+      branch: ((frontend-branch))
       uri: https://github.com/alphagov/frontend
       tag_filter: release_*
 
   - <<: *git-repo
     name: publisher
     source:
-      branch: master
+      branch: ((publisher-branch))
       uri: https://github.com/alphagov/publisher
       tag_filter: release_*
 
   - <<: *git-repo
     name: publishing-api
     source:
-      branch: master
+      branch: ((publishing-api-branch))
       uri: https://github.com/alphagov/publishing-api
       tag_filter: release_*
 
   - <<: *git-repo
     name: content-store
     source:
-      branch: master
+      branch: ((content-store-branch))
       uri: https://github.com/alphagov/content-store
       tag_filter: release_*
 
   - <<: *git-repo
     name: router
     source:
-      branch: master
+      branch: ((router-branch))
       uri: https://github.com/alphagov/router
       tag_filter: release_*
 
   - <<: *git-repo
     name: router-api
     source:
-      branch: master
+      branch: ((router-api-branch))
       uri: https://github.com/alphagov/router
       tag_filter: release_*
 
@@ -108,8 +108,10 @@ jobs:
     plan:
     - get: govuk-infrastructure
       trigger: true
-    - file: govuk-infrastructure/concourse/pipelines/deploy.yml
-      set_pipeline: deploy-apps-test
+    - set_pipeline: deploy-apps-test
+      file: govuk-infrastructure/concourse/pipelines/deploy.yml
+      var_files:
+      - govuk-infrastructure/concourse/settings/test.yml
 
   - name: deploy-frontend
     plan:

--- a/concourse/settings/test.yml
+++ b/concourse/settings/test.yml
@@ -1,0 +1,8 @@
+---
+content-store-branch: master
+frontend-branch: master
+publisher-branch: master
+publishing-api-branch: master
+router-api-branch: master
+router-branch: master
+

--- a/concourse/settings/test.yml
+++ b/concourse/settings/test.yml
@@ -1,4 +1,6 @@
 ---
+govuk-infrastructure-branch: main
+
 content-store-branch: master
 frontend-branch: master
 publisher-branch: master


### PR DESCRIPTION
This will enable a git-based workflow for deploying branches of applications and infrastructure code to particular environments. This is useful in lower environments (like test or integration) as a way of demonstrating that changes work in a production-like setting.

GOV.UK developers currently deploy branches of applications by triggering a Jenkins job with custom parameters. Concourse does not have an equivalent user interface for providing parameters to builds.

This PR proposes the following workflow:

* Raise a PR against govuk-infrastructure, updating `concourse/settings/test.yml`
* This gives the team an opportunity to get visibility on which branches are being deployed (which is currently possible through the releases app)
* It also gives the team an opportunity to reject or approve the change to which branches are running in an environment. (Perhaps someone else is about to deploy a different branch of the same application - this gives them an opportunity to coordinate).
* Merge the PR once approved
* Concourse will pick up the change on `main` and automatically update the pipeline to deploy the branch of your app.
* Your app will be continuously deployed from your branch until you raise a PR to switch govuk-infrastructure back to `main`

It's also possible to update the branch of govuk-infrastructure in a similar way (although this might get a bit confusing).