### PR TITLE
Remove -ecs suffix from signon subdomain

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -62,7 +62,7 @@ module "signon_public_alb" {
   app_name                  = "signon"
   vpc_id                    = local.vpc_id
   public_zone_id            = aws_route53_zone.workspace_public.zone_id
-  dns_a_record_name         = "signon-ecs"
+  dns_a_record_name         = "signon"
   public_subnets            = local.public_subnets
   external_app_domain       = local.workspace_external_domain
   certificate               = aws_acm_certificate.workspace_public.arn

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -31,7 +31,7 @@ locals {
     draft_router_api_uri    = "http://draft-router-api.${local.mesh_domain}",
     router_urls             = "router.${local.mesh_domain}:3055"       # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
     draft_router_urls       = "draft-router.${local.mesh_domain}:3055" # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
-    signon_uri              = "https://signon-ecs.${local.workspace_external_domain}",
+    signon_uri              = "https://signon.${local.workspace_external_domain}",
     static_uri              = "http://static.${local.mesh_domain}"
     website_root            = "https://${module.www_origin.fqdn}",
 


### PR DESCRIPTION
The `ecs` suffix is unnecessary in this domain name.

Before: `signon-ecs.ecs.etc`
After: `signon.ecs.etc`