### PR TITLE
Set correct Slack channel for on_failure alerts

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -147,7 +147,7 @@ jobs:
     on_failure: &notify-slack-failure
       put: deploy-slack-channel
       params:
-        channel: "#govuk-deploy-test"
+        channel: "#govuk-deploy-alerts"
         username: 'Concourse deploy pipeline'
         icon_emoji: ':concourse:'
         silent: true


### PR DESCRIPTION
This channel key isn't required but it's a handy flag for where
the Slack messages are being sent.