### PR TITLE
Fix Statsd security group rules

### DIFF
--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -207,6 +207,7 @@ module "statsd" {
   govuk_management_access_sg_id    = var.govuk_management_access_sg_id
   mesh_name                        = var.mesh_name
   private_subnets                  = var.private_subnets
+  security_groups                  = [aws_security_group.mesh_ecs_service.id]
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
   source                           = "../../modules/statsd"

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -506,7 +506,7 @@ resource "aws_security_group_rule" "signon_to_any_any" {
 
 resource "aws_security_group_rule" "statsd_from_apps_tcp" {
   description              = "Allow services in the App Mesh to send metrics to the mesh Statsd via TCP"
-  type                     = "egress"
+  type                     = "ingress"
   from_port                = "8125"
   to_port                  = "8125"
   protocol                 = "tcp"

--- a/terraform/modules/govuk/security_group_rules.tf
+++ b/terraform/modules/govuk/security_group_rules.tf
@@ -514,5 +514,45 @@ resource "aws_security_group_rule" "statsd_from_apps_tcp" {
   source_security_group_id = aws_security_group.mesh_ecs_service.id
 }
 
+resource "aws_security_group_rule" "mesh_service_to_any_https" {
+  description       = "Mesh services send requests to anywhere over HTTPS"
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.mesh_ecs_service.id
+}
+
+resource "aws_security_group_rule" "mesh_service_to_any_dns_tcp" {
+  description       = "Mesh services send DNS queries anywhere over TCP"
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.mesh_ecs_service.id
+}
+
+resource "aws_security_group_rule" "mesh_service_to_any_dns_udp" {
+  description       = "Mesh services send DNS queries anywhere over UDP"
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.mesh_ecs_service.id
+}
+
+resource "aws_security_group_rule" "mesh_service_to_mesh_service_http" {
+  description              = "Mesh services send to requests to other mesh services over HTTP"
+  type                     = "egress"
+  protocol                 = "tcp"
+  from_port                = 80
+  to_port                  = 80
+  source_security_group_id = aws_security_group.mesh_ecs_service.id
+  security_group_id        = aws_security_group.mesh_ecs_service.id
+}
+
 # TODO: move the rest of the rules into this file unless there's a good reason
 #       for them to stay in other files.

--- a/terraform/modules/statsd/main.tf
+++ b/terraform/modules/statsd/main.tf
@@ -19,7 +19,7 @@ resource "aws_ecs_service" "statsd" {
   desired_count = 1
 
   network_configuration {
-    security_groups = [aws_security_group.service.id]
+    security_groups = concat([aws_security_group.service.id], var.security_groups)
     subnets         = var.private_subnets
   }
 

--- a/terraform/modules/statsd/variables.tf
+++ b/terraform/modules/statsd/variables.tf
@@ -25,6 +25,11 @@ variable "private_subnets" {
   type        = list
 }
 
+variable "security_groups" {
+  description = "Additional security groups to attach to the Statsd ECS Service."
+  type        = list
+}
+
 variable "service_discovery_namespace_id" {
   type = string
 }


### PR DESCRIPTION
This enables Statsd tasks to pull the Envoy image from ECR, and fixes an issue that prevents apps from sending requests to Statsd.

It also adds rules to the `mesh_ecs_service` security group, which will help us to remove the security group `govuk_management_access` from services.