### PR TITLE
Make log group workspace aware

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/main.tf
+++ b/terraform/deployments/govuk-publishing-platform/main.tf
@@ -43,5 +43,5 @@ locals {
   mongodb_security_group_id     = data.terraform_remote_state.infra_security_groups.outputs.sg_mongo_id
   mysql_security_group_id       = data.terraform_remote_state.infra_security_groups.outputs.sg_mysql-primary_id
   routerdb_security_group_id    = data.terraform_remote_state.infra_security_groups.outputs.sg_router-backend_id
-  log_group                     = "govuk" # TODO make this workspace aware
+  log_group                     = terraform.workspace == "default" ? "govuk" : "govuk-${terraform.workspace}"
 }


### PR DESCRIPTION
Otherwise all the logs from all the workspaces go in the same group, and it's impossible to work out what's going on.

I think there's a strong case that we should split the log groups up further - e.g. one per app. The AWS CLI has an `aws logs tail` command which is quite useful, but only allows tailing an entire group. That would be useless in production if we had every single app and every single envoy shipping to the same group. Anyway, that's a thought for later.