### PR TITLE
Add security group rule publishing_api_from_frontend_http

### DIFF
--- a/terraform/modules/apps/frontend/outputs.tf
+++ b/terraform/modules/apps/frontend/outputs.tf
@@ -1,0 +1,4 @@
+output "app_security_group_id" {
+  value       = module.app.security_group_id
+  description = "ID of the security group for Frontend app instances."
+}

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -107,4 +107,15 @@ resource "aws_security_group_rule" "publishing_api_from_publisher_http" {
   source_security_group_id = module.publisher_service.app_security_group_id
 }
 
+resource "aws_security_group_rule" "publishing_api_from_frontend_http" {
+  description = "Publishing API accepts requests from Frontend over HTTP"
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+
+  security_group_id        = module.publishing_api_service.app_security_group_id
+  source_security_group_id = module.frontend_service.app_security_group_id
+}
+
 # TODO: move the rest of the rules into this file.


### PR DESCRIPTION
This lets Frontend send requests to Publishing API.

It is necessary since Frontend publishes content items such as the homepage and bank holiday pages. This is logged on the tech debt board.