### PR TITLE
fixes for publishing workflow

### DIFF
--- a/terraform/deployments/apps/draft-router-api/main.tf
+++ b/terraform/deployments/apps/draft-router-api/main.tf
@@ -23,14 +23,16 @@ provider "aws" {
 }
 
 module "task_definition" {
-  source             = "../../../modules/task-definitions/router-api"
-  service_name       = "draft-router-api"
-  image_tag          = var.image_tag
-  mesh_name          = var.mesh_name
-  execution_role_arn = data.aws_iam_role.execution.arn
-  mongodb_url        = var.draft_router_mongodb_url
-  router_urls        = local.draft_router_urls
-  task_role_arn      = data.aws_iam_role.task.arn
-  sentry_environment = var.sentry_environment
-  assume_role_arn    = var.assume_role_arn
+  source                           = "../../../modules/task-definitions/router-api"
+  service_name                     = "draft-router-api"
+  image_tag                        = var.image_tag
+  mesh_name                        = var.mesh_name
+  service_discovery_namespace_name = local.service_discovery_namespace_name
+  govuk_app_domain_external        = var.app_domain
+  execution_role_arn               = data.aws_iam_role.execution.arn
+  mongodb_url                      = var.draft_router_mongodb_url
+  router_urls                      = local.draft_router_urls
+  task_role_arn                    = data.aws_iam_role.task.arn
+  sentry_environment               = var.sentry_environment
+  assume_role_arn                  = var.assume_role_arn
 }

--- a/terraform/deployments/apps/draft-router/main.tf
+++ b/terraform/deployments/apps/draft-router/main.tf
@@ -23,14 +23,16 @@ provider "aws" {
 }
 
 module "task_definition" {
-  source             = "../../../modules/task-definitions/router"
-  service_name       = "draft-router"
-  image_tag          = var.image_tag
-  mesh_name          = var.mesh_name
-  execution_role_arn = data.aws_iam_role.execution.arn
-  db_name            = "draft_router"
-  mongodb_url        = var.draft_router_mongodb_url
-  task_role_arn      = data.aws_iam_role.task.arn
-  sentry_environment = var.sentry_environment
-  assume_role_arn    = var.assume_role_arn
+  source                           = "../../../modules/task-definitions/router"
+  service_name                     = "draft-router"
+  image_tag                        = var.image_tag
+  mesh_name                        = var.mesh_name
+  execution_role_arn               = data.aws_iam_role.execution.arn
+  db_name                          = "draft_router"
+  mongodb_url                      = var.draft_router_mongodb_url
+  service_discovery_namespace_name = local.service_discovery_namespace_name
+  govuk_app_domain_external        = var.app_domain
+  task_role_arn                    = data.aws_iam_role.task.arn
+  sentry_environment               = var.sentry_environment
+  assume_role_arn                  = var.assume_role_arn
 }

--- a/terraform/deployments/apps/router-api/main.tf
+++ b/terraform/deployments/apps/router-api/main.tf
@@ -23,14 +23,16 @@ provider "aws" {
 }
 
 module "task_definition" {
-  source             = "../../../modules/task-definitions/router-api"
-  service_name       = "router-api"
-  image_tag          = var.image_tag
-  mesh_name          = var.mesh_name
-  execution_role_arn = data.aws_iam_role.execution.arn
-  mongodb_url        = var.router_mongodb_url
-  router_urls        = local.router_urls
-  task_role_arn      = data.aws_iam_role.task.arn
-  sentry_environment = var.sentry_environment
-  assume_role_arn    = var.assume_role_arn
+  source                           = "../../../modules/task-definitions/router-api"
+  service_name                     = "router-api"
+  image_tag                        = var.image_tag
+  mesh_name                        = var.mesh_name
+  execution_role_arn               = data.aws_iam_role.execution.arn
+  mongodb_url                      = var.router_mongodb_url
+  service_discovery_namespace_name = local.service_discovery_namespace_name
+  govuk_app_domain_external        = var.app_domain
+  router_urls                      = local.router_urls
+  task_role_arn                    = data.aws_iam_role.task.arn
+  sentry_environment               = var.sentry_environment
+  assume_role_arn                  = var.assume_role_arn
 }

--- a/terraform/deployments/apps/router/main.tf
+++ b/terraform/deployments/apps/router/main.tf
@@ -23,14 +23,16 @@ provider "aws" {
 }
 
 module "task_definition" {
-  source             = "../../../modules/task-definitions/router"
-  service_name       = "router"
-  image_tag          = var.image_tag
-  mesh_name          = var.mesh_name
-  execution_role_arn = data.aws_iam_role.execution.arn
-  db_name            = "router"
-  mongodb_url        = var.router_mongodb_url
-  task_role_arn      = data.aws_iam_role.task.arn
-  sentry_environment = var.sentry_environment
-  assume_role_arn    = var.assume_role_arn
+  source                           = "../../../modules/task-definitions/router"
+  service_name                     = "router"
+  image_tag                        = var.image_tag
+  mesh_name                        = var.mesh_name
+  execution_role_arn               = data.aws_iam_role.execution.arn
+  db_name                          = "router"
+  mongodb_url                      = var.router_mongodb_url
+  service_discovery_namespace_name = local.service_discovery_namespace_name
+  govuk_app_domain_external        = var.app_domain
+  task_role_arn                    = data.aws_iam_role.task.arn
+  sentry_environment               = var.sentry_environment
+  assume_role_arn                  = var.assume_role_arn
 }

--- a/terraform/modules/apps/router-api/main.tf
+++ b/terraform/modules/apps/router-api/main.tf
@@ -19,5 +19,4 @@ module "app" {
   service_discovery_namespace_id   = var.service_discovery_namespace_id
   service_discovery_namespace_name = var.service_discovery_namespace_name
   extra_security_groups            = [var.govuk_management_access_security_group]
-  custom_container_services        = [{ container_service = var.service_name, port = "3056", protocol = "tcp" }]
 }

--- a/terraform/modules/apps/router/main.tf
+++ b/terraform/modules/apps/router/main.tf
@@ -19,5 +19,5 @@ module "app" {
   service_discovery_namespace_id   = var.service_discovery_namespace_id
   service_discovery_namespace_name = var.service_discovery_namespace_name
   extra_security_groups            = [var.govuk_management_access_security_group]
-  custom_container_services        = [{ container_service = var.service_name, port = "3054", protocol = "tcp" }, { container_service = "${var.service_name}-reload", port = "3055", protocol = "tcp" }]
+  custom_container_services        = [{ container_service = var.service_name, port = "80", protocol = "tcp" }, { container_service = "${var.service_name}-reload", port = "3055", protocol = "tcp" }]
 }

--- a/terraform/modules/task-definitions/publisher/main.tf
+++ b/terraform/modules/task-definitions/publisher/main.tf
@@ -100,6 +100,8 @@ module "task_definition" {
         { "name" : "PLEK_SERVICE_CONTENT_STORE_URI", "value" : "https://www.gov.uk/api" }, # TODO: looks suspicious
         { "name" : "PLEK_SERVICE_PUBLISHING_API_URI", "value" : "http://publishing-api.${var.service_discovery_namespace_name}" },
         { "name" : "PLEK_SERVICE_STATIC_URI", "value" : "https://assets.test.publishing.service.gov.uk" },
+        # TODO: remove PLEK_SERVICE_DRAFT_ORIGIN_URI once we have the draft origin properly set up with multiple frontends
+        { "name" : "PLEK_SERVICE_DRAFT_ORIGIN_URI", "value" : "https://draft-frontend.${var.govuk_app_domain_external}" },
         { "name" : "PORT", "value" : "80" },
         { "name" : "RAILS_ENV", "value" : "production" },
         { "name" : "RAILS_SERVE_STATIC_FILES", "value" : "true" }, # TODO: temporary hack?

--- a/terraform/modules/task-definitions/router-api/main.tf
+++ b/terraform/modules/task-definitions/router-api/main.tf
@@ -39,7 +39,7 @@ module "task_definition" {
   memory                  = 1024
   execution_role_arn      = var.execution_role_arn
   task_role_arn           = var.task_role_arn
-  container_ingress_ports = "3056"
+  container_ingress_ports = "80"
 
   container_definitions = [
     {
@@ -47,12 +47,15 @@ module "task_definition" {
       "image" : "govuk/router-api:${var.image_tag}",
       "essential" : true,
       "environment" : [
+        { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
+        { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
         { "name" : "GOVUK_APP_NAME", "value" : var.service_name },
         { "name" : "GOVUK_APP_ROOT", "value" : "/var/apps/${var.service_name}" },
         { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
+        { "name" : "RAILS_ENV", "value" : "production" },
         { "name" : "PORT", "value" : "80" },
         { "name" : "ROUTER_NODES", "value" : var.router_urls },
-        { "name" : "MONGO_URI", "value" : var.mongodb_url },
+        { "name" : "MONGODB_URI", "value" : var.mongodb_url },
         { "name" : "SENTRY_ENVIRONMENT", "value" : var.sentry_environment }
       ],
       "dependsOn" : [{

--- a/terraform/modules/task-definitions/router-api/variables.tf
+++ b/terraform/modules/task-definitions/router-api/variables.tf
@@ -37,3 +37,11 @@ variable "router_urls" {
   type        = string
   description = "Comma-separated list of router nodes"
 }
+
+variable "service_discovery_namespace_name" {
+  type = string
+}
+
+variable "govuk_app_domain_external" {
+  type = string
+}

--- a/terraform/modules/task-definitions/router/main.tf
+++ b/terraform/modules/task-definitions/router/main.tf
@@ -27,7 +27,7 @@ module "task_definition" {
   memory                  = 1024
   execution_role_arn      = var.execution_role_arn
   task_role_arn           = var.task_role_arn
-  container_ingress_ports = "3054,3055"
+  container_ingress_ports = "80"
 
   container_definitions = [
     {
@@ -35,10 +35,13 @@ module "task_definition" {
       "image" : "govuk/router:${var.image_tag}",
       "essential" : true,
       "environment" : [
+        { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
+        { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
         { "name" : "GOVUK_APP_NAME", "value" : var.service_name },
         { "name" : "GOVUK_APP_ROOT", "value" : "/var/apps/${var.service_name}" },
         { "name" : "GOVUK_STATSD_PREFIX", "value" : "fargate" },
         { "name" : "PORT", "value" : "80" },
+        { "name" : "RAILS_ENV", "value" : "production" },
         { "name" : "ROUTER_APIADDR", "value" : ":3055" },
         { "name" : "ROUTER_BACKEND_HEADER_TIMEOUT", "value" : "20s" },
         { "name" : "ROUTER_PUBADDR", "value" : ":80" },

--- a/terraform/modules/task-definitions/router/variables.tf
+++ b/terraform/modules/task-definitions/router/variables.tf
@@ -36,3 +36,11 @@ variable "assume_role_arn" {
 variable "service_name" {
   type = string
 }
+
+variable "service_discovery_namespace_name" {
+  type = string
+}
+
+variable "govuk_app_domain_external" {
+  type = string
+}


### PR DESCRIPTION
fixes include:
1. missing parameters from (draft-)router and (draft-)router-api.
2. container ports
3. draft-origin address (not essential for workflow)

Some authentication fixes were done in Signon and AWS secrets
manager directly.

Tested by adding a `place` artifact in [publisher](https://publisher.test.publishing.service.gov.uk/).
Both preview and live view should display the artifact.

The signon used is still the EC2 one.

Ref:
1. [task trello card](https://trello.com/c/TNhQHa16/313-get-publishing-to-work-in-ecs)