### PR TITLE
Build & Push Smokey container image from Concourse

### DIFF
--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -1,0 +1,90 @@
+---
+definitions:
+
+resources:
+  - name: smokey
+    icon: github
+    type: git
+    source:
+      uri: git@github.com:alphagov/smokey.git
+      branch: main
+      private_key: |
+        ((govukci_private_key))
+
+  - name: govuk-infrastructure
+    icon: github
+    type: git
+    source:
+      uri: git@github.com:alphagov/govuk-infrastructure.git
+      branch: main
+      private_key: |
+        ((govukci_private_key))
+
+  - name: smokey-image
+    type: registry-image
+    icon: docker
+    source:
+      repository: govuk/smokey
+      tag: latest
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
+
+  - name: smokey-version
+    type: semver
+    source:
+      driver: s3
+      access_key_id: ((readonly_access_key_id))
+      secret_access_key: ((readonly_secret_access_key))
+      session_token: ((readonly_session_token))
+      bucket: ((readonly_private_bucket_name))
+      key: smokey-version
+      region_name: eu-west-2
+      initial_version: '1.0.0'
+
+jobs:
+  - name: update-pipeline
+    plan:
+    - get: govuk-infrastructure
+      trigger: true
+    - file: govuk-infrastructure/concourse/pipelines/build-images.yml
+      set_pipeline: build-images
+
+  - name: smokey
+    plan:
+    - in_parallel:
+      - get: smokey
+        trigger: true
+      - get: smokey-version
+        params:
+          bump: minor
+          pre_without_version: true
+          pre: release
+    - task: build-image
+      privileged: true
+      params:
+        CONTEXT: smokey
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source:
+            repository: vito/oci-build-task
+        inputs:
+        - name: smokey
+        outputs:
+        - name: image
+        run:
+          path: build
+    - put: smokey-image
+      params:
+        image: image/image.tar
+        additional_tags: smokey-version/version
+    - in_parallel:
+      - put: smokey
+        params:
+          only_tag: true
+          tag: smokey-version/version
+          repository: smokey
+      - put: smokey-version
+        params:
+          file: smokey-version/version


### PR DESCRIPTION
This adds a CI pipeline that:

1. detects new commits to the main branch
2. determines a new semantic version (version stored in its S3 bucket + 1 minor version)
3. builds a new container image
4. tags the image with `latest` and the new version
5. pushes the image to DockerHub
6. adds a tag to the commit on the GitHub repo, prefixed with "v" (e.g. v1.2.0)
7. updates S3 bucket containing the [semver-resource](https://github.com/concourse/semver-resource)

I expect we can copy this procedure for other pipelines - PaaS made their [integration test pipeline config](https://github.com/alphagov/paas-release-ci/blob/f6bef1a0cc3da5290e402506cf2e4e477817233f/pipelines/integration-test.yml) generic with variables - we can reuse the same config for multiple pipelines that do the same thing.

Tagging the commit is useful since we can watch for new version tags and trigger other builds.

I've added a pipeline: https://cd.gds-reliability.engineering/teams/govuk-ci/pipelines/build-images

<img width="1307" alt="Builds pipeline" src="https://user-images.githubusercontent.com/8124374/105526278-17fcc700-5cda-11eb-80de-919ba7f1de77.png">
