### PR TITLE
Fix certificates

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -1,5 +1,6 @@
 locals {
   workspace                 = terraform.workspace == "default" ? "ecs" : terraform.workspace #default terraform workspace mapped to ecs
+  is_default_workspace      = terraform.workspace == "default" ? true : false
   workspace_external_domain = "${local.workspace}.${var.external_app_domain}"
   workspace_internal_domain = "${local.workspace}.${var.internal_app_domain}"
   mesh_domain               = "mesh.${local.workspace_internal_domain}"

--- a/terraform/deployments/govuk-publishing-platform/dns.tf
+++ b/terraform/deployments/govuk-publishing-platform/dns.tf
@@ -31,6 +31,8 @@ resource "aws_route53_zone" "internal_private" {
 resource "aws_acm_certificate" "workspace_public" {
   domain_name = "*.${local.workspace_external_domain}"
 
+  subject_alternative_names = local.is_default_workspace ? ["*.${local.workspace}.${var.publishing_service_domain}"] : null
+
   validation_method = "DNS"
 
   lifecycle {
@@ -57,5 +59,5 @@ resource "aws_route53_record" "workspace_public" {
 
 resource "aws_acm_certificate_validation" "workspace_public" {
   certificate_arn         = aws_acm_certificate.workspace_public.arn
-  validation_record_fqdns = [for record in aws_route53_record.workspace_public : record.fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.workspace_public : record.name]
 }

--- a/terraform/modules/origin/main.tf
+++ b/terraform/modules/origin/main.tf
@@ -2,19 +2,6 @@ locals {
   mode = var.live ? "www" : "draft"
 }
 
-
-# TODO: use a single, ACM-managed cert with both domains on. There is already
-# such a cert in integration/staging/prod (but it needs defining in Terraform).
-data "aws_acm_certificate" "public_lb_default" {
-  domain   = "*.${var.publishing_service_domain}"
-  statuses = ["ISSUED"]
-}
-
-resource "aws_lb_listener_certificate" "service" {
-  listener_arn    = aws_lb_listener.origin.arn
-  certificate_arn = var.certificate
-}
-
 resource "aws_lb" "origin" {
   name               = "${local.mode}-origin-ecs-${var.workspace}"
   internal           = false
@@ -85,7 +72,7 @@ resource "aws_lb_listener" "origin" {
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = data.aws_acm_certificate.public_lb_default.arn
+  certificate_arn   = var.certificate
 
   default_action {
     type             = "forward"

--- a/terraform/modules/public-load-balancer/main.tf
+++ b/terraform/modules/public-load-balancer/main.tf
@@ -1,15 +1,3 @@
-# TODO: use a single, ACM-managed cert with both domains on. There is already
-# such a cert in integration/staging/prod (but it needs defining in Terraform).
-data "aws_acm_certificate" "public_lb_default" {
-  domain   = "*.${var.publishing_service_domain}"
-  statuses = ["ISSUED"]
-}
-
-resource "aws_lb_listener_certificate" "service" {
-  listener_arn    = aws_lb_listener.public.arn
-  certificate_arn = var.certificate
-}
-
 resource "aws_lb" "public" {
   name               = "public-${var.app_name}-${var.workspace}"
   internal           = false
@@ -35,7 +23,7 @@ resource "aws_lb_listener" "public" {
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = data.aws_acm_certificate.public_lb_default.arn
+  certificate_arn   = var.certificate
 
   default_action {
     type             = "forward"


### PR DESCRIPTION
### Please review #196 first.

Now,
1. for default/ecs workspace, we use: a single certificate with
   *.ecs.test.govuk.digital and *.ecs.test.publishing.service.gov.uk
   on both relevant ALBs and Cloudfronts
2. for other workspaces, we use only a certificate with
   *.ecs.<workspace>.govuk.digital

Ref:
1. [pr for dns validation *.ecs.test.publishing.service.gov.uk](alphagov/govuk-dns-config@9ea5f1f)