### PR TITLE
Lint govuk-publishing-platform terraform deployment with tflint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,23 @@ jobs:
               echo -e '\n-------------------------\n'
             )
           done
+
+      - name: run tflint
+        env:
+          TFLINT_VERSION: v0.24.1
+        run: |
+          TEMP_PATH="$(mktemp -d)"
+          PATH="${TEMP_PATH}:$PATH"
+          curl --silent --fail -L "https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_amd64.zip" -o tflint.zip && unzip tflint.zip -d "${TEMP_PATH}" && rm tflint.zip
+
+          for f in terraform/deployments/*/.tflint.hcl; do
+            d=$(dirname "$f")
+            (
+              echo "$d"
+              cd "$d"
+              terraform init -backend=false
+              tflint --module .
+              echo -e '\n-------------------------\n'
+            )
+          done
+

--- a/terraform/deployments/govuk-publishing-platform/.tflint.hcl
+++ b/terraform/deployments/govuk-publishing-platform/.tflint.hcl
@@ -1,0 +1,18 @@
+plugin "aws" {
+  enabled = true
+}
+
+config {
+  varfile = [
+    "../variables/test/infrastructure.tfvars",
+  ]
+}
+
+rule "terraform_comment_syntax" { enabled = true }
+rule "terraform_deprecated_index" { enabled = true }
+rule "terraform_required_providers" { enabled = true }
+rule "terraform_standard_module_structure" { enabled = true }
+rule "terraform_typed_variables" { enabled = true }
+rule "terraform_unused_declarations" { enabled = true }
+rule "terraform_unused_required_providers" { enabled = true }
+

--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -113,7 +113,7 @@ module "publisher_public_alb" {
   external_app_domain       = var.external_app_domain
   certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"
+  workspace_suffix          = terraform.workspace == "default" ? "govuk" : terraform.workspace
   service_security_group_id = module.publisher_web.security_group_id
   external_cidrs_list       = var.office_cidrs_list
 }


### PR DESCRIPTION
[tflint](https://github.com/terraform-linters/tflint) does some additional style checks on top of the validations done by `terraform validate` (which we already have a GitHub Action for).

It will catch things like:

```terraform
name = "${var.unnecessary_string_interpolations}"
```

It's configurable, and not all the rules will be the same for all of our deployments. I've written the action so it will only try to lint deployments that have a config file.

For now, I'm just covering the main govuk-publishing-deployment, which looks like it's mostly okay already! 🎉 

Downloading and not caching the 10.3 MB release zip is a bit lazy of me... but 🤷🏻 

Example of a failing action: https://github.com/alphagov/govuk-infrastructure/runs/1817276105?check_suite_focus=true