### PR TITLE
Stream task logs during deployment

### DIFF
--- a/concourse/tasks/update-ecs-service.sh
+++ b/concourse/tasks/update-ecs-service.sh
@@ -18,16 +18,33 @@ fi
 
 echo "Updating $ECS_SERVICE service..."
 
+CLUSTER=govuk
+
 aws ecs update-service \
-  --cluster govuk \
+  --cluster "$CLUSTER" \
   --service "$ECS_SERVICE" \
   --task-definition "$new_task_definition_arn" \
-  --region "$AWS_REGION"
+  --region "$AWS_REGION" > /dev/null
+
+# Get the ID of the latest task so we can stream its logs.
+# ecs-cli just wants the numeric ID of the task, not the whole ARN.
+# So we have to use `awk` to fish that out.
+task_id=$(aws ecs list-tasks \
+  --cluster "$CLUSTER" \
+  --service-name "$ECS_SERVICE" \
+  --region "$AWS_REGION" \
+  --query 'taskArns | [0]' \
+  --output text \
+  | awk -F / '{print $NF}'
+)
+echo "Task ID: $task_id"
 
 echo "Waiting for $ECS_SERVICE ECS service to reach steady state..."
 
+ecs-cli logs --region "$AWS_REGION" --cluster "$CLUSTER" --task-id "$task_id" --container-name "app" --follow &
+
 aws ecs wait services-stable \
-  --cluster govuk \
+  --cluster "$CLUSTER" \
   --services "$ECS_SERVICE" \
   --region "$AWS_REGION"
 

--- a/concourse/tasks/update-ecs-service.yml
+++ b/concourse/tasks/update-ecs-service.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: governmentpaas/awscli
+    repository: govuk/ecs-cli
     tag: latest # TODO - manage image versions ourselves instead of using latest
     username: ((docker_hub_username))
     password: ((docker_hub_authtoken))


### PR DESCRIPTION
We switched to using the ecs-cli image for run-task so we could see
application logs during tasks. It would be nice to be able to see app
logs during deploys too.

ecs-cli needs a task ID to stream logs, so we need to fish that out of
`aws ecs list-tasks`. I've assumed that there will only be one taskArn
in the response for this call, but I'm not 100% sure that's true. The
code will just try to use the first one it finds.

No need to cleanup the background process, as concourse will do it for
us when it kills the container this script runs in.

You can see the output of this in this snowflaked pipeline run:
https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/deploy-apps-test/jobs/deploy-router/builds/224
(VPN required)