### PR TITLE
Fix shell if statement in update-ecs-service

### DIFF
--- a/concourse/tasks/update-ecs-service.yml
+++ b/concourse/tasks/update-ecs-service.yml
@@ -29,13 +29,13 @@ run:
       EOF
 
       current_task_definition_arn="$(aws ecs describe-services --services "$APPLICATION" --cluster govuk --region "$AWS_REGION" | jq -r '.services[0].taskDefinition')"
-      if [ -z "${current_task_definition_arn}"]; then
+      if [ -z "${current_task_definition_arn}" ]; then
         echo "failed to retrieve current task definition for ${APPLICATION}, exiting..."
         exit 1
       fi
 
       new_task_definition_arn="$(cat "terraform-outputs/${APPLICATION}_task_definition_arn")"
-      if [ -z "${new_task_definition_arn}"]; then
+      if [ -z "${new_task_definition_arn}" ]; then
         echo "failed to retrieve new task definition for ${APPLICATION}, exiting..."
         exit 1
       fi


### PR DESCRIPTION
I spotted in Frederic's demo that when concourse runs these scripts, it
shows some errors:

```
sh: missing ]

sh: missing ]
```

This is because there's no space between the string we're checking in
the if statement and the closing `]` character.

These don't cause the script to fail, even though it's got `set -e` at
the top because they're part of an if statement.