### PR TITLE
Use current content-store virtual node name

### DIFF
--- a/terraform/deployments/apps/content-store/live.tf
+++ b/terraform/deployments/apps/content-store/live.tf
@@ -1,6 +1,6 @@
 module "live_container_definition" {
   source = "../../../modules/app-container-definition"
-  name   = "live-content-store"
+  name   = "content-store"
   image  = "govuk/content-store:bill-content-schemas" # TODO use "govuk/content-store:${var.image_tag}"
   environment_variables = merge(
     local.environment_variables,
@@ -19,7 +19,7 @@ module "live_envoy_configuration" {
   source = "../../../modules/envoy-configuration"
 
   mesh_name    = local.mesh_name
-  service_name = "live-content-store"
+  service_name = "content-store"
   log_group    = local.log_group
   aws_region   = data.aws_region.current.name
 }


### PR DESCRIPTION
The live Content Store's ECS Service name (and Virtual Node Name) is "content-store", rather than "live-content-store".

It's important that the Virtual Node Name set on the Envoy instance with the APPMESH_RESOURCE_ARN environment variable matches the real Virtual Node Name set as the `aws_appmesh_virtual_node` resource's `name`.

In this case, "content-store" rather than "live-content-store". If this is set incorrectly, the app containers are unreachable. I'm not sure why, to be honest, since [the docs](https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html) aren't that enlightening, but I would guess that the Envoy registers the task as a virtual node with Cloud Map when it comes up, but if the virtual node name is incorrect it doesn't get registered to the right virtual node.