### PR TITLE
Add Virtual Service backends to App Mesh virtual nodes

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -3,6 +3,12 @@ locals {
     cpu    = 512  # TODO parameterize this
     memory = 1024 # TODO parameterize this
 
+    backend_services = flatten([
+      local.defaults.virtual_service_backends,
+      module.static.virtual_service_names,
+      module.signon.virtual_service_names,
+    ])
+
     environment_variables = merge(
       local.defaults.environment_variables,
       {
@@ -41,8 +47,12 @@ locals {
 }
 
 module "frontend" {
-  service_name                     = "frontend"
-  mesh_name                        = aws_appmesh_mesh.govuk.id
+  service_name = "frontend"
+  mesh_name    = aws_appmesh_mesh.govuk.id
+  backend_virtual_service_names = flatten([
+    local.frontend_defaults.backend_services,
+    module.content_store.virtual_service_names,
+  ])
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
   vpc_id                           = local.vpc_id
@@ -81,8 +91,12 @@ module "frontend_public_alb" {
 }
 
 module "draft_frontend" {
-  service_name                     = "draft-frontend"
-  mesh_name                        = aws_appmesh_mesh.govuk.id
+  service_name = "draft-frontend"
+  mesh_name    = aws_appmesh_mesh.govuk.id
+  backend_virtual_service_names = flatten([
+    local.frontend_defaults.backend_services,
+    module.draft_content_store.virtual_service_names,
+  ])
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
   vpc_id                           = local.vpc_id

--- a/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
@@ -3,6 +3,13 @@ locals {
     cpu    = 512  # TODO parameterize this
     memory = 1024 # TODO parameterize this
 
+    backend_services = flatten([
+      local.defaults.virtual_service_backends,
+      module.signon.virtual_service_names,
+      module.content_store.virtual_service_names,
+      module.draft_content_store.virtual_service_names,
+    ])
+
     environment_variables = merge(
       local.defaults.environment_variables,
       {
@@ -47,6 +54,7 @@ locals {
 
 module "publishing_api_web" {
   service_name                     = "publishing-api-web"
+  backend_virtual_service_names    = local.publishing_api_defaults.backend_services
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
@@ -68,6 +76,7 @@ module "publishing_api_web" {
 
 module "publishing_api_worker" {
   service_name                     = "publishing-api-worker"
+  backend_virtual_service_names    = local.publishing_api_defaults.backend_services
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name

--- a/terraform/deployments/govuk-publishing-platform/app_router.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router.tf
@@ -28,6 +28,7 @@ module "router" {
   source = "../../modules/app"
 
   service_name                     = "router"
+  backend_virtual_service_names    = module.frontend.virtual_service_names
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
@@ -60,6 +61,7 @@ module "draft_router" {
   source = "../../modules/app"
 
   service_name                     = "draft-router"
+  backend_virtual_service_names    = module.draft_frontend.virtual_service_names
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name

--- a/terraform/deployments/govuk-publishing-platform/app_router_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router_api.tf
@@ -3,6 +3,11 @@ locals {
     cpu    = 512  # TODO parameterize this
     memory = 1024 # TODO parameterize this
 
+    backend_services = flatten([
+      local.defaults.virtual_service_backends,
+      module.signon.virtual_service_names,
+    ])
+
     environment_variables = merge(
       local.defaults.environment_variables,
       {
@@ -27,6 +32,7 @@ module "router_api" {
   source = "../../modules/app"
 
   service_name                     = "router-api"
+  backend_virtual_service_names    = local.router_api_defaults.backend_services
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
@@ -62,6 +68,7 @@ module "draft_router_api" {
   source = "../../modules/app"
 
   service_name                     = "draft-router-api"
+  backend_virtual_service_names    = local.router_api_defaults.backend_services
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -1,5 +1,10 @@
 locals {
   signon_defaults = {
+    backend_services = flatten([
+      # TODO: Add remaining services
+      local.defaults.virtual_service_backends,
+    ])
+
     environment_variables = merge(
       local.defaults.environment_variables,
       {
@@ -26,6 +31,7 @@ locals {
 
 module "signon" {
   service_name                     = "signon"
+  backend_virtual_service_names    = local.signon_defaults.backend_services
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name

--- a/terraform/deployments/govuk-publishing-platform/app_static.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_static.tf
@@ -23,6 +23,7 @@ module "static" {
   source = "../../modules/app"
 
   service_name                     = "static"
+  backend_virtual_service_names    = [] # Static doesn't use any other services
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
@@ -61,6 +62,7 @@ module "draft_static" {
   source = "../../modules/app"
 
   service_name                     = "draft-static"
+  backend_virtual_service_names    = [] # Static doesn't use any other services
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -32,5 +32,9 @@ locals {
     signon_uri              = "https://signon-ecs.${var.external_app_domain}",
     static_uri              = "https://static.${var.mesh_domain}"
     website_root            = "https://frontend.${var.external_app_domain}",
+
+    virtual_service_backends = [
+      module.statsd.virtual_service_name
+    ]
   }
 }

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -71,6 +71,7 @@ module "service_mesh_node" {
   count = var.service_mesh ? length(local.container_services) : 0
 
   source                           = "../service-mesh-node"
+  backend_virtual_service_names    = var.backend_virtual_service_names
   mesh_name                        = var.mesh_name
   port                             = local.container_services[count.index].port
   protocol                         = local.container_services[count.index].protocol

--- a/terraform/modules/app/outputs.tf
+++ b/terraform/modules/app/outputs.tf
@@ -8,3 +8,8 @@ output "security_groups" {
   value       = local.service_security_groups
   description = "The security groups applied to the ECS Service."
 }
+
+output "virtual_service_names" {
+  value       = module.service_mesh_node[*].virtual_service_name
+  description = "App Mesh virtual services for this app"
+}

--- a/terraform/modules/app/variables.tf
+++ b/terraform/modules/app/variables.tf
@@ -1,3 +1,8 @@
+variable "backend_virtual_service_names" {
+  type        = list(any)
+  description = "aws_appmesh_virtual_service names called by this app"
+}
+
 variable "vpc_id" {
   type = string
 }

--- a/terraform/modules/monitoring/grafana.tf
+++ b/terraform/modules/monitoring/grafana.tf
@@ -3,15 +3,16 @@ locals {
 }
 
 module "grafana_app" {
-  source                    = "../app"
-  vpc_id                    = var.vpc_id
-  cluster_id                = aws_ecs_cluster.cluster.id
-  service_name              = local.service_name
-  subnets                   = var.private_subnets
-  extra_security_groups     = [var.govuk_management_access_sg_id]
-  service_mesh              = false
-  desired_count             = var.desired_count
-  custom_container_services = [{ container_service = local.service_name, port = 3000, protocol = "http" }]
+  source                        = "../app"
+  vpc_id                        = var.vpc_id
+  backend_virtual_service_names = []
+  cluster_id                    = aws_ecs_cluster.cluster.id
+  service_name                  = local.service_name
+  subnets                       = var.private_subnets
+  extra_security_groups         = [var.govuk_management_access_sg_id]
+  service_mesh                  = false
+  desired_count                 = var.desired_count
+  custom_container_services     = [{ container_service = local.service_name, port = 3000, protocol = "http" }]
 
   load_balancers = [{
     target_group_arn = module.grafana_public_alb.target_group_arn

--- a/terraform/modules/service-mesh-node/main.tf
+++ b/terraform/modules/service-mesh-node/main.tf
@@ -28,9 +28,12 @@ resource "aws_appmesh_virtual_node" "service" {
   mesh_name = var.mesh_name
 
   spec {
-    backend {
-      virtual_service {
-        virtual_service_name = "${var.service_name}.${var.service_discovery_namespace_name}"
+    dynamic "backend" {
+      for_each = var.backend_virtual_service_names
+      content {
+        virtual_service {
+          virtual_service_name = backend.value
+        }
       }
     }
 

--- a/terraform/modules/service-mesh-node/outputs.tf
+++ b/terraform/modules/service-mesh-node/outputs.tf
@@ -1,3 +1,7 @@
 output "discovery_service_arn" {
   value = aws_service_discovery_service.service.arn
 }
+
+output "virtual_service_name" {
+  value = aws_appmesh_virtual_service.service.name
+}

--- a/terraform/modules/service-mesh-node/variables.tf
+++ b/terraform/modules/service-mesh-node/variables.tf
@@ -1,3 +1,8 @@
+variable "backend_virtual_service_names" {
+  type        = list(any)
+  description = "Enables the service to communicate with its dependencies (other virtual services) through the service mesh"
+}
+
 variable "mesh_name" {
   type = string
 }

--- a/terraform/modules/statsd/main.tf
+++ b/terraform/modules/statsd/main.tf
@@ -33,6 +33,7 @@ resource "aws_ecs_service" "statsd" {
 
 module "service_mesh_node" {
   mesh_name                        = var.mesh_name
+  backend_virtual_service_names    = [] # TODO: Nice to have Graphite as a virtual node (for retries etc)
   port                             = local.ingress_port
   protocol                         = "tcp"
   service_discovery_namespace_id   = var.service_discovery_namespace_id

--- a/terraform/modules/statsd/outputs.tf
+++ b/terraform/modules/statsd/outputs.tf
@@ -2,3 +2,8 @@ output "security_group_id" {
   value       = aws_security_group.service.id
   description = "ID of the security group for Statsd ECS Service."
 }
+
+output "virtual_service_name" {
+  value       = module.service_mesh_node.virtual_service_name
+  description = "Statsd App Mesh Virtual Service"
+}


### PR DESCRIPTION
This fixes a misconfiguration of our AWS App Mesh [Virtual Nodes][].

**What is App Mesh and Envoy?**

[App Mesh][] is the control plane for our Envoy proxies. Envoy, a distributed (or client-side) load balancer, pulls configuration from App Mesh that tells Envoy how to handle outgoing requests from an app.

Every app we run in ECS has an [Envoy proxy][] in front of it. Significantly, Envoy doesn't just proxy incoming requests to an app, it also _intercepts outgoing requests_ via an iptables rule. Envoy then can redirect the request to a virtual service (an abstraction of a real service) which will route requests to a virtual node (such as an ECS Service).

By intercepting requests Envoy can load balance requests to hosts in upstream clusters (and more!), and log and produce metrics in various formats. This is handy for both observability and reliability. We're also thinking about using Envoy for mTLS.

See [Life of a Request](https://www.envoyproxy.io/docs/envoy/latest/intro/life_of_a_request) through Envoy for more details of what happens when Envoy intercepts a request.

## What does this fix?

We hadn't set any virtual service backends on our virtual nodes. This meant that all outgoing requests from apps in the service mesh were considered to be leaving the service mesh.

How did that happen?

When Envoy intercepts an outgoing request from an app, it checks whether the app's virtual node has a 'backend' virtual service that corresponds to the request it has intercepted. These 'backends' are also called "upstream clusters" by Envoy, but we'll use the App Mesh terminology. If it does have a corresponding backend service, Envoy will load balance the request to the virtual service (ignoring whatever IP address the app had already acquired for the service).

If Envoy does not have a corresponding backend, then what happens next depends on the App Mesh [egress filter][], which can be `ALLOW_ALL` or `DROP_ALL`. If `DROP_ALL` (default) is used, then the request to an unknown virtual service will be dropped. DROP_ALL allows egress only from virtual nodes to other defined resources in the service mesh (and any traffic to *.amazonaws.com for AWS API calls). If `ALLOW_ALL` is used, the request will be proxied to the endpoint regardless, as this allows egress to any endpoint inside or outside of the service mesh.

When we enabled the egress filter `DROP_ALL` on our App Mesh mesh, this caused all requests made by apps in the mesh to be dropped.

The only reason service to service requests in the mesh succeeded is because of the `ALLOW_ALL` egress filter. This troubleshooting section "[Connectivity succeeds to service not listed as a virtual service backend for a virtual node](https://docs.aws.amazon.com/app-mesh/latest/userguide/troubleshoot-connectivity.html#ts-connectivity-not-virtual-service)" helped.

## What is the fix?

This happened because our configuration currently doesn't define any backing virtual services for our virtual nodes (apart from permitting the virtual services to send requests to themselves).

This changes the service mesh node module such that one can provide a list of backing virtual services for a virtual node, so that these virtual services can be treated as an Upstream Cluster by Envoy.

## More details

I'd recommend reading the AWS App Mesh documentation, but particularly the Envoy documentation.

In the course of discovering this bug with @richardTowers (props to Richard for actually spotting this!), we found that the [admin panel][] and endpoints for Envoy are quite useful. Use `/config_dump` and Envoy's port 9901. Prometheus metrics from Envoy will also help in future, as will `aws ecs exec`.

## Comment on the implementation

Having the service-mesh node implemented in the app module is a convenience but we may find we want to pull this module up and have the services/nodes defined in the deployment module. We should consider this when we start adding external services such as DocumentDB, EC2-hosted databases, Sentry, etc. as virtual services.

For now, we've left the egress filter as `ALLOW_ALL` rather than `DROP_ALL` since it'd be a lot of work and a confusing debugging experience to block all outgoing requests. We think we can add virtual services gradually - this would be worth doing since we'll get some load balancing properties and observability into outgoing requests to external services.

Richard also had an interesting idea about using a black hole IP address for the A record for services, rather than having CloudMap create DNS records. All we need is for the applications to resolve the IP address, and then for Envoy to re-resolve the domain to an IP from its cache of IPs. The IP address the app gets is ignored by Envoy if the service is recognised, so this could work - needs experimentation.

[App Mesh]: https://docs.aws.amazon.com/app-mesh/index.html
[Virtual Nodes]: https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_services.html
[Envoy proxy]: https://www.envoyproxy.io/docs/envoy/latest/
[egress filter]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appmesh_mesh#egress-filter
[admin panel]: https://www.envoyproxy.io/docs/envoy/latest/operations/admin