### PR TITLE
Refactor app deployments in concourse

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -86,7 +86,6 @@ groups:
       - update-pipeline
       - run-terraform
       - deploy-content-store
-      - deploy-draft-content-store
       - deploy-frontend
       - smoke-test-frontend
       - deploy-draft-frontend
@@ -107,11 +106,6 @@ groups:
   - name: admin
     jobs:
       - update-pipeline
-
-  - name: content-store
-    jobs:
-      - deploy-content-store
-      - deploy-draft-content-store
 
   - name: frontend
     jobs:
@@ -278,13 +272,11 @@ jobs:
       params:
         APPLICATION: publisher-web
         GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: web_task_definition
     - task: update-worker-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
         APPLICATION: publisher-worker
         GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: worker_task_definition
     - task: fetch-db-migrations-config
       file: govuk-infrastructure/concourse/tasks/fetch-task-network-config.yml
       params:
@@ -329,13 +321,11 @@ jobs:
       params:
         APPLICATION: publishing-api-web
         GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: web_task_definition
     - task: update-worker-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       params:
         APPLICATION: publishing-api-worker
         GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: worker_task_definition
     - in_parallel:
       - task: update-web-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
@@ -368,39 +358,23 @@ jobs:
       params:
         APPLICATION: content-store
         GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: live_task_definition
-    - task: update-ecs-service
-      file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
-      params:
-        ECS_SERVICE: content-store
-        GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: live_task_definition
-    serial: true
-    on_failure:
-      <<: *notify-slack-failure
-
-  - name: deploy-draft-content-store
-    plan:
     - in_parallel:
-      - get: govuk-infrastructure
-        passed:
-        - run-terraform
-        trigger: true
-      - get: release
-        resource: content-store
-        trigger: true
-    - task: update-task-definition
-      file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
-      params:
-        APPLICATION: content-store
-        GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: draft_task_definition
-    - task: update-ecs-service
-      file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
-      params:
-        ECS_SERVICE: draft-content-store
-        GOVUK_ENVIRONMENT: test
-        TASK_DEFINITION: draft_task_definition
+      - task: update-live-ecs-service
+        file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
+        params:
+          # TODO: remove this APPLICATION variable once it's no longer needed by update-ecs-service
+          APPLICATION: content-store
+          ECS_SERVICE: content-store
+          GOVUK_ENVIRONMENT: test
+          TASK_DEFINITION: live_task_definition
+      - task: update-draft-ecs-service
+        file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
+        params:
+          # TODO: remove this APPLICATION variable once it's no longer needed by update-ecs-service
+          APPLICATION: content-store
+          ECS_SERVICE: draft-content-store
+          GOVUK_ENVIRONMENT: test
+          TASK_DEFINITION: draft_task_definition
     serial: true
     on_failure:
       <<: *notify-slack-failure

--- a/concourse/tasks/fetch-task-network-config.sh
+++ b/concourse/tasks/fetch-task-network-config.sh
@@ -30,4 +30,4 @@ private_subnets=$(terraform output -json private_subnets)
 security_groups=$(terraform output -json $APPLICATION'_security_groups')
 network_config='awsvpcConfiguration={subnets='$private_subnets',securityGroups='$security_groups',assignPublicIp=DISABLED}'
 
-echo $network_config > "$root_dir/terraform-outputs/task_network_config"
+echo "$network_config" > "$root_dir/task-network-config/task_network_config"

--- a/concourse/tasks/fetch-task-network-config.yml
+++ b/concourse/tasks/fetch-task-network-config.yml
@@ -11,7 +11,7 @@ inputs:
     path: src
   - name: terraform-outputs
 outputs:
-  - name: terraform-outputs
+  - name: task-network-config
 params:
   AWS_REGION: eu-west-1
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'

--- a/concourse/tasks/run-task.sh
+++ b/concourse/tasks/run-task.sh
@@ -23,8 +23,8 @@ credential_source = Ec2InstanceMetadata
 region = $AWS_REGION
 EOF
 
-task_definition_arn="$(cat terraform-outputs/${TASK_DEFINITION})"
-network_config=$(cat terraform-outputs/task_network_config)
+task_definition_arn=$(jq -r ".${TASK_DEFINITION}.value" terraform-outputs/${APPLICATION}-terraform-outputs.json)
+network_config=$(cat task-network-config/task_network_config)
 
 echo "Starting task..."
 

--- a/concourse/tasks/run-task.yml
+++ b/concourse/tasks/run-task.yml
@@ -10,6 +10,7 @@ inputs:
   - name: govuk-infrastructure
     path: src
   - name: terraform-outputs
+  - name: task-network-config
 params:
   AWS_REGION: eu-west-1
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'

--- a/concourse/tasks/update-ecs-service.yml
+++ b/concourse/tasks/update-ecs-service.yml
@@ -11,6 +11,7 @@ inputs:
 params:
   AWS_REGION: eu-west-1
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  APPLICATION:
   ECS_SERVICE:
   TASK_DEFINITION: task_definition_arn
 run:
@@ -35,7 +36,10 @@ run:
         exit 1
       fi
 
-      new_task_definition_arn="$(cat "terraform-outputs/${TASK_DEFINITION}")"
+      # TODO: Remove this once the publisher is refactored and the prefix is no longer needed
+      terraform_output_prefix=${APPLICATION:-${ECS_SERVICE}}
+
+      new_task_definition_arn="$(jq -r ".${TASK_DEFINITION}.value" terraform-outputs/${terraform_output_prefix}-terraform-outputs.json)"
       if [ -z "${new_task_definition_arn}" ]; then
         echo "failed to retrieve new task definition for ${TASK_DEFINITION}, exiting..."
         exit 1

--- a/concourse/tasks/update-task-definition.yml
+++ b/concourse/tasks/update-task-definition.yml
@@ -19,7 +19,6 @@ params:
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
   APPLICATION:
   GOVUK_ENVIRONMENT:
-  TASK_DEFINITION: task_definition_arn
 run:
   path: sh
   # TODO: Move this script into a .sh file for portability, linting, and testing
@@ -35,7 +34,7 @@ run:
       echo "================================================="
 
       APP_DIR="src/terraform/deployments/apps/$APPLICATION"
-      cd ${APP_DIR}
+      cd "${APP_DIR}"
 
       terraform init -backend-config="bucket=govuk-terraform-$GOVUK_ENVIRONMENT" -backend-config="role_arn=$ASSUME_ROLE_ARN"
 
@@ -47,4 +46,5 @@ run:
       -var="assume_role_arn=$ASSUME_ROLE_ARN" \
       -auto-approve
 
-      terraform output "${TASK_DEFINITION}" > "$root_dir/terraform-outputs/${TASK_DEFINITION}"
+      # TODO - remove the ${APPLICATION} interpolation from this once publisher only has one terraform apply
+      terraform output -json > "$root_dir/terraform-outputs/${APPLICATION}-terraform-outputs.json"


### PR DESCRIPTION
Previously there was a race condition, where both content-store and
draft-content-store could apply the same terraform at the same time.
Even if we had locking on our terraform statefile (which we don't at the
moment), this doesn't seem like great design.

Instead, I think we should just have one job for content-store, which
updates both the draft and live version.

The process is now:
* `update-task-definition` (which applies the content-store terraform
  deployment, creating a task definition for both draft and live stacks)
* In parallel, run `update-ecs-service` for both the draft and live
  stacks

To make this work, I've refactored how the terraform outputs get passed
around. Instead of creating one file per output, the
update-task-definition task now puts all the outputs in one big JSON
file. update-ecs-service can then use `jq` (which is conveniently
already in the awscli container) to pluck out the output it wants.

Annoyingly the terraforom outputs need to go in application-specific
paths, because publisher still has separate web and worker
deployments. Once the publisher refactoring is finished, this can be
further simplified.

I think this should work for old and new-style apps.