### PR TITLE
Pin Publishing API image tag to bilbof/dockerfile-fix

### DIFF
--- a/terraform/deployments/apps/publishing-api/main.tf
+++ b/terraform/deployments/apps/publishing-api/main.tf
@@ -27,7 +27,7 @@ module "task_definition" {
   govuk_app_domain_external        = var.app_domain
   govuk_app_domain_internal        = var.app_domain_internal
   govuk_website_root               = local.website_root
-  image_tag                        = var.image_tag
+  image_tag                        = "bilbof_dockerfile-fix" # TODO: Pinned due to content-schemas issue
   mesh_name                        = var.mesh_name
   service_discovery_namespace_name = local.service_discovery_namespace_name
   statsd_host                      = local.statsd_host


### PR DESCRIPTION
This is a short term change for testing purposes.

This [image](https://hub.docker.com/layers/govuk/publishing-api/bilbof_dockerfile-fix/images/sha256-c2f14468d7135a79c48b757197a8ae754a1d7d19e4152dd930754e4db35fb3ab?context=explore) has a couple of changes to the Dockerfile that make it possible for Publishing API to process publication requests from publishing applications.

The diff for the image is at https://github.com/alphagov/publishing-api/compare/bilbof/dockerfile-fix.