### PR TITLE
Add security group rule to access ec2 mongodb

### DIFF
--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -30,6 +30,10 @@ data "aws_security_group" "redis" {
   name = "govuk_backend-redis_access"
 }
 
+data "aws_security_group" "govuk_mongo_access" {
+  name = "govuk_mongo_access"
+}
+
 data "terraform_remote_state" "infra_networking" {
   backend = "s3"
   config = {
@@ -51,6 +55,7 @@ module "govuk" {
   govuk_management_access_sg_id = data.aws_security_group.govuk_management_access.id
   documentdb_security_group_id  = data.aws_security_group.documentdb.id
   redis_security_group_id       = data.aws_security_group.redis.id
+  mongodb_security_group_id     = data.aws_security_group.govuk_mongo_access.id
   frontend_desired_count        = var.frontend_desired_count
   content_store_desired_count   = var.content_store_desired_count
   static_desired_count          = var.static_desired_count

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -217,5 +217,14 @@ resource "aws_security_group_rule" "static_alb_to_any_any" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "mongodb_from_content_store_mongodb" {
+  type                     = "ingress"
+  from_port                = 27017
+  to_port                  = 27017
+  protocol                 = "tcp"
+  security_group_id        = var.mongodb_security_group_id
+  source_security_group_id = module.content_store_service.app_security_group_id
+}
+
 
 # TODO: move the rest of the rules into this file.

--- a/terraform/modules/govuk/variables.tf
+++ b/terraform/modules/govuk/variables.tf
@@ -40,6 +40,11 @@ variable "documentdb_security_group_id" {
   type        = string
 }
 
+variable "mongodb_security_group_id" {
+  description = "ID of security group for the shared MongoDB (which isn't managed by this Terraform repo, at least initially)."
+  type        = string
+}
+
 variable "frontend_desired_count" {
   description = "Desired count of Frontend Application instances"
   type        = number


### PR DESCRIPTION
This PR adds the security group rule for Content-Store to access the
ec2 mongodb.