### PR TITLE
Add workspace awareness

### DIFF
--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -27,7 +27,7 @@ provider "aws" {
 }
 
 resource "aws_iam_role" "govuk_concourse_deployer" {
-  name        = "${terraform.workspace == "default" ? "govuk-concourse-deployer" : "govuk-concourse-deployer-${terraform.workspace}"}"
+  name        = "govuk-concourse-deployer"
   description = "Deploys applications to ECS from Concourse"
 
   assume_role_policy = <<EOF

--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -27,7 +27,7 @@ provider "aws" {
 }
 
 resource "aws_iam_role" "govuk_concourse_deployer" {
-  name        = "govuk-concourse-deployer"
+  name        = "govuk-concourse-deployer-${terraform.workspace}"
   description = "Deploys applications to ECS from Concourse"
 
   assume_role_policy = <<EOF

--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -27,7 +27,7 @@ provider "aws" {
 }
 
 resource "aws_iam_role" "govuk_concourse_deployer" {
-  name        = "govuk-concourse-deployer-${terraform.workspace}"
+  name        = "${terraform.workspace == "default" ? "govuk-concourse-deployer" : "govuk-concourse-deployer-${terraform.workspace}"}"
   description = "Deploys applications to ECS from Concourse"
 
   assume_role_policy = <<EOF

--- a/terraform/deployments/govuk-test/certificates.tf
+++ b/terraform/deployments/govuk-test/certificates.tf
@@ -12,12 +12,6 @@ resource "aws_route53_record" "workspace_public_zone_ns" {
   ttl     = "30"
 
   records = aws_route53_zone.workspace_public.name_servers
-  # [
-  #   aws_route53_zone.external_zone.name_servers.0,
-  #   aws_route53_zone.external_zone.name_servers.1,
-  #   aws_route53_zone.external_zone.name_servers.2,
-  #   aws_route53_zone.external_zone.name_servers.3,
-  # ]
 }
 
 resource "aws_acm_certificate" "workspace_public" {

--- a/terraform/deployments/govuk-test/certificates.tf
+++ b/terraform/deployments/govuk-test/certificates.tf
@@ -1,0 +1,69 @@
+# TODO: Use ecs as default workspace
+# TODO: DNS Delegation from default zone
+data "aws_route53_zone" "root_public" {
+  # Created in govuk-aws
+  name = "${var.govuk_environment}.${var.public_domain}" # test.govuk.digital
+}
+
+resource "aws_route53_record" "workspace_public_zone_ns" {
+  zone_id = data.aws_route53_zone.root_public.zone_id
+  name    = local.public_lb_domain_name
+  type    = "NS"
+  ttl     = "30"
+
+  records = aws_route53_zone.workspace_public.name_servers
+  # [
+  #   aws_route53_zone.external_zone.name_servers.0,
+  #   aws_route53_zone.external_zone.name_servers.1,
+  #   aws_route53_zone.external_zone.name_servers.2,
+  #   aws_route53_zone.external_zone.name_servers.3,
+  # ]
+}
+
+resource "aws_acm_certificate" "workspace_public" {
+  domain_name       = "*.${local.public_lb_domain_name}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_zone" "workspace_public" {
+  name = local.public_lb_domain_name # plouf.test.govuk.digital
+}
+
+resource "aws_route53_zone" "internal_public" {
+  name = local.internal_domain_name # plouf.test.govuk-internal.digital
+}
+
+resource "aws_route53_zone" "internal_private" {
+  name = local.internal_domain_name # plouf.test.govuk-internal.digital
+
+  vpc {
+    vpc_id = data.terraform_remote_state.infra_networking.outputs.vpc_id
+  }
+
+}
+
+resource "aws_route53_record" "workspace_public" {
+  for_each = {
+    for dvo in aws_acm_certificate.workspace_public.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.workspace_public.zone_id
+}
+
+resource "aws_acm_certificate_validation" "workspace_public" {
+  certificate_arn         = aws_acm_certificate.workspace_public.arn
+  validation_record_fqdns = [for record in aws_route53_record.workspace_public : record.fqdn]
+}

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -64,6 +64,7 @@ module "govuk" {
   vpc_id                            = data.terraform_remote_state.infra_networking.outputs.vpc_id
   private_subnets                   = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
   public_subnets                    = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
+  public_hosted_zone_id             = aws_route53_zone.workspace_public.zone_id
   redis_subnets                     = data.terraform_remote_state.infra_networking.outputs.private_subnet_elasticache_ids
   govuk_management_access_sg_id     = data.terraform_remote_state.infra_security_groups.outputs.sg_management_id
   documentdb_security_group_id      = data.terraform_remote_state.infra_security_groups.outputs.sg_shared_documentdb_id

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -46,7 +46,7 @@ locals {
   internal_domain_name  = "${terraform.workspace == "default" ? var.internal_domain_name : "${terraform.workspace}.${var.internal_domain_name}"}" #plouf.test.govuk-internal.digital
   public_lb_subdomain   = "${terraform.workspace == "default" ? var.govuk_environment : "${terraform.workspace}.${var.govuk_environment}"}"       #plouf.test
   public_lb_domain_name = "${local.public_lb_subdomain}.${var.public_domain}"                                                                     #plouf.test.govuk.digital
-  mesh_domain           = "${var.mesh_subdomain}.${local.internal_domain_name}"                                                                   #mesh.plouf.govuk-internal.digital
+  mesh_domain           = "${var.mesh_subdomain}.${local.internal_domain_name}"                                                                   #mesh.plouf.test.govuk-internal.digital
   mesh_name             = "${terraform.workspace == "default" ? var.mesh_name : "${var.mesh_name}-${terraform.workspace}"}"                       #govuk-plouf
   ecs_cluster_name      = "${terraform.workspace == "default" ? var.ecs_cluster_name : "${var.ecs_cluster_name}-${terraform.workspace}"}"         #ecs-plouf
 }

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -42,12 +42,22 @@ data "terraform_remote_state" "infra_security_groups" {
   }
 }
 
+locals {
+  internal_domain_name  = "${terraform.workspace == "default" ? var.internal_domain_name : "${terraform.workspace}.${var.internal_domain_name}"}" #plouf.test.govuk-internal.digital
+  public_lb_subdomain   = "${terraform.workspace == "default" ? var.govuk_environment : "${terraform.workspace}.${var.govuk_environment}"}"       #plouf.test
+  public_lb_domain_name = "${local.public_lb_subdomain}.${var.public_domain}"                                                                     #plouf.test.govuk.digital
+  mesh_domain           = "${var.mesh_subdomain}.${local.internal_domain_name}"                                                                   #mesh.plouf.govuk-internal.digital
+  mesh_name             = "${terraform.workspace == "default" ? var.mesh_name : "${var.mesh_name}-${terraform.workspace}"}"                       #govuk-plouf
+  ecs_cluster_name      = "${terraform.workspace == "default" ? var.ecs_cluster_name : "${var.ecs_cluster_name}-${terraform.workspace}"}"         #govuk-plouf
+}
+
 module "govuk" {
   source                = "../../modules/govuk"
-  mesh_name             = var.mesh_name
-  mesh_domain           = var.mesh_domain
-  public_lb_domain_name = var.public_lb_domain_name
-  internal_domain_name  = var.internal_domain_name
+  mesh_name             = local.mesh_name
+  ecs_cluster_name      = local.ecs_cluster_name
+  mesh_domain           = local.mesh_domain
+  public_lb_domain_name = local.public_lb_domain_name
+  internal_domain_name  = local.internal_domain_name
 
   ecs_default_capacity_provider = var.ecs_default_capacity_provider
 

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -48,7 +48,7 @@ locals {
   public_lb_domain_name = "${local.public_lb_subdomain}.${var.public_domain}"                                                                     #plouf.test.govuk.digital
   mesh_domain           = "${var.mesh_subdomain}.${local.internal_domain_name}"                                                                   #mesh.plouf.govuk-internal.digital
   mesh_name             = "${terraform.workspace == "default" ? var.mesh_name : "${var.mesh_name}-${terraform.workspace}"}"                       #govuk-plouf
-  ecs_cluster_name      = "${terraform.workspace == "default" ? var.ecs_cluster_name : "${var.ecs_cluster_name}-${terraform.workspace}"}"         #govuk-plouf
+  ecs_cluster_name      = "${terraform.workspace == "default" ? var.ecs_cluster_name : "${var.ecs_cluster_name}-${terraform.workspace}"}"         #ecs-plouf
 }
 
 module "govuk" {

--- a/terraform/deployments/govuk-test/main.tf
+++ b/terraform/deployments/govuk-test/main.tf
@@ -85,4 +85,12 @@ module "govuk" {
   signon_desired_count              = var.signon_desired_count
   static_desired_count              = var.static_desired_count
   draft_static_desired_count        = var.draft_static_desired_count
+  depends_on = [
+    aws_route53_zone.workspace_public,
+    aws_route53_zone.internal_public,
+    aws_route53_zone.internal_private,
+    aws_acm_certificate_validation.workspace_public,
+    aws_route53_record.workspace_public,
+    aws_acm_certificate.workspace_public,
+  ]
 }

--- a/terraform/deployments/govuk-test/variables.tf
+++ b/terraform/deployments/govuk-test/variables.tf
@@ -2,6 +2,10 @@
 # Network
 #--------------------------------------------------------------
 
+variable "govuk_environment" {
+  type = string
+}
+
 variable "mesh_name" {
   type = string
 }
@@ -10,7 +14,19 @@ variable "mesh_domain" {
   type = string
 }
 
+variable "mesh_subdomain" {
+  type = string
+}
+
+variable "ecs_cluster_name" {
+  type = string
+}
+
 variable "ecs_default_capacity_provider" {
+  type = string
+}
+
+variable "public_domain" {
   type = string
 }
 

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -3,5 +3,7 @@
 #--------------------------------------------------------------
 
 # TODO: When it becomes possible, pull these from Terraform "data" type
-mesh_domain = "mesh.govuk-internal.digital"
-mesh_name   = "govuk"
+mesh_subdomain   = "mesh"
+mesh_domain      = "mesh.govuk-internal.digital"
+mesh_name        = "govuk"
+ecs_cluster_name = "govuk"

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -6,4 +6,4 @@
 mesh_subdomain   = "mesh"
 mesh_domain      = "mesh.govuk-internal.digital"
 mesh_name        = "govuk"
-ecs_cluster_name = "govuk"
+ecs_cluster_name = "ecs"

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -5,6 +5,8 @@ ecs_default_capacity_provider = "FARGATE_SPOT"
 #--------------------------------------------------------------
 
 # TODO: Could this be named more clearly?
+govuk_environment      = "test"
+public_domain          = "govuk.digital"
 public_lb_domain_name  = "test.govuk.digital"
 internal_domain_name   = "test.govuk-internal.digital"
 govuk_aws_state_bucket = "govuk-terraform-steppingstone-test"

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -4,9 +4,11 @@ ecs_default_capacity_provider = "FARGATE_SPOT"
 # Network
 #--------------------------------------------------------------
 
-# TODO: Could this be named more clearly?
 govuk_environment      = "test"
+
+# TODO: Could this be named more clearly?
 public_domain          = "govuk.digital"
+
 public_lb_domain_name  = "test.govuk.digital"
 internal_domain_name   = "test.govuk-internal.digital"
 govuk_aws_state_bucket = "govuk-terraform-steppingstone-test"

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -15,6 +15,7 @@ locals {
   subdomain               = var.service_name
   container_services      = "${length(var.custom_container_services) == 0 ? [{ container_service = "${local.subdomain}", port = 80, protocol = "http" }] : var.custom_container_services}"
   service_security_groups = concat([aws_security_group.service.id], var.extra_security_groups)
+  security_group_name     = "${terraform.workspace == "default" ? var.service_name : "${var.service_name}-${terraform.workspace}"}"
 }
 
 resource "aws_ecs_service" "service" {
@@ -63,7 +64,7 @@ module "bootstrap_task_definition" {
 }
 
 resource "aws_security_group" "service" {
-  name        = "fargate_${var.service_name}"
+  name        = "fargate_${local.security_group_name}"
   vpc_id      = var.vpc_id
-  description = "${var.service_name} app ECS tasks"
+  description = "${local.security_group_name} app ECS tasks"
 }

--- a/terraform/modules/apps/frontend/main.tf
+++ b/terraform/modules/apps/frontend/main.tf
@@ -44,7 +44,7 @@ data "aws_acm_certificate" "public_lb_alternate" {
 }
 
 resource "aws_lb" "public" {
-  name               = "fargate-public-${var.service_name}"
+  name               = "${var.service_name}-${terraform.workspace}"
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.public_alb.id]
@@ -52,7 +52,7 @@ resource "aws_lb" "public" {
 }
 
 resource "aws_lb_target_group" "public" {
-  name        = "${var.service_name}-public"
+  name        = "${var.service_name}-${terraform.workspace}"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = var.vpc_id
@@ -84,7 +84,7 @@ resource "aws_lb_listener_certificate" "publishing_service" {
 }
 
 resource "aws_security_group" "public_alb" {
-  name        = "fargate_${var.service_name}_public_alb"
+  name        = "fargate_${var.service_name}_${terraform.workspace}_public_alb"
   vpc_id      = var.vpc_id
   description = "${var.service_name} Internet-facing ALB"
 }

--- a/terraform/modules/apps/frontend/main.tf
+++ b/terraform/modules/apps/frontend/main.tf
@@ -34,7 +34,7 @@ module "app" {
 # TODO: use a single, ACM-managed cert with both domains on. There is already
 # such a cert in integration/staging/prod (but it needs defining in Terraform).
 data "aws_acm_certificate" "public_lb_default" {
-  domain   = "*.test.govuk.digital"
+  domain   = "*.${var.public_lb_domain_name}"
   statuses = ["ISSUED"]
 }
 
@@ -89,12 +89,8 @@ resource "aws_security_group" "public_alb" {
   description = "${var.service_name} Internet-facing ALB"
 }
 
-data "aws_route53_zone" "public" {
-  name = var.public_lb_domain_name
-}
-
 resource "aws_route53_record" "public_alb" {
-  zone_id = data.aws_route53_zone.public.zone_id
+  zone_id = var.public_hosted_zone_id
   name    = var.service_name
   type    = "A"
 

--- a/terraform/modules/apps/frontend/variables.tf
+++ b/terraform/modules/apps/frontend/variables.tf
@@ -25,6 +25,11 @@ variable "govuk_management_access_security_group" {
   default     = "sg-0b873470482f6232d"
 }
 
+variable "public_hosted_zone_id" {
+  description = "Hosted Zone ID to add DNS records to for Internet-facing load balancers."
+  type        = string
+}
+
 variable "service_discovery_namespace_id" {
   type = string
 }

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -61,7 +61,7 @@ data "aws_acm_certificate" "public_lb_alternate" {
 }
 
 resource "aws_lb" "public" {
-  name               = "fargate-public-${var.service_name}"
+  name               = "${var.service_name}-${terraform.workspace}"
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.public_alb.id]
@@ -69,7 +69,7 @@ resource "aws_lb" "public" {
 }
 
 resource "aws_lb_target_group" "public" {
-  name        = "${var.service_name}-public"
+  name        = "${var.service_name}-${terraform.workspace}-public"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = var.vpc_id
@@ -101,7 +101,7 @@ resource "aws_lb_listener_certificate" "publishing_service" {
 }
 
 resource "aws_security_group" "public_alb" {
-  name        = "fargate_${var.service_name}_public_alb"
+  name        = "fargate_${var.service_name}_${terraform.workspace}_public_alb"
   vpc_id      = var.vpc_id
   description = "${var.service_name} Internet-facing ALB"
 }

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -51,7 +51,7 @@ module "worker" {
 # TODO: use a single, ACM-managed cert with both domains on. There is already
 # such a cert in integration/staging/prod (but it needs defining in Terraform).
 data "aws_acm_certificate" "public_lb_default" {
-  domain   = "*.test.govuk.digital"
+  domain   = "*.${var.public_lb_domain_name}"
   statuses = ["ISSUED"]
 }
 
@@ -106,12 +106,8 @@ resource "aws_security_group" "public_alb" {
   description = "${var.service_name} Internet-facing ALB"
 }
 
-data "aws_route53_zone" "public" {
-  name = var.public_lb_domain_name
-}
-
 resource "aws_route53_record" "public_alb" {
-  zone_id = data.aws_route53_zone.public.zone_id
+  zone_id = var.public_hosted_zone_id
   name    = var.service_name
   type    = "A"
 

--- a/terraform/modules/apps/publisher/variables.tf
+++ b/terraform/modules/apps/publisher/variables.tf
@@ -21,6 +21,11 @@ variable "service_discovery_namespace_name" {
   type = string
 }
 
+variable "public_hosted_zone_id" {
+  description = "Hosted Zone ID to add DNS records to for Internet-facing load balancers."
+  type        = string
+}
+
 variable "private_subnets" {
   description = "Subnet IDs to use for non-Internet-facing resources."
   type        = list

--- a/terraform/modules/apps/signon/main.tf
+++ b/terraform/modules/apps/signon/main.tf
@@ -7,6 +7,10 @@ terraform {
   }
 }
 
+locals {
+  workspace_suffix = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
+}
+
 module "app" {
   source                           = "../../app"
   execution_role_arn               = var.execution_role_arn
@@ -35,7 +39,8 @@ module "public_alb" {
   dns_a_record_name         = "${var.service_name}-ecs"
   public_subnets            = var.public_subnets
   app_domain                = var.public_lb_domain_name # TODO: Change to app_domain
+  public_hosted_zone_id     = var.public_hosted_zone_id
   public_lb_domain_name     = var.public_lb_domain_name
-  workspace_suffix          = "govuk" # TODO: Changeme
+  workspace_suffix          = "${local.workspace_suffix}"
   service_security_group_id = module.app.security_group_id
 }

--- a/terraform/modules/apps/signon/variables.tf
+++ b/terraform/modules/apps/signon/variables.tf
@@ -29,6 +29,11 @@ variable "mesh_name" {
   type        = string
 }
 
+variable "public_hosted_zone_id" {
+  description = "Hosted Zone ID to add DNS records to for Internet-facing load balancers."
+  type        = string
+}
+
 variable "public_lb_domain_name" {
   description = "Domain in which to create DNS records for the app's Internet-facing load balancer. For example, staging.govuk.digital"
   type        = string

--- a/terraform/modules/apps/static/main.tf
+++ b/terraform/modules/apps/static/main.tf
@@ -34,7 +34,7 @@ module "app" {
 # TODO: use a single, ACM-managed cert with both domains on. There is already
 # such a cert in integration/staging/prod (but it needs defining in Terraform).
 data "aws_acm_certificate" "public_lb_default" {
-  domain   = "*.test.govuk.digital"
+  domain   = "*.${var.public_lb_domain_name}"
   statuses = ["ISSUED"]
 }
 
@@ -89,12 +89,8 @@ resource "aws_security_group" "public_alb" {
   description = "${var.service_name} Internet-facing ALB"
 }
 
-data "aws_route53_zone" "public" {
-  name = var.public_lb_domain_name
-}
-
 resource "aws_route53_record" "public_alb" {
-  zone_id = data.aws_route53_zone.public.zone_id
+  zone_id = var.public_hosted_zone_id
   name    = "${var.service_name}-ecs"
   type    = "A"
 

--- a/terraform/modules/apps/static/main.tf
+++ b/terraform/modules/apps/static/main.tf
@@ -44,7 +44,7 @@ data "aws_acm_certificate" "public_lb_alternate" {
 }
 
 resource "aws_lb" "public" {
-  name               = "fargate-public-${var.service_name}"
+  name               = "${var.service_name}-${terraform.workspace}"
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.public_alb.id]
@@ -52,7 +52,7 @@ resource "aws_lb" "public" {
 }
 
 resource "aws_lb_target_group" "public" {
-  name        = "${var.service_name}-public"
+  name        = "${var.service_name}-${terraform.workspace}-public"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = var.vpc_id
@@ -84,7 +84,7 @@ resource "aws_lb_listener_certificate" "publishing_service" {
 }
 
 resource "aws_security_group" "public_alb" {
-  name        = "fargate_${var.service_name}_public_alb"
+  name        = "fargate_${var.service_name}_${terraform.workspace}_public_alb"
   vpc_id      = var.vpc_id
   description = "${var.service_name} Internet-facing ALB"
 }

--- a/terraform/modules/apps/static/variables.tf
+++ b/terraform/modules/apps/static/variables.tf
@@ -48,6 +48,11 @@ variable "desired_count" {
   default     = 1
 }
 
+variable "public_hosted_zone_id" {
+  description = "Hosted Zone ID to add DNS records to for Internet-facing load balancers."
+  type        = string
+}
+
 variable "public_subnets" {
   description = "Subnet IDs to use for Internet-facing resources."
   type        = list

--- a/terraform/modules/govuk/ecs_cluster.tf
+++ b/terraform/modules/govuk/ecs_cluster.tf
@@ -1,6 +1,6 @@
 # All services running on GOV.UK run in this single cluster.
 resource "aws_ecs_cluster" "cluster" {
-  name               = "govuk"
+  name               = var.ecs_cluster_name
   capacity_providers = ["FARGATE", "FARGATE_SPOT"]
 
   default_capacity_provider_strategy {
@@ -29,7 +29,7 @@ resource "aws_service_discovery_private_dns_namespace" "govuk_publishing_platfor
 }
 
 resource "aws_iam_role" "execution" {
-  name        = "fargate_execution_role"
+  name        = "fargate_execution_role_${terraform.workspace}"
   description = "Role for the ECS container agent and Docker daemon to manage the app container."
 
   assume_role_policy = <<EOF
@@ -49,7 +49,7 @@ EOF
 }
 
 resource "aws_iam_policy" "create_log_group_policy" {
-  name        = "create_log_group_policy"
+  name        = "create_log_group_policy_${terraform.workspace}"
   path        = "/createLogsGroupPolicy/"
   description = "Create Logs group"
 
@@ -83,7 +83,7 @@ resource "aws_iam_role_policy_attachment" "task_exec_policy" {
 # TODO: This allows *all* apps to access *any* secret. We should create a task execution
 # role and policy for each app to permit apps to only access required secrets.
 resource "aws_iam_policy" "access_secrets" {
-  name        = "access_secrets"
+  name        = "access_secrets_${terraform.workspace}"
   path        = "/accessSecretsPolicy/"
   description = "Allow apps in ECS to access secrets"
 
@@ -113,7 +113,7 @@ resource "aws_iam_role_policy_attachment" "access_secrets_attachment_policy" {
 # Proxy authorization for ECS tasks
 # https://docs.aws.amazon.com/app-mesh/latest/userguide/proxy-authorization.html
 resource "aws_iam_role" "task" {
-  name        = "fargate_task_role"
+  name        = "fargate_task_role_${terraform.workspace}"
   description = "Role for GOV.UK Publishing app containers (ECS tasks) to talk to other AWS services."
 
   assume_role_policy = <<EOF

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -181,6 +181,7 @@ module "signon_service" {
   cluster_id                       = aws_ecs_cluster.cluster.id
   source                           = "../../modules/apps/signon"
   desired_count                    = var.signon_desired_count
+  public_hosted_zone_id            = var.public_hosted_zone_id
   public_lb_domain_name            = var.public_lb_domain_name
   public_subnets                   = var.public_subnets
 }

--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -18,6 +18,7 @@ module "frontend_service" {
   source                           = "../../modules/apps/frontend"
   execution_role_arn               = aws_iam_role.execution.arn
   desired_count                    = var.frontend_desired_count
+  public_hosted_zone_id            = var.public_hosted_zone_id
   public_subnets                   = var.public_subnets
   public_lb_domain_name            = var.public_lb_domain_name
 }
@@ -32,6 +33,7 @@ module "draft_frontend_service" {
   source                           = "../../modules/apps/frontend"
   execution_role_arn               = aws_iam_role.execution.arn
   desired_count                    = var.draft_frontend_desired_count
+  public_hosted_zone_id            = var.public_hosted_zone_id
   public_subnets                   = var.public_subnets
   public_lb_domain_name            = var.public_lb_domain_name
 }
@@ -41,6 +43,7 @@ module "publisher_service" {
   govuk_management_access_sg_id    = var.govuk_management_access_sg_id
   mesh_name                        = aws_appmesh_mesh.govuk.id
   private_subnets                  = var.private_subnets
+  public_hosted_zone_id            = var.public_hosted_zone_id
   public_subnets                   = var.public_subnets
   public_lb_domain_name            = var.public_lb_domain_name
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
@@ -147,6 +150,7 @@ module "static_service" {
   execution_role_arn               = aws_iam_role.execution.arn
   source                           = "../../modules/apps/static"
   desired_count                    = var.static_desired_count
+  public_hosted_zone_id            = var.public_hosted_zone_id
   public_subnets                   = var.public_subnets
   public_lb_domain_name            = var.public_lb_domain_name
 }
@@ -162,6 +166,7 @@ module "draft_static_service" {
   execution_role_arn               = aws_iam_role.execution.arn
   source                           = "../../modules/apps/static"
   desired_count                    = var.draft_static_desired_count
+  public_hosted_zone_id            = var.public_hosted_zone_id
   public_subnets                   = var.public_subnets
   public_lb_domain_name            = var.public_lb_domain_name
 }

--- a/terraform/modules/govuk/variables.tf
+++ b/terraform/modules/govuk/variables.tf
@@ -6,6 +6,10 @@ variable "mesh_domain" {
   type = string
 }
 
+variable "ecs_cluster_name" {
+  type = string
+}
+
 variable "mesh_name" {
   type = string
 }

--- a/terraform/modules/govuk/variables.tf
+++ b/terraform/modules/govuk/variables.tf
@@ -35,6 +35,11 @@ variable "public_lb_domain_name" {
   type        = string
 }
 
+variable "public_hosted_zone_id" {
+  description = "Hosted Zone ID to add DNS records to for Internet-facing load balancers."
+  type        = string
+}
+
 variable "govuk_management_access_sg_id" {
   description = "ID of security group (from the govuk-aws repo) for access from jumpboxes etc. This SG is added to all ECS instances."
   type        = string

--- a/terraform/modules/public-load-balancer/main.tf
+++ b/terraform/modules/public-load-balancer/main.tf
@@ -33,6 +33,7 @@ resource "aws_lb_target_group" "public" {
   health_check {
     path = "/healthcheck"
   }
+  depends_on = [aws_lb.public]
 }
 
 resource "aws_lb_listener" "public" {
@@ -48,12 +49,8 @@ resource "aws_lb_listener" "public" {
   }
 }
 
-data "aws_route53_zone" "public" {
-  name = var.public_lb_domain_name
-}
-
 resource "aws_route53_record" "public_alb" {
-  zone_id = data.aws_route53_zone.public.zone_id
+  zone_id = var.public_hosted_zone_id
   name    = var.dns_a_record_name
   type    = "A"
 

--- a/terraform/modules/public-load-balancer/variables.tf
+++ b/terraform/modules/public-load-balancer/variables.tf
@@ -18,6 +18,11 @@ variable "dns_a_record_name" {
   description = "DNS A Record name. Should be cluster and environment-aware."
 }
 
+variable "public_hosted_zone_id" {
+  description = "Hosted Zone ID to add DNS records to for Internet-facing load balancers."
+  type        = string
+}
+
 variable "public_subnets" {
   type = list
 }

--- a/terraform/modules/redis/main.tf
+++ b/terraform/modules/redis/main.tf
@@ -8,18 +8,18 @@ terraform {
 }
 
 resource "aws_elasticache_subnet_group" "redis_cluster_subnet_group" {
-  name       = var.cluster_name
+  name       = terraform.workspace == "default" ? var.cluster_name : "${var.cluster_name}-${terraform.workspace}"
   subnet_ids = var.subnet_ids
 }
 
 resource "aws_security_group" "redis" {
-  name        = "${var.cluster_name}_elasticache"
+  name        = terraform.workspace == "default" ? "${var.cluster_name}_elasticache" : "${var.cluster_name}_elasticache-${terraform.workspace}"
   vpc_id      = var.vpc_id
   description = "Access to the ${var.cluster_name} Redis cluster"
 }
 
 resource "aws_elasticache_replication_group" "redis_cluster" {
-  replication_group_id          = var.cluster_name
+  replication_group_id          = terraform.workspace == "default" ? var.cluster_name : "${var.cluster_name}-${terraform.workspace}"
   replication_group_description = "${var.cluster_name} Redis cluster with Redis master and replica"
   node_type                     = var.node_type
   port                          = 6379
@@ -41,7 +41,7 @@ data "aws_route53_zone" "internal" {
 
 resource "aws_route53_record" "internal_service_record" {
   zone_id = data.aws_route53_zone.internal.zone_id
-  name    = "${var.cluster_name}-redis.${var.internal_domain_name}"
+  name    = terraform.workspace == "default" ? "${var.cluster_name}-redis.${var.internal_domain_name}" : "${var.cluster_name}-redis.${var.internal_domain_name}"
   type    = "CNAME"
   ttl     = 300
   records = [aws_elasticache_replication_group.redis_cluster.primary_endpoint_address]


### PR DESCRIPTION
Terraform workspace allow us to run terraform on separated workspaces, this functionality is very basic in that it simply creates a new state for the new workspace. To run the same infrastructure code from separate workspaces then you need to add some segregation logic to your code that will interpolate naming variables from the current workspace.