### PR TITLE
Bump Envoy version

### DIFF
--- a/terraform/modules/task-definition/main.tf
+++ b/terraform/modules/task-definition/main.tf
@@ -14,7 +14,7 @@ locals {
       # TODO: don't hardcode the version; track stable Envoy
       # TODO: control when Envoy updates happen (but still needs to be automatic)
       # TODO: don't hardcode the region
-      "image" : "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.15.0.0-prod",
+      "image" : "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.15.1.0-prod",
       "user" : "1337",
       "environment" : [
         { "name" : "APPMESH_VIRTUAL_NODE_NAME", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },


### PR DESCRIPTION
This is the latest version of Envoy available from AWS:

https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html