### PR TITLE
Fixup external domain names

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -22,7 +22,7 @@ locals {
         EMAIL_GROUP_FORCE_PUBLISH_ALERTS = "test-address@digital.cabinet-office.gov.uk"
         FACT_CHECK_SUBJECT_PREFIX        = "dev"
         FACT_CHECK_USERNAME              = "govuk-fact-check-test@digital.cabinet-office.gov.uk"
-        GOVUK_APP_DOMAIN_EXTERNAL        = var.external_app_domain
+        GOVUK_APP_DOMAIN_EXTERNAL        = local.workspace_external_domain
         GOVUK_APP_NAME                   = local.publisher_app_name
         GOVUK_APP_ROOT                   = "/app"
         # TODO: how does GOVUK_ASSET_ROOT relate to ASSET_HOST? Is one a function of the other? Are they both really in use? Is GOVUK_ASSET_ROOT always just "https://${ASSET_HOST}"?
@@ -107,7 +107,7 @@ module "publisher_public_alb" {
   public_zone_id            = aws_route53_zone.workspace_public.zone_id
   dns_a_record_name         = "publisher"
   public_subnets            = local.public_subnets
-  external_app_domain       = var.external_app_domain
+  external_app_domain       = local.workspace_external_domain
   certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
   workspace_suffix          = terraform.workspace == "default" ? "govuk" : terraform.workspace

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -64,7 +64,7 @@ module "signon_public_alb" {
   public_zone_id            = aws_route53_zone.workspace_public.zone_id
   dns_a_record_name         = "signon-ecs"
   public_subnets            = local.public_subnets
-  external_app_domain       = var.external_app_domain
+  external_app_domain       = local.workspace_external_domain
   certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
   workspace_suffix          = terraform.workspace == "default" ? "govuk" : terraform.workspace

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -19,8 +19,8 @@ locals {
     }
     asset_host              = "https://frontend.${local.workspace_external_domain}",
     asset_root_url          = "https://assets.${var.publishing_service_domain}",
-    assets_www_origin       = "https://www.ecs.${var.publishing_service_domain}"
-    assets_draft_origin     = "https://draft-origin-ecs.${local.workspace_external_domain}"
+    assets_www_origin       = "https://www.ecs.${var.publishing_service_domain}" # TODO: Make workspace-aware
+    assets_draft_origin     = "https://draft-origin.${local.workspace_external_domain}"
     content_store_uri       = "http://content-store.${local.mesh_domain}",
     draft_content_store_uri = "http://draft-content-store.${local.mesh_domain}",
     draft_origin_uri        = "https://draft-frontend.${local.workspace_external_domain}",

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -4,7 +4,7 @@ locals {
     environment_variables = {
       DEFAULT_TTL               = 1800,
       GOVUK_APP_DOMAIN          = local.mesh_domain,
-      GOVUK_APP_DOMAIN_EXTERNAL = var.external_app_domain,
+      GOVUK_APP_DOMAIN_EXTERNAL = local.workspace_external_domain,
       GOVUK_APP_TYPE            = "rack",
       GOVUK_STATSD_HOST         = "statsd.${var.mesh_domain}"
       GOVUK_STATSD_PROTOCOL     = "tcp"
@@ -17,21 +17,21 @@ locals {
       SENTRY_DSN      = data.aws_secretsmanager_secret.sentry_dsn.arn,
       GA_UNIVERSAL_ID = data.aws_secretsmanager_secret.ga_universal_id.arn,
     }
-    asset_host              = "https://frontend.${var.external_app_domain}",
+    asset_host              = "https://frontend.${local.workspace_external_domain}",
     asset_root_url          = "https://assets.${var.publishing_service_domain}",
     assets_www_origin       = "https://www.ecs.${var.publishing_service_domain}"
-    assets_draft_origin     = "https://draft-origin-ecs.${var.external_app_domain}"
+    assets_draft_origin     = "https://draft-origin-ecs.${local.workspace_external_domain}"
     content_store_uri       = "http://content-store.${local.mesh_domain}",
     draft_content_store_uri = "http://draft-content-store.${local.mesh_domain}",
-    draft_origin_uri        = "https://draft-frontend.${var.external_app_domain}",
+    draft_origin_uri        = "https://draft-frontend.${local.workspace_external_domain}",
     draft_static_uri        = "http://draft-static.${local.mesh_domain}"
     publishing_api_uri      = "http://publishing-api-web.${local.mesh_domain}",
-    rabbitmq_hosts          = "rabbitmq.${var.internal_app_domain}"
+    rabbitmq_hosts          = "rabbitmq.${var.internal_app_domain}" # TODO: Make workspace-aware
     router_api_uri          = "http://router-api.${local.mesh_domain}",
     draft_router_api_uri    = "http://draft-router-api.${local.mesh_domain}",
     router_urls             = "router.${local.mesh_domain}:3055"       # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
     draft_router_urls       = "draft-router.${local.mesh_domain}:3055" # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
-    signon_uri              = "https://signon-ecs.${var.external_app_domain}",
+    signon_uri              = "https://signon-ecs.${local.workspace_external_domain}",
     static_uri              = "http://static.${local.mesh_domain}"
     website_root            = "https://${module.www_origin.fqdn}",
 

--- a/terraform/deployments/govuk-publishing-platform/outputs.tf
+++ b/terraform/deployments/govuk-publishing-platform/outputs.tf
@@ -81,7 +81,7 @@ output "mesh_domain" {
 }
 
 output "external_app_domain" {
-  value = var.external_app_domain
+  value = local.workspace_external_domain
 }
 
 output "internal_app_domain" {
@@ -89,7 +89,7 @@ output "internal_app_domain" {
 }
 
 output "govuk_website_root" {
-  value = "https://frontend.${var.external_app_domain}" # TODO: Change back to www once router is up
+  value = "https://frontend.${local.workspace_external_domain}" # TODO: Change back to www once router is up
 }
 
 output "fargate_execution_iam_role_arn" {

--- a/terraform/modules/origin/main.tf
+++ b/terraform/modules/origin/main.tf
@@ -99,7 +99,7 @@ data "aws_route53_zone" "public" {
 
 resource "aws_route53_record" "origin_alb" {
   zone_id = var.public_zone_id
-  name    = "${local.mode}-origin-ecs" # TODO: Change to www-origin
+  name    = "${local.mode}-origin"
   type    = "A"
 
   alias {

--- a/terraform/modules/origin/main.tf
+++ b/terraform/modules/origin/main.tf
@@ -99,7 +99,7 @@ data "aws_route53_zone" "public" {
 
 resource "aws_route53_record" "origin_alb" {
   zone_id = var.public_zone_id
-  name    = "${local.mode}-origin-ecs"
+  name    = "${local.mode}-origin-ecs" # TODO: Change to www-origin
   type    = "A"
 
   alias {

--- a/terraform/modules/origin/outputs.tf
+++ b/terraform/modules/origin/outputs.tf
@@ -13,3 +13,7 @@ output "security_group_id" {
 output "fqdn" {
   value = "${aws_route53_record.origin_alb.name}.${var.publishing_service_domain}"
 }
+
+output "origin_app_fqdn" {
+  value = aws_route53_record.origin_alb.fqdn
+}


### PR DESCRIPTION
This:

- makes app_domains workspace-aware
   so that publisher in the bill workspace redirects to signon.bill.example rather than signon.ecs.example
- removes 'ecs' from the origin subdomain name
   so that we can go to www-origin.ecs.example, not www-origin-ecs.ecs.example