### PR TITLE
Various improvements and fixes to allow frontend workflow to work

### DIFF
--- a/terraform/deployments/apps/common.tf
+++ b/terraform/deployments/apps/common.tf
@@ -1,7 +1,8 @@
 locals {
   asset_host                       = local.website_root
-  assets_url                       = "https://assets.${var.mesh_domain}"
-  content_store_url                = "https://content-store.${var.mesh_domain}"
+  assets_url                       = "https://static-ecs.${var.app_domain}"
+  frontend_assets_url              = "https://frontend.${var.app_domain}"
+  content_store_url                = "http://content-store.${var.mesh_domain}"
   redis_port                       = 6379
   service_discovery_namespace_name = var.mesh_domain
   sentry_environment               = "${var.govuk_environment}-ecs"

--- a/terraform/deployments/apps/common.tf
+++ b/terraform/deployments/apps/common.tf
@@ -6,7 +6,7 @@ locals {
   redis_port                       = 6379
   service_discovery_namespace_name = var.mesh_domain
   sentry_environment               = "${var.govuk_environment}-ecs"
-  static_url                       = "https://static.${var.mesh_domain}"
+  static_url                       = "http://static.${var.mesh_domain}"
   statsd_host                      = "statsd.${var.mesh_domain}"     # TODO: Put Statsd in App Mesh
   website_root                     = "https://www.${var.app_domain}" # TODO: Is this correct?
   router_urls                      = "router.${var.mesh_domain}:3055"

--- a/terraform/deployments/apps/frontend/main.tf
+++ b/terraform/deployments/apps/frontend/main.tf
@@ -25,7 +25,7 @@ provider "aws" {
 module "task_definition" {
   source                           = "../../../modules/task-definitions/frontend"
   service_name                     = "frontend"
-  assets_url                       = local.assets_url
+  assets_url                       = local.frontend_assets_url
   content_store_url                = local.content_store_url
   static_url                       = local.static_url
   execution_role_arn               = data.aws_iam_role.execution.arn
@@ -37,4 +37,5 @@ module "task_definition" {
   statsd_host                      = local.statsd_host
   task_role_arn                    = data.aws_iam_role.task.arn
   assume_role_arn                  = var.assume_role_arn
+  govuk_app_domain_external        = var.app_domain
 }

--- a/terraform/deployments/apps/static/main.tf
+++ b/terraform/deployments/apps/static/main.tf
@@ -23,15 +23,18 @@ provider "aws" {
 }
 
 module "task_definition" {
-  source             = "../../../modules/task-definitions/static"
-  service_name       = "static"
-  image_tag          = var.image_tag
-  mesh_name          = var.mesh_name
-  execution_role_arn = data.aws_iam_role.execution.arn
-  assets_url         = local.assets_url
-  redis_host         = var.redis_host
-  redis_port         = local.redis_port
-  task_role_arn      = data.aws_iam_role.task.arn
-  sentry_environment = var.sentry_environment
-  assume_role_arn    = var.assume_role_arn
+  source                           = "../../../modules/task-definitions/static"
+  service_name                     = "static"
+  image_tag                        = var.image_tag
+  mesh_name                        = var.mesh_name
+  execution_role_arn               = data.aws_iam_role.execution.arn
+  assets_url                       = local.assets_url
+  redis_host                       = var.redis_host
+  redis_port                       = local.redis_port
+  task_role_arn                    = data.aws_iam_role.task.arn
+  sentry_environment               = var.sentry_environment
+  assume_role_arn                  = var.assume_role_arn
+  service_discovery_namespace_name = local.service_discovery_namespace_name
+  govuk_app_domain_external        = var.app_domain
+  govuk_website_root               = local.website_root
 }

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -52,4 +52,5 @@ module "govuk" {
   documentdb_security_group_id  = data.aws_security_group.documentdb.id
   redis_security_group_id       = data.aws_security_group.redis.id
   frontend_desired_count        = var.frontend_desired_count
+  content_store_desired_count   = var.content_store_desired_count
 }

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -53,4 +53,5 @@ module "govuk" {
   redis_security_group_id       = data.aws_security_group.redis.id
   frontend_desired_count        = var.frontend_desired_count
   content_store_desired_count   = var.content_store_desired_count
+  static_desired_count          = var.static_desired_count
 }

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -51,4 +51,5 @@ module "govuk" {
   govuk_management_access_sg_id = data.aws_security_group.govuk_management_access.id
   documentdb_security_group_id  = data.aws_security_group.documentdb.id
   redis_security_group_id       = data.aws_security_group.redis.id
+  frontend_desired_count        = var.frontend_desired_count
 }

--- a/terraform/deployments/govuk-test/variables.tf
+++ b/terraform/deployments/govuk-test/variables.tf
@@ -33,7 +33,3 @@ variable "static_desired_count" {
   default = 1
 }
 
-variable "frontend_desired_count" {
-  type    = number
-  default = 1
-}

--- a/terraform/deployments/govuk-test/variables.tf
+++ b/terraform/deployments/govuk-test/variables.tf
@@ -32,4 +32,3 @@ variable "static_desired_count" {
   type    = number
   default = 1
 }
-

--- a/terraform/deployments/govuk-test/variables.tf
+++ b/terraform/deployments/govuk-test/variables.tf
@@ -17,3 +17,23 @@ variable "public_lb_domain_name" {
 variable "infra_networking_state_bucket" {
   type = string
 }
+
+variable "frontend_desired_count" {
+  type    = number
+  default = 1
+}
+
+variable "content_store_desired_count" {
+  type    = number
+  default = 1
+}
+
+variable "static_desired_count" {
+  type    = number
+  default = 1
+}
+
+variable "frontend_desired_count" {
+  type    = number
+  default = 1
+}

--- a/terraform/deployments/variables/test/apps.tfvars
+++ b/terraform/deployments/variables/test/apps.tfvars
@@ -2,7 +2,7 @@
 # App variables
 #--------------------------------------------------------------
 
-app_domain          = "test.publishing.service.gov.uk"
+app_domain          = "test.govuk.digital" # TODO: changed from test.publishing.service.gov.uk for easier testing.
 app_domain_internal = "test.govuk-internal.digital"
 govuk_environment   = "test"
 mongodb_host        = "mongo-1.test.govuk-internal.digital,mongo-2.test.govuk-internal.digital,mongo-3.test.govuk-internal.digital"

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -3,5 +3,5 @@
 #--------------------------------------------------------------
 
 # TODO: Is this from govuk-aws? Can it be replaced?
-public_lb_domain_name = "test.govuk.digital"
+public_lb_domain_name         = "test.govuk.digital"
 infra_networking_state_bucket = "govuk-terraform-steppingstone-test"

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -21,6 +21,8 @@ resource "aws_ecs_service" "service" {
   cluster     = var.cluster_id
   launch_type = "FARGATE"
 
+  desired_count = var.desired_count
+
   health_check_grace_period_seconds = length(var.load_balancers) > 0 ? var.health_check_grace_period_seconds : null
 
   dynamic "load_balancer" {
@@ -45,8 +47,6 @@ resource "aws_ecs_service" "service" {
 
   # For bootstrapping
   task_definition = module.bootstrap_task_definition.arn
-
-  desired_count = 1
 
   lifecycle {
     # It is essential that we ignore changes to task_definition.

--- a/terraform/modules/app/variables.tf
+++ b/terraform/modules/app/variables.tf
@@ -57,3 +57,9 @@ variable "execution_role_arn" {
   description = "For use during bootstrapping"
   type        = string
 }
+
+variable "desired_count" {
+  description = "Desired count of Application instances"
+  type        = number
+  default     = 1
+}

--- a/terraform/modules/apps/content-store/main.tf
+++ b/terraform/modules/apps/content-store/main.tf
@@ -18,4 +18,5 @@ module "app" {
   service_discovery_namespace_id   = var.service_discovery_namespace_id
   service_discovery_namespace_name = var.service_discovery_namespace_name
   extra_security_groups            = [var.govuk_management_access_security_group]
+  desired_count                    = var.desired_count
 }

--- a/terraform/modules/apps/content-store/variables.tf
+++ b/terraform/modules/apps/content-store/variables.tf
@@ -40,3 +40,9 @@ variable "execution_role_arn" {
   description = "For use during bootstrapping"
   type        = string
 }
+
+variable "desired_count" {
+  description = "Desired count of Application instances"
+  type        = number
+  default     = 1
+}

--- a/terraform/modules/apps/frontend/main.tf
+++ b/terraform/modules/apps/frontend/main.tf
@@ -18,11 +18,89 @@ module "app" {
   service_discovery_namespace_id   = var.service_discovery_namespace_id
   service_discovery_namespace_name = var.service_discovery_namespace_name
   extra_security_groups            = [var.govuk_management_access_security_group]
+  desired_count                    = var.desired_count
+
+  load_balancers = [{
+    target_group_arn = aws_lb_target_group.public.arn
+    container_name   = var.service_name
+    container_port   = 80
+  }]
 }
 
-# TODO: Is this needed?
-resource "aws_security_group" "service" {
-  name        = "fargate_${var.service_name}_ingress"
+#
+# Internet-facing load balancer
+#
+
+# TODO: use a single, ACM-managed cert with both domains on. There is already
+# such a cert in integration/staging/prod (but it needs defining in Terraform).
+data "aws_acm_certificate" "public_lb_default" {
+  domain   = "*.test.govuk.digital"
+  statuses = ["ISSUED"]
+}
+
+data "aws_acm_certificate" "public_lb_alternate" {
+  domain   = "*.test.publishing.service.gov.uk"
+  statuses = ["ISSUED"]
+}
+
+resource "aws_lb" "public" {
+  name               = "fargate-public-${var.service_name}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.public_alb.id]
+  subnets            = var.public_subnets
+}
+
+resource "aws_lb_target_group" "public" {
+  name        = "${var.service_name}-public"
+  port        = 80
+  protocol    = "HTTP"
   vpc_id      = var.vpc_id
-  description = "Permit internal services to access the ${var.service_name} ECS service"
+  target_type = "ip"
+
+  health_check {
+    path = "/"
+  }
+
+  depends_on = [aws_lb.public]
+}
+
+resource "aws_lb_listener" "public" {
+  load_balancer_arn = aws_lb.public.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = data.aws_acm_certificate.public_lb_default.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.public.arn
+  }
+}
+
+resource "aws_lb_listener_certificate" "publishing_service" {
+  listener_arn    = aws_lb_listener.public.arn
+  certificate_arn = data.aws_acm_certificate.public_lb_alternate.arn
+}
+
+resource "aws_security_group" "public_alb" {
+  name        = "fargate_${var.service_name}_public_alb"
+  vpc_id      = var.vpc_id
+  description = "${var.service_name} Internet-facing ALB"
+}
+
+data "aws_route53_zone" "public" {
+  name = var.public_lb_domain_name
+}
+
+resource "aws_route53_record" "public_alb" {
+  zone_id = data.aws_route53_zone.public.zone_id
+  name    = var.service_name
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.public.dns_name
+    zone_id                = aws_lb.public.zone_id
+    evaluate_target_health = true
+  }
 }

--- a/terraform/modules/apps/frontend/outputs.tf
+++ b/terraform/modules/apps/frontend/outputs.tf
@@ -3,6 +3,11 @@ output "app_security_group_id" {
   description = "ID of the security group for Frontend app instances."
 }
 
+output "alb_security_group_id" {
+  value       = aws_security_group.public_alb.id
+  description = "ID of the security group for the Frontend app's Internet-facing load balancer."
+}
+
 output "security_groups" {
   value       = module.app.security_groups
   description = "The security groups applied to the ECS Service."

--- a/terraform/modules/apps/frontend/variables.tf
+++ b/terraform/modules/apps/frontend/variables.tf
@@ -41,3 +41,19 @@ variable "execution_role_arn" {
   description = "For use during bootstrapping"
   type        = string
 }
+
+variable "desired_count" {
+  description = "Desired count of Application instances"
+  type        = number
+  default     = 1
+}
+
+variable "public_subnets" {
+  description = "Subnet IDs to use for Internet-facing resources."
+  type        = list
+}
+
+variable "public_lb_domain_name" {
+  description = "Domain in which to create DNS records for the app's Internet-facing load balancer. For example, staging.govuk.digital"
+  type        = string
+}

--- a/terraform/modules/apps/static/main.tf
+++ b/terraform/modules/apps/static/main.tf
@@ -18,5 +18,89 @@ module "app" {
   service_discovery_namespace_id   = var.service_discovery_namespace_id
   service_discovery_namespace_name = var.service_discovery_namespace_name
   extra_security_groups            = [var.govuk_management_access_security_group]
-  custom_container_services        = [{ container_service = var.service_name, port = "3013", protocol = "tcp" }]
+  desired_count                    = var.desired_count
+
+  load_balancers = [{
+    target_group_arn = aws_lb_target_group.public.arn
+    container_name   = var.service_name
+    container_port   = 80
+  }]
+}
+
+#
+# Internet-facing load balancer
+#
+
+# TODO: use a single, ACM-managed cert with both domains on. There is already
+# such a cert in integration/staging/prod (but it needs defining in Terraform).
+data "aws_acm_certificate" "public_lb_default" {
+  domain   = "*.test.govuk.digital"
+  statuses = ["ISSUED"]
+}
+
+data "aws_acm_certificate" "public_lb_alternate" {
+  domain   = "*.test.publishing.service.gov.uk"
+  statuses = ["ISSUED"]
+}
+
+resource "aws_lb" "public" {
+  name               = "fargate-public-${var.service_name}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.public_alb.id]
+  subnets            = var.public_subnets
+}
+
+resource "aws_lb_target_group" "public" {
+  name        = "${var.service_name}-public"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path = "/templates/wrapper.html.erb"
+  }
+
+  depends_on = [aws_lb.public]
+}
+
+resource "aws_lb_listener" "public" {
+  load_balancer_arn = aws_lb.public.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = data.aws_acm_certificate.public_lb_default.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.public.arn
+  }
+}
+
+resource "aws_lb_listener_certificate" "publishing_service" {
+  listener_arn    = aws_lb_listener.public.arn
+  certificate_arn = data.aws_acm_certificate.public_lb_alternate.arn
+}
+
+resource "aws_security_group" "public_alb" {
+  name        = "fargate_${var.service_name}_public_alb"
+  vpc_id      = var.vpc_id
+  description = "${var.service_name} Internet-facing ALB"
+}
+
+data "aws_route53_zone" "public" {
+  name = var.public_lb_domain_name
+}
+
+resource "aws_route53_record" "public_alb" {
+  zone_id = data.aws_route53_zone.public.zone_id
+  name    = "${var.service_name}-ecs"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.public.dns_name
+    zone_id                = aws_lb.public.zone_id
+    evaluate_target_health = true
+  }
 }

--- a/terraform/modules/apps/static/outputs.tf
+++ b/terraform/modules/apps/static/outputs.tf
@@ -1,4 +1,14 @@
-output "security_group_id" {
+output "app_security_group_id" {
   value       = module.app.security_group_id
-  description = "ID of the security group for router-api instances."
+  description = "ID of the security group for Static app instances."
+}
+
+output "alb_security_group_id" {
+  value       = aws_security_group.public_alb.id
+  description = "ID of the security group for the Static app's Internet-facing load balancer."
+}
+
+output "security_groups" {
+  value       = module.app.security_groups
+  description = "The security groups applied to the ECS Service."
 }

--- a/terraform/modules/apps/static/variables.tf
+++ b/terraform/modules/apps/static/variables.tf
@@ -41,3 +41,19 @@ variable "execution_role_arn" {
   description = "For use during bootstrapping"
   type        = string
 }
+
+variable "desired_count" {
+  description = "Desired count of Application instances"
+  type        = number
+  default     = 1
+}
+
+variable "public_subnets" {
+  description = "Subnet IDs to use for Internet-facing resources."
+  type        = list
+}
+
+variable "public_lb_domain_name" {
+  description = "Domain in which to create DNS records for the app's Internet-facing load balancer. For example, staging.govuk.digital"
+  type        = string
+}

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -17,6 +17,9 @@ module "frontend_service" {
   cluster_id                       = aws_ecs_cluster.cluster.id
   source                           = "../../modules/apps/frontend"
   execution_role_arn               = aws_iam_role.execution.arn
+  desired_count                    = var.frontend_desired_count
+  public_subnets                   = var.public_subnets
+  public_lb_domain_name            = var.public_lb_domain_name
 }
 
 module "draft_frontend_service" {
@@ -28,6 +31,8 @@ module "draft_frontend_service" {
   cluster_id                       = aws_ecs_cluster.cluster.id
   source                           = "../../modules/apps/frontend"
   execution_role_arn               = aws_iam_role.execution.arn
+  public_subnets                   = var.public_subnets
+  public_lb_domain_name            = var.public_lb_domain_name
 }
 
 module "publisher_service" {

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -114,6 +114,9 @@ module "static_service" {
   cluster_id                       = aws_ecs_cluster.cluster.id
   execution_role_arn               = aws_iam_role.execution.arn
   source                           = "../../modules/apps/static"
+  desired_count                    = var.static_desired_count
+  public_subnets                   = var.public_subnets
+  public_lb_domain_name            = var.public_lb_domain_name
 }
 
 module "signon_service" {

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -58,6 +58,7 @@ module "content_store_service" {
   private_subnets                  = var.private_subnets
   execution_role_arn               = aws_iam_role.execution.arn
   source                           = "../../modules/apps/content-store"
+  desired_count                    = var.content_store_desired_count
 }
 
 module "draft_content_store_service" {

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -127,4 +127,44 @@ resource "aws_security_group_rule" "publishing_api_from_frontend_http" {
   source_security_group_id = module.frontend_service.app_security_group_id
 }
 
+resource "aws_security_group_rule" "frontend_to_any_any" {
+  description       = "Frontend sends requests to anywhere over any protocol"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = module.frontend_service.app_security_group_id
+}
+
+resource "aws_security_group_rule" "frontend_from_alb_http" {
+  description              = "Frontend receives requests from its public ALB over HTTP"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  security_group_id        = module.frontend_service.app_security_group_id
+  source_security_group_id = module.frontend_service.alb_security_group_id
+}
+
+resource "aws_security_group_rule" "frontend_alb_from_office_https" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = module.frontend_service.alb_security_group_id
+  cidr_blocks       = var.office_cidrs_list
+}
+
+resource "aws_security_group_rule" "frontend_alb_to_any_any" {
+  type      = "egress"
+  protocol  = "-1"
+  from_port = 0
+  to_port   = 0
+
+  security_group_id = module.frontend_service.alb_security_group_id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 # TODO: move the rest of the rules into this file.

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -27,6 +27,16 @@ resource "aws_security_group_rule" "content_store_from_publishing_api_http" {
   source_security_group_id = module.publishing_api_service.app_security_group_id
 }
 
+resource "aws_security_group_rule" "content_store_from_frontend_http" {
+  description              = "Content Store accepts requests from Frontend over HTTP"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  security_group_id        = module.content_store_service.app_security_group_id
+  source_security_group_id = module.frontend_service.app_security_group_id
+}
+
 # TODO: fix overly broad egress rules
 resource "aws_security_group_rule" "content_store_to_any_any" {
   description       = "Content Store sends requests to anywhere over any protocol"
@@ -166,5 +176,46 @@ resource "aws_security_group_rule" "frontend_alb_to_any_any" {
   security_group_id = module.frontend_service.alb_security_group_id
   cidr_blocks       = ["0.0.0.0/0"]
 }
+
+resource "aws_security_group_rule" "static_to_any_any" {
+  description       = "Static sends requests to anywhere over any protocol"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = module.static_service.app_security_group_id
+}
+
+resource "aws_security_group_rule" "static_from_alb_http" {
+  description              = "Static receives requests from its public ALB over HTTP"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  security_group_id        = module.static_service.app_security_group_id
+  source_security_group_id = module.static_service.alb_security_group_id
+}
+
+resource "aws_security_group_rule" "static_alb_from_office_https" {
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  security_group_id = module.static_service.alb_security_group_id
+  cidr_blocks       = var.office_cidrs_list
+}
+
+resource "aws_security_group_rule" "static_alb_to_any_any" {
+  type      = "egress"
+  protocol  = "-1"
+  from_port = 0
+  to_port   = 0
+
+  security_group_id = module.static_service.alb_security_group_id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 
 # TODO: move the rest of the rules into this file.

--- a/terraform/modules/govuk/variables.tf
+++ b/terraform/modules/govuk/variables.tf
@@ -39,3 +39,24 @@ variable "documentdb_security_group_id" {
   description = "ID of security group for the shared DocumentDB (which isn't managed by this Terraform repo, at least initially)."
   type        = string
 }
+
+variable "frontend_desired_count" {
+  description = "Desired count of Frontend Application instances"
+  type        = number
+}
+
+variable "content_store_desired_count" {
+  description = "Desired count of Frontend Application instances"
+  type        = number
+}
+
+variable "static_desired_count" {
+  description = "Desired count of Static Application instances"
+  type        = number
+}
+
+variable "office_cidrs_list" {
+  description = "List of GDS office CIDRs"
+  type        = list
+  default     = ["213.86.153.212/32", "213.86.153.213/32", "213.86.153.214/32", "213.86.153.235/32", "213.86.153.236/32", "213.86.153.237/32", "85.133.67.244/32"]
+}

--- a/terraform/modules/task-definition/main.tf
+++ b/terraform/modules/task-definition/main.tf
@@ -17,7 +17,8 @@ locals {
       "image" : "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.15.0.0-prod",
       "user" : "1337",
       "environment" : [
-        { "name" : "APPMESH_VIRTUAL_NODE_NAME", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" }
+        { "name" : "APPMESH_VIRTUAL_NODE_NAME", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
+        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
       ],
       "essential" : true,
       "logConfiguration" : {

--- a/terraform/modules/task-definitions/frontend/main.tf
+++ b/terraform/modules/task-definitions/frontend/main.tf
@@ -31,8 +31,8 @@ module "task_definition" {
   source             = "../../task-definition"
   mesh_name          = var.mesh_name
   service_name       = var.service_name
-  cpu                = 512
-  memory             = 1024
+  cpu                = 1024
+  memory             = 2048
   execution_role_arn = var.execution_role_arn
   task_role_arn      = var.task_role_arn
   container_definitions = [
@@ -41,11 +41,14 @@ module "task_definition" {
       "image" : "govuk/frontend:${var.image_tag}",
       "essential" : true,
       "environment" : [
+        { "name" : "APPMESH_VIRTUAL_NODE_NAME", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "RAILS_ENV", "value" : "production" },
         { "name" : "ASSET_HOST", "value" : var.assets_url },
         { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
+        { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
         { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
         { "name" : "WEBSITE_ROOT", "value" : var.govuk_website_root },
+        { "name" : "PORT", "value" : "80" },
         { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : var.content_store_url },
         { "name" : "PLEK_SERVICE_STATIC_URI", "value" : var.static_url },
         { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api.${var.service_discovery_namespace_name}" },
@@ -53,7 +56,9 @@ module "task_definition" {
         { "name" : "SENTRY_ENVIRONMENT", "value" : var.sentry_environment },
         { "name" : "STATSD_PROTOCOL", "value" : "tcp" },
         { "name" : "STATSD_HOST", "value" : var.statsd_host },
-        { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" }
+        { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
+        { "name" : "RAILS_SERVE_STATIC_FILES", "value" : "enabled" },
+        { "name" : "RAILS_SERVE_STATIC_ASSETS", "value" : "yes" },
       ],
       "logConfiguration" : {
         "logDriver" : "awslogs",
@@ -67,6 +72,7 @@ module "task_definition" {
       "portMappings" : [
         {
           "containerPort" : 80,
+          "hostPort" : 80,
           "protocol" : "tcp"
         }
       ],

--- a/terraform/modules/task-definitions/frontend/variables.tf
+++ b/terraform/modules/task-definitions/frontend/variables.tf
@@ -55,3 +55,7 @@ variable "assume_role_arn" {
   description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
   default     = null
 }
+
+variable "govuk_app_domain_external" {
+  type = string
+}

--- a/terraform/modules/task-definitions/static/variables.tf
+++ b/terraform/modules/task-definitions/static/variables.tf
@@ -42,3 +42,15 @@ variable "assets_url" {
   type        = string
   description = "URL of the Assets service"
 }
+
+variable "service_discovery_namespace_name" {
+  type = string
+}
+
+variable "govuk_website_root" {
+  type = string
+}
+
+variable "govuk_app_domain_external" {
+  type = string
+}


### PR DESCRIPTION
## Spin up frontend and fixes (b35ec6a)

Improvements:
1. add ability to set desired_count so that number of frontend tasks
2. use plain http rather than https for content-store and static
3. introduce load balancer
4. configure rails to serve assets because of no nginx

## Spin up content-store and fixes (9ab11ab)

Improvements:
1. introduce desired_count in order to enable number of content-store
tasks to be set

## Spin up Static app and fixes (038d3f6)

Improvements:
1. introduce desired_count to enable the number of Static tasks to be set
2. set Static port to 80
3. add missing secret and parameter
4. add public load balancer for static
5. configure static to serve assets

Ref:
1. [trello
   card](https://trello.com/c/mU7Gt0Bv/287-test-and-fix-frontend-app)
2. [minimal set of apps trello card](https://trello.com/c/X4jlkXyE/200-determine-a-minimal-subset-of-apps)

Co-Authored-By: Frederic Francois
<frederic.francois@digital.cabinet-office.gov.uk>