### PR TITLE
add monitoring concourse pipeline

### DIFF
--- a/concourse/pipelines/monitoring.yml
+++ b/concourse/pipelines/monitoring.yml
@@ -1,0 +1,235 @@
+---
+definitions:
+
+resources:
+  - icon: github
+    name: govuk-infrastructure
+    source:
+      branch: main
+      uri: https://github.com/alphagov/govuk-infrastructure
+    type: git
+
+groups:
+  - name: all
+    jobs:
+      - update-pipeline
+      - deploy-monitoring-infra
+      - deploy-grafana
+      - configure-grafana
+
+  - name: monitoring-infra
+    jobs:
+      - deploy-monitoring-infra
+      - deploy-grafana
+      - configure-grafana
+
+  - name: admin
+    jobs:
+      - update-pipeline
+
+jobs:
+  - name: update-pipeline
+    plan:
+    - get: govuk-infrastructure
+      trigger: true
+    - file: govuk-infrastructure/concourse/pipelines/monitoring.yml
+      set_pipeline: monitoring
+
+  - name: deploy-monitoring-infra
+    plan:
+    - get: govuk-infrastructure
+      trigger: true
+    - task: terraform-apply
+      config:
+        inputs:
+        - name: govuk-infrastructure
+        params:
+          AWS_REGION: eu-west-1
+          ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: governmentpaas/terraform
+            tag: terraform-0.13.3
+            username: ((docker_hub_username))
+            password: ((docker_hub_authtoken))
+        run:
+          dir: govuk-infrastructure/terraform/deployments/monitoring-test/infra
+          path: sh
+          args:
+          - '-c'
+          - |
+            set -eu
+
+            terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+            terraform apply \
+              -var "assume_role_arn=$ASSUME_ROLE_ARN" \
+              -var-file ../../variables/test/common.tfvars \
+              -var-file ../../variables/test/infrastructure.tfvars \
+              -auto-approve
+
+  - name: deploy-grafana
+    plan:
+    - get: govuk-infrastructure
+      passed:
+      - deploy-monitoring-infra
+      trigger: true
+    - task: update-grafana-task-definition
+      config:
+        inputs:
+        - name: govuk-infrastructure
+          path: src
+        outputs:
+        - name: terraform-outputs
+        params:
+          AWS_REGION: eu-west-1
+          ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+          GOVUK_ENVIRONMENT: test
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: governmentpaas/terraform
+            tag: terraform-0.13.3
+            username: ((docker_hub_username))
+            password: ((docker_hub_authtoken))
+        run:
+          path: sh
+          args:
+          - '-c'
+          - |
+            set -eu
+
+            root_dir=$(pwd)
+
+
+            APP_DIR="src/terraform/deployments/monitoring-test/grafana"
+            cd ${APP_DIR}
+
+            terraform init -backend-config="role_arn=$ASSUME_ROLE_ARN"
+
+            terraform apply \
+            -var "assume_role_arn=$ASSUME_ROLE_ARN" \
+            -auto-approve
+
+            terraform output task_definition_arn > "$root_dir/terraform-outputs/grafana_task_definition_arn"
+
+    - task: update-grafana-service
+      config:
+        inputs:
+        - name: terraform-outputs
+        params:
+          APPLICATION: grafana
+          AWS_REGION: eu-west-1
+          ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: governmentpaas/awscli
+            tag: latest
+            username: ((docker_hub_username))
+            password: ((docker_hub_authtoken))
+        run:
+          path: sh
+          args:
+          - '-c'
+          - |
+            set -eu
+
+            mkdir -p ~/.aws
+
+            cat <<EOF > ~/.aws/config
+            [profile default]
+            role_arn = $ASSUME_ROLE_ARN
+            credential_source = Ec2InstanceMetadata
+            EOF
+
+            current_task_definition_arn="$(aws ecs describe-services --services "$APPLICATION" --cluster monitoring --region "$AWS_REGION" | jq -r '.services[0].taskDefinition')"
+            if [ -z "${current_task_definition_arn}" ]; then
+              echo "failed to retrieve current task definition for ${APPLICATION}, exiting..."
+              exit 1
+            fi
+
+            new_task_definition_arn="$(cat "terraform-outputs/${APPLICATION}_task_definition_arn")"
+            if [ -z "${new_task_definition_arn}" ]; then
+              echo "failed to retrieve new task definition for ${APPLICATION}, exiting..."
+              exit 1
+            fi
+
+            # This conditional is used to skip `aws ecs update-service` below since its outputs may confuse readers and
+            # lead them to believe that `aws ecs update-service` is not idempotent
+            if [ "${current_task_definition_arn}" = "${new_task_definition_arn}" ]; then
+              echo "No need to update ${APPLICATION} service since its task definition was not updated"
+              exit 0
+            fi
+
+            echo "Updating $APPLICATION service..."
+
+
+            aws ecs update-service \
+              --cluster monitoring \
+              --service "$APPLICATION" \
+              --task-definition "$new_task_definition_arn" \
+              --region "$AWS_REGION"
+
+            echo "Waiting for $APPLICATION ECS service to reach steady state..."
+
+            aws ecs wait services-stable \
+              --cluster monitoring \
+              --services "$APPLICATION" \
+              --region "$AWS_REGION"
+
+            echo "Finished updating $APPLICATION to task definition $new_task_definition_arn."
+
+  - name: configure-grafana
+    plan:
+    - get: govuk-infrastructure
+      passed:
+      - deploy-grafana
+      trigger: true
+    - task: terraform-apply
+      config:
+        inputs:
+        - name: govuk-infrastructure
+          path: src
+        params:
+          AWS_REGION: eu-west-1
+          ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: governmentpaas/terraform
+            tag: terraform-0.13.3
+            username: ((docker_hub_username))
+            password: ((docker_hub_authtoken))
+        run:
+          path: sh
+          args:
+          - '-c'
+          - |
+            set -eu
+
+            root_dir=$(pwd)
+
+            APP_DIR="${root_dir}/src/terraform/deployments/monitoring-test/grafana/app-config"
+            cd ${APP_DIR}
+
+            terraform_apply() {
+              terraform apply -var "assume_role_arn=$ASSUME_ROLE_ARN" -auto-approve
+            }
+
+            terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+
+            if ! terraform_apply; then
+                # See bug https://github.com/grafana/terraform-provider-grafana/issues/129
+                # where terraform does not recreate some grafana resources if not found
+
+                echo "fixing terraform state bug by removing state"
+                terraform state rm module.grafana-app-config.grafana_data_source.cloudwatch
+
+                echo "applying terraform again"
+                terraform_apply
+            fi

--- a/terraform/deployments/monitoring-test/infra/main.tf
+++ b/terraform/deployments/monitoring-test/infra/main.tf
@@ -60,5 +60,5 @@ module "monitoring" {
   private_subnets               = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
   public_subnets                = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
   govuk_management_access_sg_id = data.terraform_remote_state.infra_security_groups.outputs.sg_management_id
-  office_cidrs_list             = var.office_cidrs_list
+  grafana_cidrs_allow_list      = concat(var.office_cidrs_list, var.concourse_cidrs_list)
 }

--- a/terraform/deployments/monitoring-test/infra/variables.tf
+++ b/terraform/deployments/monitoring-test/infra/variables.tf
@@ -21,3 +21,8 @@ variable "office_cidrs_list" {
   description = "List of GDS office CIDRs"
   type        = list
 }
+
+variable "concourse_cidrs_list" {
+  description = "List of GDS Concourse CIDRs"
+  type        = list
+}

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -3,6 +3,7 @@
 #--------------------------------------------------------------
 
 # TODO: When it becomes possible, pull these from Terraform "data" type
-mesh_domain       = "mesh.govuk-internal.digital"
-mesh_name         = "govuk"
-office_cidrs_list = ["213.86.153.212/32", "213.86.153.213/32", "213.86.153.214/32", "213.86.153.235/32", "213.86.153.236/32", "213.86.153.237/32", "85.133.67.244/32"]
+mesh_domain          = "mesh.govuk-internal.digital"
+mesh_name            = "govuk"
+office_cidrs_list    = ["213.86.153.212/32", "213.86.153.213/32", "213.86.153.214/32", "213.86.153.235/32", "213.86.153.236/32", "213.86.153.237/32", "85.133.67.244/32"]
+concourse_cidrs_list = ["35.178.226.106/32", "18.130.168.3/32"]

--- a/terraform/modules/apps/router/main.tf
+++ b/terraform/modules/apps/router/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
+}
+
+module "app" {
+  source                           = "../../app"
+  execution_role_arn               = var.execution_role_arn
+  vpc_id                           = var.vpc_id
+  cluster_id                       = var.cluster_id
+  service_name                     = var.service_name
+  subnets                          = var.private_subnets
+  mesh_name                        = var.mesh_name
+  desired_count                    = var.desired_count
+  service_discovery_namespace_id   = var.service_discovery_namespace_id
+  service_discovery_namespace_name = var.service_discovery_namespace_name
+  extra_security_groups            = [var.govuk_management_access_security_group, var.mesh_service_sg_id]
+  custom_container_services        = [{ container_service = var.service_name, port = 80, protocol = "tcp" }, { container_service = "${var.service_name}-reload", port = 3055, protocol = "tcp" }]
+}

--- a/terraform/modules/monitoring/grafana.tf
+++ b/terraform/modules/monitoring/grafana.tf
@@ -34,5 +34,5 @@ module "grafana_public_alb" {
   service_security_group_id = module.grafana_app.security_group_id
   health_check_path         = "/api/health"
   target_port               = 3000
-  external_cidrs_list       = var.office_cidrs_list
+  external_cidrs_list       = var.grafana_cidrs_allow_list
 }

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -34,7 +34,7 @@ variable "desired_count" {
   default     = 1
 }
 
-variable "office_cidrs_list" {
-  description = "List of GDS office CIDRs"
+variable "grafana_cidrs_allow_list" {
+  description = "List of CIDRs that can access Grafana"
   type        = list
 }


### PR DESCRIPTION
In #115, we introduced the new monitoring cluster with Grafana as a
Fargate ECS service in it.

In this PR, we create the associated concourse pipeline.
This can be accessed here: https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/monitoring

The concourse pipeline works as follows:
1. deploy the base monitoring cluster
2. deploy the Grafana ECS task, i.e container.
3. configure Grafana

The task to configure Grafana is designed to:
1. wait for Grafana to be up and running, as determined by HTTP status
code 200
2. apply the Terraform Grafana config
3. handle bug https://github.com/grafana/terraform-provider-grafana/issues/129
where terraform does not recreate some grafana resources if not found

In addition, we need to add CDIO Big Concourse Egress IPs to the list of
IPs allowed to reach Grafana so that Concourse can apply against Grafana.

Future work:
1. refactor shell scripts into separate files once agreed style.

Ref:
1. [trello card](https://trello.com/c/ZJuJoV3H/350-create-monitoring-concourse-pipeline)