### PR TITLE
remove superfluous APPMESH_RESOURCE_ARN

### DIFF
--- a/terraform/modules/task-definitions/content-store/main.tf
+++ b/terraform/modules/task-definitions/content-store/main.tf
@@ -49,7 +49,6 @@ module "task_definition" {
       "image" : "govuk/content-store:${var.image_tag}", # TODO: replace temporary label
       "essential" : true,
       "environment" : [
-        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "DEFAULT_TTL", "value" : "1800" },
         { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
         { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },

--- a/terraform/modules/task-definitions/frontend/main.tf
+++ b/terraform/modules/task-definitions/frontend/main.tf
@@ -41,7 +41,6 @@ module "task_definition" {
       "image" : "govuk/frontend:${var.image_tag}",
       "essential" : true,
       "environment" : [
-        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "RAILS_ENV", "value" : "production" },
         { "name" : "ASSET_HOST", "value" : var.assets_url },
         { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },

--- a/terraform/modules/task-definitions/publisher/main.tf
+++ b/terraform/modules/task-definitions/publisher/main.tf
@@ -81,7 +81,6 @@ module "task_definition" {
       "essential" : true,
       "environment" : [
         { "name" : "ASSET_HOST", "value" : var.asset_host },
-        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${local.service_name}" },
         { "name" : "BASIC_AUTH_USERNAME", "value" : "gds" },
         { "name" : "EMAIL_GROUP_BUSINESS", "value" : "test-address@digital.cabinet-office.gov.uk" },
         { "name" : "EMAIL_GROUP_CITIZEN", "value" : "test-address@digital.cabinet-office.gov.uk" },

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -75,7 +75,6 @@ module "task_definition" {
       "essential" : true,
       "environment" : [
         # TODO: factor our hardcoded stuff
-        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${local.service_name}" },
         { "name" : "CONTENT_API_PROTOTYPE", "value" : "yes" },
         { "name" : "CONTENT_STORE", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
         { "name" : "DRAFT_CONTENT_STORE", "value" : "https://draft-content-store.${var.service_discovery_namespace_name}" },

--- a/terraform/modules/task-definitions/router-api/main.tf
+++ b/terraform/modules/task-definitions/router-api/main.tf
@@ -35,7 +35,6 @@ module "task_definition" {
       "image" : "govuk/router-api:${var.image_tag}",
       "essential" : true,
       "environment" : [
-        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "GOVUK_APP_NAME", "value" : var.service_name },
         { "name" : "GOVUK_APP_ROOT", "value" : "/var/apps/${var.service_name}" },
         { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },

--- a/terraform/modules/task-definitions/router/main.tf
+++ b/terraform/modules/task-definitions/router/main.tf
@@ -35,7 +35,6 @@ module "task_definition" {
       "image" : "govuk/router:${var.image_tag}",
       "essential" : true,
       "environment" : [
-        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "GOVUK_APP_NAME", "value" : var.service_name },
         { "name" : "GOVUK_APP_ROOT", "value" : "/var/apps/${var.service_name}" },
         { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },

--- a/terraform/modules/task-definitions/signon/main.tf
+++ b/terraform/modules/task-definitions/signon/main.tf
@@ -38,7 +38,6 @@ module "task_definition" {
       "image" : "govuk/signon:deployed-to-production",
       "essential" : true,
       "environment" : [
-        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${local.service_name}" },
         { "name" : "GOVUK_APP_NAME", "value" : local.service_name },
         { "name" : "GOVUK_APP_ROOT", "value" : "/app" },
         { "name" : "PORT", "value" : "8080" },

--- a/terraform/modules/task-definitions/static/main.tf
+++ b/terraform/modules/task-definitions/static/main.tf
@@ -47,7 +47,6 @@ module "task_definition" {
       "image" : "govuk/static:${var.image_tag}",
       "essential" : true,
       "environment" : [
-        { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
         { "name" : "GOVUK_APP_NAME", "value" : var.service_name },
         { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
         { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },


### PR DESCRIPTION
We remove superflous APPMESH_RESOURCE_ARN from the application
containers themselves as they are needed only for the envoy container
inside the same task.

Ref:
1. [AWS Envoy Docs](https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html)
2. #79