### PR TITLE
Output properties needed by downstream deployments

### DIFF
--- a/terraform/deployments/govuk-test/outputs.tf
+++ b/terraform/deployments/govuk-test/outputs.tf
@@ -21,3 +21,35 @@ output "content-store_security_groups" {
 output "draft-content-store_security_groups" {
   value = module.govuk.draft_content_store_security_groups
 }
+
+output "log_group" {
+  value = "govuk" # TODO make this workspace aware
+}
+
+output "mesh_name" {
+  value = var.mesh_name
+}
+
+output "mesh_domain" {
+  value = var.mesh_domain
+}
+
+output "app_domain" {
+  value = var.public_lb_domain_name
+}
+
+output "app_domain_internal" {
+  value = var.internal_domain_name
+}
+
+output "govuk_website_root" {
+  value = "https://frontend.${var.public_lb_domain_name}" # TODO: Change back to www once router is up
+}
+
+output "fargate_execution_iam_role_arn" {
+  value = module.govuk.fargate_execution_iam_role_arn
+}
+
+output "fargate_task_iam_role_arn" {
+  value = module.govuk.fargate_task_iam_role_arn
+}

--- a/terraform/modules/app-container-definition/main.tf
+++ b/terraform/modules/app-container-definition/main.tf
@@ -32,7 +32,7 @@ output "value" {
     "logConfiguration" : {
       "logDriver" : "awslogs",
       "options" : {
-        "awslogs-create-group" : "true",
+        "awslogs-create-group" : "true", # TODO create the log group in terraform so we can configure the retention policy
         "awslogs-group" : var.log_group,
         "awslogs-region" : var.aws_region,
         "awslogs-stream-prefix" : var.name,

--- a/terraform/modules/govuk/ecs_cluster.tf
+++ b/terraform/modules/govuk/ecs_cluster.tf
@@ -48,6 +48,8 @@ resource "aws_iam_role" "execution" {
 EOF
 }
 
+# TODO don't let tasks create their own log groups -
+# create the log group in terraform
 resource "aws_iam_policy" "create_log_group_policy" {
   name        = "create_log_group_policy"
   path        = "/createLogsGroupPolicy/"

--- a/terraform/modules/govuk/outputs.tf
+++ b/terraform/modules/govuk/outputs.tf
@@ -22,3 +22,11 @@ output "draft_content_store_security_groups" {
   value       = module.draft_content_store_service.security_groups
   description = "The security groups applied to the Draft Content Store ECS Service."
 }
+
+output "fargate_execution_iam_role_arn" {
+  value = aws_iam_role.execution.arn
+}
+
+output "fargate_task_iam_role_arn" {
+  value = aws_iam_role.task.arn
+}


### PR DESCRIPTION
The govuk-test deployment has several downstream terraform deployments -
one task-definition for each application.

Rather than have these deployments depend on a shared variables file,
we'd like to have them read their settings from remote state. We prefer
this approach for a couple of reasons:

* Using remote state feels like a cleaner representation of the
  dependency between these modules
* It makes it much easier for the application task-definitions to be
  terraform workspace aware (so long as workspace names match up, they
  can read the remote state from the correct workspace)