### PR TITLE
Use public lb module for publisher and static

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -12,5 +12,6 @@ module "publisher" {
   execution_role_arn               = aws_iam_role.execution.arn
   vpc_id                           = local.vpc_id
   desired_count                    = var.publisher_desired_count
+  office_cidrs_list                = var.office_cidrs_list
 }
 

--- a/terraform/deployments/govuk-publishing-platform/app_static.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_static.tf
@@ -11,6 +11,7 @@ module "static" {
   desired_count                    = var.static_desired_count
   public_subnets                   = local.public_subnets
   public_lb_domain_name            = var.public_lb_domain_name
+  office_cidrs_list                = var.office_cidrs_list
 }
 
 module "draft_static" {
@@ -27,5 +28,6 @@ module "draft_static" {
   desired_count                    = var.draft_static_desired_count
   public_subnets                   = local.public_subnets
   public_lb_domain_name            = var.public_lb_domain_name
+  office_cidrs_list                = var.office_cidrs_list
 }
 

--- a/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
+++ b/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
@@ -78,36 +78,6 @@ resource "aws_security_group_rule" "publisher_to_any_any" {
   security_group_id = module.publisher.app_security_group_id
 }
 
-resource "aws_security_group_rule" "publisher_from_alb_http" {
-  description              = "Publisher receives requests from its public ALB over HTTP"
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  security_group_id        = module.publisher.app_security_group_id
-  source_security_group_id = module.publisher.alb_security_group_id
-}
-
-resource "aws_security_group_rule" "publisher_alb_to_publisher_http" {
-  description              = "Publisher ALB sends requests to Publisher over HTTP"
-  type                     = "egress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  security_group_id        = module.publisher.alb_security_group_id
-  source_security_group_id = module.publisher.app_security_group_id
-}
-
-resource "aws_security_group_rule" "publisher_alb_from_any_https" {
-  description       = "Publisher ALB receives requests from anywhere over HTTPS"
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = module.publisher.alb_security_group_id
-}
-
 resource "aws_security_group_rule" "redis_from_publisher_resp" {
   type                     = "ingress"
   from_port                = 6379

--- a/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
+++ b/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
@@ -187,26 +187,6 @@ resource "aws_security_group_rule" "static_to_any_any" {
   security_group_id = module.static.app_security_group_id
 }
 
-resource "aws_security_group_rule" "static_from_alb_http" {
-  description              = "Static receives requests from its public ALB over HTTP"
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  security_group_id        = module.static.app_security_group_id
-  source_security_group_id = module.static.alb_security_group_id
-}
-
-resource "aws_security_group_rule" "static_alb_from_office_https" {
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = module.static.alb_security_group_id
-  cidr_blocks       = var.office_cidrs_list
-}
-
 resource "aws_security_group_rule" "static_from_frontend_http" {
   description              = "Static receives requests from Frontend over HTTP"
   type                     = "ingress"
@@ -215,16 +195,6 @@ resource "aws_security_group_rule" "static_from_frontend_http" {
   protocol                 = "tcp"
   security_group_id        = module.static.app_security_group_id
   source_security_group_id = module.frontend.app_security_group_id
-}
-
-resource "aws_security_group_rule" "static_alb_to_any_any" {
-  type      = "egress"
-  protocol  = "-1"
-  from_port = 0
-  to_port   = 0
-
-  security_group_id = module.static.alb_security_group_id
-  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "draft_static_to_any_any" {
@@ -237,26 +207,6 @@ resource "aws_security_group_rule" "draft_static_to_any_any" {
   security_group_id = module.draft_static.app_security_group_id
 }
 
-resource "aws_security_group_rule" "draft_static_from_alb_http" {
-  description              = "Draft Static receives requests from its public ALB over HTTP"
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  security_group_id        = module.draft_static.app_security_group_id
-  source_security_group_id = module.draft_static.alb_security_group_id
-}
-
-resource "aws_security_group_rule" "draft_static_alb_from_office_https" {
-  type      = "ingress"
-  from_port = 443
-  to_port   = 443
-  protocol  = "tcp"
-
-  security_group_id = module.draft_static.alb_security_group_id
-  cidr_blocks       = var.office_cidrs_list
-}
-
 resource "aws_security_group_rule" "draft_static_from_frontend_http" {
   description              = "Draft Static receives requests from Draft Frontend over HTTP"
   type                     = "ingress"
@@ -265,16 +215,6 @@ resource "aws_security_group_rule" "draft_static_from_frontend_http" {
   protocol                 = "tcp"
   security_group_id        = module.draft_static.app_security_group_id
   source_security_group_id = module.draft_frontend.app_security_group_id
-}
-
-resource "aws_security_group_rule" "draft_static_alb_to_any_any" {
-  type      = "egress"
-  protocol  = "-1"
-  from_port = 0
-  to_port   = 0
-
-  security_group_id = module.draft_static.alb_security_group_id
-  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "mongodb_from_content_store_mongodb" {

--- a/terraform/modules/apps/publisher/main.tf
+++ b/terraform/modules/apps/publisher/main.tf
@@ -21,7 +21,7 @@ module "app" {
   extra_security_groups            = [var.govuk_management_access_sg_id, var.mesh_service_sg_id]
 
   load_balancers = [{
-    target_group_arn = aws_lb_target_group.public.arn
+    target_group_arn = module.public_alb.target_group_arn
     container_name   = "publisher-web"
     container_port   = 80
   }]
@@ -48,76 +48,16 @@ module "worker" {
 # Internet-facing load balancer
 #
 
-# TODO: use a single, ACM-managed cert with both domains on. There is already
-# such a cert in integration/staging/prod (but it needs defining in Terraform).
-data "aws_acm_certificate" "public_lb_default" {
-  domain   = "*.test.govuk.digital"
-  statuses = ["ISSUED"]
-}
+module "public_alb" {
+  source = "../../public-load-balancer"
 
-data "aws_acm_certificate" "public_lb_alternate" {
-  domain   = "*.test.publishing.service.gov.uk"
-  statuses = ["ISSUED"]
-}
-
-resource "aws_lb" "public" {
-  name               = "fargate-public-${var.service_name}"
-  internal           = false
-  load_balancer_type = "application"
-  security_groups    = [aws_security_group.public_alb.id]
-  subnets            = var.public_subnets
-}
-
-resource "aws_lb_target_group" "public" {
-  name        = "${var.service_name}-public"
-  port        = 80
-  protocol    = "HTTP"
-  vpc_id      = var.vpc_id
-  target_type = "ip"
-
-  health_check {
-    path = "/healthcheck"
-  }
-
-  depends_on = [aws_lb.public]
-}
-
-resource "aws_lb_listener" "public" {
-  load_balancer_arn = aws_lb.public.arn
-  port              = 443
-  protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = data.aws_acm_certificate.public_lb_default.arn
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.public.arn
-  }
-}
-
-resource "aws_lb_listener_certificate" "publishing_service" {
-  listener_arn    = aws_lb_listener.public.arn
-  certificate_arn = data.aws_acm_certificate.public_lb_alternate.arn
-}
-
-resource "aws_security_group" "public_alb" {
-  name        = "fargate_${var.service_name}_public_alb"
-  vpc_id      = var.vpc_id
-  description = "${var.service_name} Internet-facing ALB"
-}
-
-data "aws_route53_zone" "public" {
-  name = var.public_lb_domain_name
-}
-
-resource "aws_route53_record" "public_alb" {
-  zone_id = data.aws_route53_zone.public.zone_id
-  name    = var.service_name
-  type    = "A"
-
-  alias {
-    name                   = aws_lb.public.dns_name
-    zone_id                = aws_lb.public.zone_id
-    evaluate_target_health = true
-  }
+  app_name                  = var.service_name
+  vpc_id                    = var.vpc_id
+  dns_a_record_name         = var.service_name
+  public_subnets            = var.public_subnets
+  app_domain                = var.public_lb_domain_name # TODO: Change to app_domain
+  public_lb_domain_name     = var.public_lb_domain_name
+  workspace_suffix          = "govuk" # TODO: Changeme
+  service_security_group_id = module.app.security_group_id
+  external_cidrs_list       = var.office_cidrs_list
 }

--- a/terraform/modules/apps/publisher/outputs.tf
+++ b/terraform/modules/apps/publisher/outputs.tf
@@ -4,7 +4,7 @@ output "app_security_group_id" {
 }
 
 output "alb_security_group_id" {
-  value       = aws_security_group.public_alb.id
+  value       = module.public_alb.security_group_id
   description = "ID of the security group for the Publisher app's Internet-facing load balancer."
 }
 

--- a/terraform/modules/apps/publisher/variables.tf
+++ b/terraform/modules/apps/publisher/variables.tf
@@ -60,3 +60,8 @@ variable "desired_count" {
   type        = number
   default     = 1
 }
+
+variable "office_cidrs_list" {
+  description = "List of GDS office CIDRs"
+  type        = list
+}

--- a/terraform/modules/apps/static/main.tf
+++ b/terraform/modules/apps/static/main.tf
@@ -21,7 +21,7 @@ module "app" {
   desired_count                    = var.desired_count
 
   load_balancers = [{
-    target_group_arn = aws_lb_target_group.public.arn
+    target_group_arn = module.public_alb.target_group_arn
     container_name   = var.service_name
     container_port   = 80
   }]
@@ -31,76 +31,16 @@ module "app" {
 # Internet-facing load balancer
 #
 
-# TODO: use a single, ACM-managed cert with both domains on. There is already
-# such a cert in integration/staging/prod (but it needs defining in Terraform).
-data "aws_acm_certificate" "public_lb_default" {
-  domain   = "*.test.govuk.digital"
-  statuses = ["ISSUED"]
-}
+module "public_alb" {
+  source = "../../public-load-balancer"
 
-data "aws_acm_certificate" "public_lb_alternate" {
-  domain   = "*.test.publishing.service.gov.uk"
-  statuses = ["ISSUED"]
-}
-
-resource "aws_lb" "public" {
-  name               = "fargate-public-${var.service_name}"
-  internal           = false
-  load_balancer_type = "application"
-  security_groups    = [aws_security_group.public_alb.id]
-  subnets            = var.public_subnets
-}
-
-resource "aws_lb_target_group" "public" {
-  name        = "${var.service_name}-public"
-  port        = 80
-  protocol    = "HTTP"
-  vpc_id      = var.vpc_id
-  target_type = "ip"
-
-  health_check {
-    path = "/templates/wrapper.html.erb"
-  }
-
-  depends_on = [aws_lb.public]
-}
-
-resource "aws_lb_listener" "public" {
-  load_balancer_arn = aws_lb.public.arn
-  port              = 443
-  protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = data.aws_acm_certificate.public_lb_default.arn
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.public.arn
-  }
-}
-
-resource "aws_lb_listener_certificate" "publishing_service" {
-  listener_arn    = aws_lb_listener.public.arn
-  certificate_arn = data.aws_acm_certificate.public_lb_alternate.arn
-}
-
-resource "aws_security_group" "public_alb" {
-  name        = "fargate_${var.service_name}_public_alb"
-  vpc_id      = var.vpc_id
-  description = "${var.service_name} Internet-facing ALB"
-}
-
-data "aws_route53_zone" "public" {
-  name = var.public_lb_domain_name
-}
-
-resource "aws_route53_record" "public_alb" {
-  zone_id = data.aws_route53_zone.public.zone_id
-  name    = "${var.service_name}-ecs"
-  type    = "A"
-
-  alias {
-    name                   = aws_lb.public.dns_name
-    zone_id                = aws_lb.public.zone_id
-    evaluate_target_health = true
-  }
+  app_name                  = var.service_name
+  vpc_id                    = var.vpc_id
+  dns_a_record_name         = var.service_name
+  public_subnets            = var.public_subnets
+  app_domain                = var.public_lb_domain_name # TODO: Change to app_domain
+  public_lb_domain_name     = var.public_lb_domain_name
+  workspace_suffix          = "govuk" # TODO: Changeme
+  service_security_group_id = module.app.security_group_id
+  external_cidrs_list       = var.office_cidrs_list
 }

--- a/terraform/modules/apps/static/outputs.tf
+++ b/terraform/modules/apps/static/outputs.tf
@@ -4,7 +4,7 @@ output "app_security_group_id" {
 }
 
 output "alb_security_group_id" {
-  value       = aws_security_group.public_alb.id
+  value       = module.public_alb.security_group_id
   description = "ID of the security group for the Static app's Internet-facing load balancer."
 }
 

--- a/terraform/modules/apps/static/variables.tf
+++ b/terraform/modules/apps/static/variables.tf
@@ -61,3 +61,8 @@ variable "public_lb_domain_name" {
   description = "Domain in which to create DNS records for the app's Internet-facing load balancer. For example, staging.govuk.digital"
   type        = string
 }
+
+variable "office_cidrs_list" {
+  description = "List of GDS office CIDRs"
+  type        = list
+}


### PR DESCRIPTION
These are the last two apps which duplicate the load balancer configuration instead of using the public-load-balancer module.

I haven't done any statefile updates, so the terraform plan will be "remove all the load balancers and add new ones". That might make it a bit tricky to work out what's changed from the plan, so let me know if you want me to do the statefile wrangling. On the other hand, it should be enough just to check that there's nothing unusual in the inline load balancer configuration that I'm removing.