### PR TITLE
Fix word splitting if APPLICATION contains spaces

### DIFF
--- a/concourse/tasks/update-ecs-service.yml
+++ b/concourse/tasks/update-ecs-service.yml
@@ -30,7 +30,7 @@ run:
 
       echo "Updating $APPLICATION service..."
 
-      task_definition_arn="$(cat terraform-outputs/${APPLICATION}_task_definition_arn)"
+      task_definition_arn="$(cat "terraform-outputs/${APPLICATION}_task_definition_arn")"
 
       aws ecs update-service \
         --cluster govuk \


### PR DESCRIPTION
This is unlikely to happen in practice, but it's good practice to quote
variables so that word splitting doesn't happen in unexpected places.

At some point we should set up some CI to run shellcheck on these
snippets (e.g. using
[pipecleaner](https://github.com/alphagov/paas-cf/tree/master/tools/pipecleaner))