### PR TITLE
Run terraform validate in a GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: get date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+
       - name: cache terraform plugins
         uses: actions/cache@v2
         env:
@@ -13,10 +18,7 @@ jobs:
         with:
           path: ~/.terraform/plugin-cache
           key:
-            ${{ runner.os }}-${{ env.cache-name }}-v1-${{ hashFiles('terraform/deployments/**/main.tf') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-v1-${{ hashFiles('terraform/deployments/**/main.tf') }}
-            ${{ runner.os }}-${{ env.cache-name }}-v1-
+            ${{ env.cache-name }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('terraform/deployments/**/main.tf', 'terraform/deployments/**/versions.tf') }}
 
       - name: install terraform
         working-directory: terraform

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,50 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: terraform fmt
+      - name: cache terraform plugins
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-terraform-plugins
+        with:
+          path: ~/.terraform/plugin-cache
+          key:
+            ${{ runner.os }}-${{ env.cache-name }}-v1-${{ hashFiles('terraform/deployments/**/main.tf') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-v1-${{ hashFiles('terraform/deployments/**/main.tf') }}
+            ${{ runner.os }}-${{ env.cache-name }}-v1-
+
+      - name: install terraform
         working-directory: terraform
         run: |
           brew install tfenv
           tfenv install
+
+      - name: terraform fmt
+        working-directory: terraform
+        run: |
           if ! terraform fmt -write=false -diff=true -list=true -recursive -check .
           then
             >&2 echo "Some terraform files weren't formatted correctly. Run 'terraform fmt' to fix them."
           fi
+
+      - name: terraform validate
+        working-directory: terraform
+        env:
+          TF_IN_AUTOMATION: true
+        run: |
+          export TF_PLUGIN_CACHE_DIR=~/.terraform/plugin-cache
+          mkdir -p "$TF_PLUGIN_CACHE_DIR"
+
+          shopt -s globstar
+
+          for f in deployments/**/main.tf; do
+            d=$(dirname "$f")
+            (
+              echo "$d"
+              cd "$d"
+              terraform init -backend=false
+              terraform validate
+              echo -e '\n-------------------------\n'
+            )
+          done
 


### PR DESCRIPTION
https://www.terraform.io/docs/commands/validate.html

> The terraform validate command validates the configuration files in a directory, referring only to the configuration and not accessing any remote services such as remote state, provider APIs, etc.

> Validate runs checks that verify whether a configuration is syntactically valid and internally consistent, regardless of any provided variables or existing state. It is thus primarily useful for general verification of reusable modules, including correctness of attribute names and value types.

> It is safe to run this command automatically, for example as a post-save check in a text editor or as a test step for a re-usable module in a CI system.

I think this is the most terraform validation we can do in GitHub
without giving it actual access to our AWS account to read statefiles
and run plans.

We could also set up a concourse job to run plans against our test AWS
account though, since concourse has already got the AWS access it would
need.