### PR TITLE
Read security groups from remote state

### DIFF
--- a/terraform/deployments/govuk-test/variables.tf
+++ b/terraform/deployments/govuk-test/variables.tf
@@ -14,8 +14,9 @@ variable "public_lb_domain_name" {
   type = string
 }
 
-variable "infra_networking_state_bucket" {
-  type = string
+variable "govuk_aws_state_bucket" {
+  type        = string
+  description = "The name of the S3 bucket used for govuk-aws's terraform state files"
 }
 
 variable "frontend_desired_count" {

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -2,6 +2,6 @@
 # Network
 #--------------------------------------------------------------
 
-# TODO: Is this from govuk-aws? Can it be replaced?
-public_lb_domain_name         = "test.govuk.digital"
-infra_networking_state_bucket = "govuk-terraform-steppingstone-test"
+# TODO: Could this be named more clearly?
+public_lb_domain_name  = "test.govuk.digital"
+govuk_aws_state_bucket = "govuk-terraform-steppingstone-test"


### PR DESCRIPTION
Similar to https://github.com/alphagov/govuk-infrastructure/pull/59

The terraform module in govuk-aws that manages the security groups
already exports all the ones we need:

https://github.com/alphagov/govuk-aws/blob/master/terraform/projects/infra-security-groups/outputs.tf

This isn't a major win, as looking them up by their names ought to be
reasonably stable. But it feels a bit cleaner to me to read from the
upstream terraform statefile instead of from AWS.