### PR TITLE
Rails assets uploads

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -26,13 +26,6 @@ resources:
     type: git
 
   - <<: *git-repo
-    name: frontend
-    source:
-      branch: master
-      uri: https://github.com/alphagov/frontend
-      tag_filter: release_*
-
-  - <<: *git-repo
     name: publisher
     source:
       branch: master
@@ -105,13 +98,6 @@ resources:
       region_name: eu-west-2
       versioned_file: smokey.json
       initial_version: "0"
-
-  - <<: *git-repo
-    name: static
-    source:
-      branch: master
-      uri: https://github.com/alphagov/static
-      tag_filter: release_*
 
   - name: deploy-slack-channel
     type: slack-notification
@@ -195,6 +181,25 @@ resources:
       region_name: eu-west-2
       versioned_file: router.json
       initial_version: "0"
+
+
+  - name: frontend-image
+    type: registry-image
+    icon: docker
+    source:
+      repository: govuk/frontend
+      tag: release
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
+
+  - name: static-image
+    type: registry-image
+    icon: docker
+    source:
+      repository: govuk/static
+      tag: release
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
 
 groups:
   - name: all
@@ -433,12 +438,20 @@ jobs:
         passed:
         - run-terraform
         trigger: true
-      - get: release
-        resource: frontend
+      - get: frontend-image
         trigger: true
     - in_parallel:
+      - task: upload-rails-assets
+        file: govuk-infrastructure/concourse/tasks/upload-rails-assets.yml
+        input_mapping:
+          app-image: frontend-image
+        params:
+          IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/frontend
+          S3_BUCKET_PATH: s3://govuk-test-ecs-rails-assets/assets/frontend/
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: frontend-image
         output_mapping:
          task-definition-arn: draft-task-definition-arn
         params:
@@ -446,6 +459,8 @@ jobs:
          VARIANT: draft
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: frontend-image
         output_mapping:
          task-definition-arn: live-task-definition-arn
         params:
@@ -624,6 +639,7 @@ jobs:
       - get: release
         resource: content-store
         trigger: true
+
     - in_parallel:
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
@@ -818,12 +834,20 @@ jobs:
         passed:
         - run-terraform
         trigger: true
-      - get: release
-        resource: static
+      - get: static-image
         trigger: true
     - in_parallel:
+      - task: upload-rails-assets
+        file: govuk-infrastructure/concourse/tasks/upload-rails-assets.yml
+        input_mapping:
+          app-image: static-image
+        params:
+          IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/static
+          S3_BUCKET_PATH: s3://govuk-test-ecs-rails-assets/assets/static/
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: static-image
         output_mapping:
           task-definition-arn: draft-task-definition-arn
         params:
@@ -831,6 +855,8 @@ jobs:
           VARIANT: draft
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: static-image
         output_mapping:
           task-definition-arn: live-task-definition-arn
         params:

--- a/concourse/tasks/update-task-definition.sh
+++ b/concourse/tasks/update-task-definition.sh
@@ -10,8 +10,13 @@ role_arn = $ASSUME_ROLE_ARN
 credential_source = Ec2InstanceMetadata
 EOF
 
-BUILD_TAG=${PIN_IMAGE_TAG:-$(cat release/.git/ref)}
-IMAGE="govuk/${APPLICATION}:${BUILD_TAG}"
+if [ -f "app-image/digest" ]; then
+  IMAGE="govuk/${APPLICATION}@$(cat app-image/digest)"
+else
+  BUILD_TAG=${PIN_IMAGE_TAG:-$(cat release/.git/ref)}
+  IMAGE="govuk/${APPLICATION}:${BUILD_TAG}"
+fi
+
 echo "Creating a new task definition for ${IMAGE} in ECS"
 echo "================================================="
 

--- a/concourse/tasks/upload-rails-assets.sh
+++ b/concourse/tasks/upload-rails-assets.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+set -eu
+
+mkdir -p ~/.aws
+
+cat <<EOF > ~/.aws/config
+[profile default]
+role_arn = $ASSUME_ROLE_ARN
+credential_source = Ec2InstanceMetadata
+EOF
+
+echo "Uploading rails assets from ${IMAGE_ASSETS_PATH} to ${S3_BUCKET_PATH} ..."
+
+aws s3 sync \
+  "${IMAGE_ASSETS_PATH}" \
+  "${S3_BUCKET_PATH}"
+
+echo "Finished uploading rails assets from ${IMAGE_ASSETS_PATH} to ${S3_BUCKET_PATH}"

--- a/concourse/tasks/upload-rails-assets.yml
+++ b/concourse/tasks/upload-rails-assets.yml
@@ -3,24 +3,17 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/awscli
-    tag: latest
+    tag: latest # TODO - manage image versions ourselves instead of using latest
     username: ((docker_hub_username))
     password: ((docker_hub_authtoken))
 inputs:
   - name: govuk-infrastructure
     path: src
-  - name: release
-    optional: true
-  - name: app-terraform-outputs
   - name: app-image
-    optional: true
-outputs:
-  - name: task-definition-arn
 params:
   AWS_REGION: eu-west-1
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
-  APPLICATION:
-  VARIANT:
-  PIN_IMAGE_TAG:
+  IMAGE_ASSETS_PATH:
+  S3_BUCKET_PATH:
 run:
-  path: ./src/concourse/tasks/update-task-definition.sh
+  path: ./src/concourse/tasks/upload-rails-assets.sh

--- a/terraform/deployments/govuk-publishing-platform/rails_assets.tf
+++ b/terraform/deployments/govuk-publishing-platform/rails_assets.tf
@@ -1,0 +1,13 @@
+locals {
+  workspace_transformation = terraform.workspace == "default" ? "ecs" : terraform.workspace
+}
+
+
+resource "aws_s3_bucket" "rails_assets" {
+  bucket = "govuk-${var.govuk_environment}-${local.workspace_transformation}-rails-assets"
+
+  tags = {
+    name            = "govuk-${var.govuk_environment}-${local.workspace_transformation}-rails-assets"
+    aws_environment = var.govuk_environment
+  }
+}


### PR DESCRIPTION
Proposal to add rails assets to s3 by using the precompiled assets in the docker
image. For now, we use only static and frontend as test cases.

The deployment process for static and frontend app is as follows:
1. a new resource monitors the app image container with tag:
   `release`, when the sha256/digest of the image changes
   because a new container image has uploaded, a new app deploy happens.

   Later, we can filter via semantic versioning later when we integrate fully
   the AWS ECR.

2. The app image already contains the precompiles assets and are
   uploaded to S3, we uploaded all the public assets of an app to
   <bucket_name>/assets/<app_name>. While there will be only assets
   directory in the bucket, this is easier since no S3 rerouting rule
   needs to be added.

3. The task definition uses the sha256/digest rather than the tag.
   This can be changed later when we moved to semantic versioning.

Ref:
1. [trello card](https://trello.com/c/NRLwGdBJ/172-static-assets-in-ecs)