### PR TITLE
Fixup content store deployments

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -205,7 +205,7 @@ jobs:
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: frontend
+        ECS_SERVICE: frontend
         GOVUK_ENVIRONMENT: test
     serial: true
     on_failure: &notify-slack-failure
@@ -247,7 +247,7 @@ jobs:
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: draft-frontend
+        ECS_SERVICE: draft-frontend
         GOVUK_ENVIRONMENT: test
     serial: true
     on_failure: &notify-slack-failure
@@ -275,31 +275,37 @@ jobs:
       params:
         APPLICATION: publisher-web
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: web_task_definition
     - task: update-worker-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
         APPLICATION: publisher-worker
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: worker_task_definition
     - task: fetch-db-migrations-config
       file: govuk-infrastructure/concourse/tasks/fetch-task-network-config.yml
       params:
         APPLICATION: publisher-web
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: web_task_definition
     - task: run-db-migrations
       file: govuk-infrastructure/concourse/tasks/run-task.yml
       params:
         APPLICATION: publisher-web
         COMMAND: "rails db:migrate"
+        TASK_DEFINITION: web_task_definition
     - task: update-web-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: publisher-web
+        ECS_SERVICE: publisher-web
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: web_task_definition
     - task: update-worker-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: publisher-worker
+        ECS_SERVICE: publisher-worker
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: worker_task_definition
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -318,21 +324,25 @@ jobs:
       params:
         APPLICATION: publishing-api-web
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: web_task_definition
     - task: update-worker-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
         APPLICATION: publishing-api-worker
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: worker_task_definition
     - task: update-web-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: publishing-api-web
+        ECS_SERVICE: publishing-api-web
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: web_task_definition
     - task: update-worker-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: publishing-api-worker
+        ECS_SERVICE: publishing-api-worker
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: worker_task_definition
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -351,11 +361,13 @@ jobs:
       params:
         APPLICATION: content-store
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: live_task_definition
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: content-store
+        ECS_SERVICE: content-store
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: live_task_definition
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -372,13 +384,15 @@ jobs:
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
-        APPLICATION: draft-content-store
+        APPLICATION: content-store
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: draft_task_definition
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: draft-content-store
+        ECS_SERVICE: draft-content-store
         GOVUK_ENVIRONMENT: test
+        TASK_DEFINITION: draft_task_definition
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -400,7 +414,7 @@ jobs:
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: router
+        ECS_SERVICE: router
         GOVUK_ENVIRONMENT: test
     serial: true
     on_failure:
@@ -423,7 +437,7 @@ jobs:
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: draft-router
+        ECS_SERVICE: draft-router
         GOVUK_ENVIRONMENT: test
     serial: true
     on_failure:
@@ -446,7 +460,7 @@ jobs:
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: router-api
+        ECS_SERVICE: router-api
         GOVUK_ENVIRONMENT: test
     serial: true
     on_failure:
@@ -469,7 +483,7 @@ jobs:
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: draft-router-api
+        ECS_SERVICE: draft-router-api
         GOVUK_ENVIRONMENT: test
     serial: true
     on_failure:
@@ -492,7 +506,7 @@ jobs:
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: signon
+        ECS_SERVICE: signon
         GOVUK_ENVIRONMENT: test
     serial: true
     on_failure:
@@ -515,7 +529,7 @@ jobs:
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: static
+        ECS_SERVICE: static
         GOVUK_ENVIRONMENT: test
     serial: true
     on_failure:
@@ -538,7 +552,7 @@ jobs:
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       params:
-        APPLICATION: draft-static
+        ECS_SERVICE: draft-static
         GOVUK_ENVIRONMENT: test
     serial: true
     on_failure:

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -111,19 +111,13 @@ groups:
   - name: content-store
     jobs:
       - deploy-content-store
-
-  - name: draft-content-store
-    jobs:
       - deploy-draft-content-store
 
   - name: frontend
     jobs:
       - deploy-frontend
-      - smoke-test-frontend
-
-  - name: draft-frontend
-    jobs:
       - deploy-draft-frontend
+      - smoke-test-frontend
 
   - name: publisher
     jobs:
@@ -136,17 +130,11 @@ groups:
   - name: router
     jobs:
       - deploy-router
-
-  - name: draft-router
-    jobs:
       - deploy-draft-router
 
   - name: router-api
     jobs:
       - deploy-router-api
-
-  - name: draft-router-api
-    jobs:
       - deploy-draft-router-api
 
   - name: signon
@@ -156,9 +144,6 @@ groups:
   - name: static
     jobs:
       - deploy-static
-
-  - name: draft-static
-    jobs:
       - deploy-draft-static
 
 jobs:

--- a/concourse/tasks/run-task.sh
+++ b/concourse/tasks/run-task.sh
@@ -12,6 +12,7 @@ root_dir=$(pwd)
 : "${APPLICATION:?APPLICATION not set}"
 : "${COMMAND:?COMMAND not set}"
 : "${CLUSTER:?COMMAND not set}"
+: "${TASK_DEFINITION:?TASK_DEFINITION not set}"
 
 mkdir -p ~/.aws
 
@@ -22,7 +23,7 @@ credential_source = Ec2InstanceMetadata
 region = $AWS_REGION
 EOF
 
-task_definition_arn="$(cat terraform-outputs/${APPLICATION}_task_definition_arn)"
+task_definition_arn="$(cat terraform-outputs/${TASK_DEFINITION})"
 network_config=$(cat terraform-outputs/task_network_config)
 
 echo "Starting task..."

--- a/concourse/tasks/run-task.yml
+++ b/concourse/tasks/run-task.yml
@@ -16,5 +16,6 @@ params:
   APPLICATION:
   CLUSTER: task_runner
   COMMAND:
+  TASK_DEFINITION: task_definition_arn
 run:
   path: ./src/concourse/tasks/run-task.sh

--- a/concourse/tasks/update-ecs-service.yml
+++ b/concourse/tasks/update-ecs-service.yml
@@ -11,7 +11,8 @@ inputs:
 params:
   AWS_REGION: eu-west-1
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
-  APPLICATION:
+  ECS_SERVICE:
+  TASK_DEFINITION: task_definition_arn
 run:
   path: sh
   # TODO: Move this script into a .sh file for portability, linting, and testing
@@ -28,39 +29,38 @@ run:
       credential_source = Ec2InstanceMetadata
       EOF
 
-      current_task_definition_arn="$(aws ecs describe-services --services "$APPLICATION" --cluster govuk --region "$AWS_REGION" | jq -r '.services[0].taskDefinition')"
+      current_task_definition_arn="$(aws ecs describe-services --services "$ECS_SERVICE" --cluster govuk --region "$AWS_REGION" | jq -r '.services[0].taskDefinition')"
       if [ -z "${current_task_definition_arn}" ]; then
-        echo "failed to retrieve current task definition for ${APPLICATION}, exiting..."
+        echo "failed to retrieve current task definition for ${ECS_SERVICE}, exiting..."
         exit 1
       fi
 
-      new_task_definition_arn="$(cat "terraform-outputs/${APPLICATION}_task_definition_arn")"
+      new_task_definition_arn="$(cat "terraform-outputs/${TASK_DEFINITION}")"
       if [ -z "${new_task_definition_arn}" ]; then
-        echo "failed to retrieve new task definition for ${APPLICATION}, exiting..."
+        echo "failed to retrieve new task definition for ${TASK_DEFINITION}, exiting..."
         exit 1
       fi
 
       # This conditional is used to skip `aws ecs update-service` below since its outputs may confuse readers and
       # lead them to believe that `aws ecs update-service` is not idempotent
       if [ "${current_task_definition_arn}" = "${new_task_definition_arn}" ]; then
-        echo "No need to update ${APPLICATION} service since its task definition was not updated"
+        echo "No need to update ${ECS_SERVICE} service since its task definition was not updated"
         exit 0
       fi
 
-      echo "Updating $APPLICATION service..."
-
+      echo "Updating $ECS_SERVICE service..."
 
       aws ecs update-service \
         --cluster govuk \
-        --service "$APPLICATION" \
+        --service "$ECS_SERVICE" \
         --task-definition "$new_task_definition_arn" \
         --region "$AWS_REGION"
 
-      echo "Waiting for $APPLICATION ECS service to reach steady state..."
+      echo "Waiting for $ECS_SERVICE ECS service to reach steady state..."
 
       aws ecs wait services-stable \
         --cluster govuk \
-        --services "$APPLICATION" \
+        --services "$ECS_SERVICE" \
         --region "$AWS_REGION"
 
-      echo "Finished updating $APPLICATION to task definition $new_task_definition_arn."
+      echo "Finished updating $ECS_SERVICE to task definition $new_task_definition_arn."

--- a/concourse/tasks/update-task-definition.yml
+++ b/concourse/tasks/update-task-definition.yml
@@ -19,6 +19,7 @@ params:
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
   APPLICATION:
   GOVUK_ENVIRONMENT:
+  TASK_DEFINITION: task_definition_arn
 run:
   path: sh
   # TODO: Move this script into a .sh file for portability, linting, and testing
@@ -36,12 +37,14 @@ run:
       APP_DIR="src/terraform/deployments/apps/$APPLICATION"
       cd ${APP_DIR}
 
-      terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+      terraform init -backend-config="bucket=govuk-terraform-$GOVUK_ENVIRONMENT" -backend-config="role_arn=$ASSUME_ROLE_ARN"
 
+      # TODO: These var-files won't be necessary once refactoring is complete
       terraform apply -var-file=../../variables/$GOVUK_ENVIRONMENT/common.tfvars \
       -var-file=../../variables/$GOVUK_ENVIRONMENT/apps.tfvars \
       -var=image_tag=$BUILD_TAG \
-      -var "assume_role_arn=$ASSUME_ROLE_ARN" \
+      -var="govuk_environment=$GOVUK_ENVIRONMENT" \
+      -var="assume_role_arn=$ASSUME_ROLE_ARN" \
       -auto-approve
 
-      terraform output task_definition_arn > "$root_dir/terraform-outputs/${APPLICATION}_task_definition_arn"
+      terraform output "${TASK_DEFINITION}" > "$root_dir/terraform-outputs/${TASK_DEFINITION}"

--- a/terraform/deployments/apps/content-store/main.tf
+++ b/terraform/deployments/apps/content-store/main.tf
@@ -38,8 +38,8 @@ data "aws_secretsmanager_secret" "sentry_dsn" {
 data "terraform_remote_state" "govuk_aws_mongo" {
   backend = "s3"
   config = {
-    bucket   = "govuk-terraform-steppingstone-${var.environment}"
-    key      = "${var.environment == "test" ? "pink" : "blue"}/app-mongo.tfstate"
+    bucket   = "govuk-terraform-steppingstone-${var.govuk_environment}"
+    key      = "${var.govuk_environment == "test" ? "pink" : "blue"}/app-mongo.tfstate"
     region   = data.aws_region.current.name
     role_arn = var.assume_role_arn
   }
@@ -49,7 +49,7 @@ data "terraform_remote_state" "govuk" {
   backend   = "s3"
   workspace = terraform.workspace
   config = {
-    bucket   = "govuk-terraform-${var.environment}"
+    bucket   = "govuk-terraform-${var.govuk_environment}"
     key      = "projects/govuk.tfstate"
     region   = data.aws_region.current.name
     role_arn = var.assume_role_arn
@@ -72,7 +72,7 @@ locals {
     data.terraform_remote_state.govuk_aws_mongo.outputs.mongo_3_service_dns_name,
   ])
 
-  sentry_environment = "${var.environment}-ecs"
+  sentry_environment = "${var.govuk_environment}-ecs"
   statsd_host        = "statsd.${local.mesh_domain}" # TODO: Put Statsd in App Mesh
 
   environment_variables = {

--- a/terraform/deployments/apps/content-store/outputs.tf
+++ b/terraform/deployments/apps/content-store/outputs.tf
@@ -1,0 +1,9 @@
+output "draft_task_definition" {
+  description = "ARNs of the draft task definition revision"
+  value       = aws_ecs_task_definition.draft.arn
+}
+
+output "live_task_definition" {
+  description = "ARNs of the live task definition revision"
+  value       = aws_ecs_task_definition.live.arn
+}

--- a/terraform/deployments/apps/content-store/variables.tf
+++ b/terraform/deployments/apps/content-store/variables.tf
@@ -3,7 +3,7 @@ variable "image_tag" {
   description = "The Docker image tag to be specified in a task definition"
 }
 
-variable "environment" {
+variable "govuk_environment" {
   type        = string
   description = "test, integration, staging or production"
 }

--- a/terraform/deployments/apps/publisher-web/outputs.tf
+++ b/terraform/deployments/apps/publisher-web/outputs.tf
@@ -1,1 +1,4 @@
-../outputs.tf
+output "web_task_definition" {
+  value       = module.task_definition.arn
+  description = "ARN of the web task definition revision"
+}

--- a/terraform/deployments/apps/publisher-worker/outputs.tf
+++ b/terraform/deployments/apps/publisher-worker/outputs.tf
@@ -1,1 +1,4 @@
-../outputs.tf
+output "worker_task_definition" {
+  value       = module.task_definition.arn
+  description = "ARN of the worker task definition revision"
+}

--- a/terraform/deployments/apps/publishing-api-web/outputs.tf
+++ b/terraform/deployments/apps/publishing-api-web/outputs.tf
@@ -1,1 +1,4 @@
-../outputs.tf
+output "web_task_definition" {
+  value       = module.task_definition.arn
+  description = "ARN of the web task definition revision"
+}

--- a/terraform/deployments/apps/publishing-api-worker/outputs.tf
+++ b/terraform/deployments/apps/publishing-api-worker/outputs.tf
@@ -1,1 +1,4 @@
-../outputs.tf
+output "worker_task_definition" {
+  value       = module.task_definition.arn
+  description = "ARN of the worker task definition revision"
+}


### PR DESCRIPTION
This will enable us to apply content-store after its refactoring.


The task definition Concourse script now supports an app deployment module outputting multiple task definition arns.

content-store's outputs.tf before:

```terraform
output "task_definition_arn" {
  value       = module.task_definition.arn
  description = "ARN of the task definition revision"
}
```

content-store's outputs.tf after:

```terraform
output "draft_task_definition" {
  description = "ARNs of the draft task definition revision"
  value       = aws_ecs_task_definition.draft.arn
}

output "live_task_definition" {
  description = "ARNs of the live task definition revision"
  value       = aws_ecs_task_definition.live.arn
}
```

Following this change, the deploy pipeline must now select the correct task definition to use on the ECS Service.

We could dynamically select a task definition by specifying 'live' or 'web' or 'draft-worker' in the pipeline job params. I found it simpler to make the dependency on the output of modules explicit (`live_task_definition`).

This has further implications for other things dependent on the output of the app deployments. For example, `tools/run-task.sh` needs to be rewritten (it won't work for a few apps, but that's OK).