### PR TITLE
Actions: Install terraform with setup-terraform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,10 @@ jobs:
           key:
             ${{ env.cache-name }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('terraform/deployments/**/main.tf', 'terraform/deployments/**/versions.tf') }}
 
-      - name: install terraform
-        working-directory: terraform
-        run: |
-          brew install tfenv
-          tfenv install
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.13.3
+          terraform_wrapper: false
 
       - name: terraform fmt
         working-directory: terraform


### PR DESCRIPTION
Instead of `brew` and `tfenv`.

This should have much better caching than the brew / tfenv combination,
which should speed up our actions a fair bit (from a quick look, it should
save about 50 seconds on each run).

We already have the terraform version in multiple places (concourse,
tfenv, now github actions too). I don't think there's an elegant way to
have a single-source-of-truth for them, so I think the best bet is
probably to write a test to check that they're in sync.