### PR TITLE
Add Concourse ReadOnly role for Terraform plans

### DIFF
--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -53,3 +53,28 @@ resource "aws_iam_role_policy_attachment" "concourse_admin" {
   role       = aws_iam_role.govuk_concourse_deployer.id
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
+
+resource "aws_iam_role" "govuk_concourse_terraform_planner" {
+  name        = "govuk-concourse-deployer"
+  description = "Runs Terraform plan from Concourse"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Principal": {
+              "AWS": "arn:aws:iam::047969882937:role/cd-govuk-tools-concourse-worker"
+            }
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "concourse_readonly" {
+  role       = aws_iam_role.govuk_concourse_terraform_planner.id
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}


### PR DESCRIPTION
This role will be used by the CI pipeline for performing plans against the test environment.

Plan: 2 to add, 0 to change, 0 to destroy.
- aws_iam_role.govuk_concourse_terraform_planner will be created
- aws_iam_role_policy_attachment.concourse_readonly will be created

The AWS managed policy ReadOnlyAccess provides read-only access to all AWS services and resources.