### PR TITLE
Use govuk-aws/infra-networking remote state

### DIFF
--- a/terraform/deployments/govuk-test/outputs.tf
+++ b/terraform/deployments/govuk-test/outputs.tf
@@ -1,5 +1,5 @@
 output "private_subnets" {
-  value = var.private_subnets
+  value = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
 }
 
 output "publisher_security_groups" {

--- a/terraform/deployments/govuk-test/variables.tf
+++ b/terraform/deployments/govuk-test/variables.tf
@@ -10,18 +10,10 @@ variable "mesh_domain" {
   type = string
 }
 
-variable "private_subnets" {
-  type = list
-}
-
 variable "public_lb_domain_name" {
   type = string
 }
 
-variable "public_subnets" {
-  type = list
-}
-
-variable "vpc_id" {
+variable "infra_networking_state_bucket" {
   type = string
 }

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -2,8 +2,6 @@
 # Network
 #--------------------------------------------------------------
 
-# TODO: Are these from govuk-aws? Can they be replaced?
+# TODO: Is this from govuk-aws? Can it be replaced?
 public_lb_domain_name = "test.govuk.digital"
-private_subnets       = ["subnet-6dc4370b", "subnet-463bfd0e", "subnet-bfecd0e4"]
-public_subnets        = ["subnet-6cc4370a", "subnet-ba30f6f2", "subnet-bfe6dae4"]
-vpc_id                = "vpc-9e62bcf8"
+infra_networking_state_bucket = "govuk-terraform-steppingstone-test"


### PR DESCRIPTION
Hard-configuring the VPC ID and the subnets feels a bit fragile. If for some reason we were to destroy and re-create the VPC, we'd have to remember to update the values here.

Instead, we can use terraform's [terraform_remote_state](https://www.terraform.io/docs/providers/terraform/d/remote_state.html) data source to pull the outputs from the [govuk-aws/infra-networking](https://github.com/alphagov/govuk-aws/tree/test-revive/terraform/projects/infra-networking) outputs.

This effectively models the fact that the govuk-test deployment is "downstream" of the infra-networking deployment.

This reduces the number of "infrastructure" variables to the point where we could consider promoting the modules/govuk to be a deployment, with small, environment specific `.backend` files. These files should only need a few settings. Currently these are:

* `infra_networking_state_bucket`
* `public_lb_domain_name`
* `mesh_domain`
* `mesh_name`

We could use the same pattern for the various `apps` deployments - at the moment they have shared `common.tf` and `variables.tf` which mostly set things which could instead be provided as outputs of the `govuk-test` deployment.
