### PR TITLE
[spike] Run Sidekiq in ECS (sidecar approach)

### DIFF
--- a/terraform/modules/container-definition/README.md
+++ b/terraform/modules/container-definition/README.md
@@ -1,0 +1,7 @@
+# Container Definition
+
+This module represents an ECS Container Definition. These are managed within
+Task Definition Terraform resources.
+
+The intent of this module is to provide a consistent and opinionated way to
+create container definitions (i.e. Envoy is required, logConfiguration)

--- a/terraform/modules/container-definition/main.tf
+++ b/terraform/modules/container-definition/main.tf
@@ -1,0 +1,24 @@
+locals {
+  definition = {
+    "command" : var.command,
+    "essential" : true,
+    "environment" : var.environment_variables,
+    "dependsOn" : [{
+      "containerName" : "envoy",
+      "condition" : "START"
+    }],
+    "image" : "govuk/${var.service_name}:${var.image_tag}",
+    "logConfiguration" : {
+      "logDriver" : "awslogs",
+      "options" : {
+        "awslogs-create-group" : "true",
+        "awslogs-group" : "awslogs-fargate",
+        "awslogs-region" : "eu-west-1",
+        "awslogs-stream-prefix" : "awslogs-${var.service_name}"
+      }
+    },
+    "mountPoints" : [],
+    "portMappings" : var.portMappings,
+    "secrets" : var.secrets
+  }
+}

--- a/terraform/modules/container-definition/output.tf
+++ b/terraform/modules/container-definition/output.tf
@@ -1,0 +1,3 @@
+output "definition" {
+  value = local.definition
+}

--- a/terraform/modules/container-definition/variables.tf
+++ b/terraform/modules/container-definition/variables.tf
@@ -1,0 +1,27 @@
+variable "command" {
+  type = list
+}
+
+variable "environment_variables" {
+  type = list
+}
+
+variable "image_tag" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "secrets" {
+  type = list
+}
+
+variable "service_name" {
+  type = string
+}
+
+variable "portMappings" {
+  type = list
+}

--- a/terraform/modules/task-definitions/publisher/main.tf
+++ b/terraform/modules/task-definitions/publisher/main.tf
@@ -63,6 +63,142 @@ data "aws_secretsmanager_secret" "sentry_dsn" {
 
 locals {
   service_name = "publisher"
+  # subdomain = join(compact([local.service_name, var.procfile_process]), "-")
+
+  default_container_definition = {
+    "image" : "govuk/publisher:${var.image_tag}", # TODO: use deployed-to-production label or similar.
+    "essential" : true,
+    "environment" : [
+      { "name" : "ASSET_HOST", "value" : var.asset_host },
+      { "name" : "BASIC_AUTH_USERNAME", "value" : "gds" },
+      { "name" : "EMAIL_GROUP_BUSINESS", "value" : "test-address@digital.cabinet-office.gov.uk" },
+      { "name" : "EMAIL_GROUP_CITIZEN", "value" : "test-address@digital.cabinet-office.gov.uk" },
+      { "name" : "EMAIL_GROUP_DEV", "value" : "test-address@digital.cabinet-office.gov.uk" },
+      { "name" : "EMAIL_GROUP_FORCE_PUBLISH_ALERTS", "value" : "test-address@digital.cabinet-office.gov.uk" },
+      { "name" : "FACT_CHECK_SUBJECT_PREFIX", "value" : "dev" },
+      { "name" : "FACT_CHECK_USERNAME", "value" : "govuk-fact-check-test@digital.cabinet-office.gov.uk" },
+      { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
+      { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
+      { "name" : "GOVUK_APP_NAME", "value" : "publisher" },
+      { "name" : "GOVUK_APP_ROOT", "value" : "/app" },
+      { "name" : "GOVUK_APP_TYPE", "value" : "rack" },
+      { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
+      # TODO: how does GOVUK_ASSET_ROOT relate to ASSET_HOST? Is one a function of the other? Are they both really in use? Is GOVUK_ASSET_ROOT always just "https://${ASSET_HOST}"?
+      { "name" : "GOVUK_ASSET_ROOT", "value" : "https://assets.test.publishing.service.gov.uk" },
+      { "name" : "GOVUK_GROUP", "value" : "deploy" },
+      { "name" : "GOVUK_USER", "value" : "deploy" },
+      { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
+      { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : "https://www.gov.uk/api" }, # TODO: looks suspicious
+      { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api.${var.service_discovery_namespace_name}" },
+      { "name" : "PLEK_SERVICE_STATIC_URI", "value" : "https://assets.test.publishing.service.gov.uk" },
+      { "name" : "PORT", "value" : "80" },
+      { "name" : "RAILS_ENV", "value" : "production" },
+      { "name" : "RAILS_SERVE_STATIC_FILES", "value" : "true" }, # TODO: temporary hack?
+      # TODO: we shouldn't be specifying both REDIS_{HOST,PORT} *and* REDIS_URL.
+      { "name" : "REDIS_HOST", "value" : var.redis_host },
+      { "name" : "REDIS_PORT", "value" : tostring(var.redis_port) },
+      { "name" : "REDIS_URL", "value" : "redis://${var.redis_host}:${var.redis_port}" },
+      { "name" : "STATSD_PROTOCOL", "value" : "tcp" },
+      { "name" : "STATSD_HOST", "value" : var.statsd_host },
+      { "name" : "WEBSITE_ROOT", "value" : var.govuk_website_root },
+      { "name" : "SENTRY_ENVIRONMENT", "value" : var.sentry_environment }
+    ],
+    "dependsOn" : [{
+      "containerName" : "envoy",
+      "condition" : "START"
+    }],
+    "logConfiguration" : {
+      "logDriver" : "awslogs",
+      "options" : {
+        "awslogs-create-group" : "true",
+        "awslogs-group" : "awslogs-fargate",
+        "awslogs-region" : "eu-west-1", # TODO: hardcoded region
+        "awslogs-stream-prefix" : "awslogs-${local.service_name}"
+      }
+    },
+    "mountPoints" : [],
+    "secrets" : [
+      {
+        "name" : "ASSET_MANAGER_BEARER_TOKEN",
+        "valueFrom" : data.aws_secretsmanager_secret.asset_manager_bearer_token.arn
+      },
+      {
+        "name" : "FACT_CHECK_PASSWORD",
+        "valueFrom" : data.aws_secretsmanager_secret.fact_check_password.arn
+      },
+      {
+        "name" : "FACT_CHECK_REPLY_TO_ADDRESS",
+        "valueFrom" : data.aws_secretsmanager_secret.fact_check_reply_to_address.arn
+      },
+      {
+        "name" : "FACT_CHECK_REPLY_TO_ID",
+        "valueFrom" : data.aws_secretsmanager_secret.fact_check_reply_to_id.arn
+      },
+      {
+        "name" : "GOVUK_NOTIFY_API_KEY",
+        "valueFrom" : data.aws_secretsmanager_secret.govuk_notify_api_key.arn
+      },
+      {
+        "name" : "GOVUK_NOTIFY_TEMPLATE_ID",
+        "valueFrom" : data.aws_secretsmanager_secret.govuk_notify_template_id.arn
+      },
+      {
+        "name" : "JWT_AUTH_SECRET",
+        "valueFrom" : data.aws_secretsmanager_secret.jwt_auth_secret.arn
+      },
+      {
+        "name" : "LINK_CHECKER_API_BEARER_TOKEN",
+        "valueFrom" : data.aws_secretsmanager_secret.link_checker_api_bearer_token.arn
+      },
+      {
+        "name" : "LINK_CHECKER_API_SECRET_TOKEN",
+        "valueFrom" : data.aws_secretsmanager_secret.link_checker_api_secret_token.arn
+      },
+      {
+        # TODO: Only the password should be a secret in the MONGODB_URI.
+        "name" : "MONGODB_URI",
+        "valueFrom" : data.aws_secretsmanager_secret.mongodb_uri.arn
+      },
+      {
+        "name" : "GDS_SSO_OAUTH_ID",
+        "valueFrom" : data.aws_secretsmanager_secret.oauth_id.arn
+      },
+      {
+        "name" : "GDS_SSO_OAUTH_SECRET",
+        "valueFrom" : data.aws_secretsmanager_secret.oauth_secret.arn
+      },
+      {
+        "name" : "PUBLISHING_API_BEARER_TOKEN",
+        "valueFrom" : data.aws_secretsmanager_secret.publishing_api_bearer_token.arn
+      },
+      {
+        "name" : "SECRET_KEY_BASE",
+        "valueFrom" : data.aws_secretsmanager_secret.secret_key_base.arn
+      },
+      {
+        "name" : "SENTRY_DSN",
+        "valueFrom" : data.aws_secretsmanager_secret.sentry_dsn.arn
+      }
+    ]
+  }
+
+  worker_container_parameters = {
+    "name" : "${local.service_name}-worker",
+    "command" : ["foreman", "run", "worker"],
+    "portMappings" : []
+  }
+
+  web_container_parameters = {
+    "name" : local.service_name,
+    "command" : ["foreman", "run", "web"],
+    "portMappings" : [
+      {
+        "containerPort" : 80,
+        "hostPort" : 80,
+        "protocol" : "tcp"
+      }
+    ]
+  }
 }
 
 module "task_definition" {
@@ -74,130 +210,7 @@ module "task_definition" {
   execution_role_arn = var.execution_role_arn
   task_role_arn      = var.task_role_arn
   container_definitions = [
-    {
-      # TODO: factor out all the remaining hardcoded values (see ../content-store for an example where this has been done)
-      "name" : "publisher",
-      "image" : "govuk/publisher:${var.image_tag}", # TODO: use deployed-to-production label or similar.
-      "essential" : true,
-      "environment" : [
-        { "name" : "ASSET_HOST", "value" : var.asset_host },
-        { "name" : "BASIC_AUTH_USERNAME", "value" : "gds" },
-        { "name" : "EMAIL_GROUP_BUSINESS", "value" : "test-address@digital.cabinet-office.gov.uk" },
-        { "name" : "EMAIL_GROUP_CITIZEN", "value" : "test-address@digital.cabinet-office.gov.uk" },
-        { "name" : "EMAIL_GROUP_DEV", "value" : "test-address@digital.cabinet-office.gov.uk" },
-        { "name" : "EMAIL_GROUP_FORCE_PUBLISH_ALERTS", "value" : "test-address@digital.cabinet-office.gov.uk" },
-        { "name" : "FACT_CHECK_SUBJECT_PREFIX", "value" : "dev" },
-        { "name" : "FACT_CHECK_USERNAME", "value" : "govuk-fact-check-test@digital.cabinet-office.gov.uk" },
-        { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
-        { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
-        { "name" : "GOVUK_APP_NAME", "value" : "publisher" },
-        { "name" : "GOVUK_APP_ROOT", "value" : "/app" },
-        { "name" : "GOVUK_APP_TYPE", "value" : "rack" },
-        { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
-        # TODO: how does GOVUK_ASSET_ROOT relate to ASSET_HOST? Is one a function of the other? Are they both really in use? Is GOVUK_ASSET_ROOT always just "https://${ASSET_HOST}"?
-        { "name" : "GOVUK_ASSET_ROOT", "value" : "https://assets.test.publishing.service.gov.uk" },
-        { "name" : "GOVUK_GROUP", "value" : "deploy" },
-        { "name" : "GOVUK_USER", "value" : "deploy" },
-        { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
-        { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : "https://www.gov.uk/api" }, # TODO: looks suspicious
-        { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api.${var.service_discovery_namespace_name}" },
-        { "name" : "PLEK_SERVICE_STATIC_URI", "value" : "https://assets.test.publishing.service.gov.uk" },
-        { "name" : "PORT", "value" : "80" },
-        { "name" : "RAILS_ENV", "value" : "production" },
-        { "name" : "RAILS_SERVE_STATIC_FILES", "value" : "true" }, # TODO: temporary hack?
-        # TODO: we shouldn't be specifying both REDIS_{HOST,PORT} *and* REDIS_URL.
-        { "name" : "REDIS_HOST", "value" : var.redis_host },
-        { "name" : "REDIS_PORT", "value" : tostring(var.redis_port) },
-        { "name" : "REDIS_URL", "value" : "redis://${var.redis_host}:${var.redis_port}" },
-        { "name" : "STATSD_PROTOCOL", "value" : "tcp" },
-        { "name" : "STATSD_HOST", "value" : var.statsd_host },
-        { "name" : "WEBSITE_ROOT", "value" : var.govuk_website_root },
-        { "name" : "SENTRY_ENVIRONMENT", "value" : var.sentry_environment }
-      ],
-      "dependsOn" : [{
-        "containerName" : "envoy",
-        "condition" : "START"
-      }],
-      "logConfiguration" : {
-        "logDriver" : "awslogs",
-        "options" : {
-          "awslogs-create-group" : "true",
-          "awslogs-group" : "awslogs-fargate",
-          "awslogs-region" : "eu-west-1", # TODO: hardcoded region
-          "awslogs-stream-prefix" : "awslogs-publisher"
-        }
-      },
-      "mountPoints" : [],
-      "portMappings" : [
-        {
-          "containerPort" : 80,
-          "hostPort" : 80,
-          "protocol" : "tcp"
-        }
-      ],
-      "secrets" : [
-        {
-          "name" : "ASSET_MANAGER_BEARER_TOKEN",
-          "valueFrom" : data.aws_secretsmanager_secret.asset_manager_bearer_token.arn
-        },
-        {
-          "name" : "FACT_CHECK_PASSWORD",
-          "valueFrom" : data.aws_secretsmanager_secret.fact_check_password.arn
-        },
-        {
-          "name" : "FACT_CHECK_REPLY_TO_ADDRESS",
-          "valueFrom" : data.aws_secretsmanager_secret.fact_check_reply_to_address.arn
-        },
-        {
-          "name" : "FACT_CHECK_REPLY_TO_ID",
-          "valueFrom" : data.aws_secretsmanager_secret.fact_check_reply_to_id.arn
-        },
-        {
-          "name" : "GOVUK_NOTIFY_API_KEY",
-          "valueFrom" : data.aws_secretsmanager_secret.govuk_notify_api_key.arn
-        },
-        {
-          "name" : "GOVUK_NOTIFY_TEMPLATE_ID",
-          "valueFrom" : data.aws_secretsmanager_secret.govuk_notify_template_id.arn
-        },
-        {
-          "name" : "JWT_AUTH_SECRET",
-          "valueFrom" : data.aws_secretsmanager_secret.jwt_auth_secret.arn
-        },
-        {
-          "name" : "LINK_CHECKER_API_BEARER_TOKEN",
-          "valueFrom" : data.aws_secretsmanager_secret.link_checker_api_bearer_token.arn
-        },
-        {
-          "name" : "LINK_CHECKER_API_SECRET_TOKEN",
-          "valueFrom" : data.aws_secretsmanager_secret.link_checker_api_secret_token.arn
-        },
-        {
-          # TODO: Only the password should be a secret in the MONGODB_URI.
-          "name" : "MONGODB_URI",
-          "valueFrom" : data.aws_secretsmanager_secret.mongodb_uri.arn
-        },
-        {
-          "name" : "GDS_SSO_OAUTH_ID",
-          "valueFrom" : data.aws_secretsmanager_secret.oauth_id.arn
-        },
-        {
-          "name" : "GDS_SSO_OAUTH_SECRET",
-          "valueFrom" : data.aws_secretsmanager_secret.oauth_secret.arn
-        },
-        {
-          "name" : "PUBLISHING_API_BEARER_TOKEN",
-          "valueFrom" : data.aws_secretsmanager_secret.publishing_api_bearer_token.arn
-        },
-        {
-          "name" : "SECRET_KEY_BASE",
-          "valueFrom" : data.aws_secretsmanager_secret.secret_key_base.arn
-        },
-        {
-          "name" : "SENTRY_DSN",
-          "valueFrom" : data.aws_secretsmanager_secret.sentry_dsn.arn
-        }
-      ]
-    }
+    merge(local.default_container_definition, local.web_container_parameters),
+    merge(local.default_container_definition, local.worker_container_parameters),
   ]
 }

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -67,7 +67,7 @@ locals {
       # TODO: factor our hardcoded stuff
       { "name" : "CONTENT_API_PROTOTYPE", "value" : "yes" },
       { "name" : "CONTENT_STORE", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
-      { "name" : "DRAFT_CONTENT_STORE", "value" : "https://draft-content-store.${var.service_discovery_namespace_name}" },
+      { "name" : "DRAFT_CONTENT_STORE", "value" : "http://draft-content-store.${var.service_discovery_namespace_name}" },
       { "name" : "EVENT_LOG_AWS_ACCESS_ID", "value" : "AKIAJE6VSW25CYBUMQJA" },
       { "name" : "EVENT_LOG_AWS_BUCKETNAME", "value" : "govuk-${local.service_name}-event-log-test" },
       { "name" : "EVENT_LOG_AWS_USERNAME", "value" : "govuk-${local.service_name}-event-log_user" },

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -15,10 +15,6 @@ provider "aws" {
   }
 }
 
-locals {
-  service_name = "publishing-api"
-}
-
 data "aws_secretsmanager_secret" "content_store_bearer_token" {
   name = "publishing_api_app-CONTENT_STORE_BEARER_TOKEN"
 }
@@ -60,116 +56,114 @@ data "aws_secretsmanager_secret" "sentry_dsn" {
 }
 
 locals {
-  default_container_definition = {
-    "image" : "govuk/${local.service_name}:${var.image_tag}",
-    "essential" : true,
-    "environment" : [
-      # TODO: factor our hardcoded stuff
-      { "name" : "CONTENT_API_PROTOTYPE", "value" : "yes" },
-      { "name" : "CONTENT_STORE", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
-      { "name" : "DRAFT_CONTENT_STORE", "value" : "http://draft-content-store.${var.service_discovery_namespace_name}" },
-      { "name" : "EVENT_LOG_AWS_ACCESS_ID", "value" : "AKIAJE6VSW25CYBUMQJA" },
-      { "name" : "EVENT_LOG_AWS_BUCKETNAME", "value" : "govuk-${local.service_name}-event-log-test" },
-      { "name" : "EVENT_LOG_AWS_USERNAME", "value" : "govuk-${local.service_name}-event-log_user" },
-      { "name" : "DEFAULT_TTL", "value" : "1800" },
-      { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
-      { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
-      { "name" : "GOVUK_APP_NAME", "value" : "publishing-api" },
-      { "name" : "GOVUK_APP_TYPE", "value" : "rack" },
-      { "name" : "GOVUK_CONTENT_SCHEMAS_PATH", "value" : "/govuk-content-schemas" },
-      { "name" : "GOVUK_GROUP", "value" : "deploy" }, # TODO: clean up?
-      { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
-      { "name" : "GOVUK_USER", "value" : "deploy" }, # TODO: clean up?
-      { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
-      { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
-      { "name" : "PLEK_SERVICE_DRAFT_CONTENT_STORE_URI", "value" : "http://draft-content-store.${var.service_discovery_namespace_name}" },
-      { "name" : "PORT", "value" : "80" },
-      { "name" : "RABBITMQ_HOSTS", "value" : "rabbitmq.${var.govuk_app_domain_internal}" },
-      { "name" : "RABBITMQ_USER", "value" : "publishing_api" },
-      { "name" : "RABBITMQ_VHOST", "value" : "/" },
-      { "name" : "REDIS_HOST", "value" : var.redis_host },
-      { "name" : "REDIS_PORT", "value" : tostring(var.redis_port) },
-      { "name" : "REDIS_URL", "value" : "redis://${var.redis_host}:${var.redis_port}" },
-      { "name" : "RAILS_ENV", "value" : "production" },
-      { "name" : "STATSD_PROTOCOL", "value" : "tcp" },
-      { "name" : "STATSD_HOST", "value" : var.statsd_host },
-      { "name" : "UNICORN_WORKER_PROCESSES", "value" : "8" }
-    ],
-    "dependsOn" : [{
-      "containerName" : "envoy",
-      "condition" : "START"
-    }],
-    "logConfiguration" : {
-      "logDriver" : "awslogs",
-      "options" : {
-        "awslogs-create-group" : "true",
-        "awslogs-group" : "awslogs-fargate",
-        "awslogs-region" : "eu-west-1",
-        "awslogs-stream-prefix" : "awslogs-${local.service_name}"
-      }
+  service_name = "publishing-api"
+
+  environment_variables = [
+    # TODO: factor our hardcoded stuff
+    { "name" : "CONTENT_API_PROTOTYPE", "value" : "yes" },
+    { "name" : "CONTENT_STORE", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
+    { "name" : "DRAFT_CONTENT_STORE", "value" : "http://draft-content-store.${var.service_discovery_namespace_name}" },
+    { "name" : "EVENT_LOG_AWS_ACCESS_ID", "value" : "AKIAJE6VSW25CYBUMQJA" },
+    { "name" : "EVENT_LOG_AWS_BUCKETNAME", "value" : "govuk-${local.service_name}-event-log-test" },
+    { "name" : "EVENT_LOG_AWS_USERNAME", "value" : "govuk-${local.service_name}-event-log_user" },
+    { "name" : "DEFAULT_TTL", "value" : "1800" },
+    { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
+    { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
+    { "name" : "GOVUK_APP_NAME", "value" : "publishing-api" },
+    { "name" : "GOVUK_APP_TYPE", "value" : "rack" },
+    { "name" : "GOVUK_CONTENT_SCHEMAS_PATH", "value" : "/govuk-content-schemas" },
+    { "name" : "GOVUK_GROUP", "value" : "deploy" }, # TODO: clean up?
+    { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
+    { "name" : "GOVUK_USER", "value" : "deploy" }, # TODO: clean up?
+    { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
+    { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
+    { "name" : "PLEK_SERVICE_DRAFT_CONTENT_STORE_URI", "value" : "http://draft-content-store.${var.service_discovery_namespace_name}" },
+    { "name" : "PORT", "value" : "80" },
+    { "name" : "RABBITMQ_HOSTS", "value" : "rabbitmq.${var.govuk_app_domain_internal}" },
+    { "name" : "RABBITMQ_USER", "value" : "publishing_api" },
+    { "name" : "RABBITMQ_VHOST", "value" : "/" },
+    { "name" : "REDIS_HOST", "value" : var.redis_host },
+    { "name" : "REDIS_PORT", "value" : tostring(var.redis_port) },
+    { "name" : "REDIS_URL", "value" : "redis://${var.redis_host}:${var.redis_port}" },
+    { "name" : "RAILS_ENV", "value" : "production" },
+    { "name" : "STATSD_PROTOCOL", "value" : "tcp" },
+    { "name" : "STATSD_HOST", "value" : var.statsd_host },
+    { "name" : "UNICORN_WORKER_PROCESSES", "value" : "8" }
+  ]
+
+  secrets = [
+    {
+      "name" : "CONTENT_STORE_BEARER_TOKEN",
+      "valueFrom" : data.aws_secretsmanager_secret.content_store_bearer_token.arn
     },
-    "mountPoints" : [],
-    "secrets" : [
-      {
-        "name" : "CONTENT_STORE_BEARER_TOKEN",
-        "valueFrom" : data.aws_secretsmanager_secret.content_store_bearer_token.arn
-      },
-      {
-        "name" : "DATABASE_URL",
-        "valueFrom" : data.aws_secretsmanager_secret.database_url.arn
-      },
-      {
-        "name" : "DRAFT_CONTENT_STORE_BEARER_TOKEN",
-        "valueFrom" : data.aws_secretsmanager_secret.draft_content_store_bearer_token.arn
-      },
-      {
-        "name" : "EVENT_LOG_AWS_SECRET_KEY",
-        "valueFrom" : data.aws_secretsmanager_secret.event_log_aws_secret_key.arn
-      },
-      {
-        "name" : "GDS_SSO_OAUTH_ID",
-        "valueFrom" : data.aws_secretsmanager_secret.oauth_id.arn
-      },
-      {
-        "name" : "GDS_SSO_OAUTH_SECRET",
-        "valueFrom" : data.aws_secretsmanager_secret.oauth_secret.arn
-      },
-      {
-        "name" : "RABBITMQ_PASSWORD",
-        "valueFrom" : data.aws_secretsmanager_secret.rabbitmq_password.arn
-      },
-      {
-        "name" : "ROUTER_API_BEARER_TOKEN",
-        "valueFrom" : data.aws_secretsmanager_secret.router_api_bearer_token.arn
-      },
-      {
-        "name" : "SECRET_KEY_BASE",
-        "valueFrom" : data.aws_secretsmanager_secret.secret_key_base.arn
-      },
-      {
-        "name" : "SENTRY_DSN",
-        "valueFrom" : data.aws_secretsmanager_secret.sentry_dsn.arn
-      }
-    ]
-  }
+    {
+      "name" : "DATABASE_URL",
+      "valueFrom" : data.aws_secretsmanager_secret.database_url.arn
+    },
+    {
+      "name" : "DRAFT_CONTENT_STORE_BEARER_TOKEN",
+      "valueFrom" : data.aws_secretsmanager_secret.draft_content_store_bearer_token.arn
+    },
+    {
+      "name" : "EVENT_LOG_AWS_SECRET_KEY",
+      "valueFrom" : data.aws_secretsmanager_secret.event_log_aws_secret_key.arn
+    },
+    {
+      "name" : "GDS_SSO_OAUTH_ID",
+      "valueFrom" : data.aws_secretsmanager_secret.oauth_id.arn
+    },
+    {
+      "name" : "GDS_SSO_OAUTH_SECRET",
+      "valueFrom" : data.aws_secretsmanager_secret.oauth_secret.arn
+    },
+    {
+      "name" : "RABBITMQ_PASSWORD",
+      "valueFrom" : data.aws_secretsmanager_secret.rabbitmq_password.arn
+    },
+    {
+      "name" : "ROUTER_API_BEARER_TOKEN",
+      "valueFrom" : data.aws_secretsmanager_secret.router_api_bearer_token.arn
+    },
+    {
+      "name" : "SECRET_KEY_BASE",
+      "valueFrom" : data.aws_secretsmanager_secret.secret_key_base.arn
+    },
+    {
+      "name" : "SENTRY_DSN",
+      "valueFrom" : data.aws_secretsmanager_secret.sentry_dsn.arn
+    }
+  ]
+}
 
-  worker_container_parameters = {
-    "name" : "${local.service_name}-worker",
-    "command" : ["foreman", "run", "worker"],
-    "portMappings" : []
-  }
+module "web" {
+  source = "../../container-definition"
 
-  web_container_parameters = {
-    "name" : local.service_name,
-    "command" : ["foreman", "run", "web"],
-    "portMappings" : [
-      {
-        "containerPort" : 80,
-        "hostPort" : 80,
-        "protocol" : "tcp"
-      }
-    ]
-  }
+  command               = ["foreman", "run", "web"]
+  environment_variables = local.environment_variables
+  image_tag             = var.image_tag
+  name                  = local.service_name
+  secrets               = local.secrets
+  service_name          = local.service_name
+  portMappings = [
+    {
+      "containerPort" : 80,
+      "hostPort" : 80,
+      "protocol" : "tcp"
+    }
+  ]
+}
+
+module "worker" {
+  count  = var.worker_count
+  source = "../../container-definition"
+
+  command               = ["foreman", "run", "worker"]
+  environment_variables = local.environment_variables
+  image_tag             = var.image_tag
+  name                  = "${local.service_name}-worker-${count.index}"
+  secrets               = local.secrets
+  service_name          = local.service_name
+  portMappings          = []
 }
 
 module "task_definition" {
@@ -181,8 +175,10 @@ module "task_definition" {
   execution_role_arn = var.execution_role_arn
   task_role_arn      = var.task_role_arn
 
-  container_definitions = [
-    merge(local.default_container_definition, local.web_container_parameters),
-    merge(local.default_container_definition, local.worker_container_parameters),
-  ]
+  container_definitions = flatten(
+    concat(
+      [module.web.definition],
+      [for worker in module.worker : worker.definition]
+    )
+  )
 }

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -177,7 +177,7 @@ module "task_definition" {
   mesh_name          = var.mesh_name
   service_name       = local.service_name
   cpu                = 512
-  memory             = 1024
+  memory             = 2048
   execution_role_arn = var.execution_role_arn
   task_role_arn      = var.task_role_arn
 

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -59,6 +59,119 @@ data "aws_secretsmanager_secret" "sentry_dsn" {
   name = "SENTRY_DSN"
 }
 
+locals {
+  default_container_definition = {
+    "image" : "govuk/${local.service_name}:${var.image_tag}",
+    "essential" : true,
+    "environment" : [
+      # TODO: factor our hardcoded stuff
+      { "name" : "CONTENT_API_PROTOTYPE", "value" : "yes" },
+      { "name" : "CONTENT_STORE", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
+      { "name" : "DRAFT_CONTENT_STORE", "value" : "https://draft-content-store.${var.service_discovery_namespace_name}" },
+      { "name" : "EVENT_LOG_AWS_ACCESS_ID", "value" : "AKIAJE6VSW25CYBUMQJA" },
+      { "name" : "EVENT_LOG_AWS_BUCKETNAME", "value" : "govuk-${local.service_name}-event-log-test" },
+      { "name" : "EVENT_LOG_AWS_USERNAME", "value" : "govuk-${local.service_name}-event-log_user" },
+      { "name" : "DEFAULT_TTL", "value" : "1800" },
+      { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
+      { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
+      { "name" : "GOVUK_APP_NAME", "value" : "publishing-api" },
+      { "name" : "GOVUK_APP_TYPE", "value" : "rack" },
+      { "name" : "GOVUK_CONTENT_SCHEMAS_PATH", "value" : "/govuk-content-schemas" },
+      { "name" : "GOVUK_GROUP", "value" : "deploy" }, # TODO: clean up?
+      { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
+      { "name" : "GOVUK_USER", "value" : "deploy" }, # TODO: clean up?
+      { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
+      { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
+      { "name" : "PLEK_SERVICE_DRAFT_CONTENT_STORE_URI", "value" : "http://draft-content-store.${var.service_discovery_namespace_name}" },
+      { "name" : "PORT", "value" : "80" },
+      { "name" : "RABBITMQ_HOSTS", "value" : "rabbitmq.${var.govuk_app_domain_internal}" },
+      { "name" : "RABBITMQ_USER", "value" : "publishing_api" },
+      { "name" : "RABBITMQ_VHOST", "value" : "/" },
+      { "name" : "REDIS_HOST", "value" : var.redis_host },
+      { "name" : "REDIS_PORT", "value" : tostring(var.redis_port) },
+      { "name" : "REDIS_URL", "value" : "redis://${var.redis_host}:${var.redis_port}" },
+      { "name" : "RAILS_ENV", "value" : "production" },
+      { "name" : "STATSD_PROTOCOL", "value" : "tcp" },
+      { "name" : "STATSD_HOST", "value" : var.statsd_host },
+      { "name" : "UNICORN_WORKER_PROCESSES", "value" : "8" }
+    ],
+    "dependsOn" : [{
+      "containerName" : "envoy",
+      "condition" : "START"
+    }],
+    "logConfiguration" : {
+      "logDriver" : "awslogs",
+      "options" : {
+        "awslogs-create-group" : "true",
+        "awslogs-group" : "awslogs-fargate",
+        "awslogs-region" : "eu-west-1",
+        "awslogs-stream-prefix" : "awslogs-${local.service_name}"
+      }
+    },
+    "mountPoints" : [],
+    "secrets" : [
+      {
+        "name" : "CONTENT_STORE_BEARER_TOKEN",
+        "valueFrom" : data.aws_secretsmanager_secret.content_store_bearer_token.arn
+      },
+      {
+        "name" : "DATABASE_URL",
+        "valueFrom" : data.aws_secretsmanager_secret.database_url.arn
+      },
+      {
+        "name" : "DRAFT_CONTENT_STORE_BEARER_TOKEN",
+        "valueFrom" : data.aws_secretsmanager_secret.draft_content_store_bearer_token.arn
+      },
+      {
+        "name" : "EVENT_LOG_AWS_SECRET_KEY",
+        "valueFrom" : data.aws_secretsmanager_secret.event_log_aws_secret_key.arn
+      },
+      {
+        "name" : "GDS_SSO_OAUTH_ID",
+        "valueFrom" : data.aws_secretsmanager_secret.oauth_id.arn
+      },
+      {
+        "name" : "GDS_SSO_OAUTH_SECRET",
+        "valueFrom" : data.aws_secretsmanager_secret.oauth_secret.arn
+      },
+      {
+        "name" : "RABBITMQ_PASSWORD",
+        "valueFrom" : data.aws_secretsmanager_secret.rabbitmq_password.arn
+      },
+      {
+        "name" : "ROUTER_API_BEARER_TOKEN",
+        "valueFrom" : data.aws_secretsmanager_secret.router_api_bearer_token.arn
+      },
+      {
+        "name" : "SECRET_KEY_BASE",
+        "valueFrom" : data.aws_secretsmanager_secret.secret_key_base.arn
+      },
+      {
+        "name" : "SENTRY_DSN",
+        "valueFrom" : data.aws_secretsmanager_secret.sentry_dsn.arn
+      }
+    ]
+  }
+
+  worker_container_parameters = {
+    "name" : "${local.service_name}-worker",
+    "command" : ["foreman", "run", "worker"],
+    "portMappings" : []
+  }
+
+  web_container_parameters = {
+    "name" : local.service_name,
+    "command" : ["foreman", "run", "web"],
+    "portMappings" : [
+      {
+        "containerPort" : 80,
+        "hostPort" : 80,
+        "protocol" : "tcp"
+      }
+    ]
+  }
+}
+
 module "task_definition" {
   source             = "../../task-definition"
   mesh_name          = var.mesh_name
@@ -69,105 +182,7 @@ module "task_definition" {
   task_role_arn      = var.task_role_arn
 
   container_definitions = [
-    {
-      "name" : local.service_name,
-      "image" : "govuk/${local.service_name}:${var.image_tag}",
-      "essential" : true,
-      "environment" : [
-        # TODO: factor our hardcoded stuff
-        { "name" : "CONTENT_API_PROTOTYPE", "value" : "yes" },
-        { "name" : "CONTENT_STORE", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
-        { "name" : "DRAFT_CONTENT_STORE", "value" : "https://draft-content-store.${var.service_discovery_namespace_name}" },
-        { "name" : "EVENT_LOG_AWS_ACCESS_ID", "value" : "AKIAJE6VSW25CYBUMQJA" },
-        { "name" : "EVENT_LOG_AWS_BUCKETNAME", "value" : "govuk-${local.service_name}-event-log-test" },
-        { "name" : "EVENT_LOG_AWS_USERNAME", "value" : "govuk-${local.service_name}-event-log_user" },
-        { "name" : "DEFAULT_TTL", "value" : "1800" },
-        { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
-        { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
-        { "name" : "GOVUK_APP_NAME", "value" : "publishing-api" },
-        { "name" : "GOVUK_APP_TYPE", "value" : "rack" },
-        { "name" : "GOVUK_CONTENT_SCHEMAS_PATH", "value" : "/govuk-content-schemas" },
-        { "name" : "GOVUK_GROUP", "value" : "deploy" }, # TODO: clean up?
-        { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
-        { "name" : "GOVUK_USER", "value" : "deploy" }, # TODO: clean up?
-        { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
-        { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : "http://content-store.${var.service_discovery_namespace_name}" },
-        { "name" : "PLEK_SERVICE_DRAFT_CONTENT_STORE_URI", "value" : "http://draft-content-store.${var.service_discovery_namespace_name}" },
-        { "name" : "PORT", "value" : "80" },
-        { "name" : "RABBITMQ_HOSTS", "value" : "rabbitmq.${var.govuk_app_domain_internal}" },
-        { "name" : "RABBITMQ_USER", "value" : "publishing_api" },
-        { "name" : "RABBITMQ_VHOST", "value" : "/" },
-        { "name" : "REDIS_HOST", "value" : var.redis_host },
-        { "name" : "REDIS_PORT", "value" : tostring(var.redis_port) },
-        { "name" : "REDIS_URL", "value" : "redis://${var.redis_host}:${var.redis_port}" },
-        { "name" : "RAILS_ENV", "value" : "production" },
-        { "name" : "STATSD_PROTOCOL", "value" : "tcp" },
-        { "name" : "STATSD_HOST", "value" : var.statsd_host },
-        { "name" : "UNICORN_WORKER_PROCESSES", "value" : "8" }
-      ],
-      "dependsOn" : [{
-        "containerName" : "envoy",
-        "condition" : "START"
-      }],
-      "logConfiguration" : {
-        "logDriver" : "awslogs",
-        "options" : {
-          "awslogs-create-group" : "true",
-          "awslogs-group" : "awslogs-fargate",
-          "awslogs-region" : "eu-west-1",
-          "awslogs-stream-prefix" : "awslogs-${local.service_name}"
-        }
-      },
-      "mountPoints" : [],
-      "portMappings" : [
-        {
-          "containerPort" : 80,
-          "hostPort" : 80,
-          "protocol" : "tcp"
-        }
-      ],
-      "secrets" : [
-        {
-          "name" : "CONTENT_STORE_BEARER_TOKEN",
-          "valueFrom" : data.aws_secretsmanager_secret.content_store_bearer_token.arn
-        },
-        {
-          "name" : "DATABASE_URL",
-          "valueFrom" : data.aws_secretsmanager_secret.database_url.arn
-        },
-        {
-          "name" : "DRAFT_CONTENT_STORE_BEARER_TOKEN",
-          "valueFrom" : data.aws_secretsmanager_secret.draft_content_store_bearer_token.arn
-        },
-        {
-          "name" : "EVENT_LOG_AWS_SECRET_KEY",
-          "valueFrom" : data.aws_secretsmanager_secret.event_log_aws_secret_key.arn
-        },
-        {
-          "name" : "GDS_SSO_OAUTH_ID",
-          "valueFrom" : data.aws_secretsmanager_secret.oauth_id.arn
-        },
-        {
-          "name" : "GDS_SSO_OAUTH_SECRET",
-          "valueFrom" : data.aws_secretsmanager_secret.oauth_secret.arn
-        },
-        {
-          "name" : "RABBITMQ_PASSWORD",
-          "valueFrom" : data.aws_secretsmanager_secret.rabbitmq_password.arn
-        },
-        {
-          "name" : "ROUTER_API_BEARER_TOKEN",
-          "valueFrom" : data.aws_secretsmanager_secret.router_api_bearer_token.arn
-        },
-        {
-          "name" : "SECRET_KEY_BASE",
-          "valueFrom" : data.aws_secretsmanager_secret.secret_key_base.arn
-        },
-        {
-          "name" : "SENTRY_DSN",
-          "valueFrom" : data.aws_secretsmanager_secret.sentry_dsn.arn
-        }
-      ]
-    }
+    merge(local.default_container_definition, local.web_container_parameters),
+    merge(local.default_container_definition, local.worker_container_parameters),
   ]
 }

--- a/terraform/modules/task-definitions/publishing-api/variables.tf
+++ b/terraform/modules/task-definitions/publishing-api/variables.tf
@@ -53,3 +53,9 @@ variable "assume_role_arn" {
   description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
   default     = null
 }
+
+variable "worker_count" {
+  type        = number
+  description = "Specify the number of worker containers per task"
+  default     = 1
+}


### PR DESCRIPTION
This is a spike to illustrate the design for [Sidekiq workers in ECS](https://docs.google.com/document/d/1XyzUHH-M1xxH7SMhRYyoJqxjZHOHeD2x-ZSX11EHh_k/edit#) (internal)

A summary of the design doc is below.

## Problem

The GOV.UK publishing platform runs [Sidekiq](https://github.com/mperham/sidekiq) (Redis-backed queue) to process jobs asynchronously. Workers are involved in cases such as sending emails and publishing content.

## Spiked solution

When Sidekiq workers are required, we will run a sidecar container in ECS. This is demonstrated in these commits.

Where necessary, a task will run an additional container (another instance of the same app image) with the Docker CMD set in the ECS Container Definition (e.g., but not necessarily) `foreman run worker`.

This will enable us to vertically scale the Sidekiq instances, since we can increase the CPU/Memory of individual containers in the Container Definition, in addition to the resources available to the task in the Task Definition.

We can also run multiple workers as sidecar containers. However, there is a limit to the independent horizontal scalability of this approach, since Fargate tasks don't scale infinitely (Max sizing: 4 vCPUs and 30GB Memory). See the final commit for an example of how this could work.

## Other options

**Run web and worker process within the same containers**

Since we will require apps to have a [Procfile](https://ddollar.github.io/foreman/#PROCFILE), we could use `foreman start` rather than `foreman run web` as the Docker CMD, which would start both processes.

Benefits: Minimal infrastructure changes required.
Downsides: Not possible to independently scale web and worker processes.

**Run workers as a separate ECS Service**

We could create a separate ECS Service to run Sidekiq.

Benefits: Fully independent vertical and horizontal scaling possible for web and worker processes. Enables easier autoscaling of each process. Don't have to build a new task definition for ad-hoc tasks.
Downsides: Possibility of worker services being out of sync with web services, making rollbacks more involved. More Terraform and Concourse configuration.