### PR TITLE
fix frontend asset images

### DIFF
--- a/terraform/modules/task-definitions/frontend/main.tf
+++ b/terraform/modules/task-definitions/frontend/main.tf
@@ -57,8 +57,9 @@ module "task_definition" {
         { "name" : "STATSD_PROTOCOL", "value" : "tcp" },
         { "name" : "STATSD_HOST", "value" : var.statsd_host },
         { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
-        { "name" : "RAILS_SERVE_STATIC_FILES", "value" : "enabled" },
+        { "name" : "RAILS_SERVE_STATIC_FILES", "value" : "yes" },
         { "name" : "RAILS_SERVE_STATIC_ASSETS", "value" : "yes" },
+        { "name" : "HEROKU_APP_NAME", "value" : "yes" },
       ],
       "logConfiguration" : {
         "logDriver" : "awslogs",


### PR DESCRIPTION
If rails is serving files rather the nginx or other web servers,
need to set config.action_dispatch.x_sendfile_header to nil

In the frontend case, this is set via setting the env variable:
`HEROKU_APP_NAME`

The other env variable change `RAILS_SERVE_STATIC_FILES` is only
to keep consistency with the frontend heroku config.