### PR TITLE
Output redis host and port

### DIFF
--- a/terraform/deployments/govuk-test/outputs.tf
+++ b/terraform/deployments/govuk-test/outputs.tf
@@ -53,3 +53,11 @@ output "fargate_execution_iam_role_arn" {
 output "fargate_task_iam_role_arn" {
   value = module.govuk.fargate_task_iam_role_arn
 }
+
+output "redis_host" {
+  value = module.govuk.redis_host
+}
+
+output "redis_port" {
+  value = module.govuk.redis_port
+}

--- a/terraform/modules/govuk/outputs.tf
+++ b/terraform/modules/govuk/outputs.tf
@@ -30,3 +30,11 @@ output "fargate_execution_iam_role_arn" {
 output "fargate_task_iam_role_arn" {
   value = aws_iam_role.task.arn
 }
+
+output "redis_host" {
+  value = module.shared_redis_cluster.redis_host
+}
+
+output "redis_port" {
+  value = module.shared_redis_cluster.redis_port
+}

--- a/terraform/modules/redis/main.tf
+++ b/terraform/modules/redis/main.tf
@@ -7,6 +7,10 @@ terraform {
   }
 }
 
+locals {
+  redis_port = 6379
+}
+
 resource "aws_elasticache_subnet_group" "redis_cluster_subnet_group" {
   name       = var.cluster_name
   subnet_ids = var.subnet_ids
@@ -22,7 +26,7 @@ resource "aws_elasticache_replication_group" "redis_cluster" {
   replication_group_id          = var.cluster_name
   replication_group_description = "${var.cluster_name} Redis cluster with Redis master and replica"
   node_type                     = var.node_type
-  port                          = 6379
+  port                          = local.redis_port
   number_cache_clusters         = 2
   parameter_group_name          = "default.redis3.2"
   automatic_failover_enabled    = true

--- a/terraform/modules/redis/outputs.tf
+++ b/terraform/modules/redis/outputs.tf
@@ -3,7 +3,11 @@ output "security_group_id" {
   description = "ID of the security group for Redis cluster"
 }
 
-output "service_dns_name" {
-  value       = "${aws_route53_record.internal_service_record.fqdn}"
+output "redis_host" {
+  value       = aws_route53_record.internal_service_record.fqdn
   description = "Internal DNS name to access the Redis service"
+}
+
+output "redis_port" {
+  value = local.redis_port
 }


### PR DESCRIPTION
We'll need these for any app task definitions which need REDIS_HOST and REDIS_PORT as environment variables.

Note that REDIS_URL shouldn't be needed unless the URL gets more complicated (e.g. needs basic auth creds or something). See [govuk_sidekiq's docs](https://github.com/alphagov/govuk_sidekiq/blob/2c30a9b02c5b1741b6069b87583ffb722b9542a0/README.md#4-configure-puppet).

Terraform plan output:

```
Plan: 0 to add, 0 to change, 0 to destroy.


Changes to Outputs:

  + redis_host = "shared-redis.test.govuk-internal.digital"

  + redis_port = 6379
```