### PR TITLE
Add `terraform fmt` as a pre-commit script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
+---
 repos:
--   repo: git@github.com:Yelp/detect-secrets
+  - repo: git@github.com:Yelp/detect-secrets
     rev: v0.14.3
     hooks:
-    -   id: detect-secrets
+      - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
+  - repo: git://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.45.0
+    hooks:
+      - id: terraform_fmt


### PR DESCRIPTION
This should help reduce the cycle time if you forget to run terraform
fmt before committing something. At the moment, you'd have to wait for
GitHub Actions to catch your mistake. This way, it will remind you
automatically.

Output looks like this:

```
Terraform fmt.................................................Failed
- hook id: terraform_fmt
- files were modified by this hook

main.tf
```

... after which there will be some unstaged changes to main.tf which you
can stage if you're happy with them.