### PR TITLE
Enable envoy access logs for all apps

### DIFF
--- a/terraform/modules/app/appmesh.tf
+++ b/terraform/modules/app/appmesh.tf
@@ -37,6 +37,14 @@ resource "aws_appmesh_virtual_node" "service" {
         service_name   = aws_service_discovery_service.service[count.index].name
       }
     }
+
+    logging {
+      access_log {
+        file {
+          path = "/dev/stdout"
+        }
+      }
+    }
   }
 
   depends_on = [aws_service_discovery_service.service]


### PR DESCRIPTION
As described in the AWS docs on AppMesh "Observability":

https://docs.aws.amazon.com/app-mesh/latest/userguide/observability.html

> When you send Envoy access logs to /dev/stdout, they are mixed in with
> the Envoy container logs. You can export them to a log storage and
> processing service like CloudWatch Logs using standard Docker log
> drivers such as awslogs. For more information, see Using the awslogs Log
> Driver in the Amazon ECS Developer Guide. To export only the Envoy
> access logs (and ignore the other Envoy container logs), you can set the
> ENVOY_LOG_LEVEL to off. For more information, see Access logging in the
> Envoy documentation.

It's possible that this approach would get expensive at
production-levels of traffic. I think it's worth doing for now though,
as it might help use troubleshoot issues while we're developing.