### PR TITLE
Refactor workspace

### DIFF
--- a/concourse/tasks/update-ecs-service.sh
+++ b/concourse/tasks/update-ecs-service.sh
@@ -18,8 +18,6 @@ fi
 
 echo "Updating $ECS_SERVICE service..."
 
-CLUSTER=govuk
-
 aws ecs update-service \
   --cluster "$CLUSTER" \
   --service "$ECS_SERVICE" \

--- a/concourse/tasks/update-ecs-service.yml
+++ b/concourse/tasks/update-ecs-service.yml
@@ -14,5 +14,6 @@ params:
   AWS_REGION: eu-west-1
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
   ECS_SERVICE:
+  CLUSTER: govuk-ecs
 run:
   path: ./src/concourse/tasks/update-ecs-service.sh

--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -14,7 +14,6 @@ locals {
     environment_variables = merge(
       local.defaults.environment_variables,
       {
-        ASSET_HOST                       = local.defaults.asset_host
         BASIC_AUTH_USERNAME              = "gds"
         EMAIL_GROUP_BUSINESS             = "test-address@digital.cabinet-office.gov.uk"
         EMAIL_GROUP_CITIZEN              = "test-address@digital.cabinet-office.gov.uk"
@@ -110,7 +109,7 @@ module "publisher_public_alb" {
   external_app_domain       = local.workspace_external_domain
   certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = terraform.workspace == "default" ? "govuk" : terraform.workspace
+  workspace                 = local.workspace
   service_security_group_id = module.publisher_web.security_group_id
   external_cidrs_list       = var.office_cidrs_list
 }

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -67,6 +67,6 @@ module "signon_public_alb" {
   external_app_domain       = local.workspace_external_domain
   certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = terraform.workspace == "default" ? "govuk" : terraform.workspace
+  workspace                 = local.workspace
   service_security_group_id = module.signon.security_group_id
 }

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -1,26 +1,29 @@
 locals {
-  mesh_domain = terraform.workspace == "default" ? var.mesh_domain : "mesh-${terraform.workspace}.govuk-internal.digital"
+  workspace                 = terraform.workspace == "default" ? "ecs" : terraform.workspace #default terraform workspace mapped to ecs
+  workspace_external_domain = "${local.workspace}.${var.external_app_domain}"
+  workspace_internal_domain = "${local.workspace}.${var.internal_app_domain}"
+  mesh_domain               = "mesh.${local.workspace_internal_domain}"
+  public_entry_url          = terraform.workspace == "default" ? "https://www.ecs.${var.publishing_service_domain}" : "https://${module.www_origin.fqdn}"
   defaults = {
     environment_variables = {
       DEFAULT_TTL               = 1800,
       GOVUK_APP_DOMAIN          = local.mesh_domain,
       GOVUK_APP_DOMAIN_EXTERNAL = local.workspace_external_domain,
       GOVUK_APP_TYPE            = "rack",
-      GOVUK_STATSD_HOST         = "statsd.${var.mesh_domain}"
+      GOVUK_STATSD_HOST         = "statsd.${local.mesh_domain}"
       GOVUK_STATSD_PROTOCOL     = "tcp"
-      GOVUK_WEBSITE_ROOT        = "https://${module.www_origin.fqdn}",
+      GOVUK_WEBSITE_ROOT        = local.public_entry_url
       PORT                      = 80,
       RAILS_ENV                 = "production",
-      SENTRY_ENVIRONMENT        = "${var.govuk_environment}-ecs",
+      SENTRY_ENVIRONMENT        = "${var.govuk_environment}-ecsplatform-${local.workspace}",
     }
     secrets_from_arns = {
       # SENTRY_DSN      = data.aws_secretsmanager_secret.sentry_dsn.arn,
       GA_UNIVERSAL_ID = data.aws_secretsmanager_secret.ga_universal_id.arn,
     }
-    asset_host              = "https://frontend.${local.workspace_external_domain}",
     asset_root_url          = "https://assets.${var.publishing_service_domain}",
-    assets_www_origin       = "https://www.ecs.${var.publishing_service_domain}" # TODO: Make workspace-aware
-    assets_draft_origin     = "https://draft-origin.${local.workspace_external_domain}"
+    assets_www_origin       = local.public_entry_url,
+    assets_draft_origin     = "https://${module.draft_origin.fqdn}"
     content_store_uri       = "http://content-store.${local.mesh_domain}",
     draft_content_store_uri = "http://draft-content-store.${local.mesh_domain}",
     draft_origin_uri        = "https://draft-frontend.${local.workspace_external_domain}",
@@ -29,11 +32,11 @@ locals {
     rabbitmq_hosts          = "rabbitmq.${var.internal_app_domain}" # TODO: Make workspace-aware
     router_api_uri          = "http://router-api.${local.mesh_domain}",
     draft_router_api_uri    = "http://draft-router-api.${local.mesh_domain}",
-    router_urls             = "router.${local.mesh_domain}:3055"       # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
-    draft_router_urls       = "draft-router.${local.mesh_domain}:3055" # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
+    router_urls             = "router.${local.mesh_domain}:3055",       # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
+    draft_router_urls       = "draft-router.${local.mesh_domain}:3055", # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
     signon_uri              = "https://signon.${local.workspace_external_domain}",
-    static_uri              = "http://static.${local.mesh_domain}"
-    website_root            = "https://${module.www_origin.fqdn}",
+    static_uri              = "http://static.${local.mesh_domain}",
+    website_root            = local.public_entry_url,
 
     virtual_service_backends = [
       module.statsd.virtual_service_name

--- a/terraform/deployments/govuk-publishing-platform/dns.tf
+++ b/terraform/deployments/govuk-publishing-platform/dns.tf
@@ -1,10 +1,3 @@
-locals {
-  workspace_external_domain = terraform.workspace == "default" ? "ecs.${var.external_app_domain}" : "${terraform.workspace}.${var.external_app_domain}"
-  workspace_internal_domain = terraform.workspace == "default" ? "ecs.${var.internal_app_domain}" : "${terraform.workspace}.${var.internal_app_domain}"
-}
-
-
-
 data "aws_route53_zone" "public" {
   name = var.external_app_domain
 }
@@ -35,10 +28,9 @@ resource "aws_route53_zone" "internal_private" {
 
 }
 
-
-
 resource "aws_acm_certificate" "workspace_public" {
-  domain_name       = "*.${local.workspace_external_domain}"
+  domain_name = "*.${local.workspace_external_domain}"
+
   validation_method = "DNS"
 
   lifecycle {

--- a/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
@@ -1,13 +1,6 @@
-locals {
-  mesh_name = terraform.workspace == "default" ? var.mesh_name : "mesh-${terraform.workspace}"
-}
-
-
-
-
 # All services running on GOV.UK run in this single cluster.
 resource "aws_ecs_cluster" "cluster" {
-  name               = local.mesh_name
+  name               = "govuk-${local.workspace}"
   capacity_providers = ["FARGATE", "FARGATE_SPOT"]
 
   default_capacity_provider_strategy {
@@ -21,7 +14,7 @@ resource "aws_ecs_cluster" "cluster" {
 }
 
 resource "aws_appmesh_mesh" "govuk" {
-  name = local.mesh_name
+  name = "govuk-${local.workspace}"
 
   spec {
     egress_filter {

--- a/terraform/deployments/govuk-publishing-platform/origins.tf
+++ b/terraform/deployments/govuk-publishing-platform/origins.tf
@@ -7,7 +7,7 @@ module "www_origin" {
   external_app_domain       = var.external_app_domain
   certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = terraform.workspace == "default" ? "govuk" : terraform.workspace
+  workspace                 = local.workspace
   external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
 
   apps_security_config_list = {
@@ -25,7 +25,7 @@ module "draft_origin" {
   external_app_domain       = var.external_app_domain
   certificate               = aws_acm_certificate.workspace_public.arn
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = terraform.workspace == "default" ? "govuk" : terraform.workspace
+  workspace                 = local.workspace
   external_cidrs_list       = concat(var.office_cidrs_list, data.fastly_ip_ranges.fastly.cidr_blocks)
   live                      = false
 

--- a/terraform/deployments/govuk-publishing-platform/outputs.tf
+++ b/terraform/deployments/govuk-publishing-platform/outputs.tf
@@ -73,7 +73,7 @@ output "log_group" {
 }
 
 output "mesh_name" {
-  value = local.mesh_name
+  value = aws_appmesh_mesh.govuk.name
 }
 
 output "mesh_domain" {

--- a/terraform/deployments/govuk-publishing-platform/rails_assets.tf
+++ b/terraform/deployments/govuk-publishing-platform/rails_assets.tf
@@ -1,20 +1,8 @@
-locals {
-  workspace_transformation = terraform.workspace == "default" ? "ecs" : terraform.workspace
-}
-
-
 resource "aws_s3_bucket" "rails_assets" {
-  bucket = "govuk-${var.govuk_environment}-${local.workspace_transformation}-rails-assets"
-
-  # Unless we're in staging or production, it's okay to delete this bucket
-  # even if it still contains objects.
-  #
-  # In the lower environments, we want to be able to run `terraform destroy`
-  # without having to manually delete all the assets from the bucket.
-  force_destroy = contains(["staging", "production"], var.govuk_environment) ? false : true
+  bucket = "govuk-${var.govuk_environment}-${local.workspace}-rails-assets"
 
   tags = {
-    name            = "govuk-${var.govuk_environment}-${local.workspace_transformation}-rails-assets"
+    name            = "govuk-${var.govuk_environment}-${local.workspace}-rails-assets"
     aws_environment = var.govuk_environment
   }
 }

--- a/terraform/deployments/govuk-publishing-platform/variables.tf
+++ b/terraform/deployments/govuk-publishing-platform/variables.tf
@@ -3,15 +3,6 @@ variable "external_app_domain" {
   description = "e.g. test.govuk.digital"
 }
 
-variable "mesh_name" {
-  type = string
-}
-
-variable "mesh_domain" {
-  type        = string
-  description = "e.g. mesh.govuk-internal.digital"
-}
-
 variable "ecs_default_capacity_provider" {
   type = string
 }

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -13,8 +13,6 @@ external_app_domain       = "test.govuk.digital"
 #--------------------------------------------------------------
 
 # TODO: When it becomes possible, pull these from Terraform "data" type
-mesh_domain       = "mesh.govuk-internal.digital"
-mesh_name         = "govuk"
 office_cidrs_list = ["213.86.153.212/32", "213.86.153.213/32", "213.86.153.214/32", "213.86.153.235/32", "213.86.153.236/32", "213.86.153.237/32", "85.133.67.244/32"]
 
 # TODO: Move into a monitoring tfvars file.

--- a/terraform/modules/monitoring/grafana.tf
+++ b/terraform/modules/monitoring/grafana.tf
@@ -49,7 +49,7 @@ module "grafana_public_alb" {
   external_app_domain       = var.external_app_domain
   certificate               = data.aws_acm_certificate.public_lb_alternate
   publishing_service_domain = var.publishing_service_domain
-  workspace_suffix          = "govuk" # TODO: Changeme
+  workspace                 = "govuk" # TODO: Changeme
   service_security_group_id = module.grafana_app.security_group_id
   health_check_path         = "/api/health"
   target_port               = 3000

--- a/terraform/modules/origin/main.tf
+++ b/terraform/modules/origin/main.tf
@@ -16,7 +16,7 @@ resource "aws_lb_listener_certificate" "service" {
 }
 
 resource "aws_lb" "origin" {
-  name               = "${local.mode}-origin-ecs-${var.workspace_suffix}"
+  name               = "${local.mode}-origin-ecs-${var.workspace}"
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.origin_alb.id]
@@ -25,7 +25,7 @@ resource "aws_lb" "origin" {
 
 
 resource "aws_lb_target_group" "origin-frontend" {
-  name        = "${local.mode}-origin-frontend-${var.workspace_suffix}"
+  name        = "${local.mode}-origin-frontend-${var.workspace}"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = var.vpc_id
@@ -53,7 +53,7 @@ resource "aws_lb_listener_rule" "origin-frontend" {
 }
 
 resource "aws_lb_target_group" "origin-static" {
-  name        = "${local.mode}-origin-static-${var.workspace_suffix}"
+  name        = "${local.mode}-origin-static-${var.workspace}"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = var.vpc_id

--- a/terraform/modules/origin/security_groups.tf
+++ b/terraform/modules/origin/security_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "origin_alb" {
-  name        = "fargate_${local.mode}_origin_${var.workspace_suffix}_alb"
+  name        = "fargate_${local.mode}_origin_${var.workspace}_alb"
   vpc_id      = var.vpc_id
-  description = "${local.mode}-origin Internet-facing ALB in ${var.workspace_suffix} cluster"
+  description = "${local.mode}-origin Internet-facing ALB in ${var.workspace} cluster"
 }
 
 resource "aws_security_group_rule" "service_from_origin_alb_http" {

--- a/terraform/modules/origin/variables.tf
+++ b/terraform/modules/origin/variables.tf
@@ -40,7 +40,6 @@ variable "public_zone_id" {
   type = string
 }
 
-variable "workspace_suffix" {
-  type    = string
-  default = "govuk" # TODO: Is this the default value?
+variable "workspace" {
+  type = string
 }

--- a/terraform/modules/public-load-balancer/main.tf
+++ b/terraform/modules/public-load-balancer/main.tf
@@ -11,7 +11,7 @@ resource "aws_lb_listener_certificate" "service" {
 }
 
 resource "aws_lb" "public" {
-  name               = "public-${var.app_name}-${var.workspace_suffix}"
+  name               = "public-${var.app_name}-${var.workspace}"
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.public_alb.id]
@@ -19,7 +19,7 @@ resource "aws_lb" "public" {
 }
 
 resource "aws_lb_target_group" "public" {
-  name        = "${var.app_name}-${var.workspace_suffix}-public"
+  name        = "public-${var.app_name}-${var.workspace}"
   port        = var.target_port
   protocol    = "HTTP"
   vpc_id      = var.vpc_id

--- a/terraform/modules/public-load-balancer/security_groups.tf
+++ b/terraform/modules/public-load-balancer/security_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "public_alb" {
-  name        = "fargate_${var.app_name}_${var.workspace_suffix}_public_alb"
+  name        = "fargate_${var.app_name}_${var.workspace}_public_alb"
   vpc_id      = var.vpc_id
-  description = "${var.app_name} Internet-facing ALB in ${var.workspace_suffix} cluster"
+  description = "${var.app_name} Internet-facing ALB in govuk-${var.workspace} cluster"
 }
 
 resource "aws_security_group_rule" "service_from_alb_http" {

--- a/terraform/modules/public-load-balancer/variables.tf
+++ b/terraform/modules/public-load-balancer/variables.tf
@@ -54,7 +54,6 @@ variable "target_port" {
   default = 80
 }
 
-variable "workspace_suffix" {
-  type    = string
-  default = "govuk" # TODO: Is this the default value?
+variable "workspace" {
+  type = string
 }


### PR DESCRIPTION
At entry point of variables definition, defaults.tf, we map
newly defined variable `workspace` to `ecs` for default terraform.workspace
or value of terraform workspace. This variable is then used throughout the code
base for simplicity.

Other main fixes:
1. main cluster is named `govuk-<workspace>`
2. mesh name is `mesh.<workspace>.<internal_domain_name>`