### PR TITLE
Remove app secrets from Envoy containers

### DIFF
--- a/terraform/modules/app/task_definition.tf
+++ b/terraform/modules/app/task_definition.tf
@@ -59,7 +59,7 @@ module "envoy_container_definition" {
   log_group         = var.log_group
   log_stream_prefix = "awslogs-${var.service_name}-envoy"
   name              = "envoy"
-  secrets_from_arns = var.secrets_from_arns
+  secrets_from_arns = {}
   ports             = []
   user              = local.user_id
 }


### PR DESCRIPTION
App secrets were erroneously provided to Envoy instances
as environment variables. Envoy requires no secrets provided
via env vars.