### PR TITLE
Add tflint config for the workspaces plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,15 @@ jobs:
       - name: run tflint
         env:
           TFLINT_VERSION: v0.24.1
+          TFLINT_RULESET_WORKSPACES_VERSION: 0.2.0
         run: |
           TEMP_PATH="$(mktemp -d)"
           PATH="${TEMP_PATH}:$PATH"
           curl --silent --fail -L "https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_amd64.zip" -o tflint.zip && unzip tflint.zip -d "${TEMP_PATH}" && rm tflint.zip
+          curl --silent --fail -L "https://github.com/richardTowers/tflint-ruleset-workspaces/releases/download/${TFLINT_RULESET_WORKSPACES_VERSION}/tflint-ruleset-workspaces-linux" -o tflint-ruleset-workspaces
+          chmod +x tflint-ruleset-workspaces
+          mkdir -p ~/.tflint.d/plugins
+          mv tflint-ruleset-workspaces ~/.tflint.d/plugins
 
           for f in terraform/deployments/*/.tflint.hcl; do
             d=$(dirname "$f")
@@ -74,7 +79,7 @@ jobs:
               echo "$d"
               cd "$d"
               terraform init -backend=false
-              tflint --module .
+              TF_WORKSPACE=example_workspace tflint --module .
               echo -e '\n-------------------------\n'
             )
           done

--- a/terraform/deployments/govuk-publishing-platform/.tflint.hcl
+++ b/terraform/deployments/govuk-publishing-platform/.tflint.hcl
@@ -2,6 +2,51 @@ plugin "aws" {
   enabled = true
 }
 
+plugin "workspaces" {
+  enabled = true
+
+  resource "aws_appmesh_mesh" {
+    attribute = "name"
+  }
+
+  resource "aws_ecs_cluster" {
+    attribute = "name"
+  }
+
+  resource "aws_elasticache_replication_group" {
+    attribute = "replication_group_id"
+  }
+
+  resource "aws_elasticache_subnet_group" {
+    attribute = "name"
+  }
+
+  resource "aws_iam_policy" {
+    attribute = "name"
+  }
+
+  resource "aws_iam_role" {
+    attribute = "name"
+  }
+
+  resource "aws_lb" {
+    attribute = "name"
+  }
+
+  resource "aws_lb_target_group" {
+    attribute = "name"
+  }
+
+  resource "aws_security_group" {
+    attribute = "name"
+  }
+
+  resource "aws_service_discovery_private_dns_namespace" {
+    attribute = "name"
+  }
+
+}
+
 config {
   varfile = [
     "../variables/test/infrastructure.tfvars",


### PR DESCRIPTION
See https://github.com/richardTowers/tflint-ruleset-workspaces/ (I wrote this, so it's probably worth a quick review of that codebase as part of this PR).

Note that we're linting a non-default workspace because in the `default` workspace resources are namespaced as "-govuk" or "-ecs", which the plugin doesn't understand.

Going to mark this as draft for now so I can push some broken commits to demonstrate that it works.