### PR TITLE
Change statsd namespace for ECS tasks

### DIFF
--- a/terraform/deployments/apps/content-store/live.tf
+++ b/terraform/deployments/apps/content-store/live.tf
@@ -5,7 +5,7 @@ module "live_container_definition" {
   environment_variables = merge(
     local.environment_variables,
     {
-      GOVUK_STATSD_PREFIX         = "govuk.app.${local.app_name}.ecs"
+      GOVUK_STATSD_PREFIX         = "govuk-ecs.app.${local.app_name}"
       PLEK_SERVICE_ROUTER_API_URI = "http://router-api.${local.mesh_domain}"
       MONGODB_URI                 = "mongodb://${local.mongodb_host}/live_content_store_production"
     },

--- a/terraform/modules/task-definitions/frontend/main.tf
+++ b/terraform/modules/task-definitions/frontend/main.tf
@@ -50,7 +50,7 @@ module "task_definition" {
         { "name" : "GOVUK_APP_DOMAIN", "value" : var.service_discovery_namespace_name },
         { "name" : "GOVUK_APP_DOMAIN_EXTERNAL", "value" : var.govuk_app_domain_external },
         { "name" : "GOVUK_STATSD_HOST", "value" : var.statsd_host },
-        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk.app.${local.app_name}.ecs" },
+        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk-ecs.app.${local.app_name}" },
         { "name" : "GOVUK_STATSD_PROTOCOL", "value" : "tcp" },
         { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
         { "name" : "WEBSITE_ROOT", "value" : var.govuk_website_root },

--- a/terraform/modules/task-definitions/publisher/main.tf
+++ b/terraform/modules/task-definitions/publisher/main.tf
@@ -95,7 +95,7 @@ module "task_definition" {
         { "name" : "GOVUK_APP_ROOT", "value" : "/app" },
         { "name" : "GOVUK_APP_TYPE", "value" : "rack" },
         { "name" : "GOVUK_STATSD_HOST", "value" : var.statsd_host },
-        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk.app.${local.app_name}.ecs" },
+        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk-ecs.app.${local.app_name}" },
         { "name" : "GOVUK_STATSD_PROTOCOL", "value" : "tcp" },
         # TODO: how does GOVUK_ASSET_ROOT relate to ASSET_HOST? Is one a function of the other? Are they both really in use? Is GOVUK_ASSET_ROOT always just "https://${ASSET_HOST}"?
         { "name" : "GOVUK_ASSET_ROOT", "value" : "https://assets.test.publishing.service.gov.uk" },

--- a/terraform/modules/task-definitions/publishing-api/main.tf
+++ b/terraform/modules/task-definitions/publishing-api/main.tf
@@ -90,7 +90,7 @@ module "task_definition" {
         { "name" : "GOVUK_CONTENT_SCHEMAS_PATH", "value" : "/govuk-content-schemas" },
         { "name" : "GOVUK_GROUP", "value" : "deploy" }, # TODO: clean up?
         { "name" : "GOVUK_STATSD_HOST", "value" : var.statsd_host },
-        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk.app.${local.app_name}.ecs" },
+        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk-ecs.app.${local.app_name}" },
         { "name" : "GOVUK_STATSD_PROTOCOL", "value" : "tcp" },
         { "name" : "GOVUK_USER", "value" : "deploy" }, # TODO: clean up?
         { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },

--- a/terraform/modules/task-definitions/router-api/main.tf
+++ b/terraform/modules/task-definitions/router-api/main.tf
@@ -56,7 +56,7 @@ module "task_definition" {
         { "name" : "GOVUK_APP_NAME", "value" : var.service_name },
         { "name" : "GOVUK_APP_ROOT", "value" : "/var/apps/${var.service_name}" },
         { "name" : "GOVUK_STATSD_HOST", "value" : var.statsd_host },
-        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk.app.${local.app_name}.ecs" },
+        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk-ecs.app.${local.app_name}" },
         { "name" : "GOVUK_STATSD_PROTOCOL", "value" : "tcp" },
         { "name" : "RAILS_ENV", "value" : "production" },
         { "name" : "PLEK_SERVICE_SIGNON_URI", "value" : "https://signon-ecs.${var.govuk_app_domain_external}" },

--- a/terraform/modules/task-definitions/signon/main.tf
+++ b/terraform/modules/task-definitions/signon/main.tf
@@ -61,7 +61,7 @@ module "task_definition" {
         { "name" : "GOVUK_APP_ROOT", "value" : "/app" },
         { "name" : "GOVUK_APP_TYPE", "value" : "rack" },
         { "name" : "GOVUK_STATSD_HOST", "value" : var.statsd_host },
-        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk.app.${local.service_name}.ecs" },
+        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk-ecs.app.${local.service_name}" },
         { "name" : "GOVUK_STATSD_PROTOCOL", "value" : "tcp" },
         { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
         { "name" : "PORT", "value" : "80" },

--- a/terraform/modules/task-definitions/static/main.tf
+++ b/terraform/modules/task-definitions/static/main.tf
@@ -57,7 +57,7 @@ module "task_definition" {
         { "name" : "GOVUK_APP_ROOT", "value" : "/var/apps/${var.service_name}" },
         { "name" : "GOVUK_WEBSITE_ROOT", "value" : var.govuk_website_root },
         { "name" : "GOVUK_STATSD_HOST", "value" : var.statsd_host },
-        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk.app.${local.app_name}.ecs" },
+        { "name" : "GOVUK_STATSD_PREFIX", "value" : "govuk-ecs.app.${local.app_name}" },
         { "name" : "GOVUK_STATSD_PROTOCOL", "value" : "tcp" },
         { "name" : "PORT", "value" : "80" },
         { "name" : "ASSET_HOST", "value" : var.assets_url },


### PR DESCRIPTION
This will separate the metrics for apps running in ECS and EC2.

Initially we intended the metrics from both platforms to be displayed as one platform in Grafana.

On reflection it would be better for these metrics to be separate, and displayed in separate dashboards. This will
avoid confusion - you don't want to see metrics from one platform while debugging another platform.

After this change, we'll use the ECS metrics in the newly created ECS Grafana, and leave the EC2 side of things untouched.

We may need to recreate 5-6 alerts that use app metrics. This should be pretty trivial to do in Puppet.