### PR TITLE
Add wrapper script for aws ecs run-task for ease of running adhoc tasks

### DIFF
--- a/terraform/deployments/govuk-test/outputs.tf
+++ b/terraform/deployments/govuk-test/outputs.tf
@@ -5,3 +5,7 @@ output "private_subnets" {
 output "publisher_security_groups" {
   value = module.govuk.publisher_security_groups
 }
+
+output "frontend_security_groups" {
+  value = module.govuk.frontend_security_groups
+}

--- a/terraform/modules/apps/frontend/outputs.tf
+++ b/terraform/modules/apps/frontend/outputs.tf
@@ -2,3 +2,8 @@ output "app_security_group_id" {
   value       = module.app.security_group_id
   description = "ID of the security group for Frontend app instances."
 }
+
+output "security_groups" {
+  value       = module.app.security_groups
+  description = "The security groups applied to the ECS Service."
+}

--- a/terraform/modules/govuk/outputs.tf
+++ b/terraform/modules/govuk/outputs.tf
@@ -2,3 +2,8 @@ output "publisher_security_groups" {
   value       = module.publisher_service.security_groups
   description = "The security groups applied to the Publisher ECS Service."
 }
+
+output "frontend_security_groups" {
+  value       = module.frontend_service.security_groups
+  description = "The security groups applied to the Frontend ECS Service."
+}

--- a/terraform/modules/task-definitions/frontend/main.tf
+++ b/terraform/modules/task-definitions/frontend/main.tf
@@ -19,6 +19,10 @@ data "aws_secretsmanager_secret" "secret_key_base" {
   name = "frontend_app-SECRET_KEY_BASE" # pragma: allowlist secret
 }
 
+data "aws_secretsmanager_secret" "publishing_api_bearer_token" {
+  name = "frontend_app_PUBLISHING_API_BEARER_TOKEN" # pragma: allowlist secret
+}
+
 data "aws_secretsmanager_secret" "sentry_dsn" {
   name = "SENTRY_DSN"
 }
@@ -44,6 +48,7 @@ module "task_definition" {
         { "name" : "WEBSITE_ROOT", "value" : var.govuk_website_root },
         { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : var.content_store_url },
         { "name" : "PLEK_SERVICE_STATIC_URI", "value" : var.static_url },
+        { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api.${var.service_discovery_namespace_name}" },
         { "name" : "GOVUK_ASSET_ROOT", "value" : var.assets_url },
         { "name" : "SENTRY_ENVIRONMENT", "value" : var.sentry_environment },
         { "name" : "STATSD_PROTOCOL", "value" : "tcp" },
@@ -73,6 +78,10 @@ module "task_definition" {
         {
           "name" : "SENTRY_DSN",
           "valueFrom" : data.aws_secretsmanager_secret.sentry_dsn.arn
+        },
+        {
+          "name" : "PUBLISHING_API_BEARER_TOKEN",
+          "valueFrom" : data.aws_secretsmanager_secret.publishing_api_bearer_token.arn
         }
       ]
     }

--- a/tools/run-task.sh
+++ b/tools/run-task.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# This temporary script runs an arbitrary task using an existing task defintion
+# in a new container, using ECS RunTask. This script will be replaced by
+# features built into the GDS CLI.
+
+set -eu
+
+OPTIND=1 # Reset in case getopts has been used previously in the shell.
+
+cluster="task_runner"
+govuk_env="test"
+
+function show_help {
+  echo "Usage: cd govuk-infrastructure && gds aws govuk-tools-internal-admin ./tools/run-rake-task -a frontend rake db:migrate"
+  exit 64
+}
+
+while getopts :a:c:e:h opt; do
+    case $opt in
+      h) show_help;;
+      a)
+        application=${OPTARG}
+        ;;
+      e)
+        govuk_env=${OPTARG:-$govuk_env}
+        ;;
+      :)
+        echo "Option -$OPTARG requires an app as the argument. e.g. -a frontend"
+        show_help
+        ;;
+    esac
+done
+
+shift $((OPTIND-1))
+[ "${1:-}" = "--" ] && shift
+command=$@
+
+if [ -z "${application}" ]; then echo "[Error] You must set the application arg" && show_help && exit 1; fi
+if [ -z "${command}" ]; then echo "[Error] You must provide a command" && show_help && exit 1; fi
+
+echo "[Warning] This is a temporary tool for use by the replatforming team."
+
+root_dir="${PWD}"
+
+app_dir="$root_dir/terraform/deployments/apps/$application"
+env_dir="$root_dir/terraform/deployments/govuk-test"
+
+echo "Fetching task_definition_arn from Terraform statefile in $app_dir"
+cd ${app_dir}
+terraform init >/dev/null
+task_definition_arn=$(terraform output task_definition_arn)
+
+echo "Fetching network_config from Terraform statefile in $env_dir"
+cd ${env_dir}
+terraform init >/dev/null
+private_subnets=$(terraform output -json private_subnets)
+security_groups=$(terraform output -json $application'_security_groups')
+network_config="awsvpcConfiguration={subnets=$private_subnets,securityGroups=$security_groups,assignPublicIp=DISABLED}"
+
+echo "Starting task:
+  cluster: $cluster
+  application: $application
+  environment: $govuk_env
+  task_definition_arn: $task_definition_arn
+  network_config: $network_config
+  command: $command"
+
+task=$(aws ecs run-task --cluster $cluster \
+--task-definition $task_definition_arn --launch-type FARGATE --count 1 \
+--network-configuration $network_config \
+--started-by $(whoami) \
+--overrides '{
+  "containerOverrides": [{
+    "name": "'"$application"'",
+    "command": ["/bin/bash", "-c", "'"$command"'"]
+  }]
+}')
+
+task_arn=$(echo $task | jq .tasks[0].taskArn)
+
+echo "Waiting for task $task_arn to finish..."
+echo "View task: https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/clusters/$cluster/tasks"
+
+aws ecs wait tasks-stopped --tasks=[$task_arn] --cluster $cluster
+
+task_results=$(aws ecs describe-tasks --tasks=[$task_arn] --cluster $cluster)
+exit_code=$(echo $task_results | jq [.tasks[0].containers[].exitCode] | jq add)
+
+echo "Task finished. Exit code: $exit_code"
+
+exit $exit_code


### PR DESCRIPTION
This is a tool to enable running ad-hoc tasks. It's expected to live
a few months until GDS CLI provides this feature. Building this into
GDS CLI at the moment is probably premature since the project may
change significantly in the next few months, so this tool should meet
our needs for now.

The tool prints a warning to users to let them know it's not going to
be around for long.

Expected usages:

```
# Run an ad-hoc rake task
run-task.sh -a frontend rake my:task
# Check connectivity between services in the mesh
run-task.sh -a publisher curl http://publishing-api.mesh.govuk-internal.digital
```
This allows one to perform temporary tasks easily.
