### PR TITLE
Add deployment for draft content store

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -85,6 +85,7 @@ groups:
     jobs:
       - update-pipeline
       - deploy-content-store
+      - deploy-draft-content-store
       - deploy-frontend
       - smoke-test-frontend
       - deploy-publisher
@@ -101,6 +102,10 @@ groups:
   - name: content-store
     jobs:
       - deploy-content-store
+
+  - name: draft-content-store
+    jobs:
+      - deploy-draft-content-store
 
   - name: frontend
     jobs:
@@ -243,6 +248,26 @@ jobs:
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
         APPLICATION: content-store
+        GOVUK_ENVIRONMENT: test
+    serial: true
+    on_failure:
+      <<: *notify-slack-failure
+
+  - name: deploy-draft-content-store
+    plan:
+    - get: govuk-infrastructure
+    - get: release
+      resource: content-store
+      trigger: true
+    - task: update-task-definition
+      file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+      params:
+        APPLICATION: draft-content-store
+        GOVUK_ENVIRONMENT: test
+    - task: update-ecs-service
+      file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
+      params:
+        APPLICATION: draft-content-store
         GOVUK_ENVIRONMENT: test
     serial: true
     on_failure:

--- a/terraform/deployments/apps/content-store/main.tf
+++ b/terraform/deployments/apps/content-store/main.tf
@@ -27,7 +27,7 @@ module "task_definition" {
   service_name                     = "content-store"
   govuk_app_domain_external        = var.app_domain
   govuk_website_root               = local.website_root
-  image_tag                        = var.image_tag
+  image_tag                        = "bill-content-schemas" # TODO: Change back once content schemas are available
   mesh_name                        = var.mesh_name
   mongodb_url                      = "mongodb://${var.mongodb_host}/content_store_production"
   service_discovery_namespace_name = local.service_discovery_namespace_name

--- a/terraform/deployments/apps/draft-content-store/common.tf
+++ b/terraform/deployments/apps/draft-content-store/common.tf
@@ -1,0 +1,1 @@
+../common.tf

--- a/terraform/deployments/apps/draft-content-store/main.tf
+++ b/terraform/deployments/apps/draft-content-store/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  backend "s3" {
+    bucket  = "govuk-terraform-test"
+    key     = "projects/draft-content-store.tfstate"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.13"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = var.assume_role_arn
+  }
+}
+
+module "task_definition" {
+  source                           = "../../../modules/task-definitions/content-store"
+  service_name                     = "draft-content-store"
+  govuk_app_domain_external        = var.app_domain
+  govuk_website_root               = local.website_root
+  image_tag                        = var.image_tag
+  mesh_name                        = var.mesh_name
+  mongodb_url                      = "mongodb://${var.mongodb_host}/draft_content_store_production"
+  service_discovery_namespace_name = local.service_discovery_namespace_name
+  statsd_host                      = local.statsd_host
+  execution_role_arn               = data.aws_iam_role.execution.arn
+  task_role_arn                    = data.aws_iam_role.task.arn
+  sentry_environment               = var.sentry_environment
+  assume_role_arn                  = var.assume_role_arn
+}

--- a/terraform/deployments/apps/draft-content-store/main.tf
+++ b/terraform/deployments/apps/draft-content-store/main.tf
@@ -27,7 +27,7 @@ module "task_definition" {
   service_name                     = "draft-content-store"
   govuk_app_domain_external        = var.app_domain
   govuk_website_root               = local.website_root
-  image_tag                        = var.image_tag
+  image_tag                        = "bill-content-schemas" # TODO: Change back once content schemas are available
   mesh_name                        = var.mesh_name
   mongodb_url                      = "mongodb://${var.mongodb_host}/draft_content_store_production"
   service_discovery_namespace_name = local.service_discovery_namespace_name

--- a/terraform/deployments/apps/draft-content-store/main.tf
+++ b/terraform/deployments/apps/draft-content-store/main.tf
@@ -30,6 +30,7 @@ module "task_definition" {
   image_tag                        = "bill-content-schemas" # TODO: Change back once content schemas are available
   mesh_name                        = var.mesh_name
   mongodb_url                      = "mongodb://${var.mongodb_host}/draft_content_store_production"
+  router_api_hostname_prefix       = "draft-"
   service_discovery_namespace_name = local.service_discovery_namespace_name
   statsd_host                      = local.statsd_host
   execution_role_arn               = data.aws_iam_role.execution.arn

--- a/terraform/deployments/apps/draft-content-store/outputs.tf
+++ b/terraform/deployments/apps/draft-content-store/outputs.tf
@@ -1,0 +1,1 @@
+../outputs.tf

--- a/terraform/deployments/apps/draft-content-store/variables.tf
+++ b/terraform/deployments/apps/draft-content-store/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf

--- a/terraform/deployments/govuk-test/outputs.tf
+++ b/terraform/deployments/govuk-test/outputs.tf
@@ -9,3 +9,7 @@ output "publisher_security_groups" {
 output "frontend_security_groups" {
   value = module.govuk.frontend_security_groups
 }
+
+output "signon_security_groups" {
+  value = module.govuk.signon_security_groups
+}

--- a/terraform/deployments/govuk-test/outputs.tf
+++ b/terraform/deployments/govuk-test/outputs.tf
@@ -13,3 +13,11 @@ output "frontend_security_groups" {
 output "signon_security_groups" {
   value = module.govuk.signon_security_groups
 }
+
+output "content-store_security_groups" {
+  value = module.govuk.content_store_security_groups
+}
+
+output "draft-content-store_security_groups" {
+  value = module.govuk.draft_content_store_security_groups
+}

--- a/terraform/modules/apps/content-store/outputs.tf
+++ b/terraform/modules/apps/content-store/outputs.tf
@@ -2,3 +2,8 @@ output "app_security_group_id" {
   value       = module.app.security_group_id
   description = "ID of the security group for Content Store (or draft) instances."
 }
+
+output "security_groups" {
+  value       = module.app.security_groups
+  description = "The security groups applied to the ECS Service."
+}

--- a/terraform/modules/apps/router-api/outputs.tf
+++ b/terraform/modules/apps/router-api/outputs.tf
@@ -1,4 +1,4 @@
-output "security_group_id" {
+output "app_security_group_id" {
   value       = module.app.security_group_id
   description = "ID of the security group for router-api instances."
 }

--- a/terraform/modules/apps/router/outputs.tf
+++ b/terraform/modules/apps/router/outputs.tf
@@ -1,4 +1,4 @@
-output "security_group_id" {
+output "app_security_group_id" {
   value       = module.app.security_group_id
   description = "ID of the security group for router instances."
 }

--- a/terraform/modules/apps/signon/outputs.tf
+++ b/terraform/modules/apps/signon/outputs.tf
@@ -2,3 +2,8 @@ output "security_group_id" {
   value       = module.app.security_group_id
   description = "ID of the security group for signon instances."
 }
+
+output "security_groups" {
+  value       = module.app.security_groups
+  description = "The security groups applied to the ECS Service."
+}

--- a/terraform/modules/govuk/outputs.tf
+++ b/terraform/modules/govuk/outputs.tf
@@ -7,3 +7,8 @@ output "frontend_security_groups" {
   value       = module.frontend_service.security_groups
   description = "The security groups applied to the Frontend ECS Service."
 }
+
+output "signon_security_groups" {
+  value       = module.signon_service.security_groups
+  description = "The security groups applied to the Signon ECS Service."
+}

--- a/terraform/modules/govuk/outputs.tf
+++ b/terraform/modules/govuk/outputs.tf
@@ -12,3 +12,13 @@ output "signon_security_groups" {
   value       = module.signon_service.security_groups
   description = "The security groups applied to the Signon ECS Service."
 }
+
+output "content_store_security_groups" {
+  value       = module.content_store_service.security_groups
+  description = "The security groups applied to the Content Store ECS Service."
+}
+
+output "draft_content_store_security_groups" {
+  value       = module.draft_content_store_service.security_groups
+  description = "The security groups applied to the Draft Content Store ECS Service."
+}

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -27,6 +27,16 @@ resource "aws_security_group_rule" "content_store_from_publishing_api_http" {
   source_security_group_id = module.publishing_api_service.app_security_group_id
 }
 
+resource "aws_security_group_rule" "draft_content_store_from_publishing_api_http" {
+  description              = "Draft Content Store accepts requests from Publishing API over HTTP"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  security_group_id        = module.draft_content_store_service.app_security_group_id
+  source_security_group_id = module.publishing_api_service.app_security_group_id
+}
+
 resource "aws_security_group_rule" "content_store_from_frontend_http" {
   description              = "Content Store accepts requests from Frontend over HTTP"
   type                     = "ingress"

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -245,5 +245,14 @@ resource "aws_security_group_rule" "mongodb_from_content_store_mongodb" {
   source_security_group_id = module.content_store_service.app_security_group_id
 }
 
+resource "aws_security_group_rule" "mongodb_from_draft_content_store_mongodb" {
+  type                     = "ingress"
+  from_port                = 27017
+  to_port                  = 27017
+  protocol                 = "tcp"
+  security_group_id        = var.mongodb_security_group_id
+  source_security_group_id = module.draft_content_store_service.app_security_group_id
+}
+
 
 # TODO: move the rest of the rules into this file.

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -264,5 +264,16 @@ resource "aws_security_group_rule" "mongodb_from_draft_content_store_mongodb" {
   source_security_group_id = module.draft_content_store_service.app_security_group_id
 }
 
+resource "aws_security_group_rule" "router_api_from_content_store_http" {
+  description = "Router API accepts requests from Content Store over HTTP"
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+
+  security_group_id        = module.router_api_service.app_security_group_id
+  source_security_group_id = module.content_store_service.app_security_group_id
+}
+
 
 # TODO: move the rest of the rules into this file.

--- a/terraform/modules/task-definitions/content-store/main.tf
+++ b/terraform/modules/task-definitions/content-store/main.tf
@@ -63,6 +63,7 @@ module "task_definition" {
         { "name" : "MONGODB_URI", "value" : var.mongodb_url },
         { "name" : "PLEK_SERVICE_PERFORMANCEPLATFORM_BIG_SCREEN_VIEW_URI", "value" : "" },
         { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api.${var.service_discovery_namespace_name}" },
+        { "name" : "PLEK_SERVICE_ROUTER_API_URI", "value" : "http://${var.router_api_hostname_prefix}router-api.${var.service_discovery_namespace_name}" },
         { "name" : "PLEK_SERVICE_RUMMAGER_URI", "value" : "" },
         { "name" : "PLEK_SERVICE_SPOTLIGHT_URI", "value" : "" },
         { "name" : "PORT", "value" : "80" },

--- a/terraform/modules/task-definitions/content-store/variables.tf
+++ b/terraform/modules/task-definitions/content-store/variables.tf
@@ -6,6 +6,12 @@ variable "govuk_website_root" {
   type = string
 }
 
+variable "router_api_hostname_prefix" {
+  type        = string
+  default     = ""
+  description = "Leave unset, or use 'draft-' to send requests to the draft router-api."
+}
+
 variable "image_tag" {
   description = "Container Image Tag"
   type        = string

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -93,6 +93,7 @@ module "task_definition" {
         { "name" : "GOVUK_USER", "value" : "deploy" }, # TODO: clean up?
         { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
         { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
+        { "name" : "PLEK_SERVICE_DRAFT_CONTENT_STORE_URI", "value" : "http://draft-content-store.${var.service_discovery_namespace_name}" },
         { "name" : "PORT", "value" : "80" },
         { "name" : "RABBITMQ_HOSTS", "value" : "rabbitmq.${var.govuk_app_domain_internal}" },
         { "name" : "RABBITMQ_USER", "value" : "publishing_api" },

--- a/terraform/modules/task-definitions/signon/main.tf
+++ b/terraform/modules/task-definitions/signon/main.tf
@@ -38,11 +38,14 @@ module "task_definition" {
       "image" : "govuk/signon:deployed-to-production",
       "essential" : true,
       "environment" : [
+        { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
+        { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
         { "name" : "GOVUK_APP_NAME", "value" : local.service_name },
         { "name" : "GOVUK_APP_ROOT", "value" : "/app" },
-        { "name" : "PORT", "value" : "8080" },
+        { "name" : "GOVUK_APP_TYPE", "value" : "rack" },
+        { "name" : "PORT", "value" : "80" },
         { "name" : "DATABASE_URL", "value" : var.signon_db_url },
-        { "name" : "RAILS_ENV", "value" : "development" },
+        { "name" : "RAILS_ENV", "value" : "production" },
         { "name" : "TEST_DATABASE_URL", "value" : var.signon_test_db_url },
         { "name" : "SENTRY_ENVIRONMENT", "value" : var.sentry_environment }
       ],
@@ -62,8 +65,8 @@ module "task_definition" {
       "mountPoints" : [],
       "portMappings" : [
         {
-          "containerPort" : 8080,
-          "hostPort" : 8080,
+          "containerPort" : 80,
+          "hostPort" : 80,
           "protocol" : "tcp"
         },
       ],


### PR DESCRIPTION
This makes it possible to deploy the draft content store.

Further work is required to deploy this application from Concourse.