### PR TITLE
Add redis_from_publishing_api_resp security group rule

### DIFF
--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -87,6 +87,15 @@ resource "aws_security_group_rule" "redis_from_publisher_resp" {
   source_security_group_id = module.publisher_service.app_security_group_id
 }
 
+resource "aws_security_group_rule" "redis_from_publishing_api_resp" {
+  type                     = "ingress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = var.redis_security_group_id
+  source_security_group_id = module.publishing_api_service.app_security_group_id
+}
+
 resource "aws_security_group_rule" "documentdb_from_publisher_mongodb" {
   type                     = "ingress"
   from_port                = 27017


### PR DESCRIPTION
This allows Publishing API to use the EC2-hosted redis.