### PR TITLE
Workspace

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -111,7 +111,7 @@ module "publisher_public_alb" {
   public_subnets            = local.public_subnets
   external_app_domain       = var.external_app_domain
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = "govuk" # TODO: Changeme
+  workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
   service_security_group_id = module.publisher_web.security_group_id
   external_cidrs_list       = var.office_cidrs_list
 }

--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -107,6 +107,7 @@ module "publisher_public_alb" {
 
   app_name                  = local.publisher_app_name
   vpc_id                    = local.vpc_id
+  public_zone_id            = aws_route53_zone.workspace_public.zone_id
   dns_a_record_name         = "publisher"
   public_subnets            = local.public_subnets
   external_app_domain       = var.external_app_domain

--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -111,6 +111,7 @@ module "publisher_public_alb" {
   dns_a_record_name         = "publisher"
   public_subnets            = local.public_subnets
   external_app_domain       = var.external_app_domain
+  certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
   workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
   service_security_group_id = module.publisher_web.security_group_id

--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -113,7 +113,7 @@ module "publisher_public_alb" {
   external_app_domain       = var.external_app_domain
   certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
+  workspace_suffix          = terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"
   service_security_group_id = module.publisher_web.security_group_id
   external_cidrs_list       = var.office_cidrs_list
 }

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -61,6 +61,7 @@ module "signon_public_alb" {
 
   app_name                  = "signon"
   vpc_id                    = local.vpc_id
+  public_zone_id            = aws_route53_zone.workspace_public.zone_id
   dns_a_record_name         = "signon-ecs"
   public_subnets            = local.public_subnets
   external_app_domain       = var.external_app_domain

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -65,6 +65,7 @@ module "signon_public_alb" {
   dns_a_record_name         = "signon-ecs"
   public_subnets            = local.public_subnets
   external_app_domain       = var.external_app_domain
+  certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
   workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
   service_security_group_id = module.signon.security_group_id

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -67,6 +67,6 @@ module "signon_public_alb" {
   external_app_domain       = var.external_app_domain
   certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
+  workspace_suffix          = terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"
   service_security_group_id = module.signon.security_group_id
 }

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -65,6 +65,6 @@ module "signon_public_alb" {
   public_subnets            = local.public_subnets
   external_app_domain       = var.external_app_domain
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = "govuk" # TODO: Changeme
+  workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
   service_security_group_id = module.signon.security_group_id
 }

--- a/terraform/deployments/govuk-publishing-platform/app_statsd.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_statsd.tf
@@ -2,7 +2,7 @@ module "statsd" {
   cluster_id                       = aws_ecs_cluster.cluster.id
   execution_role_arn               = aws_iam_role.execution.arn
   internal_app_domain              = var.internal_app_domain
-  mesh_name                        = var.mesh_name
+  mesh_name                        = aws_appmesh_mesh.govuk.id
   private_subnets                  = local.private_subnets
   security_groups                  = [aws_security_group.mesh_ecs_service.id, local.govuk_management_access_sg_id]
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -1,5 +1,5 @@
 locals {
-    mesh_domain = "${terraform.workspace == "default" ? var.mesh_domain : "mesh-${terraform.workspace}.govuk-internal.digital"}"   
+  mesh_domain = terraform.workspace == "default" ? var.mesh_domain : "mesh-${terraform.workspace}.govuk-internal.digital"
   defaults = {
     environment_variables = {
       DEFAULT_TTL               = 1800,

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -1,8 +1,9 @@
 locals {
+    mesh_domain = "${terraform.workspace == "default" ? var.mesh_domain : "mesh-${terraform.workspace}.govuk-internal.digital"}"   
   defaults = {
     environment_variables = {
       DEFAULT_TTL               = 1800,
-      GOVUK_APP_DOMAIN          = var.mesh_domain,
+      GOVUK_APP_DOMAIN          = local.mesh_domain,
       GOVUK_APP_DOMAIN_EXTERNAL = var.external_app_domain,
       GOVUK_APP_TYPE            = "rack",
       GOVUK_STATSD_HOST         = "statsd.${var.mesh_domain}"

--- a/terraform/deployments/govuk-publishing-platform/dns.tf
+++ b/terraform/deployments/govuk-publishing-platform/dns.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "workspace_public_zone_ns" {
   zone_id = data.aws_route53_zone.public.zone_id
   name    = local.workspace_external_domain
   type    = "NS"
-  ttl     = "30"
+  ttl     = "300"
 
   records = aws_route53_zone.workspace_public.name_servers
 }

--- a/terraform/deployments/govuk-publishing-platform/dns.tf
+++ b/terraform/deployments/govuk-publishing-platform/dns.tf
@@ -1,0 +1,36 @@
+locals {
+  workspace_external_domain = "${terraform.workspace == "default" ? "ecs.${var.external_app_domain}" : "${terraform.workspace}.${var.external_app_domain}"}"
+  workspace_internal_domain = "${terraform.workspace == "default" ? "ecs.${var.internal_app_domain}" : "${terraform.workspace}.${var.internal_app_domain}"}"
+}
+
+
+
+data "aws_route53_zone" "public" {
+  name = var.external_app_domain
+}
+
+resource "aws_route53_record" "workspace_public_zone_ns" {
+  zone_id = data.aws_route53_zone.public.zone_id
+  name    = local.workspace_external_domain
+  type    = "NS"
+  ttl     = "30"
+
+  records = aws_route53_zone.workspace_public.name_servers
+}
+
+resource "aws_route53_zone" "workspace_public" {
+  name  = local.workspace_external_domain
+}
+
+resource "aws_route53_zone" "internal_public" {
+  name  = local.workspace_internal_domain
+}
+
+resource "aws_route53_zone" "internal_private" {
+  name  = local.workspace_internal_domain
+
+  vpc {
+    vpc_id = data.terraform_remote_state.infra_networking.outputs.vpc_id
+  }
+
+}

--- a/terraform/deployments/govuk-publishing-platform/dns.tf
+++ b/terraform/deployments/govuk-publishing-platform/dns.tf
@@ -1,6 +1,6 @@
 locals {
-  workspace_external_domain = "${terraform.workspace == "default" ? "ecs.${var.external_app_domain}" : "${terraform.workspace}.${var.external_app_domain}"}"
-  workspace_internal_domain = "${terraform.workspace == "default" ? "ecs.${var.internal_app_domain}" : "${terraform.workspace}.${var.internal_app_domain}"}"
+  workspace_external_domain = terraform.workspace == "default" ? "ecs.${var.external_app_domain}" : "${terraform.workspace}.${var.external_app_domain}"
+  workspace_internal_domain = terraform.workspace == "default" ? "ecs.${var.internal_app_domain}" : "${terraform.workspace}.${var.internal_app_domain}"
 }
 
 
@@ -19,15 +19,15 @@ resource "aws_route53_record" "workspace_public_zone_ns" {
 }
 
 resource "aws_route53_zone" "workspace_public" {
-  name  = local.workspace_external_domain
+  name = local.workspace_external_domain
 }
 
 resource "aws_route53_zone" "internal_public" {
-  name  = local.workspace_internal_domain
+  name = local.workspace_internal_domain
 }
 
 resource "aws_route53_zone" "internal_private" {
-  name  = local.workspace_internal_domain
+  name = local.workspace_internal_domain
 
   vpc {
     vpc_id = data.terraform_remote_state.infra_networking.outputs.vpc_id
@@ -49,9 +49,9 @@ resource "aws_acm_certificate" "workspace_public" {
 resource "aws_route53_record" "workspace_public" {
   for_each = {
     for dvo in aws_acm_certificate.workspace_public.domain_validation_options : dvo.domain_name => {
-      name    = dvo.resource_record_name
-      record  = dvo.resource_record_value
-      type    = dvo.resource_record_type
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
     }
   }
 
@@ -60,10 +60,10 @@ resource "aws_route53_record" "workspace_public" {
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = aws_route53_zone.workspace_public.zone_id 
+  zone_id         = aws_route53_zone.workspace_public.zone_id
 }
 
 resource "aws_acm_certificate_validation" "workspace_public" {
-  certificate_arn         =  aws_acm_certificate.workspace_public.arn
+  certificate_arn         = aws_acm_certificate.workspace_public.arn
   validation_record_fqdns = [for record in aws_route53_record.workspace_public : record.fqdn]
 }

--- a/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
@@ -36,7 +36,7 @@ resource "aws_service_discovery_private_dns_namespace" "govuk_publishing_platfor
 }
 
 resource "aws_iam_role" "execution" {
-  name        = "fargate_execution_role"
+  name        = "fargate_execution_role-${terraform.workspace}"
   description = "Role for the ECS container agent and Docker daemon to manage the app container."
 
   assume_role_policy = <<EOF
@@ -122,7 +122,7 @@ resource "aws_iam_role_policy_attachment" "access_secrets_attachment_policy" {
 # Proxy authorization for ECS tasks
 # https://docs.aws.amazon.com/app-mesh/latest/userguide/proxy-authorization.html
 resource "aws_iam_role" "task" {
-  name        = "fargate_task_role"
+  name        = "fargate_task_role-${terraform.workspace}"
   description = "Role for GOV.UK Publishing app containers (ECS tasks) to talk to other AWS services."
 
   assume_role_policy = <<EOF

--- a/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
@@ -7,7 +7,7 @@ locals {
 
 # All services running on GOV.UK run in this single cluster.
 resource "aws_ecs_cluster" "cluster" {
-  name               = "govuk"
+  name               = local.mesh_name
   capacity_providers = ["FARGATE", "FARGATE_SPOT"]
 
   default_capacity_provider_strategy {

--- a/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
@@ -1,5 +1,5 @@
 locals {
-  mesh_name             = "${terraform.workspace == "default" ? var.mesh_name : "mesh-${terraform.workspace}"}"
+  mesh_name = terraform.workspace == "default" ? var.mesh_name : "mesh-${terraform.workspace}"
 }
 
 

--- a/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
@@ -1,3 +1,10 @@
+locals {
+  mesh_name             = "${terraform.workspace == "default" ? var.mesh_name : "mesh-${terraform.workspace}"}"
+}
+
+
+
+
 # All services running on GOV.UK run in this single cluster.
 resource "aws_ecs_cluster" "cluster" {
   name               = "govuk"
@@ -14,7 +21,7 @@ resource "aws_ecs_cluster" "cluster" {
 }
 
 resource "aws_appmesh_mesh" "govuk" {
-  name = var.mesh_name
+  name = local.mesh_name
 
   spec {
     egress_filter {
@@ -24,7 +31,7 @@ resource "aws_appmesh_mesh" "govuk" {
 }
 
 resource "aws_service_discovery_private_dns_namespace" "govuk_publishing_platform" {
-  name = var.mesh_domain
+  name = local.mesh_domain
   vpc  = local.vpc_id
 }
 

--- a/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
@@ -58,7 +58,7 @@ EOF
 # TODO don't let tasks create their own log groups -
 # create the log group in terraform
 resource "aws_iam_policy" "create_log_group_policy" {
-  name        = "create_log_group_policy"
+  name        = "create_log_group_policy-${terraform.workspace}"
   path        = "/createLogsGroupPolicy/"
   description = "Create Logs group"
 
@@ -92,7 +92,7 @@ resource "aws_iam_role_policy_attachment" "task_exec_policy" {
 # TODO: This allows *all* apps to access *any* secret. We should create a task execution
 # role and policy for each app to permit apps to only access required secrets.
 resource "aws_iam_policy" "access_secrets" {
-  name        = "access_secrets"
+  name        = "access_secrets-${terraform.workspace}"
   path        = "/accessSecretsPolicy/"
   description = "Allow apps in ECS to access secrets"
 

--- a/terraform/deployments/govuk-publishing-platform/origins.tf
+++ b/terraform/deployments/govuk-publishing-platform/origins.tf
@@ -5,7 +5,7 @@ module "www_origin" {
   public_subnets            = local.public_subnets
   external_app_domain       = var.external_app_domain
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = "govuk" # TODO: Changeme
+  workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
   external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
 
   apps_security_config_list = {
@@ -21,7 +21,7 @@ module "draft_origin" {
   public_subnets            = local.public_subnets
   external_app_domain       = var.external_app_domain
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = "govuk" # TODO: Changeme
+  workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
   external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
   live                      = false
 

--- a/terraform/deployments/govuk-publishing-platform/origins.tf
+++ b/terraform/deployments/govuk-publishing-platform/origins.tf
@@ -6,7 +6,7 @@ module "www_origin" {
   public_zone_id            = aws_route53_zone.workspace_public.zone_id
   external_app_domain       = var.external_app_domain
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
+  workspace_suffix          = terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"
   external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
 
   apps_security_config_list = {
@@ -23,7 +23,7 @@ module "draft_origin" {
   public_zone_id            = aws_route53_zone.workspace_public.zone_id
   external_app_domain       = var.external_app_domain
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
+  workspace_suffix          = terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"
   external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
   live                      = false
 

--- a/terraform/deployments/govuk-publishing-platform/origins.tf
+++ b/terraform/deployments/govuk-publishing-platform/origins.tf
@@ -3,6 +3,7 @@ module "www_origin" {
 
   vpc_id                    = local.vpc_id
   public_subnets            = local.public_subnets
+  public_zone_id            = aws_route53_zone.workspace_public.zone_id
   external_app_domain       = var.external_app_domain
   publishing_service_domain = var.publishing_service_domain
   workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"
@@ -19,6 +20,7 @@ module "draft_origin" {
 
   vpc_id                    = local.vpc_id
   public_subnets            = local.public_subnets
+  public_zone_id            = aws_route53_zone.workspace_public.zone_id
   external_app_domain       = var.external_app_domain
   publishing_service_domain = var.publishing_service_domain
   workspace_suffix          = "${terraform.workspace == "default" ? "govuk" : "${terraform.workspace}"}"

--- a/terraform/deployments/govuk-publishing-platform/outputs.tf
+++ b/terraform/deployments/govuk-publishing-platform/outputs.tf
@@ -73,11 +73,11 @@ output "log_group" {
 }
 
 output "mesh_name" {
-  value = var.mesh_name
+  value = local.mesh_name
 }
 
 output "mesh_domain" {
-  value = var.mesh_domain
+  value = local.mesh_domain
 }
 
 output "external_app_domain" {

--- a/terraform/deployments/govuk-publishing-platform/security_groups.tf
+++ b/terraform/deployments/govuk-publishing-platform/security_groups.tf
@@ -1,13 +1,13 @@
 # Security groups for the GOV.UK Publishing microservices are defined here.
 
 resource "aws_security_group" "mesh_ecs_service" {
-  name        = "mesh_ecs_service"
+  name        = "mesh_ecs_service-${terraform.workspace}"
   vpc_id      = local.vpc_id
   description = "Associated with all ECS Services that are virtual services in the AppMesh mesh"
 }
 
 resource "aws_security_group" "smokey" {
-  name        = "ecs_fargate_smokey"
+  name        = "ecs_fargate_smokey-${terraform.workspace}"
   vpc_id      = local.vpc_id
   description = "Smoke test runner"
 }

--- a/terraform/deployments/govuk-publishing-platform/shared_redis_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/shared_redis_cluster.tf
@@ -1,7 +1,7 @@
 # TODO - inline this module
 
 locals {
-  cluster_name      = "${terraform.workspace == "default" ? "shared" : "${terraform.workspace}"}"
+  cluster_name = terraform.workspace == "default" ? "shared" : "${terraform.workspace}"
 }
 
 module "shared_redis_cluster" {

--- a/terraform/deployments/govuk-publishing-platform/shared_redis_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/shared_redis_cluster.tf
@@ -5,10 +5,11 @@ locals {
 }
 
 module "shared_redis_cluster" {
-  source              = "../../modules/redis"
-  vpc_id              = local.vpc_id
-  cluster_name        = local.cluster_name
-  internal_app_domain = var.internal_app_domain
-  subnet_ids          = local.redis_subnets
+  source                   = "../../modules/redis"
+  vpc_id                   = local.vpc_id
+  internal_private_zone_id = aws_route53_zone.internal_private.zone_id
+  cluster_name             = local.cluster_name
+  internal_app_domain      = var.internal_app_domain
+  subnet_ids               = local.redis_subnets
 }
 

--- a/terraform/deployments/govuk-publishing-platform/shared_redis_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/shared_redis_cluster.tf
@@ -1,8 +1,13 @@
 # TODO - inline this module
 
+locals {
+  cluster_name      = "${terraform.workspace == "default" ? "shared" : "${terraform.workspace}"}"
+}
+
 module "shared_redis_cluster" {
   source              = "../../modules/redis"
   vpc_id              = local.vpc_id
+  cluster_name        = local.cluster_name
   internal_app_domain = var.internal_app_domain
   subnet_ids          = local.redis_subnets
 }

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -74,7 +74,7 @@ module "service_mesh_node" {
 }
 
 resource "aws_security_group" "service" {
-  name        = "fargate_${var.service_name}"
+  name        = "fargate_${var.service_name}-${terraform.workspace}"
   vpc_id      = var.vpc_id
   description = "${var.service_name} app ECS tasks"
 }

--- a/terraform/modules/monitoring/grafana.tf
+++ b/terraform/modules/monitoring/grafana.tf
@@ -29,14 +29,25 @@ module "grafana_app" {
   execution_role_arn    = aws_iam_role.monitoring_execution.arn
 }
 
+data "aws_acm_certificate" "public_lb_alternate" {
+  domain   = "*.${var.external_app_domain}"
+  statuses = ["ISSUED"]
+}
+
+data "aws_route53_zone" "public" {
+  name = var.external_app_domain
+}
+
 module "grafana_public_alb" {
   source = "../public-load-balancer"
 
   app_name                  = "grafana"
   vpc_id                    = var.vpc_id
+  public_zone_id            = data.aws_route53_zone.public
   dns_a_record_name         = "${local.service_name}-ecs"
   public_subnets            = var.public_subnets
   external_app_domain       = var.external_app_domain
+  certificate               = data.aws_acm_certificate.public_lb_alternate
   publishing_service_domain = var.publishing_service_domain
   workspace_suffix          = "govuk" # TODO: Changeme
   service_security_group_id = module.grafana_app.security_group_id

--- a/terraform/modules/origin/main.tf
+++ b/terraform/modules/origin/main.tf
@@ -103,7 +103,7 @@ data "aws_route53_zone" "public" {
 }
 
 resource "aws_route53_record" "origin_alb" {
-  zone_id = data.aws_route53_zone.public.zone_id
+  zone_id = var.public_zone_id
   name    = "${local.mode}-origin-ecs"
   type    = "A"
 

--- a/terraform/modules/origin/variables.tf
+++ b/terraform/modules/origin/variables.tf
@@ -32,6 +32,10 @@ variable "vpc_id" {
   type = string
 }
 
+variable "public_zone_id" {
+  type = string
+}
+
 variable "workspace_suffix" {
   type    = string
   default = "govuk" # TODO: Is this the default value?

--- a/terraform/modules/public-load-balancer/main.tf
+++ b/terraform/modules/public-load-balancer/main.tf
@@ -12,7 +12,7 @@ data "aws_acm_certificate" "public_lb_alternate" {
 
 resource "aws_lb_listener_certificate" "service" {
   listener_arn    = aws_lb_listener.public.arn
-  certificate_arn = data.aws_acm_certificate.public_lb_alternate.arn
+  certificate_arn = var.certificate
 }
 
 resource "aws_lb" "public" {

--- a/terraform/modules/public-load-balancer/main.tf
+++ b/terraform/modules/public-load-balancer/main.tf
@@ -53,7 +53,7 @@ data "aws_route53_zone" "public" {
 }
 
 resource "aws_route53_record" "public_alb" {
-  zone_id = data.aws_route53_zone.public.zone_id
+  zone_id = var.public_zone_id
   name    = var.dns_a_record_name
   type    = "A"
 

--- a/terraform/modules/public-load-balancer/variables.tf
+++ b/terraform/modules/public-load-balancer/variables.tf
@@ -3,6 +3,10 @@ variable "external_app_domain" {
   description = "e.g. test.govuk.digital. Domain in which to create DNS records for the app's Internet-facing load balancer."
 }
 
+variable "certificate" {
+  type        = string
+}
+
 variable "app_name" {
   type        = string
   description = "A GOV.UK application name. E.g. publisher, content-publisher"

--- a/terraform/modules/public-load-balancer/variables.tf
+++ b/terraform/modules/public-load-balancer/variables.tf
@@ -4,7 +4,7 @@ variable "external_app_domain" {
 }
 
 variable "certificate" {
-  type        = string
+  type = string
 }
 
 variable "app_name" {

--- a/terraform/modules/public-load-balancer/variables.tf
+++ b/terraform/modules/public-load-balancer/variables.tf
@@ -36,6 +36,10 @@ variable "vpc_id" {
   type = string
 }
 
+variable "public_zone_id" {
+  type = string
+}
+
 variable "health_check_path" {
   type    = string
   default = "/healthcheck"

--- a/terraform/modules/redis/main.tf
+++ b/terraform/modules/redis/main.tf
@@ -44,7 +44,7 @@ data "aws_route53_zone" "internal" {
 }
 
 resource "aws_route53_record" "internal_service_record" {
-  zone_id = data.aws_route53_zone.internal.zone_id
+  zone_id = var.internal_private_zone_id
   name    = "${var.cluster_name}-redis.${var.internal_app_domain}"
   type    = "CNAME"
   ttl     = 300

--- a/terraform/modules/redis/variables.tf
+++ b/terraform/modules/redis/variables.tf
@@ -24,3 +24,7 @@ variable "node_type" {
 variable "vpc_id" {
   type = string
 }
+
+variable "internal_private_zone_id" {
+  type = string
+}

--- a/terraform/modules/statsd/main.tf
+++ b/terraform/modules/statsd/main.tf
@@ -83,7 +83,7 @@ module "task_definition" {
 }
 
 resource "aws_security_group" "service" {
-  name        = "fargate_${local.service_name}"
+  name        = "fargate_${local.service_name}-${terraform.workspace}"
   vpc_id      = var.vpc_id
   description = "${local.service_name} ECS Service"
 }


### PR DESCRIPTION
This modify the codebase to make it "workspace aware".
It make the name attribute of resources generated through the terraform.workspace variable to avoid interference between workspaces.
It adds management of DNS zones and certificates as those are needed for new workspaces and were previously not created through terraform.
It adds new input variables for modules that need DNS zone/certificate (like public-load-balancer)