### PR TITLE
Refactor mesh subdomain

### DIFF
--- a/terraform/deployments/apps/publishing-api-web/main.tf
+++ b/terraform/deployments/apps/publishing-api-web/main.tf
@@ -29,7 +29,6 @@ module "task_definition" {
   govuk_website_root               = local.website_root
   image_tag                        = "bilbof_dockerfile-fix" # TODO: Pinned due to content-schemas issue
   mesh_name                        = var.mesh_name
-  mesh_subdomain                   = "publishing-api"
   service_discovery_namespace_name = local.service_discovery_namespace_name
   statsd_host                      = local.statsd_host
   execution_role_arn               = data.aws_iam_role.execution.arn

--- a/terraform/deployments/apps/publishing-api-worker/main.tf
+++ b/terraform/deployments/apps/publishing-api-worker/main.tf
@@ -30,7 +30,6 @@ module "task_definition" {
   govuk_website_root               = local.website_root
   image_tag                        = "bilbof_dockerfile-fix" # TODO: Pinned due to content-schemas issue
   mesh_name                        = var.mesh_name
-  mesh_subdomain                   = "publishing-api-worker"
   service_discovery_namespace_name = local.service_discovery_namespace_name
   statsd_host                      = local.statsd_host
   execution_role_arn               = data.aws_iam_role.execution.arn

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -12,7 +12,7 @@ terraform {
 }
 
 locals {
-  subdomain               = coalesce(var.mesh_subdomain, var.service_name)
+  subdomain               = var.service_name
   container_services      = "${length(var.custom_container_services) == 0 ? [{ container_service = "${local.subdomain}", port = 80, protocol = "http" }] : var.custom_container_services}"
   service_security_groups = concat([aws_security_group.service.id], var.extra_security_groups)
 }

--- a/terraform/modules/app/variables.tf
+++ b/terraform/modules/app/variables.tf
@@ -16,12 +16,6 @@ variable "mesh_name" {
   type = string
 }
 
-variable "mesh_subdomain" {
-  type        = string
-  default     = ""
-  description = "The subdomain for the service in Cloud Map. Defaults to service_name if unset."
-}
-
 variable "service_discovery_namespace_id" {
   type = string
 }

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -15,7 +15,6 @@ module "app" {
   service_name                     = "${var.service_name}-web"
   subnets                          = var.private_subnets
   mesh_name                        = var.mesh_name
-  mesh_subdomain                   = "publisher"
   desired_count                    = var.desired_count
   service_discovery_namespace_id   = var.service_discovery_namespace_id
   service_discovery_namespace_name = var.service_discovery_namespace_name

--- a/terraform/modules/apps/publishing-api/main.tf
+++ b/terraform/modules/apps/publishing-api/main.tf
@@ -16,7 +16,6 @@ module "web" {
   subnets                          = var.private_subnets
   mesh_name                        = var.mesh_name
   desired_count                    = var.desired_count
-  mesh_subdomain                   = "publishing-api"
   service_discovery_namespace_id   = var.service_discovery_namespace_id
   service_discovery_namespace_name = var.service_discovery_namespace_name
   extra_security_groups            = [var.govuk_management_access_security_group]
@@ -31,7 +30,6 @@ module "worker" {
   subnets                          = var.private_subnets
   mesh_name                        = var.mesh_name
   desired_count                    = var.desired_count
-  mesh_subdomain                   = "publishing-api-worker"
   service_discovery_namespace_id   = var.service_discovery_namespace_id
   service_discovery_namespace_name = var.service_discovery_namespace_name
   extra_security_groups            = [module.web.security_group_id, var.govuk_management_access_security_group]

--- a/terraform/modules/task-definition/main.tf
+++ b/terraform/modules/task-definition/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 locals {
-  virtual_node_name = coalesce(var.mesh_subdomain, var.service_name)
+  virtual_node_name = var.service_name
 
   container_definitions = [
     {

--- a/terraform/modules/task-definition/variables.tf
+++ b/terraform/modules/task-definition/variables.tf
@@ -2,12 +2,6 @@ variable "mesh_name" {
   type = string
 }
 
-variable "mesh_subdomain" {
-  type        = string
-  default     = ""
-  description = "Must match the mesh_subdomain defined in the app module. Defaults to service_name if unset."
-}
-
 variable "service_name" {
   description = "Service name of the Fargate service, cluster, task etc."
   type        = string

--- a/terraform/modules/task-definitions/content-store/main.tf
+++ b/terraform/modules/task-definitions/content-store/main.tf
@@ -61,7 +61,7 @@ module "task_definition" {
         { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
         { "name" : "MONGODB_URI", "value" : var.mongodb_url },
         { "name" : "PLEK_SERVICE_PERFORMANCEPLATFORM_BIG_SCREEN_VIEW_URI", "value" : "" },
-        { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api.${var.service_discovery_namespace_name}" },
+        { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api-web.${var.service_discovery_namespace_name}" },
         { "name" : "PLEK_SERVICE_ROUTER_API_URI", "value" : "http://${var.router_api_hostname_prefix}router-api.${var.service_discovery_namespace_name}" },
         { "name" : "PLEK_SERVICE_RUMMAGER_URI", "value" : "" },
         { "name" : "PLEK_SERVICE_SPOTLIGHT_URI", "value" : "" },

--- a/terraform/modules/task-definitions/frontend/main.tf
+++ b/terraform/modules/task-definitions/frontend/main.tf
@@ -50,7 +50,7 @@ module "task_definition" {
         { "name" : "PORT", "value" : "80" },
         { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : var.content_store_url },
         { "name" : "PLEK_SERVICE_STATIC_URI", "value" : var.static_url },
-        { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api.${var.service_discovery_namespace_name}" },
+        { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api-web.${var.service_discovery_namespace_name}" },
         { "name" : "GOVUK_ASSET_ROOT", "value" : var.assets_url },
         { "name" : "SENTRY_ENVIRONMENT", "value" : var.sentry_environment },
         { "name" : "STATSD_PROTOCOL", "value" : "tcp" },

--- a/terraform/modules/task-definitions/publisher/main.tf
+++ b/terraform/modules/task-definitions/publisher/main.tf
@@ -67,7 +67,6 @@ module "task_definition" {
   service_name       = var.service_name
   cpu                = 512
   memory             = 1024
-  mesh_subdomain     = var.mesh_subdomain
   execution_role_arn = var.execution_role_arn
   task_role_arn      = var.task_role_arn
   container_definitions = [

--- a/terraform/modules/task-definitions/publisher/main.tf
+++ b/terraform/modules/task-definitions/publisher/main.tf
@@ -97,7 +97,7 @@ module "task_definition" {
         { "name" : "GOVUK_USER", "value" : "deploy" },
         { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
         { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : "https://www.gov.uk/api" }, # TODO: looks suspicious
-        { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api.${var.service_discovery_namespace_name}" },
+        { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api-web.${var.service_discovery_namespace_name}" },
         { "name" : "PLEK_SERVICE_STATIC_URI", "value" : "https://assets.test.publishing.service.gov.uk" },
         { "name" : "PORT", "value" : "80" },
         { "name" : "RAILS_ENV", "value" : "production" },

--- a/terraform/modules/task-definitions/publisher/variables.tf
+++ b/terraform/modules/task-definitions/publisher/variables.tf
@@ -21,11 +21,6 @@ variable "mesh_name" {
   type = string
 }
 
-variable "mesh_subdomain" {
-  type    = string
-  default = "publisher"
-}
-
 variable "execution_role_arn" {
   type = string
 }

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -65,7 +65,6 @@ module "task_definition" {
   service_name       = var.service_name
   cpu                = 512
   memory             = 1024
-  mesh_subdomain     = var.mesh_subdomain
   execution_role_arn = var.execution_role_arn
   task_role_arn      = var.task_role_arn
 

--- a/terraform/modules/task-definitions/publishing-api/variables.tf
+++ b/terraform/modules/task-definitions/publishing-api/variables.tf
@@ -29,11 +29,6 @@ variable "mesh_name" {
   type = string
 }
 
-variable "mesh_subdomain" {
-  type    = string
-  default = "publishing-api"
-}
-
 variable "redis_host" {
   type = string
 }


### PR DESCRIPTION
The ECS services; publishing-api and publisher have DNS subdomains and mesh_subdomains. To make these variables easier to understand we have changed the internal DNS record to the service name (for example, `publishing-api-web.mesh`) 

Trello: https://trello.com/c/hFvyUMeC/312-change-web-process-subdomains-to-include-web-suffix