### PR TITLE
Fix healthchecks

### DIFF
--- a/terraform/modules/apps/frontend/main.tf
+++ b/terraform/modules/apps/frontend/main.tf
@@ -43,4 +43,5 @@ module "public_alb" {
   workspace_suffix          = "govuk" # TODO: Changeme
   service_security_group_id = module.app.security_group_id
   external_cidrs_list       = var.office_cidrs_list
+  health_check_path         = "/"
 }

--- a/terraform/modules/apps/static/main.tf
+++ b/terraform/modules/apps/static/main.tf
@@ -43,4 +43,5 @@ module "public_alb" {
   workspace_suffix          = "govuk" # TODO: Changeme
   service_security_group_id = module.app.security_group_id
   external_cidrs_list       = var.office_cidrs_list
+  health_check_path         = "/templates/wrapper.html.erb" # TODO: create a proper healthcheck endpoint in static
 }


### PR DESCRIPTION
I broke the healthchecks for frontend and static in #139.

publisher has a /healthcheck endpoint, but the other apps don't.

This sets them back to the values they had before (which are not great, but at least they work).