### PR TITLE
introduce www/draft-origin for assets of apps 

### DIFF
--- a/terraform/deployments/apps/common.tf
+++ b/terraform/deployments/apps/common.tf
@@ -11,10 +11,10 @@ locals {
   sentry_environment               = "${var.govuk_environment}-ecs"
   static_url                       = "http://static.${var.mesh_domain}"
   draft_static_url                 = "http://draft-static.${var.mesh_domain}"
-  statsd_host                      = "statsd.${var.mesh_domain}"                   # TODO: Put Statsd in App Mesh
-  website_root                     = "https://frontend.${var.external_app_domain}" # TODO: Change back to www once router is up
-  router_urls                      = "router.${var.mesh_domain}:3055"              # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
-  draft_router_urls                = "draft-router.${var.mesh_domain}:3055"        # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
+  statsd_host                      = "statsd.${var.mesh_domain}" # TODO: Put Statsd in App Mesh
+  website_root                     = "https://${module.www_origin.fqdn}"
+  router_urls                      = "router.${var.mesh_domain}:3055"       # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
+  draft_router_urls                = "draft-router.${var.mesh_domain}:3055" # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
 }
 
 data "aws_iam_role" "execution" {

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -7,7 +7,7 @@ locals {
       GOVUK_APP_TYPE            = "rack",
       GOVUK_STATSD_HOST         = "statsd.${var.mesh_domain}"
       GOVUK_STATSD_PROTOCOL     = "tcp"
-      GOVUK_WEBSITE_ROOT        = "https://frontend.${var.external_app_domain}", # TODO: Change back to www once router is up
+      GOVUK_WEBSITE_ROOT        = "https://${module.www_origin.fqdn}",
       PORT                      = 80,
       RAILS_ENV                 = "production",
       SENTRY_ENVIRONMENT        = "${var.govuk_environment}-ecs",
@@ -18,6 +18,8 @@ locals {
     }
     asset_host              = "https://frontend.${var.external_app_domain}",
     asset_root_url          = "https://assets.${var.publishing_service_domain}",
+    assets_www_origin       = "https://www.ecs.${var.publishing_service_domain}"
+    assets_draft_origin     = "https://draft-origin-ecs.${var.external_app_domain}"
     content_store_uri       = "http://content-store.${var.mesh_domain}",
     draft_content_store_uri = "http://draft-content-store.${var.mesh_domain}",
     draft_origin_uri        = "https://draft-frontend.${var.external_app_domain}",
@@ -31,7 +33,7 @@ locals {
     draft_router_urls       = "draft-router.${var.mesh_domain}:3055" # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
     signon_uri              = "https://signon-ecs.${var.external_app_domain}",
     static_uri              = "http://static.${var.mesh_domain}"
-    website_root            = "https://frontend.${var.external_app_domain}",
+    website_root            = "https://${module.www_origin.fqdn}",
 
     virtual_service_backends = [
       module.statsd.virtual_service_name

--- a/terraform/deployments/govuk-publishing-platform/origins.tf
+++ b/terraform/deployments/govuk-publishing-platform/origins.tf
@@ -1,0 +1,32 @@
+module "www_origin" {
+  source = "../../modules/origin"
+
+  vpc_id                    = local.vpc_id
+  public_subnets            = local.public_subnets
+  external_app_domain       = var.external_app_domain
+  publishing_service_domain = var.publishing_service_domain
+  workspace_suffix          = "govuk" # TODO: Changeme
+  external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
+
+  apps_security_config_list = {
+    "frontend" = { security_group_id = module.frontend.security_group_id, target_port = 80 },
+    "static"   = { security_group_id = module.static.security_group_id, target_port = 80 },
+  }
+}
+
+module "draft_origin" {
+  source = "../../modules/origin"
+
+  vpc_id                    = local.vpc_id
+  public_subnets            = local.public_subnets
+  external_app_domain       = var.external_app_domain
+  publishing_service_domain = var.publishing_service_domain
+  workspace_suffix          = "govuk" # TODO: Changeme
+  external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
+  live                      = false
+
+  apps_security_config_list = {
+    "draft-frontend" = { security_group_id = module.draft_frontend.security_group_id, target_port = 80 },
+    "draft-static"   = { security_group_id = module.draft_static.security_group_id, target_port = 80 }
+  }
+}

--- a/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
+++ b/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
@@ -163,14 +163,28 @@ data "aws_nat_gateway" "govuk" {
   subnet_id = local.public_subnets[count.index]
 }
 
-resource "aws_security_group_rule" "frontend_alb_from_test_nat_gateways_https" {
-  description = "Frontend ALB receives HTTPS requests from apps in ECS"
+resource "aws_security_group_rule" "www_origin_alb_from_test_nat_gateways_https" {
+  description = "www-origin ALB receives HTTPS requests from apps in ECS"
   type        = "ingress"
   from_port   = 443
   to_port     = 443
   protocol    = "tcp"
 
-  security_group_id = module.frontend_public_alb.security_group_id
+  security_group_id = module.www_origin.security_group_id
+  cidr_blocks = [
+    for nat_gateway in data.aws_nat_gateway.govuk :
+    "${nat_gateway.public_ip}/32"
+  ]
+}
+
+resource "aws_security_group_rule" "draft_origin_alb_from_test_nat_gateways_https" {
+  description = "draft-origin ALB receives HTTPS requests from apps in ECS"
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+
+  security_group_id = module.draft_origin.security_group_id
   cidr_blocks = [
     for nat_gateway in data.aws_nat_gateway.govuk :
     "${nat_gateway.public_ip}/32"

--- a/terraform/modules/origin/README.md
+++ b/terraform/modules/origin/README.md
@@ -1,0 +1,5 @@
+# origin
+
+A module which creates the origin Application Load Balancer and acts as the entry
+point to the environment from the public side (as opposed to the publishing side).
+ 

--- a/terraform/modules/origin/main.tf
+++ b/terraform/modules/origin/main.tf
@@ -1,0 +1,115 @@
+locals {
+  mode = var.live ? "www" : "draft"
+}
+
+
+# TODO: use a single, ACM-managed cert with both domains on. There is already
+# such a cert in integration/staging/prod (but it needs defining in Terraform).
+data "aws_acm_certificate" "public_lb_default" {
+  domain   = "*.${var.publishing_service_domain}"
+  statuses = ["ISSUED"]
+}
+
+data "aws_acm_certificate" "public_lb_alternate" {
+  domain   = "*.${var.external_app_domain}"
+  statuses = ["ISSUED"]
+}
+
+resource "aws_lb_listener_certificate" "service" {
+  listener_arn    = aws_lb_listener.origin.arn
+  certificate_arn = data.aws_acm_certificate.public_lb_alternate.arn
+}
+
+resource "aws_lb" "origin" {
+  name               = "${local.mode}-origin-ecs-${var.workspace_suffix}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.origin_alb.id]
+  subnets            = var.public_subnets
+}
+
+
+resource "aws_lb_target_group" "origin-frontend" {
+  name        = "${local.mode}-origin-frontend-${var.workspace_suffix}"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path = "/"
+  }
+}
+
+resource "aws_lb_listener_rule" "origin-frontend" {
+  listener_arn = aws_lb_listener.origin.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.origin-frontend.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/assets/frontend/*"]
+    }
+  }
+}
+
+resource "aws_lb_target_group" "origin-static" {
+  name        = "${local.mode}-origin-static-${var.workspace_suffix}"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path = "/templates/core_layout.html.erb"
+  }
+}
+
+resource "aws_lb_listener_rule" "origin-static" {
+  listener_arn = aws_lb_listener.origin.arn
+  priority     = 99
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.origin-static.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/assets/static/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener" "origin" {
+  load_balancer_arn = aws_lb.origin.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = data.aws_acm_certificate.public_lb_default.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.origin-frontend.arn
+  }
+}
+
+data "aws_route53_zone" "public" {
+  name = var.external_app_domain
+}
+
+resource "aws_route53_record" "origin_alb" {
+  zone_id = data.aws_route53_zone.public.zone_id
+  name    = "${local.mode}-origin-ecs"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.origin.dns_name
+    zone_id                = aws_lb.origin.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/modules/origin/outputs.tf
+++ b/terraform/modules/origin/outputs.tf
@@ -1,0 +1,15 @@
+output "frontend_target_group_arn" {
+  value = aws_lb_target_group.origin-frontend.arn
+}
+
+output "static_target_group_arn" {
+  value = aws_lb_target_group.origin-static.arn
+}
+
+output "security_group_id" {
+  value = aws_security_group.origin_alb.id
+}
+
+output "fqdn" {
+  value = "${aws_route53_record.origin_alb.name}.${var.publishing_service_domain}"
+}

--- a/terraform/modules/origin/security_groups.tf
+++ b/terraform/modules/origin/security_groups.tf
@@ -1,0 +1,36 @@
+resource "aws_security_group" "origin_alb" {
+  name        = "fargate_${local.mode}_origin_${var.workspace_suffix}_alb"
+  vpc_id      = var.vpc_id
+  description = "${local.mode}-origin Internet-facing ALB in ${var.workspace_suffix} cluster"
+}
+
+resource "aws_security_group_rule" "service_from_origin_alb_http" {
+  for_each                 = var.apps_security_config_list
+  description              = "${each.key} receives requests from the ${local.mode}-origin ALB over HTTP"
+  type                     = "ingress"
+  from_port                = each.value.target_port
+  to_port                  = each.value.target_port
+  protocol                 = "tcp"
+  security_group_id        = each.value.security_group_id
+  source_security_group_id = aws_security_group.origin_alb.id
+}
+
+resource "aws_security_group_rule" "origin_alb_from_any_https" {
+  description       = "${local.mode}-origin ALB allows requests from CIDRs list over HTTPS"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = var.external_cidrs_list
+  security_group_id = aws_security_group.origin_alb.id
+}
+
+resource "aws_security_group_rule" "origin_alb_to_any_any" {
+  type      = "egress"
+  protocol  = "-1"
+  from_port = 0
+  to_port   = 0
+
+  security_group_id = aws_security_group.origin_alb.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/terraform/modules/origin/variables.tf
+++ b/terraform/modules/origin/variables.tf
@@ -1,0 +1,38 @@
+variable "external_app_domain" {
+  type        = string
+  description = "e.g. test.govuk.digital. Domain in which to create DNS records for the app's Internet-facing load balancer."
+}
+
+variable "live" {
+  description = "Determines whether the origin is a live or a draft one"
+  type        = bool
+  default     = true
+}
+
+variable "apps_security_config_list" {
+  type        = map(any)
+  description = "map in the format {<app_name> = { security_group_id=<security_group_id>, target_port=<target_port>}}"
+}
+
+variable "external_cidrs_list" {
+  type    = list(any)
+  default = ["0.0.0.0/0"]
+}
+
+variable "publishing_service_domain" {
+  type        = string
+  description = "e.g. test.publishing.service.gov.uk"
+}
+
+variable "public_subnets" {
+  type = list(any)
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "workspace_suffix" {
+  type    = string
+  default = "govuk" # TODO: Is this the default value?
+}


### PR DESCRIPTION
This PR is the continuation of the work to add Fastly CDN in front of
the Test environment for basic authentication.

In order to route all public user traffic (except traffic usually going to
assets.*.publishing.service.gov.uk) via the CDN so that they can be
authenticated, we need to introduce the origin component of GOV.UK.

The origin component of GOV.UK acts as a `single` entry point to the
GOV.UK environment and fans out the requests to different other apps of
GOV.UK. The origin component of GOV.UK is implemented in the EC2 platform
using nginx configs and GOV.UK router app

This PR implements the nginx routing using a AWS Application Load
Balancer in the new ECS environment with the use of path prefix
matching to redirect requests to the correct frontend GOV.UK apps.

In effect, if HTTP request arrives with:
1. /assets/frontend/* this is directed to the Frontend app
2. /assets/static/* this is directed to the Static app
3. otherwise, all traffic goes to the Frontend app
   (when Router is properly implemented, this should go to the Router
app)

Ref:
1. [trello card](https://trello.com/c/TjJOKSKp/404-basic-auth-for-integration-environment)
