### PR TITLE
Create modules for configuring task definitions

### DIFF
--- a/terraform/modules/app-container-definition/main.tf
+++ b/terraform/modules/app-container-definition/main.tf
@@ -1,0 +1,49 @@
+variable "name" {
+  type = string
+}
+variable "image" {
+  type = string
+}
+variable "environment_variables" {
+  type = map
+}
+variable "log_group" {
+  type = string
+}
+variable "secrets_from_arns" {
+  type = map
+}
+variable "aws_region" {
+  type = string
+}
+output "value" {
+  value = {
+    "name" : var.name,
+    "image" : var.image,
+    "essential" : true,
+    "environment" : [for key, value in var.environment_variables : { name : key, value : value }],
+    "dependsOn" : [{
+      "containerName" : "envoy",
+      "condition" : "START"
+    }],
+    "logConfiguration" : {
+      "logDriver" : "awslogs",
+      "options" : {
+        "awslogs-create-group" : "true",
+        "awslogs-group" : var.log_group,
+        "awslogs-region" : var.aws_region,
+        "awslogs-stream-prefix" : var.name,
+      }
+    },
+    "mountPoints" : [],
+    "portMappings" : [
+      {
+        "containerPort" : 80,
+        "hostPort" : 80,
+        "protocol" : "tcp"
+      }
+    ],
+    "secrets" : [for key, value in var.secrets_from_arns : { name : key, valueFrom : value }]
+  }
+}
+

--- a/terraform/modules/app-container-definition/main.tf
+++ b/terraform/modules/app-container-definition/main.tf
@@ -16,16 +16,19 @@ variable "secrets_from_arns" {
 variable "aws_region" {
   type = string
 }
+variable "depends_on" {
+  type        = map
+  default     = {}
+  description = "Other containers which this depends on (e.g. for envoy, set this to {envoy: \"START\"})"
+}
+
 output "value" {
   value = {
     "name" : var.name,
     "image" : var.image,
     "essential" : true,
     "environment" : [for key, value in var.environment_variables : { name : key, value : value }],
-    "dependsOn" : [{
-      "containerName" : "envoy",
-      "condition" : "START"
-    }],
+    "dependsOn" : [for key, value in var.depends_on : { containerName : key, condition : value }],
     "logConfiguration" : {
       "logDriver" : "awslogs",
       "options" : {

--- a/terraform/modules/envoy-configuration/main.tf
+++ b/terraform/modules/envoy-configuration/main.tf
@@ -1,0 +1,77 @@
+# See the user guide at
+# https://docs.aws.amazon.com/app-mesh/latest/userguide/app-mesh-ug.pdf
+# for more details on configuring Envoy in AppMesh
+
+variable "mesh_name" {
+  type = string
+}
+
+variable "service_name" {
+  description = "Service name of the Fargate service, cluster, task etc."
+  type        = string
+}
+
+variable "log_group" {
+  type = string
+}
+
+variable "aws_region" {
+  type = string
+}
+
+locals {
+  # 1337 is an arbitrary choice copied from the examples in the user guide.
+  user_id = "1337"
+}
+
+output "container_definition" {
+  value = {
+    "name" : "envoy",
+    # TODO: don't hardcode the version; track stable Envoy
+    # TODO: control when Envoy updates happen (but still needs to be automatic)
+    "image" : "840364872350.dkr.ecr.${var.aws_region}.amazonaws.com/aws-appmesh-envoy:v1.15.1.0-prod",
+    "user" : local.user_id,
+    "environment" : [
+      { "name" : "APPMESH_RESOURCE_ARN", "value" : "mesh/${var.mesh_name}/virtualNode/${var.service_name}" },
+    ],
+    "essential" : true,
+    "logConfiguration" : {
+      "logDriver" : "awslogs",
+      "options" : {
+        "awslogs-create-group" : "true",
+        "awslogs-group" : var.log_group,
+        "awslogs-region" : var.aws_region,
+        "awslogs-stream-prefix" : "awslogs-${var.service_name}-envoy"
+      }
+    }
+  }
+}
+
+output "proxy_properties" {
+  value = {
+    AppPorts = "80"
+
+    # From the user guide: "Envoy doesn't proxy traffic to these IP addresses.
+    # Set this value to 169.254.170.2,169.254.169.254, which ignores the Amazon
+    # EC2 metadata server and the Amazon ECS task metadata endpoint. The
+    # metadata endpoint provides IAM roles for tasks credentials. You can add
+    # additional addresses."
+    EgressIgnoredIPs = "169.254.170.2,169.254.169.254"
+
+    # From the user guide: The Envoy proxy doesn't route traffic from processes
+    # that use this user ID. You can choose any userID that you want for this
+    # property value, but this ID must be the same as the user ID for the
+    # Envoy container in your task definition. This matching allows Envoy to
+    # ignore its own traffic without usingthe proxy. Our examples use 1337 for
+    # historical purposes.
+    IgnoredUID = local.user_id
+
+    # From the user guide: "This is the egress port for the Envoy proxy
+    # container. Set this value to 15001."
+    ProxyEgressPort = 15001
+
+    # From the user guide: "This is the ingress port for the Envoy proxy
+    # container. Set this value to 15000"
+    ProxyIngressPort = 15000
+  }
+}


### PR DESCRIPTION
These modules will be used instead of the task-definition and task-definitions/* modules to create ECS Task Definitions for the GOV.UK applications (the so called "small" terraform deployments which are run by concourse).

We've kept these as simple as possible, by only having them take inputs and produce outputs - they don't create any resources in AWS directly. Instead, the deployment will create the resource using the outputs from the modules.

https://trello.com/c/u36XaWOu/320-refactor-terraform-app-deployments