### PR TITLE
Experimental local grafana

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,22 @@
+Local grafana
+=============
+
+As a first step towards an observability stack, here's some code to spin up a
+Grafana locally (using docker), and point it at the AWS datasources.
+
+Getting started
+---------------
+
+Run docker-compose, providing AWS session tokens as env vars to allow it to
+access AWS CloudWatch:
+
+```
+gds aws govuk-test-internal-admin -- docker-compose up
+```
+
+This will automatically run terraform using the grafana terraform provider to
+initialise the datasources and dashboards configured in the terraform
+directory.
+
+Grafana data and terraform state is persisted in docker volumes.
+

--- a/grafana/docker-compose.yml
+++ b/grafana/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3"
+services:
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+    - "3000:3000"
+    volumes:
+    - /var/lib/grafana
+    environment:
+    - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+    - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+    - GF_SECURITY_ADMIN_USER=admin
+    - GF_SECURITY_ADMIN_PASSWORD=admin
+  grafana-setup:
+    image: governmentpaas/terraform:terraform-0.13.3
+    depends_on:
+    - grafana
+    restart: "no"
+    volumes:
+    - ./terraform:/terraform:ro
+    - /terraform-data-dir
+    - /terraform-state-dir
+    entrypoint:
+    - sh
+    - -c
+    - |
+      set -eu
+
+      while ! wget -q -O - http://grafana:3000/api/health | grep "ok"; do
+        echo "Waiting for grafana to be ready..."
+        sleep 1
+      done
+
+      export TF_DATA_DIR=/terraform-data-dir
+      cd /terraform
+      terraform init -backend-config path=/terraform-state-dir/terraform.tfstate
+      terraform apply -auto-approve -var grafana_url="http://grafana:3000"
+

--- a/grafana/terraform/main.tf
+++ b/grafana/terraform/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  backend "local" {}
+}
+
+variable "grafana_url" {
+  type    = string
+  default = "http://localhost:3000"
+}
+
+provider "grafana" {
+  url  = var.grafana_url
+  auth = "admin:admin"
+}
+
+resource "grafana_data_source" "cloudwatch" {
+  type = "cloudwatch"
+  name = "cloudwatch"
+  json_data {
+    default_region = "eu-west-1"
+    auth_type      = "AWS SDK Default"
+  }
+}
+
+resource "grafana_folder" "govuk_publishing_platform" {
+  title = "GOV.UK Publishing Platform"
+}
+

--- a/grafana/terraform/system_metrics.tf
+++ b/grafana/terraform/system_metrics.tf
@@ -1,0 +1,476 @@
+locals {
+  dashboard_config = {
+    "annotations" : {
+      "list" : [
+        {
+          "builtIn" : 1,
+          "datasource" : "-- Grafana --",
+          "enable" : true,
+          "hide" : true,
+          "iconColor" : "rgba(0, 211, 255, 1)",
+          "name" : "Annotations & Alerts",
+          "type" : "dashboard"
+        }
+      ]
+    },
+    "editable" : true,
+    "gnetId" : null,
+    "graphTooltip" : 0,
+    "links" : [],
+    "panels" : [
+      {
+        "aliasColors" : {},
+        "bars" : false,
+        "dashLength" : 10,
+        "dashes" : false,
+        "datasource" : "cloudwatch",
+        "fieldConfig" : {
+          "defaults" : {
+            "custom" : {}
+          },
+          "overrides" : []
+        },
+        "fill" : 1,
+        "fillGradient" : 0,
+        "gridPos" : {
+          "h" : 8,
+          "w" : 12,
+          "x" : 0,
+          "y" : 0
+        },
+        "hiddenSeries" : false,
+        "id" : 2,
+        "legend" : {
+          "avg" : false,
+          "current" : false,
+          "max" : false,
+          "min" : false,
+          "show" : true,
+          "total" : false,
+          "values" : false
+        },
+        "lines" : true,
+        "linewidth" : 1,
+        "nullPointMode" : "null",
+        "options" : {
+          "alertThreshold" : true
+        },
+        "percentage" : false,
+        "pluginVersion" : "7.3.4",
+        "pointradius" : 2,
+        "points" : false,
+        "renderer" : "flot",
+        "seriesOverrides" : [],
+        "spaceLength" : 10,
+        "stack" : false,
+        "steppedLine" : false,
+        "targets" : [
+          {
+            "alias" : "",
+            "dimensions" : {
+              "ClusterName" : "govuk",
+              "ServiceName" : "*"
+            },
+            "expression" : "",
+            "id" : "",
+            "matchExact" : true,
+            "metricName" : "CPUUtilization",
+            "namespace" : "AWS/ECS",
+            "period" : "",
+            "queryType" : "randomWalk",
+            "refId" : "A",
+            "region" : "default",
+            "statistics" : [
+              "Average"
+            ]
+          }
+        ],
+        "thresholds" : [],
+        "timeFrom" : null,
+        "timeRegions" : [],
+        "timeShift" : null,
+        "title" : "CPU Utilization by App",
+        "tooltip" : {
+          "shared" : true,
+          "sort" : 0,
+          "value_type" : "individual"
+        },
+        "type" : "graph",
+        "xaxis" : {
+          "buckets" : null,
+          "mode" : "time",
+          "name" : null,
+          "show" : true,
+          "values" : []
+        },
+        "yaxes" : [
+          {
+            "format" : "short",
+            "label" : null,
+            "logBase" : 1,
+            "max" : "100",
+            "min" : null,
+            "show" : true
+          },
+          {
+            "format" : "short",
+            "label" : null,
+            "logBase" : 1,
+            "max" : null,
+            "min" : null,
+            "show" : true
+          }
+        ],
+        "yaxis" : {
+          "align" : false,
+          "alignLevel" : null
+        }
+      },
+      {
+        "aliasColors" : {},
+        "bars" : false,
+        "dashLength" : 10,
+        "dashes" : false,
+        "datasource" : "cloudwatch",
+        "fieldConfig" : {
+          "defaults" : {
+            "custom" : {}
+          },
+          "overrides" : []
+        },
+        "fill" : 1,
+        "fillGradient" : 0,
+        "gridPos" : {
+          "h" : 8,
+          "w" : 12,
+          "x" : 12,
+          "y" : 0
+        },
+        "hiddenSeries" : false,
+        "id" : 4,
+        "legend" : {
+          "avg" : false,
+          "current" : false,
+          "max" : false,
+          "min" : false,
+          "show" : true,
+          "total" : false,
+          "values" : false
+        },
+        "lines" : true,
+        "linewidth" : 1,
+        "nullPointMode" : "null",
+        "options" : {
+          "alertThreshold" : true
+        },
+        "percentage" : false,
+        "pluginVersion" : "7.3.4",
+        "pointradius" : 2,
+        "points" : false,
+        "renderer" : "flot",
+        "seriesOverrides" : [],
+        "spaceLength" : 10,
+        "stack" : false,
+        "steppedLine" : false,
+        "targets" : [
+          {
+            "alias" : "",
+            "dimensions" : {
+              "ClusterName" : "govuk",
+              "ServiceName" : "*"
+            },
+            "expression" : "",
+            "id" : "",
+            "matchExact" : true,
+            "metricName" : "MemoryUtilized",
+            "namespace" : "ECS/ContainerInsights",
+            "period" : "",
+            "queryType" : "randomWalk",
+            "refId" : "A",
+            "region" : "default",
+            "statistics" : [
+              "Average"
+            ]
+          }
+        ],
+        "thresholds" : [],
+        "timeFrom" : null,
+        "timeRegions" : [],
+        "timeShift" : null,
+        "title" : "Memory Utilization by App",
+        "tooltip" : {
+          "shared" : true,
+          "sort" : 0,
+          "value_type" : "individual"
+        },
+        "type" : "graph",
+        "xaxis" : {
+          "buckets" : null,
+          "mode" : "time",
+          "name" : null,
+          "show" : true,
+          "values" : []
+        },
+        "yaxes" : [
+          {
+            "format" : "short",
+            "label" : null,
+            "logBase" : 1,
+            "max" : null,
+            "min" : null,
+            "show" : true
+          },
+          {
+            "format" : "short",
+            "label" : null,
+            "logBase" : 1,
+            "max" : null,
+            "min" : null,
+            "show" : true
+          }
+        ],
+        "yaxis" : {
+          "align" : false,
+          "alignLevel" : null
+        }
+      },
+      {
+        "aliasColors" : {},
+        "bars" : false,
+        "dashLength" : 10,
+        "dashes" : false,
+        "datasource" : "cloudwatch",
+        "fieldConfig" : {
+          "defaults" : {
+            "custom" : {}
+          },
+          "overrides" : []
+        },
+        "fill" : 0,
+        "fillGradient" : 0,
+        "gridPos" : {
+          "h" : 8,
+          "w" : 12,
+          "x" : 0,
+          "y" : 8
+        },
+        "hiddenSeries" : false,
+        "id" : 6,
+        "legend" : {
+          "avg" : false,
+          "current" : false,
+          "max" : false,
+          "min" : false,
+          "show" : true,
+          "total" : false,
+          "values" : false
+        },
+        "lines" : true,
+        "linewidth" : 1,
+        "nullPointMode" : "null",
+        "options" : {
+          "alertThreshold" : true
+        },
+        "percentage" : false,
+        "pluginVersion" : "7.3.4",
+        "pointradius" : 2,
+        "points" : false,
+        "renderer" : "flot",
+        "seriesOverrides" : [],
+        "spaceLength" : 10,
+        "stack" : false,
+        "steppedLine" : false,
+        "targets" : [
+          {
+            "alias" : "",
+            "dimensions" : {
+              "ClusterName" : "govuk",
+              "ServiceName" : "*"
+            },
+            "expression" : "",
+            "id" : "",
+            "matchExact" : true,
+            "metricName" : "RunningTaskCount",
+            "namespace" : "ECS/ContainerInsights",
+            "period" : "",
+            "queryType" : "randomWalk",
+            "refId" : "A",
+            "region" : "default",
+            "statistics" : [
+              "Average"
+            ]
+          }
+        ],
+        "thresholds" : [],
+        "timeFrom" : null,
+        "timeRegions" : [],
+        "timeShift" : null,
+        "title" : "Running Task Count by App",
+        "tooltip" : {
+          "shared" : true,
+          "sort" : 0,
+          "value_type" : "individual"
+        },
+        "type" : "graph",
+        "xaxis" : {
+          "buckets" : null,
+          "mode" : "time",
+          "name" : null,
+          "show" : true,
+          "values" : []
+        },
+        "yaxes" : [
+          {
+            "format" : "short",
+            "label" : null,
+            "logBase" : 1,
+            "max" : null,
+            "min" : null,
+            "show" : true
+          },
+          {
+            "format" : "short",
+            "label" : null,
+            "logBase" : 1,
+            "max" : null,
+            "min" : null,
+            "show" : true
+          }
+        ],
+        "yaxis" : {
+          "align" : false,
+          "alignLevel" : null
+        }
+      },
+      {
+        "aliasColors" : {},
+        "bars" : false,
+        "dashLength" : 10,
+        "dashes" : false,
+        "datasource" : "cloudwatch",
+        "fieldConfig" : {
+          "defaults" : {
+            "custom" : {}
+          },
+          "overrides" : []
+        },
+        "fill" : 1,
+        "fillGradient" : 0,
+        "gridPos" : {
+          "h" : 8,
+          "w" : 12,
+          "x" : 12,
+          "y" : 8
+        },
+        "hiddenSeries" : false,
+        "id" : 8,
+        "legend" : {
+          "avg" : false,
+          "current" : false,
+          "max" : false,
+          "min" : false,
+          "show" : true,
+          "total" : false,
+          "values" : false
+        },
+        "lines" : true,
+        "linewidth" : 1,
+        "nullPointMode" : "null",
+        "options" : {
+          "alertThreshold" : true
+        },
+        "percentage" : false,
+        "pluginVersion" : "7.3.4",
+        "pointradius" : 2,
+        "points" : false,
+        "renderer" : "flot",
+        "seriesOverrides" : [],
+        "spaceLength" : 10,
+        "stack" : false,
+        "steppedLine" : false,
+        "targets" : [
+          {
+            "alias" : "",
+            "dimensions" : {
+              "ClusterName" : "govuk",
+              "ServiceName" : "*"
+            },
+            "expression" : "",
+            "id" : "",
+            "matchExact" : true,
+            "metricName" : "NetworkRxBytes",
+            "namespace" : "ECS/ContainerInsights",
+            "period" : "",
+            "queryType" : "randomWalk",
+            "refId" : "A",
+            "region" : "default",
+            "statistics" : [
+              "Average"
+            ]
+          }
+        ],
+        "thresholds" : [],
+        "timeFrom" : null,
+        "timeRegions" : [],
+        "timeShift" : null,
+        "title" : "NetworkRx by App",
+        "tooltip" : {
+          "shared" : true,
+          "sort" : 0,
+          "value_type" : "individual"
+        },
+        "type" : "graph",
+        "xaxis" : {
+          "buckets" : null,
+          "mode" : "time",
+          "name" : null,
+          "show" : true,
+          "values" : []
+        },
+        "yaxes" : [
+          {
+            "format" : "short",
+            "label" : null,
+            "logBase" : 1,
+            "max" : null,
+            "min" : null,
+            "show" : true
+          },
+          {
+            "format" : "short",
+            "label" : null,
+            "logBase" : 1,
+            "max" : null,
+            "min" : null,
+            "show" : true
+          }
+        ],
+        "yaxis" : {
+          "align" : false,
+          "alignLevel" : null
+        }
+      }
+    ],
+    "schemaVersion" : 26,
+    "style" : "dark",
+    "tags" : [],
+    "templating" : {
+      "list" : []
+    },
+    "time" : {
+      "from" : "now-6h",
+      "to" : "now"
+    },
+    "timepicker" : {},
+    "timezone" : "",
+    "title" : "System Metrics",
+    "uid" : "P4LjXx0Mk"
+  }
+}
+
+resource "grafana_dashboard" "system_metrics" {
+  folder = grafana_folder.govuk_publishing_platform.id
+
+  config_json = jsonencode(local.dashboard_config)
+}
+

--- a/grafana/terraform/versions.tf
+++ b/grafana/terraform/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    grafana = {
+      source = "grafana/grafana"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Since a lot of our metrics and logs are available through AWS APIs, it's reasonably easy to use a locally running Grafana instance to create dashboards and such.

I thought this would be a good toe in the water of the observability piece, until we've got time to deploy Grafana to ECS.

At the moment we use Puppet to configure our dashboards, which won't fly in the new world. I've used terraform instead, which I think actually works quite nicely.

I've tied everything together with a docker-compose file, so you should just be able to:

```
gds aws govuk-test-internal-admin -- docker-compose up
```

And you'll get a grafana running on http://localhost:3000, username admin, password admin, with an example dashboard already set up. This will work until your AWS session runs out.

Giving grafana admin permissions to AWS is definitely ill advised, but I think it's okay for the test account. We should create a less privileged IAM role which we're able to assume for looking at logs and metrics etc.