### PR TITLE
Fix failed apply due to route53 conflict

### DIFF
--- a/terraform/modules/apps/static/main.tf
+++ b/terraform/modules/apps/static/main.tf
@@ -36,7 +36,7 @@ module "public_alb" {
 
   app_name                  = var.service_name
   vpc_id                    = var.vpc_id
-  dns_a_record_name         = var.service_name
+  dns_a_record_name         = "${var.service_name}-ecs"
   public_subnets            = var.public_subnets
   app_domain                = var.public_lb_domain_name # TODO: Change to app_domain
   public_lb_domain_name     = var.public_lb_domain_name


### PR DESCRIPTION
```
[Tried to create resource record set [name='static.test.govuk.digital.', type='A'] but it already exists]
```

We worked around this by setting "static-ecs" as the A record before:

https://github.com/alphagov/govuk-infrastructure/blob/4203c8259861cec120c1709a033c2c98bfced19a/terraform/modules/apps/static/main.tf#L98