### PR TITLE
Move concourse_iam to its own terraform deployment

### DIFF
--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -6,6 +6,26 @@
 # the role in our account, which allows concourse to do the things it needs to
 # do.
 
+terraform {
+  backend "s3" {
+    bucket  = "govuk-terraform-test"
+    key     = "projects/concourse-iam.tfstate"
+    region  = "eu-west-1"
+    encrypt = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.13"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
 resource "aws_iam_role" "govuk_concourse_deployer" {
   name        = "govuk-concourse-deployer"
   description = "Deploys applications to ECS from Concourse"


### PR DESCRIPTION
The fact that Big Concourse has some AWS permissions isn't really
anything to do with the govuk deployment.

Additionally, having it there leads to an annoying chicken-and-egg issue
now that we're trying to have concourse deploy the terraform. The first
time concourse tries to apply deployments/govuk-test, it won't have
permission. Which means a developer will have to apply it from their
machine.

Pulling this out into its own deployment means we can have a slightly
nicer bootstrapping process:

* A developer runs `terraform apply` in `deployments/concourse-iam` to
  give concourse permission to deploy into the account
* A developer runs `fly set-pipeline` to upload the pipeline to Big
  Concourse
* The pipeline runs, applying all the other terraform deployments