### PR TITLE
Fix Shared Redis Cluster hostname

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -36,11 +36,8 @@ locals {
         PLEK_SERVICE_DRAFT_ORIGIN_URI = local.defaults.draft_origin_uri
         # TODO: temporary hack
         RAILS_SERVE_STATIC_FILES = "true"
-        # TODO: we shouldn't be specifying both REDIS_{HOST,PORT} *and* REDIS_URL.
-        REDIS_HOST   = var.redis_host
-        REDIS_PORT   = tostring(var.redis_port)
-        REDIS_URL    = local.defaults.redis_url
-        WEBSITE_ROOT = local.defaults.website_root
+        REDIS_URL                = module.shared_redis_cluster.uri
+        WEBSITE_ROOT             = local.defaults.website_root
       }
     )
 

--- a/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
@@ -30,7 +30,7 @@ locals {
         RABBITMQ_HOSTS                       = local.defaults.rabbitmq_hosts
         RABBITMQ_USER                        = "publishing_api"
         RABBITMQ_VHOST                       = "/"
-        REDIS_URL                            = local.defaults.redis_url
+        REDIS_URL                            = module.shared_redis_cluster.uri
         UNICORN_WORKER_PROCESSES             = "8"
       }
     )

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -12,7 +12,7 @@ locals {
         GOVUK_APP_ROOT           = "/app"
         GOVUK_STATSD_PREFIX      = "govuk-ecs.app.signon"
         RAILS_SERVE_STATIC_FILES = "true"
-        REDIS_URL                = "redis://${var.redis_host}:${var.redis_port}"
+        REDIS_URL                = module.shared_redis_cluster.uri
       }
     )
 

--- a/terraform/deployments/govuk-publishing-platform/app_static.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_static.tf
@@ -9,7 +9,7 @@ locals {
         GOVUK_APP_NAME                   = "static",
         GOVUK_APP_ROOT                   = "/var/apps/static",
         PLEK_SERVICE_ACCOUNT_MANAGER_URI = "",
-        REDIS_URL                        = local.defaults.redis_url,
+        REDIS_URL                        = module.shared_redis_cluster.uri,
         RAILS_SERVE_STATIC_FILES         = "enabled",
         RAILS_SERVE_STATIC_ASSETS        = "yes",
       }

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -27,7 +27,6 @@ locals {
     draft_static_uri        = "http://draft-static.${local.mesh_domain}"
     publishing_api_uri      = "http://publishing-api-web.${local.mesh_domain}",
     rabbitmq_hosts          = "rabbitmq.${var.internal_app_domain}"
-    redis_url               = "redis://${var.redis_host}:${var.redis_port}"
     router_api_uri          = "http://router-api.${local.mesh_domain}",
     draft_router_api_uri    = "http://draft-router-api.${local.mesh_domain}",
     router_urls             = "router.${local.mesh_domain}:3055"       # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.

--- a/terraform/deployments/govuk-publishing-platform/outputs.tf
+++ b/terraform/deployments/govuk-publishing-platform/outputs.tf
@@ -100,14 +100,6 @@ output "fargate_task_iam_role_arn" {
   value = aws_iam_role.task.arn
 }
 
-output "redis_host" {
-  value = module.shared_redis_cluster.redis_host
-}
-
-output "redis_port" {
-  value = module.shared_redis_cluster.redis_port
-}
-
 output "signon" {
   value = {
     web = {

--- a/terraform/deployments/govuk-publishing-platform/shared_redis_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/shared_redis_cluster.tf
@@ -9,7 +9,5 @@ module "shared_redis_cluster" {
   vpc_id                   = local.vpc_id
   internal_private_zone_id = aws_route53_zone.internal_private.zone_id
   cluster_name             = local.cluster_name
-  internal_app_domain      = var.internal_app_domain
   subnet_ids               = local.redis_subnets
 }
-

--- a/terraform/deployments/govuk-publishing-platform/variables.tf
+++ b/terraform/deployments/govuk-publishing-platform/variables.tf
@@ -12,16 +12,6 @@ variable "mesh_domain" {
   description = "e.g. mesh.govuk-internal.digital"
 }
 
-variable "redis_host" {
-  type        = string
-  description = "Shared Redis FQDN"
-}
-
-variable "redis_port" {
-  type    = string
-  default = 6379
-}
-
 variable "ecs_default_capacity_provider" {
   type = string
 }

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -8,8 +8,6 @@ publishing_service_domain = "test.publishing.service.gov.uk"
 internal_app_domain       = "test.govuk-internal.digital"
 external_app_domain       = "test.govuk.digital"
 
-redis_host = "shared-redis.test.govuk-internal.digital"
-
 #--------------------------------------------------------------
 # Network
 #--------------------------------------------------------------

--- a/terraform/modules/redis/main.tf
+++ b/terraform/modules/redis/main.tf
@@ -35,17 +35,9 @@ resource "aws_elasticache_replication_group" "redis_cluster" {
   security_group_ids            = [aws_security_group.redis.id]
 }
 
-
-/// internal route53 record
-
-data "aws_route53_zone" "internal" {
-  name         = var.internal_app_domain
-  private_zone = true
-}
-
 resource "aws_route53_record" "internal_service_record" {
   zone_id = var.internal_private_zone_id
-  name    = "${var.cluster_name}-redis.${var.internal_app_domain}"
+  name    = "redis"
   type    = "CNAME"
   ttl     = 300
   records = [aws_elasticache_replication_group.redis_cluster.primary_endpoint_address]

--- a/terraform/modules/redis/outputs.tf
+++ b/terraform/modules/redis/outputs.tf
@@ -3,9 +3,8 @@ output "security_group_id" {
   description = "ID of the security group for Redis cluster"
 }
 
-output "redis_host" {
-  value       = aws_route53_record.internal_service_record.fqdn
-  description = "Internal DNS name to access the Redis service"
+output "uri" {
+  value = "redis://${aws_route53_record.internal_service_record.fqdn}:${local.redis_port}"
 }
 
 output "redis_port" {

--- a/terraform/modules/redis/variables.tf
+++ b/terraform/modules/redis/variables.tf
@@ -3,12 +3,6 @@ variable "cluster_name" {
   default = "shared"
 }
 
-variable "internal_app_domain" {
-  description = "Domain in which to create DNS records for private resources. For example, test.govuk-internal.digital"
-  type        = string
-  default     = "test.govuk-internal.digital"
-}
-
 variable "subnet_ids" {
   type        = list(any)
   description = "Subnet IDs to assign to the aws_elasticache_subnet_group"


### PR DESCRIPTION
The Redis cluster hostname includes the subdomain test.govuk-internal.digital (`internal_app_domain`) twice.

Before:

```
redis://bill-redis.test.govuk-internal.digital.bill.test.govuk-internal.digital:6379
```

After:

```
redis://redis.bill.test.govuk-internal.digital:6379
```