### PR TITLE
Allow ingress from statsd in ECS to graphite in EC2

### DIFF
--- a/terraform/modules/govuk/main.tf
+++ b/terraform/modules/govuk/main.tf
@@ -204,10 +204,9 @@ module "statsd" {
   cluster_id                       = aws_ecs_cluster.cluster.id
   execution_role_arn               = aws_iam_role.execution.arn
   internal_domain_name             = var.internal_domain_name
-  govuk_management_access_sg_id    = var.govuk_management_access_sg_id
   mesh_name                        = var.mesh_name
   private_subnets                  = var.private_subnets
-  security_groups                  = [aws_security_group.mesh_ecs_service.id]
+  security_groups                  = [aws_security_group.mesh_ecs_service.id, var.govuk_management_access_sg_id]
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
   source                           = "../../modules/statsd"

--- a/terraform/modules/statsd/variables.tf
+++ b/terraform/modules/statsd/variables.tf
@@ -6,11 +6,6 @@ variable "execution_role_arn" {
   type = string
 }
 
-variable "govuk_management_access_sg_id" {
-  type        = string
-  description = "Gives access to Graphite in EC2"
-}
-
 variable "internal_domain_name" {
   description = "Domain in which to create DNS records for private resources. For example, test.govuk-internal.digital"
   type        = string


### PR DESCRIPTION
This adds the govuk_management_access security group to the statsd ECS service.

Graphite (hosted in EC2) has two security groups
• govuk_graphite_access for ELB ingress
• govuk_management_access for ingress from Statsd

We plan to remove govuk_management_access from govuk-infrastructure in future, as it is poorly named and is a bit of a bag of rules.