### PR TITLE
Fix Redis cluster

### DIFF
--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -466,4 +466,14 @@ resource "aws_security_group_rule" "draft_router_from_draft_router_api_tcp" {
   source_security_group_id = module.draft_router_api_service.app_security_group_id
 }
 
+resource "aws_security_group_rule" "redis_to_any_any" {
+  description       = "Redis cluster sends requests to anywhere over any protocol"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = module.shared_redis_cluster.security_group_id
+}
+
 # TODO: move the rest of the rules into this file.

--- a/terraform/modules/redis/main.tf
+++ b/terraform/modules/redis/main.tf
@@ -20,19 +20,15 @@ resource "aws_security_group" "redis" {
 
 resource "aws_elasticache_replication_group" "redis_cluster" {
   replication_group_id          = var.cluster_name
-  replication_group_description = "${var.cluster_name} redis cluster"
+  replication_group_description = "${var.cluster_name} Redis cluster with Redis master and replica"
   node_type                     = var.node_type
   port                          = 6379
-  parameter_group_name          = "default.redis3.2.cluster.on"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis3.2"
   automatic_failover_enabled    = true
   engine_version                = "3.2.10"
   subnet_group_name             = aws_elasticache_subnet_group.redis_cluster_subnet_group.name
   security_group_ids            = [aws_security_group.redis.id]
-
-  cluster_mode {
-    replicas_per_node_group = 1
-    num_node_groups         = 1
-  }
 }
 
 
@@ -48,5 +44,5 @@ resource "aws_route53_record" "internal_service_record" {
   name    = "${var.cluster_name}-redis.${var.internal_domain_name}"
   type    = "CNAME"
   ttl     = 300
-  records = [aws_elasticache_replication_group.redis_cluster.configuration_endpoint_address]
+  records = [aws_elasticache_replication_group.redis_cluster.primary_endpoint_address]
 }


### PR DESCRIPTION
This fixes #87 by turning off clustering mode for the Redis cluster
because some apps are not compatible/configured with that feature.

We also add a security group to allow traffic to exit the Redis cluster.

Ref:
1. [aws docs](https://aws.amazon.com/blogs/database/work-with-cluster-mode-on-amazon-elasticache-for-redis/)