### PR TITLE
Fastly cdn terraform

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/cdn.tf
+++ b/terraform/deployments/govuk-publishing-platform/cdn.tf
@@ -1,0 +1,23 @@
+resource "fastly_service_v1" "www_service" {
+  count = local.is_default_workspace ? 1 : 0
+  name  = "www_service_${var.govuk_environment}"
+
+  domain {
+    name    = "www1.ecs.${var.publishing_service_domain}" #TODO: replace www1 with www as this is for testing only
+    comment = "www CDN entry point for the ${var.govuk_environment} GOV.UK environment"
+  }
+
+  force_destroy = true
+
+  vcl {
+    name = "www_main_vcl_template"
+    content = templatefile("templates/www_vcl_template.tpl",
+      { origin_hostname                     = module.www_origin.origin_app_fqdn
+        basic_authentication_encoded_secret = contains(["staging", "production"], var.govuk_environment) ? "" : data.aws_secretsmanager_secret_version.cdn_basic_authentication_encoded_secret[0].secret_string,
+        allowed_ip_addresses                = [for cidr in concat(var.office_cidrs_list, local.nat_gateway_public_cidrs_list) : cidrhost(cidr, 0)],
+        default_ttl                         = var.cdn_cache_default_ttl,
+      }
+    )
+    main = true
+  }
+}

--- a/terraform/deployments/govuk-publishing-platform/main.tf
+++ b/terraform/deployments/govuk-publishing-platform/main.tf
@@ -27,10 +27,7 @@ provider "aws" {
   }
 }
 
-provider "fastly" {
-  # We only want to use fastly's data API
-  api_key = "test"
-}
+provider "fastly" {}
 
 locals {
   vpc_id                        = data.terraform_remote_state.infra_networking.outputs.vpc_id

--- a/terraform/deployments/govuk-publishing-platform/remote_state.tf
+++ b/terraform/deployments/govuk-publishing-platform/remote_state.tf
@@ -39,3 +39,15 @@ data "terraform_remote_state" "infra_security_groups" {
 }
 
 data "fastly_ip_ranges" "fastly" {}
+
+data "aws_nat_gateway" "govuk" {
+  count     = length(local.public_subnets)
+  subnet_id = local.public_subnets[count.index]
+}
+
+locals {
+  nat_gateway_public_cidrs_list = [
+    for nat_gateway in data.aws_nat_gateway.govuk :
+    "${nat_gateway.public_ip}/32"
+  ]
+}

--- a/terraform/deployments/govuk-publishing-platform/secrets_manager.tf
+++ b/terraform/deployments/govuk-publishing-platform/secrets_manager.tf
@@ -170,3 +170,15 @@ data "aws_secretsmanager_secret" "draft_router_api_oauth_secret" {
 data "aws_secretsmanager_secret" "draft_router_api_secret_key_base" {
   name = "draft-router-api_SECRET_KEY_BASE"
 }
+
+# CDN
+
+data "aws_secretsmanager_secret" "cdn_basic_authentication_encoded_secret" {
+  count = contains(["staging", "production"], var.govuk_environment) ? 0 : 1
+  name  = "CDN_basic_authentication_encoded_secret"
+}
+
+data "aws_secretsmanager_secret_version" "cdn_basic_authentication_encoded_secret" {
+  count     = contains(["staging", "production"], var.govuk_environment) ? 0 : 1
+  secret_id = data.aws_secretsmanager_secret.cdn_basic_authentication_encoded_secret[0].id
+}

--- a/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
+++ b/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
@@ -158,11 +158,6 @@ resource "aws_security_group_rule" "draft_frontend_to_any_any" {
   security_group_id = module.draft_frontend.security_group_id
 }
 
-data "aws_nat_gateway" "govuk" {
-  count     = length(local.public_subnets)
-  subnet_id = local.public_subnets[count.index]
-}
-
 resource "aws_security_group_rule" "www_origin_alb_from_test_nat_gateways_https" {
   description = "www-origin ALB receives HTTPS requests from apps in ECS"
   type        = "ingress"
@@ -171,10 +166,7 @@ resource "aws_security_group_rule" "www_origin_alb_from_test_nat_gateways_https"
   protocol    = "tcp"
 
   security_group_id = module.www_origin.security_group_id
-  cidr_blocks = [
-    for nat_gateway in data.aws_nat_gateway.govuk :
-    "${nat_gateway.public_ip}/32"
-  ]
+  cidr_blocks       = local.nat_gateway_public_cidrs_list
 }
 
 resource "aws_security_group_rule" "draft_origin_alb_from_test_nat_gateways_https" {
@@ -185,10 +177,7 @@ resource "aws_security_group_rule" "draft_origin_alb_from_test_nat_gateways_http
   protocol    = "tcp"
 
   security_group_id = module.draft_origin.security_group_id
-  cidr_blocks = [
-    for nat_gateway in data.aws_nat_gateway.govuk :
-    "${nat_gateway.public_ip}/32"
-  ]
+  cidr_blocks       = local.nat_gateway_public_cidrs_list
 }
 
 resource "aws_security_group_rule" "static_to_any_any" {

--- a/terraform/deployments/govuk-publishing-platform/templates/www_vcl_template.tpl
+++ b/terraform/deployments/govuk-publishing-platform/templates/www_vcl_template.tpl
@@ -1,0 +1,317 @@
+backend origin {
+    .connect_timeout = 5s;
+    .dynamic = true;
+    .port = "443";
+    .host = "${origin_hostname}";
+    .first_byte_timeout = 15s;
+    .max_connections = 200;
+    .between_bytes_timeout = 10s;
+    .ssl = true;
+    .ssl_check_cert = always;
+    .min_tls_version = "1.2";
+    .ssl_ciphers = "ECDHE-RSA-AES256-GCM-SHA384";
+    .ssl_cert_hostname = "${origin_hostname}";
+    .ssl_sni_hostname = "${origin_hostname}";
+
+    .probe = {
+        .request =
+            "HEAD / HTTP/1.1"
+            "Host: ${origin_hostname}"
+            "User-Agent: Fastly healthcheck"
+%{ if basic_authentication_encoded_secret != "" ~}
+            "Authorization: Basic ${basic_authentication_encoded_secret}"
+%{ endif ~}
+            "Connection: close";
+        .threshold = 1;
+        .window = 2;
+        .timeout = 5s;
+        .initial = 1;
+        .expected_response = 200;
+        .interval = 10s;
+    }
+}
+
+
+acl purge_ip_allowlist {
+  "23.235.32.0"/20;   # Fastly cache node
+  "43.249.72.0"/22;   # Fastly cache node
+  "103.244.50.0"/24;  # Fastly cache node
+  "103.245.222.0"/23; # Fastly cache node
+  "103.245.224.0"/24; # Fastly cache node
+  "104.156.80.0"/20;  # Fastly cache node
+  "151.101.0.0"/16;   # Fastly cache node
+  "157.52.64.0"/18;   # Fastly cache node
+  "172.111.64.0"/18;  # Fastly cache node
+  "185.31.16.0"/22;   # Fastly cache node
+  "199.27.72.0"/21;   # Fastly cache node
+  "199.232.0.0"/16;   # Fastly cache node
+  "202.21.128.0"/24;  # Fastly cache node
+  "203.57.145.0"/24;  # Fastly cache node
+  "167.82.0.0"/17;    # Fastly cache node
+  "167.82.128.0"/20;  # Fastly cache node
+  "167.82.160.0"/20;  # Fastly cache node
+  "167.82.224.0"/20;  # Fastly cache node
+}
+
+acl allowed_ip_addresses {
+  %{ for ip_address in allowed_ip_addresses ~}
+  "${ip_address}";
+  %{ endfor ~}
+}
+
+sub vcl_recv {
+
+  # Require authentication for FASTLYPURGE requests unless from IP in ACL
+  if (req.request == "FASTLYPURGE" && client.ip !~ purge_ip_allowlist) {
+    set req.http.Fastly-Purge-Requires-Auth = "1";
+  }
+
+  %{ if basic_authentication_encoded_secret != "" }
+  if (! (client.ip ~ allowed_ip_addresses)) {
+    # Check whether the basic auth credentials are correct in integration
+    if (req.http.Authorization != "Basic ${basic_authentication_encoded_secret}") {
+      error 401 "Unauthorized";
+    }
+  }
+  %{ endif }
+
+  # Force SSL.
+  if (!req.http.Fastly-SSL) {
+     error 801 "Force SSL";
+  }
+
+  # Serve a 404 Not Found response if request URL matches "/autodiscover/autodiscover.xml"
+  if (req.url.path ~ "(?i)/autodiscover/autodiscover.xml$") {
+    error 804 "Not Found";
+  }
+
+  # Serve from stale for 24 hours if origin is sick
+  set req.grace = 24h;
+
+  # Default backend, these details will be overwritten if other backends are
+  # chosen
+  set req.backend = origin;
+  set req.http.Fastly-Backend-Name = "origin";
+
+  # Set header to show recommended related links for Whitehall content. This is to be used
+  # as a rollback mechanism should we ever need to stop showing these links.
+  set req.http.Govuk-Use-Recommended-Related-Links = "true";
+
+  # Set a request id header to allow requests to be traced through the stack
+  set req.http.GOVUK-Request-Id = uuid.version4();
+
+  if (req.url.path == "/find-coronavirus-local-restrictions") {
+    # get rid of all but the postcode param
+    set req.url = querystring.filter_except(req.url, "postcode");
+  }
+
+  # Unspoofable original client address (e.g. for rate limiting).
+  set req.http.True-Client-IP = req.http.Fastly-Client-IP;
+
+  # Reset proxy headers at the boundary to our network.
+  unset req.http.Client-IP;
+  set req.http.X-Forwarded-For = req.http.Fastly-Client-IP;
+
+  # Set a TLSversion request header for requests going to the Licensify application
+  # This is used to block unsecure requests at the application level for payment security reasons and an absence of caching in Licensify
+  if (req.url ~ "^/apply-for-a-licence/.*") {
+    set req.http.TLSversion = tls.client.protocol;
+  }
+
+%{ if basic_authentication_encoded_secret != "" }
+  if (req.backend == origin) {
+    set req.http.Authorization = "Basic ${basic_authentication_encoded_secret}";
+  }
+%{ endif }
+
+#FASTLY recv
+
+  if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+    return(pass);
+  }
+
+  if (req.http.Cookie ~ "_finder-frontend_account_session") {
+    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedIn";
+  } else {
+    set req.http.GOVUK-ABTest-AccountExperiment = "LoggedOut";
+  }
+
+  return(lookup);
+}
+
+sub vcl_fetch {
+#FASTLY fetch
+
+  set beresp.http.Fastly-Backend-Name = req.http.Fastly-Backend-Name;
+
+  if ((beresp.status >= 500 && beresp.status <= 599) && req.restarts < 3 && (req.request == "GET" || req.request == "HEAD") && !beresp.http.No-Fallback) {
+    set beresp.saintmode = 5s;
+    return (restart);
+  }
+
+  if (req.restarts == 0) {
+    # Keep stale for origin
+    set beresp.grace = 24h;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+
+  if (beresp.status >= 500 && beresp.status <= 599) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "max-age=0") {
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "no-(store|cache)") {
+    return (pass);
+  }
+
+  # Fastly doesn't recognise 307 as cacheable by default as it is based on an
+  # old version of Varnish that also lacked 307 support.
+  if (beresp.status == 307) {
+    set beresp.cacheable = true;
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = ${default_ttl}s;
+  }
+
+  # Override default.vcl behaviour of return(pass).
+  if (beresp.http.Set-Cookie) {
+    return (deliver);
+  }
+}
+
+sub vcl_hit {
+#FASTLY hit
+}
+
+sub vcl_miss {
+#FASTLY miss
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+}
+
+sub vcl_error {
+  if (obj.status == 801) {
+    set obj.status = 301;
+    set obj.response = "Moved Permanently";
+    set obj.http.Location = "https://" req.http.host req.url;
+    set obj.http.Fastly-Backend-Name = "force_ssl";
+    synthetic {""};
+    return (deliver);
+  }
+
+  # Arbitrary 302 redirects called from vcl_recv.
+  if (obj.status == 802) {
+    set obj.status = 302;
+    set obj.http.Location = "https://" req.http.host obj.response;
+    set obj.response = "Moved";
+    synthetic {""};
+    return (deliver);
+  }
+
+  if (obj.status == 804) {
+    set obj.status = 404;
+    set obj.response = "Not Found";
+    set obj.http.Fastly-Backend-Name = "force_not_found";
+
+    synthetic {"
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>We cannot find the page you're looking for. Please try searching on <a href="https://www.gov.uk/">GOV.UK</a>.</p>
+        </body>
+      </html>"};
+
+    return (deliver);
+  }
+
+  %{ if basic_authentication_encoded_secret != "" }
+  if (obj.status == 401) {
+    set obj.http.WWW-Authenticate = "Basic";
+    synthetic {""};
+    return (deliver);
+  }
+  %{ endif }
+
+  # Serve stale from error subroutine as recommended in:
+  # https://docs.fastly.com/guides/performance-tuning/serving-stale-content
+  # The use of `req.restarts == 0` condition is to enforce the restriction
+  # of serving stale only when the backend is the origin.
+  if ((req.restarts == 0) && (obj.status >= 500 && obj.status < 600)) {
+    /* deliver stale object if it is available */
+    if (stale.exists) {
+      return(deliver_stale);
+    }
+  }
+
+  # Assume we've hit vcl_error() because the backend is unavailable
+  # for the first two retries. By restarting, vcl_recv() will try
+  # serving from stale before failing over to the mirrors.
+  if (req.restarts < 3) {
+    return (restart);
+  }
+
+  set obj.http.Fastly-Backend-Name = "error";
+  synthetic {"
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Welcome to GOV.UK</title>
+        <style>
+          body { font-family: Arial, sans-serif; margin: 0; }
+          header { background: black; }
+          h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+          p { color: black; margin: 30px auto; max-width: 990px; }
+        </style>
+      </head>
+      <body>
+        <header><h1>GOV.UK</h1></header>
+        <p>We're experiencing technical difficulties. Please try again later.</p>
+        <p>You can <a href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
+      </body>
+    </html>"};
+
+  return (deliver);
+
+#FASTLY error
+}
+
+# pipe cannot be included.
+
+sub vcl_pass {
+#FASTLY pass
+}
+
+sub vcl_hash {
+#FASTLY hash
+}

--- a/terraform/deployments/govuk-publishing-platform/variables.tf
+++ b/terraform/deployments/govuk-publishing-platform/variables.tf
@@ -102,3 +102,9 @@ variable "assume_role_arn" {
   description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
   default     = null
 }
+
+variable "cdn_cache_default_ttl" {
+  type        = number
+  description = "Maxmimum amount of time for which the object will be considered fresh in the cache"
+  default     = 900
+}

--- a/terraform/modules/.terraform.tfstate.lock.info
+++ b/terraform/modules/.terraform.tfstate.lock.info
@@ -1,0 +1,1 @@
+{"ID":"cccd4c6d-3e7c-ccdf-7cac-5b1ca5d30c34","Operation":"OperationTypeInvalid","Info":"","Who":"fredericfrancois@gds8074.local","Version":"0.14.6","Created":"2021-04-07T16:30:46.658145Z","Path":"terraform.tfstate"}


### PR DESCRIPTION
Manage Fastly CDN Service with Terraform

As part of the [firebreak
project](https://trello.com/c/crnmDAG6/450-%F0%9F%94%A5%F0%9F%8C%B4%F0%9F%8C%B4-manage-fastly-configuration-with-terraform-in-test),
this PR adds the necessary terraform code to create a new Fastly service
for the test GOV.UK environment.

This Fastly service is a stripped down version of the one already in
integration except that there are no tables, cookies etc but basic
authentication is present.

Fastly service URL is: https://www1.ecs.test.publishing.service.gov.uk/

**Deployment**

In order to deploy this code, you need to export the environment
variable `FASTLY_API_KEY` with the key being stored under
`fastly/engineer_test_environment` in the 2ndline Pass (see
[PR](alphagov/govuk-secrets#1132))

**Caveats**
Known caveats:
1. Code depends on the Basic authentication encoded secret to exist in
AWS Secrets Manager under the name: `CDN_basic_authentication_encoded_secret`
2. the TLS certificate for `*.ecs.test.publishing.service.gov.uk` was
already created in Fastly portal for another service and is reused here.
3. the size of the frontend needs to be increased in terms of CPU since twice
the number of Fastly cache nodes where pointing to it since there will be
2 Fastly services.