### PR TITLE
fix cert in public-load-balancer module

### DIFF
--- a/terraform/modules/public-load-balancer/main.tf
+++ b/terraform/modules/public-load-balancer/main.tf
@@ -5,11 +5,6 @@ data "aws_acm_certificate" "public_lb_default" {
   statuses = ["ISSUED"]
 }
 
-data "aws_acm_certificate" "public_lb_alternate" {
-  domain   = "*.${var.external_app_domain}"
-  statuses = ["ISSUED"]
-}
-
 resource "aws_lb_listener_certificate" "service" {
   listener_arn    = aws_lb_listener.public.arn
   certificate_arn = var.certificate


### PR DESCRIPTION
Now, the cert `*.<workspace>.<env>.govuk.digital` is created in this terraform repo. These is no need to fetch it and this code is redundant as not used anywhere.