### PR TITLE
Pull update-pipeline to the left of the pipeline

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -271,6 +271,8 @@ jobs:
     plan:
     - in_parallel:
       - get: govuk-infrastructure
+        passed:
+        - update-pipeline
         trigger: true
       - get: content-store-terraform-outputs
       - get: publisher-terraform-outputs


### PR DESCRIPTION
While the run-terraform task definition is inlined, it makes sense to run it after the pipeline is up-to-date. Otherwise we get a weird race condition where the pipeline and run-terraform update at the same time.

| Before | After |
|-----|-----|
| ![image](https://user-images.githubusercontent.com/1696784/111788960-9465ed80-88b8-11eb-9b7c-2c9d09c63a72.png) | ![image](https://user-images.githubusercontent.com/1696784/111788925-8c0db280-88b8-11eb-9ef7-aa4f7c8950c2.png) |

(Note: ignore the background image, that's a red herring)
