### PR TITLE
Various minor changes pending from previous work

### DIFF
--- a/terraform/modules/apps/frontend/frontend_console.json
+++ b/terraform/modules/apps/frontend/frontend_console.json
@@ -43,7 +43,7 @@
     "image": "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.15.0.0-prod",
     "user": "1337",
     "environment": [
-      { "name": "APPMESH_VIRTUAL_NODE_NAME", "value": "mesh/govuk/virtualNode/frontend-console" },
+      { "name": "APPMESH_RESOURCE_ARN", "value": "mesh/govuk/virtualNode/frontend-console" },
       { "name": "ENVOY_LOG_LEVEL", "value": "debug" }
     ],
     "essential": true,

--- a/terraform/modules/task-definition/main.tf
+++ b/terraform/modules/task-definition/main.tf
@@ -17,7 +17,6 @@ locals {
       "image" : "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.15.1.0-prod",
       "user" : "1337",
       "environment" : [
-        { "name" : "APPMESH_VIRTUAL_NODE_NAME", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
       ],
       "essential" : true,

--- a/terraform/modules/task-definitions/content-store/main.tf
+++ b/terraform/modules/task-definitions/content-store/main.tf
@@ -49,7 +49,7 @@ module "task_definition" {
       "image" : "govuk/content-store:${var.image_tag}", # TODO: replace temporary label
       "essential" : true,
       "environment" : [
-        { "name" : "APPMESH_VIRTUAL_NODE_NAME", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
+        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "DEFAULT_TTL", "value" : "1800" },
         { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
         { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },

--- a/terraform/modules/task-definitions/frontend/main.tf
+++ b/terraform/modules/task-definitions/frontend/main.tf
@@ -41,7 +41,7 @@ module "task_definition" {
       "image" : "govuk/frontend:${var.image_tag}",
       "essential" : true,
       "environment" : [
-        { "name" : "APPMESH_VIRTUAL_NODE_NAME", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
+        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "RAILS_ENV", "value" : "production" },
         { "name" : "ASSET_HOST", "value" : var.assets_url },
         { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },

--- a/terraform/modules/task-definitions/frontend/main.tf
+++ b/terraform/modules/task-definitions/frontend/main.tf
@@ -57,9 +57,11 @@ module "task_definition" {
         { "name" : "STATSD_PROTOCOL", "value" : "tcp" },
         { "name" : "STATSD_HOST", "value" : var.statsd_host },
         { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
+        # TODO: Setting RAILS_SERVE_STATIC_FILES, RAILS_SERVE_STATIC_ASSETS and HEROKU_APP_NAME are temporary workarounds for serving static assets.
+        # Remove them once we have a production solution for assets.
         { "name" : "RAILS_SERVE_STATIC_FILES", "value" : "yes" },
         { "name" : "RAILS_SERVE_STATIC_ASSETS", "value" : "yes" },
-        { "name" : "HEROKU_APP_NAME", "value" : "yes" },
+        { "name" : "HEROKU_APP_NAME", "value" : var.service_name },
       ],
       "logConfiguration" : {
         "logDriver" : "awslogs",

--- a/terraform/modules/task-definitions/publisher/main.tf
+++ b/terraform/modules/task-definitions/publisher/main.tf
@@ -81,7 +81,7 @@ module "task_definition" {
       "essential" : true,
       "environment" : [
         { "name" : "ASSET_HOST", "value" : var.asset_host },
-        { "name" : "APPMESH_VIRTUAL_NODE_NAME", "value" : "mesh/${var.mesh_name}/virtualNode/${local.service_name}" },
+        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${local.service_name}" },
         { "name" : "BASIC_AUTH_USERNAME", "value" : "gds" },
         { "name" : "EMAIL_GROUP_BUSINESS", "value" : "test-address@digital.cabinet-office.gov.uk" },
         { "name" : "EMAIL_GROUP_CITIZEN", "value" : "test-address@digital.cabinet-office.gov.uk" },

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -75,7 +75,7 @@ module "task_definition" {
       "essential" : true,
       "environment" : [
         # TODO: factor our hardcoded stuff
-        { "name" : "APPMESH_VIRTUAL_NODE_NAME", "value" : "mesh/${var.mesh_name}/virtualNode/${local.service_name}" },
+        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${local.service_name}" },
         { "name" : "CONTENT_API_PROTOTYPE", "value" : "yes" },
         { "name" : "CONTENT_STORE", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
         { "name" : "DRAFT_CONTENT_STORE", "value" : "https://draft-content-store.${var.service_discovery_namespace_name}" },

--- a/terraform/modules/task-definitions/router-api/main.tf
+++ b/terraform/modules/task-definitions/router-api/main.tf
@@ -35,6 +35,7 @@ module "task_definition" {
       "image" : "govuk/router-api:${var.image_tag}",
       "essential" : true,
       "environment" : [
+        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "GOVUK_APP_NAME", "value" : var.service_name },
         { "name" : "GOVUK_APP_ROOT", "value" : "/var/apps/${var.service_name}" },
         { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },

--- a/terraform/modules/task-definitions/router/main.tf
+++ b/terraform/modules/task-definitions/router/main.tf
@@ -35,6 +35,7 @@ module "task_definition" {
       "image" : "govuk/router:${var.image_tag}",
       "essential" : true,
       "environment" : [
+        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "GOVUK_APP_NAME", "value" : var.service_name },
         { "name" : "GOVUK_APP_ROOT", "value" : "/var/apps/${var.service_name}" },
         { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },

--- a/terraform/modules/task-definitions/signon/main.tf
+++ b/terraform/modules/task-definitions/signon/main.tf
@@ -38,6 +38,7 @@ module "task_definition" {
       "image" : "govuk/signon:deployed-to-production",
       "essential" : true,
       "environment" : [
+        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${local.service_name}" },
         { "name" : "GOVUK_APP_NAME", "value" : local.service_name },
         { "name" : "GOVUK_APP_ROOT", "value" : "/app" },
         { "name" : "PORT", "value" : "8080" },

--- a/terraform/modules/task-definitions/static/main.tf
+++ b/terraform/modules/task-definitions/static/main.tf
@@ -60,6 +60,8 @@ module "task_definition" {
         { "name" : "REDIS_URL", "value" : "redis://${var.redis_host}:${var.redis_port}" },
         { "name" : "SENTRY_ENVIRONMENT", "value" : var.sentry_environment },
         { "name" : "RAILS_ENV", "value" : "production" },
+        # TODO: Setting RAILS_SERVE_STATIC_FILES and RAILS_SERVE_STATIC_ASSETS are temporary workarounds for serving static assets.
+        # Remove them once we have a production solution for assets.
         { "name" : "RAILS_SERVE_STATIC_FILES", "value" : "enabled" },
         { "name" : "RAILS_SERVE_STATIC_ASSETS", "value" : "yes" },
       ],

--- a/terraform/modules/task-definitions/static/main.tf
+++ b/terraform/modules/task-definitions/static/main.tf
@@ -47,7 +47,7 @@ module "task_definition" {
       "image" : "govuk/static:${var.image_tag}",
       "essential" : true,
       "environment" : [
-        { "name" : "APPMESH_VIRTUAL_NODE_NAME", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
+        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "GOVUK_APP_NAME", "value" : var.service_name },
         { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
         { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },


### PR DESCRIPTION
### Replace `APPMESH_VIRTUAL_NODE_NAME` by `APPMESH_RESOURCE_ARN` (2022e19)

With envoy image: `1.15.0 or later`, we should use `APPMESH_RESOURCE_ARN`
configuration parameter rather than the deprecated
`APPMESH_VIRTUAL_NODE_NAME`.

Ref:
1. [AWS Envoy Docs](https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html)

### Add `APPMESH_RESOURCE_ARN` parameter (8f93f49)

Add `APPMESH_RESOURCE_ARN` parameter to missing:
1. router
2. router-api
3. static

### Add TODO for assets workaround (9dac450)

We defined some extra parameters for the Frontend and Static App to serve  static assets directly rather than through nginx. We need to record that these need to be remove once we have a production ready solution to this issue.

Ref:
1. #58