### PR TITLE
Use the public-load-balancer module for frontend

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -10,6 +10,7 @@ module "frontend" {
   desired_count                    = var.frontend_desired_count
   public_subnets                   = local.public_subnets
   public_lb_domain_name            = var.public_lb_domain_name
+  office_cidrs_list                = var.office_cidrs_list
 }
 
 module "draft_frontend" {
@@ -25,5 +26,6 @@ module "draft_frontend" {
   desired_count                    = var.draft_frontend_desired_count
   public_subnets                   = local.public_subnets
   public_lb_domain_name            = var.public_lb_domain_name
+  office_cidrs_list                = var.office_cidrs_list
 }
 

--- a/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
+++ b/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
@@ -178,36 +178,6 @@ resource "aws_security_group_rule" "frontend_to_any_any" {
   security_group_id = module.frontend.app_security_group_id
 }
 
-resource "aws_security_group_rule" "frontend_from_alb_http" {
-  description              = "Frontend receives requests from its public ALB over HTTP"
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  security_group_id        = module.frontend.app_security_group_id
-  source_security_group_id = module.frontend.alb_security_group_id
-}
-
-resource "aws_security_group_rule" "frontend_alb_from_office_https" {
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = module.frontend.alb_security_group_id
-  cidr_blocks       = var.office_cidrs_list
-}
-
-resource "aws_security_group_rule" "frontend_alb_to_any_any" {
-  type      = "egress"
-  protocol  = "-1"
-  from_port = 0
-  to_port   = 0
-
-  security_group_id = module.frontend.alb_security_group_id
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
 resource "aws_security_group_rule" "draft_frontend_to_any_any" {
   description       = "Draft Frontend sends requests to anywhere over any protocol"
   type              = "egress"
@@ -217,37 +187,6 @@ resource "aws_security_group_rule" "draft_frontend_to_any_any" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = module.draft_frontend.app_security_group_id
 }
-
-resource "aws_security_group_rule" "draft_frontend_from_alb_http" {
-  description              = "Draft Frontend receives requests from its public ALB over HTTP"
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  security_group_id        = module.draft_frontend.app_security_group_id
-  source_security_group_id = module.draft_frontend.alb_security_group_id
-}
-
-resource "aws_security_group_rule" "draft_frontend_alb_from_office_https" {
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = module.draft_frontend.alb_security_group_id
-  cidr_blocks       = var.office_cidrs_list
-}
-
-resource "aws_security_group_rule" "draft_frontend_alb_to_any_any" {
-  type      = "egress"
-  protocol  = "-1"
-  from_port = 0
-  to_port   = 0
-
-  security_group_id = module.draft_frontend.alb_security_group_id
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
 
 data "aws_nat_gateway" "govuk" {
   count     = length(local.public_subnets)

--- a/terraform/modules/apps/frontend/main.tf
+++ b/terraform/modules/apps/frontend/main.tf
@@ -42,4 +42,5 @@ module "public_alb" {
   public_lb_domain_name     = var.public_lb_domain_name
   workspace_suffix          = "govuk" # TODO: Changeme
   service_security_group_id = module.app.security_group_id
+  external_cidrs_list       = var.office_cidrs_list
 }

--- a/terraform/modules/apps/frontend/outputs.tf
+++ b/terraform/modules/apps/frontend/outputs.tf
@@ -4,7 +4,7 @@ output "app_security_group_id" {
 }
 
 output "alb_security_group_id" {
-  value       = aws_security_group.public_alb.id
+  value       = module.public_alb.security_group_id
   description = "ID of the security group for the Frontend app's Internet-facing load balancer."
 }
 

--- a/terraform/modules/apps/frontend/variables.tf
+++ b/terraform/modules/apps/frontend/variables.tf
@@ -61,3 +61,8 @@ variable "public_lb_domain_name" {
   description = "Domain in which to create DNS records for the app's Internet-facing load balancer. For example, staging.govuk.digital"
   type        = string
 }
+
+variable "office_cidrs_list" {
+  description = "List of GDS office CIDRs"
+  type        = list
+}

--- a/terraform/modules/public-load-balancer/outputs.tf
+++ b/terraform/modules/public-load-balancer/outputs.tf
@@ -2,6 +2,10 @@ output "target_group_arn" {
   value = aws_lb_target_group.public.arn
 }
 
+output "security_group_id" {
+  value = aws_security_group.public_alb.id
+}
+
 output "fqdn" {
   value = "${aws_route53_record.public_alb.name}.${var.public_lb_domain_name}"
 }


### PR DESCRIPTION
This reduces a big chunk of duplication, and will make my next
refactoring a little bit easier.

I did some terraform state moves to get a better feel for what this will
actually do. It looks like most of the resources will need replacing, but
for the most part the changes look quite small.

See [the terraform plan in concourse](https://cd.gds-reliability.engineering/teams/govuk-ci/pipelines/ci-govuk-infrastructure-main/jobs/terraform-plan-govuk-deployment/builds/114) for more details on what this will do.