### PR TITLE
Run deploy tasks in parallel

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -294,18 +294,19 @@ jobs:
         APPLICATION: publisher-web
         COMMAND: "rails db:migrate"
         TASK_DEFINITION: web_task_definition
-    - task: update-web-ecs-service
-      file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
-      params:
-        ECS_SERVICE: publisher-web
-        GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: web_task_definition
-    - task: update-worker-ecs-service
-      file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
-      params:
-        ECS_SERVICE: publisher-worker
-        GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: worker_task_definition
+    - in_parallel:
+      - task: update-web-ecs-service
+        file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
+        params:
+          ECS_SERVICE: publisher-web
+          GOVUK_ENVIRONMENT: test
+          TASK_DEFINITION: web_task_definition
+      - task: update-worker-ecs-service
+        file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
+        params:
+          ECS_SERVICE: publisher-worker
+          GOVUK_ENVIRONMENT: test
+          TASK_DEFINITION: worker_task_definition
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -331,18 +332,19 @@ jobs:
         APPLICATION: publishing-api-worker
         GOVUK_ENVIRONMENT: test
         TASK_DEFINITION: worker_task_definition
-    - task: update-web-ecs-service
-      file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
-      params:
-        ECS_SERVICE: publishing-api-web
-        GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: web_task_definition
-    - task: update-worker-ecs-service
-      file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
-      params:
-        ECS_SERVICE: publishing-api-worker
-        GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: worker_task_definition
+    - in_parallel:
+      - task: update-web-ecs-service
+        file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
+        params:
+          ECS_SERVICE: publishing-api-web
+          GOVUK_ENVIRONMENT: test
+          TASK_DEFINITION: web_task_definition
+      - task: update-worker-ecs-service
+        file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
+        params:
+          ECS_SERVICE: publishing-api-worker
+          GOVUK_ENVIRONMENT: test
+          TASK_DEFINITION: worker_task_definition
     serial: true
     on_failure:
       <<: *notify-slack-failure

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -190,13 +190,14 @@ jobs:
 
   - name: deploy-frontend
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: frontend
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: frontend
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -232,13 +233,14 @@ jobs:
 
   - name: deploy-draft-frontend
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: frontend
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: frontend
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -263,13 +265,14 @@ jobs:
 
   - name: deploy-publisher
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: publisher
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: publisher
+        trigger: true
     - task: update-web-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -313,13 +316,14 @@ jobs:
 
   - name: deploy-publishing-api
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: publishing-api
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: publishing-api
+        trigger: true
     - task: update-web-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -351,13 +355,14 @@ jobs:
 
   - name: deploy-content-store
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: content-store
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: content-store
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -376,13 +381,14 @@ jobs:
 
   - name: deploy-draft-content-store
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: content-store
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: content-store
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -401,13 +407,14 @@ jobs:
 
   - name: deploy-router
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: router
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: router
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -424,13 +431,14 @@ jobs:
 
   - name: deploy-draft-router
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: router
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: router
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -447,13 +455,14 @@ jobs:
 
   - name: deploy-router-api
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: router-api
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: router-api
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -470,13 +479,14 @@ jobs:
 
   - name: deploy-draft-router-api
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: router-api
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: router-api
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -493,13 +503,14 @@ jobs:
 
   - name: deploy-signon
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: signon
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: signon
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -516,13 +527,14 @@ jobs:
 
   - name: deploy-static
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: static
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: static
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
@@ -539,13 +551,14 @@ jobs:
 
   - name: deploy-draft-static
     plan:
-    - get: govuk-infrastructure
-      passed:
-      - run-terraform
-      trigger: true
-    - get: release
-      resource: static
-      trigger: true
+    - in_parallel:
+      - get: govuk-infrastructure
+        passed:
+        - run-terraform
+        trigger: true
+      - get: release
+        resource: static
+        trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:


### PR DESCRIPTION
We can make use of the [in_parallel step](https://concourse-ci.org/jobs.html#in-parallel-step) in Concourse jobs where tasks don't depend on each other.

This makes app deployments complete up to 2x faster. Publisher deploys (which update multiple ECS services) take 4mins, down from 8mins. All apps see a 1min reduction in build time due to fetching git repos in parallel.

<img width="659" alt="Parallel builds" src="https://user-images.githubusercontent.com/8124374/104475338-e3408f80-55b6-11eb-8461-f669d5326d34.png">

Here we can get repos, register new task definitions, and apply the new task definitions to ECS Services, with each step running multiple tasks in parallel, which will speed up deploy times for these services.
