### PR TITLE
allow Fastly to access frontend public alb

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -86,7 +86,7 @@ module "frontend_public_alb" {
   publishing_service_domain = var.publishing_service_domain
   workspace_suffix          = "govuk" # TODO: Changeme
   service_security_group_id = module.frontend.security_group_id
-  external_cidrs_list       = var.office_cidrs_list
+  external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
   health_check_path         = "/"
 }
 

--- a/terraform/deployments/govuk-publishing-platform/main.tf
+++ b/terraform/deployments/govuk-publishing-platform/main.tf
@@ -11,6 +11,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.13"
     }
+
+    fastly = {
+      source  = "fastly/fastly"
+      version = "0.24.0"
+    }
   }
 }
 
@@ -20,6 +25,11 @@ provider "aws" {
   assume_role {
     role_arn = var.assume_role_arn
   }
+}
+
+provider "fastly" {
+  # We only want to use fastly's data API
+  api_key = "test"
 }
 
 locals {

--- a/terraform/deployments/govuk-publishing-platform/remote_state.tf
+++ b/terraform/deployments/govuk-publishing-platform/remote_state.tf
@@ -37,3 +37,5 @@ data "terraform_remote_state" "infra_security_groups" {
     role_arn = var.assume_role_arn
   }
 }
+
+data "fastly_ip_ranges" "fastly" {}


### PR DESCRIPTION
This PR allows Fastly CDN nodes to access the public ALB of the frontend ECS app.

Fastly is temporarily routed to the frontend app until router functionality works.

Ref:
[1] [trello card](https://trello.com/c/TjJOKSKp/404-basic-auth-for-integration-environment)