### PR TITLE
Remove Router nodes variables

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_router_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router_api.tf
@@ -45,8 +45,7 @@ module "router_api" {
   environment_variables = merge(
     local.router_api_defaults.environment_variables,
     {
-      ROUTER_NODES = local.defaults.router_urls,
-      MONGODB_URI  = "${local.router_api_defaults.mongodb_url}/router",
+      MONGODB_URI = "${local.router_api_defaults.mongodb_url}/router",
     },
   )
   secrets_from_arns = merge(
@@ -82,8 +81,7 @@ module "draft_router_api" {
   environment_variables = merge(
     local.router_api_defaults.environment_variables,
     {
-      ROUTER_NODES = local.defaults.draft_router_urls,
-      MONGODB_URI  = "${local.router_api_defaults.mongodb_url}/draft_router",
+      MONGODB_URI = "${local.router_api_defaults.mongodb_url}/draft_router",
     },
   )
   secrets_from_arns = merge(

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -33,8 +33,6 @@ locals {
     rabbitmq_hosts          = "rabbitmq.${var.internal_app_domain}" # TODO: Make workspace-aware
     router_api_uri          = "http://router-api.${local.mesh_domain}",
     draft_router_api_uri    = "http://draft-router-api.${local.mesh_domain}",
-    router_urls             = "router.${local.mesh_domain}:3055",       # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
-    draft_router_urls       = "draft-router.${local.mesh_domain}:3055", # TODO(https://trello.com/c/gmzObCBG/95): router-api expects a list of individual instances, so this won't work as-is.
     signon_uri              = "https://signon.${local.workspace_external_domain}",
     static_uri              = "http://static.${local.mesh_domain}",
     website_root            = local.public_entry_url,


### PR DESCRIPTION
This PR removes the Router nodes variables. These variables were previously required by Router API to know the Router instances it should call the `/reload` endpoint at after updating routes, however Router instances now poll for updates on a regular basis, removing the need for Router API to manually tell them to reload.