### PR TITLE
Fix router's mongodb URL

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_content_store.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_content_store.tf
@@ -30,11 +30,12 @@ locals {
       }
     )
 
-    mongodb_host = join(",", [
+    mongodb_url = format(
+      "mongodb://%s,%s,%s",
       data.terraform_remote_state.govuk_aws_mongo.outputs.mongo_1_service_dns_name,
       data.terraform_remote_state.govuk_aws_mongo.outputs.mongo_2_service_dns_name,
       data.terraform_remote_state.govuk_aws_mongo.outputs.mongo_3_service_dns_name,
-    ])
+    )
   }
 }
 
@@ -62,7 +63,7 @@ module "content_store" {
     {
       GOVUK_STATSD_PREFIX         = "govuk-ecs.app.content-store"
       PLEK_SERVICE_ROUTER_API_URI = local.defaults.router_api_uri
-      MONGODB_URI                 = "mongodb://${local.content_store_defaults.mongodb_host}/live_content_store_production"
+      MONGODB_URI                 = "${local.content_store_defaults.mongodb_url}/live_content_store_production"
     },
   )
   secrets_from_arns  = local.content_store_defaults.secrets_from_arns
@@ -100,7 +101,7 @@ module "draft_content_store" {
       GOVUK_APP_NAME              = "draft-content-store",
       GOVUK_STATSD_PREFIX         = "govuk-ecs.app.draft-content-store"
       PLEK_SERVICE_ROUTER_API_URI = local.defaults.draft_router_api_uri
-      MONGODB_URI                 = "mongodb://${local.content_store_defaults.mongodb_host}/draft_content_store_production"
+      MONGODB_URI                 = "${local.content_store_defaults.mongodb_url}/draft_content_store_production"
     }
   )
   secrets_from_arns  = local.content_store_defaults.secrets_from_arns

--- a/terraform/deployments/govuk-publishing-platform/app_router.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router.tf
@@ -16,11 +16,12 @@ locals {
 
     secrets_from_arns = local.defaults.secrets_from_arns
 
-    mongodb_hosts = join(",", [
+    mongodb_url = format(
+      "mongodb://%s,%s,%s",
       data.terraform_remote_state.govuk_aws_router_mongo.outputs.router_backend_1_service_dns_name,
       data.terraform_remote_state.govuk_aws_router_mongo.outputs.router_backend_2_service_dns_name,
       data.terraform_remote_state.govuk_aws_router_mongo.outputs.router_backend_3_service_dns_name,
-    ])
+    )
   }
 }
 
@@ -46,7 +47,7 @@ module "router" {
     local.router_defaults.environment_variables,
     {
       ROUTER_MONGO_DB  = "router"
-      ROUTER_MONGO_URL = "mongodb://${local.router_defaults.mongodb_hosts}/router",
+      ROUTER_MONGO_URL = "${local.router_defaults.mongodb_url}/router",
     },
   )
   secrets_from_arns  = local.router_defaults.secrets_from_arns
@@ -79,7 +80,7 @@ module "draft_router" {
     local.router_defaults.environment_variables,
     {
       ROUTER_MONGO_DB  = "draft_router"
-      ROUTER_MONGO_URL = "mongodb://${local.router_defaults.mongodb_hosts}/draft_router",
+      ROUTER_MONGO_URL = "${local.router_defaults.mongodb_url}/draft_router",
     },
   )
   secrets_from_arns  = local.router_defaults.secrets_from_arns

--- a/terraform/deployments/govuk-publishing-platform/app_router.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router.tf
@@ -16,11 +16,11 @@ locals {
 
     secrets_from_arns = local.defaults.secrets_from_arns
 
-    mongodb_hosts = "mongodb://${join(",", [
+    mongodb_hosts = join(",", [
       data.terraform_remote_state.govuk_aws_router_mongo.outputs.router_backend_1_service_dns_name,
       data.terraform_remote_state.govuk_aws_router_mongo.outputs.router_backend_2_service_dns_name,
       data.terraform_remote_state.govuk_aws_router_mongo.outputs.router_backend_3_service_dns_name,
-    ])}"
+    ])
   }
 }
 

--- a/terraform/deployments/govuk-publishing-platform/app_router_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router_api.tf
@@ -19,11 +19,12 @@ locals {
 
     secrets_from_arns = local.defaults.secrets_from_arns
 
-    mongodb_hosts = join(",", [
+    mongodb_url = format(
+      "mongodb://%s,%s,%s",
       data.terraform_remote_state.govuk_aws_router_mongo.outputs.router_backend_1_service_dns_name,
       data.terraform_remote_state.govuk_aws_router_mongo.outputs.router_backend_2_service_dns_name,
       data.terraform_remote_state.govuk_aws_router_mongo.outputs.router_backend_3_service_dns_name,
-    ])
+    )
   }
 }
 
@@ -45,7 +46,7 @@ module "router_api" {
     local.router_api_defaults.environment_variables,
     {
       ROUTER_NODES = local.defaults.router_urls,
-      MONGODB_URI  = "mongodb://${local.router_api_defaults.mongodb_hosts}/router",
+      MONGODB_URI  = "${local.router_api_defaults.mongodb_url}/router",
     },
   )
   secrets_from_arns = merge(
@@ -82,7 +83,7 @@ module "draft_router_api" {
     local.router_api_defaults.environment_variables,
     {
       ROUTER_NODES = local.defaults.draft_router_urls,
-      MONGODB_URI  = "mongodb://${local.router_api_defaults.mongodb_hosts}/draft_router",
+      MONGODB_URI  = "${local.router_api_defaults.mongodb_url}/draft_router",
     },
   )
   secrets_from_arns = merge(


### PR DESCRIPTION
As part of https://github.com/alphagov/govuk-infrastructure/pull/188 I
spotted that the logs for deploying router contained:

```
2021/03/16 14:21:39 mgo: connecting to mongodb://mongodb://router-backend-1.pink.test.govuk-internal.digital,router-backend-2.pink.test.govuk-internal.digital,router-backend-3.pink.test.govuk-internal.digital/draft_router

2021/03/16 14:21:50 router: recovered from panic in ReloadRoutes: mgo: no reachable servers

2021/03/16 14:21:50 router: original routes have not been modified
```

Note `mongodb://mongodb://` - so good they named it twice.