### PR TITLE
Add security group rule for Publishing API to access Postgres.

### DIFF
--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -47,6 +47,7 @@ module "govuk" {
   public_subnets                = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
   govuk_management_access_sg_id = data.terraform_remote_state.infra_security_groups.outputs.sg_management_id
   documentdb_security_group_id  = data.terraform_remote_state.infra_security_groups.outputs.sg_shared_documentdb_id
+  postgresql_security_group_id  = data.terraform_remote_state.infra_security_groups.outputs.sg_postgresql-primary_id
   redis_security_group_id       = data.terraform_remote_state.infra_security_groups.outputs.sg_backend-redis_id
   mongodb_security_group_id     = data.terraform_remote_state.infra_security_groups.outputs.sg_mongo_id
   frontend_desired_count        = var.frontend_desired_count

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -107,6 +107,17 @@ resource "aws_security_group_rule" "redis_from_publisher_resp" {
   source_security_group_id = module.publisher_service.app_security_group_id
 }
 
+resource "aws_security_group_rule" "postgres_from_publishing_api_5432" {
+  description = "Postgres RDS accepts requests from Publishing API"
+  type        = "ingress"
+  from_port   = 5432
+  to_port     = 5432
+  protocol    = "tcp"
+
+  security_group_id        = var.postgresql_security_group_id
+  source_security_group_id = module.publishing_api_service.app_security_group_id
+}
+
 resource "aws_security_group_rule" "redis_from_publishing_api_resp" {
   type                     = "ingress"
   from_port                = 6379
@@ -274,6 +285,5 @@ resource "aws_security_group_rule" "router_api_from_content_store_http" {
   security_group_id        = module.router_api_service.app_security_group_id
   source_security_group_id = module.content_store_service.app_security_group_id
 }
-
 
 # TODO: move the rest of the rules into this file.

--- a/terraform/modules/govuk/variables.tf
+++ b/terraform/modules/govuk/variables.tf
@@ -26,22 +26,27 @@ variable "public_lb_domain_name" {
 }
 
 variable "govuk_management_access_sg_id" {
-  description = "ID of security group (defined outside this Terraform repo) for access from jumpboxes etc. This SG is added to all ECS instances."
+  description = "ID of security group (from the govuk-aws repo) for access from jumpboxes etc. This SG is added to all ECS instances."
+  type        = string
+}
+
+variable "postgresql_security_group_id" {
+  description = "ID of security group (from the govuk-aws repo) for the shared Postgres RDS."
   type        = string
 }
 
 variable "redis_security_group_id" {
-  description = "ID of security group for the shared Redis (defined outside this Terraform repo)."
+  description = "ID of security group (from the govuk-aws repo) for the shared Redis."
   type        = string
 }
 
 variable "documentdb_security_group_id" {
-  description = "ID of security group for the shared DocumentDB (which isn't managed by this Terraform repo, at least initially)."
+  description = "ID of security group (from the govuk-aws repo) for the shared DocumentDB."
   type        = string
 }
 
 variable "mongodb_security_group_id" {
-  description = "ID of security group for the shared MongoDB (which isn't managed by this Terraform repo, at least initially)."
+  description = "ID of security group (from the govuk-aws repo) for the shared MongoDB."
   type        = string
 }
 


### PR DESCRIPTION
Publishing API needs to talk to the existing RDS Postgres database. Add a data resource to look up the existing security group (which is managed from the old govuk-aws repo) and add a rule to allow these connections.

Also tweak the descriptions of the existing variables for similar security groups.

Tested: `terraform plan` produces expected output

```
  # module.govuk.aws_security_group_rule.postgres_from_publishing_api_5432 will be created
  + resource "aws_security_group_rule" "postgres_from_publishing_api_5432" {
      + description              = "Postgres RDS accepts requests from Publishing API"
      + from_port                = 5432
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = ...
      + self                     = false
      + source_security_group_id = ...
      + to_port                  = 5432
      + type                     = "ingress"
    }
```
(plus the trivial updates to the descriptions)