### PR TITLE
Add origin cloudfront

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/.terraform.lock.hcl
+++ b/terraform/deployments/govuk-publishing-platform/.terraform.lock.hcl
@@ -6,8 +6,6 @@ provider "registry.terraform.io/fastly/fastly" {
   constraints = "0.24.0"
   hashes = [
     "h1:2KzSQsT1Z870qPkUTWT3xUMTCvAA9/Xqn/fUzWTyqbE=",
-    "h1:O6NSgvY6xEXO6S269CC7zSm/bGRcEZu2YHrSz704oa8=",
-    "h1:xikn4kvuDCHCypHP5p2kM13lTHYZqaaJi+HmrpRVaXo=",
     "zh:083f8f5263f133a65bbc54c5b57857a2e97491151d2d97cefc4fe90313d07c53",
     "zh:0d2371268e9e318f20011a4d25d12beb88f61589867236c303f0ed999ef24ed6",
     "zh:1edaab7a4d6400f9898ae03b7cf5c44166f8e9283278c3eef7a77d43263a17d3",
@@ -23,21 +21,38 @@ provider "registry.terraform.io/fastly/fastly" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.13.0"
-  constraints = ">= 3.0.0, ~> 3.13"
+  version     = "3.36.0"
+  constraints = ">= 3.0.0, ~> 3.33"
   hashes = [
-    "h1:TqhdcDLwrEd37h/xbuaGgaintjftRjRLEltoCSA2jrM=",
-    "h1:ejZr/PC9VWdex2b0XjQxeJY2LJl3Ll1iSssnjjdlH2A=",
-    "h1:kXU5fbn63Gj1ixR8n1Dwm256MVqXfMrSgefLC6ITt0g=",
-    "zh:214983ba36641acf4685b62a5ad19b2b1fa89aebb8d3dbb370040da6a334af67",
-    "zh:257bde9f8a5ced50798a3b62d4ba8e7ff891e124e1f906c7073ee9e9c2e281d7",
-    "zh:3275dd5d8dc8ac3318c56e0b16f2d361f07944f549b848c4c9d62d520005755b",
-    "zh:5e289b4056fbb5bab4805c5afdc99c5f5b110912ac4cab696515bfdf153e192d",
-    "zh:7c58d22c361d4b29531bf41053c1e6765f2c04a183856bc1c8dadfa668e199f1",
-    "zh:9063a1cc5b596fee653c7183d79c71b841e288176b6c844a2942ca609bb858a8",
-    "zh:ad081b12d3a668aa7e3a2718ec2c20be033f963b85e735bcb9fa904500a52dba",
-    "zh:c2afbac72532a0b439094dc6faf2afddcf8075cd87810a2577a48d0b405c560b",
-    "zh:db7bbbae3446bfcc01b6e89c0e6cfe9d88dd29bb4ee4f077cab8a773207a834d",
-    "zh:e2dc2e5ddf84ce30b125b7f156dc1c587899cee7fbdf469e5fc286288b964bb5",
+    "h1:KL3jLlJjk3d9/IoXqDWmsBglsLIYRL8ieAEG0Zl+3fE=",
+    "zh:17b1e924f1efc0084823bbcdd9565b6b7018b17e8471f65fc59c2d9617e28b60",
+    "zh:1fd5dfe2d22db93c576c2f328b4a9cf28e09b88496888a54a25325c638a69bec",
+    "zh:269d7e870fc86db4336ac215282ac0a97522209453ce6cc9022ab2079e4e7a3b",
+    "zh:3b107da332bccec4a6e60ed790323d7cc8d264d8b5709cb14a931728bb06241e",
+    "zh:74480ff5c05f9156f32c9d93c2c43bb13d7ae21bdc85b727550fe4c1812252ca",
+    "zh:79c60989f44dba2851c790dc15f18b80ba811e6140260cc42b9fe343656e3a01",
+    "zh:7f6fd96abd233acc52ec412bc72fb52784e47475f16eaa908e72c4c4b0997109",
+    "zh:b2fba2820c505a10211199112d3e16cac224b638ba6f8b09b8b635746cc49a11",
+    "zh:c4f53cb16f5e7439cefcddcc2e91798e5ec6a11ca6f9442e2ec509cd0859625c",
+    "zh:ec54a1b2ffbec157fad0b6e0efc0d8da1e1153874060d47497ab1a5e9d6ab26f",
+    "zh:f01d0fe3f7757fe290dc7889ffe1d926da665a7a0bb895b9f2518c3ac5c6963c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.0.0"
+  constraints = "3.0.0"
+  hashes = [
+    "h1:yhHJpb4IfQQfuio7qjUXuUFTU/s+ensuEpm23A+VWz0=",
+    "zh:0fcb00ff8b87dcac1b0ee10831e47e0203a6c46aafd76cb140ba2bab81f02c6b",
+    "zh:123c984c0e04bad910c421028d18aa2ca4af25a153264aef747521f4e7c36a17",
+    "zh:287443bc6fd7fa9a4341dec235589293cbcc6e467a042ae225fd5d161e4e68dc",
+    "zh:2c1be5596dd3cca4859466885eaedf0345c8e7628503872610629e275d71b0d2",
+    "zh:684a2ef6f415287944a3d966c4c8cee82c20e393e096e2f7cdcb4b2528407f6b",
+    "zh:7625ccbc6ff17c2d5360ff2af7f9261c3f213765642dcd84e84ae02a3768fd51",
+    "zh:9a60811ab9e6a5bfa6352fbb943bb530acb6198282a49373283a8fa3aa2b43fc",
+    "zh:c73e0eaeea6c65b1cf5098b101d51a2789b054201ce7986a6d206a9e2dacaefd",
+    "zh:e8f9ed41ac83dbe407de9f0206ef1148204a0d51ba240318af801ffb3ee5f578",
+    "zh:fbdd0684e62563d3ac33425b0ac9439d543a3942465f4b26582bcfabcb149515",
   ]
 }

--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -21,9 +21,6 @@ locals {
         PLEK_SERVICE_CONTENT_STORE_URI  = local.defaults.content_store_uri
         PLEK_SERVICE_STATIC_URI         = local.defaults.static_uri
         GOVUK_ASSET_ROOT                = local.defaults.asset_root_url
-        RAILS_SERVE_STATIC_FILES        = "yes"
-        RAILS_SERVE_STATIC_ASSETS       = "yes"
-        HEROKU_APP_NAME                 = "frontend"
       }
     )
 

--- a/terraform/deployments/govuk-publishing-platform/app_static.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_static.tf
@@ -10,8 +10,6 @@ locals {
         GOVUK_APP_ROOT                   = "/var/apps/static",
         PLEK_SERVICE_ACCOUNT_MANAGER_URI = "",
         REDIS_URL                        = module.shared_redis_cluster.uri,
-        RAILS_SERVE_STATIC_FILES         = "enabled",
-        RAILS_SERVE_STATIC_ASSETS        = "yes",
       }
     )
 
@@ -53,10 +51,6 @@ module "static" {
   memory             = local.static_defaults.memory
   task_role_arn      = aws_iam_role.task.arn
   execution_role_arn = aws_iam_role.execution.arn
-  load_balancers = [{
-    target_group_arn = module.www_origin.static_target_group_arn
-    container_port   = 80
-  }]
 }
 
 module "draft_static" {
@@ -93,8 +87,4 @@ module "draft_static" {
   memory             = local.static_defaults.memory
   task_role_arn      = aws_iam_role.task.arn
   execution_role_arn = aws_iam_role.execution.arn
-  load_balancers = [{
-    target_group_arn = module.draft_origin.static_target_group_arn
-    container_port   = 80
-  }]
 }

--- a/terraform/deployments/govuk-publishing-platform/main.tf
+++ b/terraform/deployments/govuk-publishing-platform/main.tf
@@ -9,12 +9,17 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.13"
+      version = "~> 3.33"
     }
 
     fastly = {
       source  = "fastly/fastly"
       version = "0.24.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "3.0.0"
     }
   }
 }
@@ -27,10 +32,21 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us_east_1"
+
+  assume_role {
+    role_arn = var.assume_role_arn
+  }
+}
+
 provider "fastly" {
   # We only want to use fastly's data API
   api_key = "test"
 }
+
+provider "random" {}
 
 locals {
   vpc_id                        = data.terraform_remote_state.infra_networking.outputs.vpc_id

--- a/terraform/deployments/govuk-publishing-platform/origins.tf
+++ b/terraform/deployments/govuk-publishing-platform/origins.tf
@@ -1,36 +1,82 @@
+resource "aws_acm_certificate" "public_north_virginia" {
+  provider    = aws.us_east_1
+  domain_name = "*.${local.workspace_external_domain}"
+
+  subject_alternative_names = local.is_default_workspace ? ["*.${local.workspace}.${var.publishing_service_domain}"] : null
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "public_north_virginia" {
+  provider = aws.us_east_1
+  for_each = {
+    for dvo in aws_acm_certificate.public_north_virginia.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.workspace_public.zone_id
+}
+
+resource "aws_acm_certificate_validation" "public_north_virginia" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.public_north_virginia.arn
+  validation_record_fqdns = [for record in aws_route53_record.public_north_virginia : record.name]
+}
+
+
 module "www_origin" {
   source = "../../modules/origin"
 
-  vpc_id                    = local.vpc_id
-  public_subnets            = local.public_subnets
-  public_zone_id            = aws_route53_zone.workspace_public.zone_id
-  external_app_domain       = var.external_app_domain
-  certificate               = aws_acm_certificate.workspace_public.arn
-  publishing_service_domain = var.publishing_service_domain
-  workspace                 = local.workspace
-  external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
+  vpc_id                               = local.vpc_id
+  aws_region                           = data.aws_region.current.name
+  assume_role_arn                      = var.assume_role_arn
+  public_subnets                       = local.public_subnets
+  public_zone_id                       = aws_route53_zone.workspace_public.zone_id
+  external_app_domain                  = aws_route53_zone.workspace_public.name
+  load_balancer_certificate_arn        = aws_acm_certificate.workspace_public.arn
+  cloudfront_certificate_arn           = aws_acm_certificate.public_north_virginia.arn
+  publishing_service_domain            = var.publishing_service_domain
+  workspace                            = local.workspace
+  is_default_workspace                 = local.is_default_workspace
+  external_cidrs_list                  = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
+  rails_assets_s3_regional_domain_name = aws_s3_bucket.rails_assets.bucket_regional_domain_name
 
   apps_security_config_list = {
     "frontend" = { security_group_id = module.frontend.security_group_id, target_port = 80 },
-    "static"   = { security_group_id = module.static.security_group_id, target_port = 80 },
   }
 }
 
 module "draft_origin" {
   source = "../../modules/origin"
 
-  vpc_id                    = local.vpc_id
-  public_subnets            = local.public_subnets
-  public_zone_id            = aws_route53_zone.workspace_public.zone_id
-  external_app_domain       = var.external_app_domain
-  certificate               = aws_acm_certificate.workspace_public.arn
-  publishing_service_domain = var.publishing_service_domain
-  workspace                 = local.workspace
-  external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
-  live                      = false
+  vpc_id                               = local.vpc_id
+  aws_region                           = data.aws_region.current.name
+  assume_role_arn                      = var.assume_role_arn
+  public_subnets                       = local.public_subnets
+  public_zone_id                       = aws_route53_zone.workspace_public.zone_id
+  external_app_domain                  = aws_route53_zone.workspace_public.name
+  load_balancer_certificate_arn        = aws_acm_certificate.workspace_public.arn
+  cloudfront_certificate_arn           = aws_acm_certificate.public_north_virginia.arn
+  publishing_service_domain            = var.publishing_service_domain
+  workspace                            = local.workspace
+  is_default_workspace                 = local.is_default_workspace
+  external_cidrs_list                  = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
+  rails_assets_s3_regional_domain_name = aws_s3_bucket.rails_assets.bucket_regional_domain_name
+  is_live                              = false
 
   apps_security_config_list = {
     "draft-frontend" = { security_group_id = module.draft_frontend.security_group_id, target_port = 80 },
-    "draft-static"   = { security_group_id = module.draft_static.security_group_id, target_port = 80 }
   }
 }

--- a/terraform/deployments/govuk-publishing-platform/rails_assets.tf
+++ b/terraform/deployments/govuk-publishing-platform/rails_assets.tf
@@ -6,3 +6,23 @@ resource "aws_s3_bucket" "rails_assets" {
     aws_environment = var.govuk_environment
   }
 }
+
+data "aws_iam_policy_document" "cloudfront_access_s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.rails_assets.arn}/*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        module.www_origin.cloudfront_access_identity_iam_arn,
+        module.draft_origin.cloudfront_access_identity_iam_arn
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudfront_access_s3_policy" {
+  bucket = aws_s3_bucket.rails_assets.id
+  policy = data.aws_iam_policy_document.cloudfront_access_s3_policy.json
+}

--- a/terraform/deployments/govuk-publishing-platform/variables.tf
+++ b/terraform/deployments/govuk-publishing-platform/variables.tf
@@ -34,7 +34,7 @@ variable "office_cidrs_list" {
 
 variable "frontend_desired_count" {
   type    = number
-  default = 1
+  default = 2
 }
 
 variable "draft_frontend_desired_count" {

--- a/terraform/modules/origin/README.md
+++ b/terraform/modules/origin/README.md
@@ -1,5 +1,11 @@
 # origin
 
-A module which creates the origin Application Load Balancer and acts as the entry
-point to the environment from the public side (as opposed to the publishing side).
- 
+Creates the public traffic entry point to the environment(as opposed to the publishing one).
+
+The traffic flow is as follows:
+1. it is intended that public requests enters via:
+    (a) Fastly CDN if using default/ecs workspace or
+    (b) AWS CloudFront CDN directly for other workspaces (defined in this module)
+2. CloudFront is protected via AWS WAF ACL which allows request coming only Fastly and office IPs only
+3. CloudFront routes requests with path matching /assets/* to S3 rails asset bucket or
+   origin Application Load-balancer which is connected to the frontend for now until router is ready.

--- a/terraform/modules/origin/alb.tf
+++ b/terraform/modules/origin/alb.tf
@@ -1,0 +1,66 @@
+resource "aws_lb" "origin" {
+  name               = "${local.live_or_draft_prefix}-origin-${var.workspace}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.origin_alb.id]
+  subnets            = var.public_subnets
+}
+
+resource "aws_lb_target_group" "origin-frontend" {
+  name        = "${local.live_or_draft_prefix}-origin-frontend-${var.workspace}"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path = "/"
+  }
+}
+
+resource "aws_lb_listener" "origin" {
+  load_balancer_arn = aws_lb.origin.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = var.load_balancer_certificate_arn
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Access denied"
+      status_code  = "403"
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "authentication" {
+  listener_arn = aws_lb_listener.origin.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.origin-frontend.arn
+  }
+
+  condition {
+    http_header {
+      http_header_name = "X-Cloudfront-Token"
+      values           = [random_password.origin_alb_x_custom_header_secret.result]
+    }
+  }
+}
+
+resource "aws_route53_record" "origin_alb" {
+  zone_id = var.public_zone_id
+  name    = "${local.live_or_draft_prefix}-origin-alb"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.origin.dns_name
+    zone_id                = aws_lb.origin.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/modules/origin/outputs.tf
+++ b/terraform/modules/origin/outputs.tf
@@ -2,18 +2,14 @@ output "frontend_target_group_arn" {
   value = aws_lb_target_group.origin-frontend.arn
 }
 
-output "static_target_group_arn" {
-  value = aws_lb_target_group.origin-static.arn
-}
-
 output "security_group_id" {
   value = aws_security_group.origin_alb.id
 }
 
 output "fqdn" {
-  value = "${aws_route53_record.origin_alb.name}.${var.publishing_service_domain}"
+  value = aws_route53_record.origin_cloudfront.fqdn
 }
 
-output "origin_app_fqdn" {
-  value = aws_route53_record.origin_alb.fqdn
+output "cloudfront_access_identity_iam_arn" {
+  value = aws_cloudfront_origin_access_identity.cloudfront_s3_access.iam_arn
 }

--- a/terraform/modules/origin/security_groups.tf
+++ b/terraform/modules/origin/security_groups.tf
@@ -1,12 +1,12 @@
 resource "aws_security_group" "origin_alb" {
-  name        = "fargate_${local.mode}_origin_${var.workspace}_alb"
+  name        = "fargate_${local.live_or_draft_prefix}_origin_${var.workspace}_alb"
   vpc_id      = var.vpc_id
-  description = "${local.mode}-origin Internet-facing ALB in ${var.workspace} cluster"
+  description = "${local.live_or_draft_prefix}-origin Internet-facing ALB in govuk-${var.workspace} cluster"
 }
 
 resource "aws_security_group_rule" "service_from_origin_alb_http" {
   for_each                 = var.apps_security_config_list
-  description              = "${each.key} receives requests from the ${local.mode}-origin ALB over HTTP"
+  description              = "${each.key} receives requests from the ${local.live_or_draft_prefix}-origin-${var.workspace} ALB over HTTP"
   type                     = "ingress"
   from_port                = each.value.target_port
   to_port                  = each.value.target_port
@@ -15,13 +15,14 @@ resource "aws_security_group_rule" "service_from_origin_alb_http" {
   source_security_group_id = aws_security_group.origin_alb.id
 }
 
-resource "aws_security_group_rule" "origin_alb_from_any_https" {
-  description       = "${local.mode}-origin ALB allows requests from CIDRs list over HTTPS"
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = var.external_cidrs_list
+resource "aws_security_group_rule" "origin_alb_from_cidrs_https" {
+  description = "${local.live_or_draft_prefix}-origin-${var.workspace} ALB allows requests from CIDRs list over HTTPS"
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  # We use a secret custom header to authenticate requests via the origin ALB
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.origin_alb.id
 }
 

--- a/terraform/modules/origin/variables.tf
+++ b/terraform/modules/origin/variables.tf
@@ -1,13 +1,17 @@
 variable "external_app_domain" {
   type        = string
-  description = "e.g. test.govuk.digital. Domain in which to create DNS records for the app's Internet-facing load balancer."
+  description = "e.g. ecs.test.govuk.digital. Domain in which to create DNS records for the app's Internet-facing load balancer."
 }
 
-variable "certificate" {
+variable "load_balancer_certificate_arn" {
   type = string
 }
 
-variable "live" {
+variable "cloudfront_certificate_arn" {
+  type = string
+}
+
+variable "is_live" {
   description = "Determines whether the origin is a live or a draft one"
   type        = bool
   default     = true
@@ -42,4 +46,22 @@ variable "public_zone_id" {
 
 variable "workspace" {
   type = string
+}
+
+variable "is_default_workspace" {
+  type = bool
+}
+
+variable "rails_assets_s3_regional_domain_name" {
+  type = string
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "assume_role_arn" {
+  type        = string
+  description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
+  default     = null
 }

--- a/terraform/modules/origin/waf.tf
+++ b/terraform/modules/origin/waf.tf
@@ -1,0 +1,46 @@
+resource "aws_wafv2_ip_set" "origin_cloudfront_ipv4_access" {
+  provider           = aws.us_east_1
+  name               = "${local.live_or_draft_prefix}_origin_${var.workspace}_cloudfront_access"
+  description        = "access to ${local.live_or_draft_prefix} origin ${var.workspace} cloudfront"
+  scope              = "CLOUDFRONT"
+  ip_address_version = "IPV4"
+  addresses          = var.external_cidrs_list
+}
+
+resource "aws_wafv2_web_acl" "origin_cloudfront_web_acl" {
+  provider    = aws.us_east_1
+  name        = "${local.live_or_draft_prefix}_origin_${var.workspace}_cloudfront_web_acl"
+  description = "Web ACL for ${local.live_or_draft_prefix}-origin ${var.workspace} cloudfront"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    block {}
+  }
+
+  rule {
+    name     = "allow-requests-from-selected-IPv4-addresses"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.origin_cloudfront_ipv4_access.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.live_or_draft_prefix}-origin-${var.workspace}-cloudfront-ip-allow"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.live_or_draft_prefix}-origin-${var.workspace}-cloudfront"
+    sampled_requests_enabled   = true
+  }
+}


### PR DESCRIPTION
### Please review #196 and #197 first.

Creates the public entry point (as opposed to the publishing one).
1. public requests should enter via:
    (a) Fastly CDN if using the default/ecs workspace or
    (b) AWS CloudFront for other workspaces
2. CloudFront has an AWS WAF ACL which only allows requests from Fastly or office IPs
3. CloudFront routes requests with path matching /assets/* to the S3 rails asset bucket
4. CloudFront routes all other requests to the origin ALB

Future work:
1. Tunning Cloudfront parameters (E.g. Should Fastly health checks be terminated at the ALB rather than sent to the container?)
2. Configure logging of AWS Cloudfront and WAF

Ref:
1. [trello card](https://trello.com/c/NRLwGdBJ/172-static-assets-in-ecs)
2. [PR for assets uploads](https://github.com/alphagov/govuk-infrastructure/pull/180)
