### PR TITLE
Add Static app

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -61,6 +61,13 @@ resources:
       uri: https://github.com/alphagov/router
       tag_filter: release_*
 
+  - <<: *git-repo
+    name: static
+    source:
+      branch: master
+      uri: https://github.com/alphagov/static
+      tag_filter: release_*
+
   - name: deploy-slack-channel
     type: slack-notification
     source:
@@ -77,6 +84,7 @@ groups:
       - deploy-publishing-api
       - deploy-router
       - deploy-router-api
+      - deploy-static
 
   - name: admin
     jobs:
@@ -102,6 +110,10 @@ groups:
   - name: router
     jobs:
       - deploy-router
+
+  - name: static
+    jobs:
+      - deploy-static
 
 jobs:
   - name: update-pipeline
@@ -252,6 +264,26 @@ jobs:
         APPLICATION: router-api
         GOVUK_ENVIRONMENT: test
       task: deploy-app
+    serial: true
+    on_failure:
+      <<: *notify-slack-failure
+
+  - name: deploy-static
+    plan:
+    - get: govuk-infrastructure
+    - get: release
+      resource: static
+      trigger: true
+    - task: update-task-definition
+      file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+      params:
+        APPLICATION: static
+        GOVUK_ENVIRONMENT: test
+    - task: update-ecs-service
+      file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
+      params:
+        APPLICATION: static
+        GOVUK_ENVIRONMENT: test
     serial: true
     on_failure:
       <<: *notify-slack-failure

--- a/terraform/deployments/apps/static/common.tf
+++ b/terraform/deployments/apps/static/common.tf
@@ -1,0 +1,1 @@
+../common.tf

--- a/terraform/deployments/apps/static/main.tf
+++ b/terraform/deployments/apps/static/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  backend "s3" {
+    bucket  = "govuk-terraform-test"
+    key     = "projects/static.tfstate"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.13"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = var.assume_role_arn
+  }
+}
+
+module "task_definition" {
+  source             = "../../../modules/task-definitions/static"
+  service_name       = "static"
+  image_tag          = var.image_tag
+  mesh_name          = var.mesh_name
+  execution_role_arn = data.aws_iam_role.execution.arn
+  assets_url         = local.assets_url
+  redis_host         = var.redis_host
+  redis_port         = local.redis_port
+  task_role_arn      = data.aws_iam_role.task.arn
+  sentry_environment = var.sentry_environment
+  assume_role_arn    = var.assume_role_arn
+}

--- a/terraform/deployments/apps/static/outputs.tf
+++ b/terraform/deployments/apps/static/outputs.tf
@@ -1,0 +1,1 @@
+../outputs.tf

--- a/terraform/deployments/apps/static/variables.tf
+++ b/terraform/deployments/apps/static/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf

--- a/terraform/modules/apps/static/README.md
+++ b/terraform/modules/apps/static/README.md
@@ -1,0 +1,3 @@
+# Static application
+
+This project module manages the resources required to run Static.

--- a/terraform/modules/apps/static/main.tf
+++ b/terraform/modules/apps/static/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
+}
+
+module "app" {
+  source                           = "../../app"
+  execution_role_arn               = var.execution_role_arn
+  vpc_id                           = var.vpc_id
+  cluster_id                       = var.cluster_id
+  service_name                     = var.service_name
+  subnets                          = var.private_subnets
+  mesh_name                        = var.mesh_name
+  service_discovery_namespace_id   = var.service_discovery_namespace_id
+  service_discovery_namespace_name = var.service_discovery_namespace_name
+  extra_security_groups            = [var.govuk_management_access_security_group]
+  custom_container_services        = [{ container_service = var.service_name, port = "3013", protocol = "tcp" }]
+}

--- a/terraform/modules/apps/static/outputs.tf
+++ b/terraform/modules/apps/static/outputs.tf
@@ -1,0 +1,4 @@
+output "security_group_id" {
+  value       = module.app.security_group_id
+  description = "ID of the security group for router-api instances."
+}

--- a/terraform/modules/apps/static/variables.tf
+++ b/terraform/modules/apps/static/variables.tf
@@ -1,0 +1,43 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "cluster_id" {
+  description = "ECS cluster to deploy into."
+  type        = string
+}
+
+variable "service_name" {
+  description = "Service name of the Fargate service, cluster, task etc."
+  type        = string
+  default     = "static"
+}
+
+variable "private_subnets" {
+  description = "Subnet IDs to use for non-Internet-facing resources."
+  type        = list
+}
+
+variable "govuk_management_access_security_group" {
+  description = "Group used to allow access by management systems"
+  type        = string
+  default     = "sg-0b873470482f6232d"
+}
+
+variable "mesh_name" {
+  description = "App Mesh mesh name. For example, 'govuk'"
+  type        = string
+}
+
+variable "service_discovery_namespace_id" {
+  type = string
+}
+
+variable "service_discovery_namespace_name" {
+  type = string
+}
+
+variable "execution_role_arn" {
+  description = "For use during bootstrapping"
+  type        = string
+}

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -98,3 +98,14 @@ module "router_api_service" {
   execution_role_arn               = aws_iam_role.execution.arn
   source                           = "../../modules/apps/router-api"
 }
+
+module "static_service" {
+  mesh_name                        = aws_appmesh_mesh.govuk.id
+  service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  private_subnets                  = var.private_subnets
+  vpc_id                           = var.vpc_id
+  cluster_id                       = aws_ecs_cluster.cluster.id
+  execution_role_arn               = aws_iam_role.execution.arn
+  source                           = "../../modules/apps/static"
+}

--- a/terraform/modules/task-definitions/static/main.tf
+++ b/terraform/modules/task-definitions/static/main.tf
@@ -1,0 +1,96 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = var.assume_role_arn
+  }
+}
+
+data "aws_secretsmanager_secret" "ga_universal_id" {
+  name = "GA_UNIVERSAL_ID"
+}
+
+data "aws_secretsmanager_secret" "publishing_api_bearer_token" {
+  name = "${var.service_name}_PUBLISHING_API_BEARER_TOKEN" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "secret_key_base" {
+  name = "${var.service_name}_SECRET_KEY_BASE" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "sentry_dsn" {
+  name = "SENTRY_DSN"
+}
+
+module "task_definition" {
+  source                  = "../../task-definition"
+  mesh_name               = var.mesh_name
+  service_name            = var.service_name
+  cpu                     = 512
+  memory                  = 1024
+  execution_role_arn      = var.execution_role_arn
+  task_role_arn           = var.task_role_arn
+  container_ingress_ports = "3013"
+
+  container_definitions = [
+    {
+      "name" : var.service_name,
+      "image" : "govuk/static:${var.image_tag}",
+      "essential" : true,
+      "environment" : [
+        { "name" : "GOVUK_APP_NAME", "value" : var.service_name },
+        { "name" : "GOVUK_APP_ROOT", "value" : "/var/apps/${var.service_name}" },
+        { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
+        { "name" : "PORT", "value" : "3013" },
+        { "name" : "ASSET_HOST", "value" : var.assets_url },
+        { "name" : "PLEK_SERVICE_ACCOUNT_MANAGER_URI", "value" : "" },
+        { "name" : "REDIS_URL", "value" : "redis://${var.redis_host}:${var.redis_port}" },
+        { "name" : "SENTRY_ENVIRONMENT", "value" : var.sentry_environment }
+      ],
+      "dependsOn" : [{
+        "containerName" : "envoy",
+        "condition" : "START"
+      }],
+      "logConfiguration" : {
+        "logDriver" : "awslogs",
+        "options" : {
+          "awslogs-create-group" : "true",
+          "awslogs-group" : "awslogs-fargate",
+          "awslogs-region" : "eu-west-1",
+          "awslogs-stream-prefix" : "awslogs-${var.service_name}"
+        }
+      },
+      "mountPoints" : [],
+      "portMappings" : [
+        {
+          "containerPort" : 3013,
+          "hostPort" : 3013,
+          "protocol" : "tcp"
+        },
+      ],
+      "secrets" : [
+        {
+          "name" : "SENTRY_DSN",
+          "valueFrom" : data.aws_secretsmanager_secret.sentry_dsn.arn
+        },
+        {
+          "name" = "PUBLISHING_API_BEARER",
+          "valueFrom" : data.aws_secretsmanager_secret.publishing_api_bearer_token.arn
+        },
+        {
+          "name" = "GA_UNIVERSAL_ID",
+          "valueFrom" : data.aws_secretsmanager_secret.ga_universal_id.arn
+        },
+      ]
+    }
+  ]
+}

--- a/terraform/modules/task-definitions/static/outputs.tf
+++ b/terraform/modules/task-definitions/static/outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  value       = module.task_definition.arn
+  description = "ARN of the created task definition"
+}

--- a/terraform/modules/task-definitions/static/variables.tf
+++ b/terraform/modules/task-definitions/static/variables.tf
@@ -1,0 +1,44 @@
+variable "image_tag" {
+  description = "Container Image Tag"
+  type        = string
+}
+
+variable "mesh_name" {
+  type = string
+}
+
+variable "execution_role_arn" {
+  type = string
+}
+
+variable "task_role_arn" {
+  type = string
+}
+
+variable "sentry_environment" {
+  type = string
+}
+
+variable "assume_role_arn" {
+  type        = string
+  description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
+  default     = null
+}
+
+variable "service_name" {
+  type = string
+}
+
+variable "redis_host" {
+  type = string
+}
+
+variable "redis_port" {
+  type    = number
+  default = 6379
+}
+
+variable "assets_url" {
+  type        = string
+  description = "URL of the Assets service"
+}


### PR DESCRIPTION
This PR adds the Static app in the new platform as part of the work on
spinning up a minimal GOV.UK stack in ECS.

We verified that:
1. new secrets have been added via aws cli
2. govuk-test deployment can be applied with no errors
3. concourse deployment of the Static app is successful

Ref:
1. [task trello card](https://trello.com/c/iC7BWjB6/282-spin-up-static-app)
2. [minimal set of apps trello card](https://trello.com/c/X4jlkXyE/200-determine-a-minimal-subset-of-apps)