### PR TITLE
Add container healthcheck for Envoy

### DIFF
--- a/terraform/modules/app/task_definition.tf
+++ b/terraform/modules/app/task_definition.tf
@@ -36,7 +36,7 @@ module "app_container_definition" {
   aws_region            = var.aws_region
   command               = var.command
   environment_variables = var.environment_variables
-  dependsOn             = [{ containerName : "envoy", condition : "START" }]
+  dependsOn             = [{ containerName : "envoy", condition : "HEALTHY" }]
   log_group             = var.log_group
   log_stream_prefix     = var.service_name
   name                  = "app"
@@ -53,6 +53,7 @@ module "envoy_container_definition" {
   environment_variables = {
     APPMESH_RESOURCE_ARN = "mesh/${var.mesh_name}/virtualNode/${var.service_name}"
   }
+  health_check = "curl -f http://localhost:9901 || exit 1"
   # TODO: don't hardcode the version; track stable Envoy
   # TODO: control when Envoy updates happen (but still needs to be automatic)
   image             = "840364872350.dkr.ecr.${var.aws_region}.amazonaws.com/aws-appmesh-envoy:v1.16.1.0-prod"

--- a/terraform/modules/container-definition/main.tf
+++ b/terraform/modules/container-definition/main.tf
@@ -5,7 +5,10 @@ output "json_format" {
     essential   = true,
     environment = [for key, value in var.environment_variables : { name : key, value : tostring(value) }],
     dependsOn   = var.dependsOn
-    image       = var.image
+    healthCheck = {
+      command = ["/bin/bash", "-c", var.health_check]
+    }
+    image = var.image
     logConfiguration = {
       logDriver = "awslogs",
       options = {

--- a/terraform/modules/container-definition/variables.tf
+++ b/terraform/modules/container-definition/variables.tf
@@ -24,6 +24,12 @@ variable "dependsOn" {
   description = "See ECS Task Definition spec for dependsOn"
 }
 
+variable "health_check" {
+  type        = string
+  default     = "exit 0"
+  description = "Command checks the container is ready to receive requests."
+}
+
 variable "image" {
   type    = string
   default = null


### PR DESCRIPTION
We saw intermittent connection errors which were caused by Envoy not being ready to receive requests. This change ensures the Envoy process is up and healthy before starting the app container.