### PR TITLE
Fix publisher db migrations

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -410,7 +410,7 @@ jobs:
       file: govuk-infrastructure/concourse/tasks/run-task.yml
       params:
         APPLICATION: publisher-web
-        COMMAND: "rails db:migrate"
+        COMMAND: "bundle exec rails db:migrate"
         TASK_DEFINITION: web_task_definition
     - in_parallel:
       - task: update-web-ecs-service


### PR DESCRIPTION
A look in CloudWatch logs revealed that the cause of this failure was:

```
/bin/bash: rails: command not found
```

I've tested this by running `fly set-pipeline` and what was red is now
green.

See also:
- [the original failure](https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/deploy-apps-test/jobs/deploy-publisher/builds/138)
- [the CloudWatch logs](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/awslogs-fargate/log-events/awslogs-publisher$252Fpublisher-web$252Fcfec786d4b57473e9e49030dd5c97ff9)
- [a passing build with this change applied](https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/deploy-apps-test/jobs/deploy-publisher/builds/139)

... at some point we should update run-task.sh to print the task logs, but that's too much work for this fix.