### PR TITLE
Make the pipeline workspace aware

### DIFF
--- a/concourse/docs/creating_new_deploy_concourse_pipeline.md
+++ b/concourse/docs/creating_new_deploy_concourse_pipeline.md
@@ -1,0 +1,31 @@
+# Creating New Deploy Concourse Pipeline
+
+The most straight forward way of creating a new GOV.UK environment to test your
+changes is to create a new `Deploy` Concourse pipeline which will create a new
+`test` GOV.UK environment via Terraform workspace.
+
+## Instructions
+
+1. Clone this repo and create your own branch where you will modify the
+   [deploy-parameters.yml](../pipelines/deploy-parameters.yml).
+
+   The parameter definitions are:
+   `workspace`: terraform workspace where your resources will be created
+   `govuk_infrastructure_branch`: name of the branch of this repo you just created
+
+   Push your changes to GitHub after your finished.
+
+1. Set-up your Fly Concourse CLI tool to target the `govuk-tools` team in the
+   [Big Concourse](https://cd.gds-reliability.engineering/teams/govuk-tools)
+
+1. Create a new pipeline:
+
+   ```shell
+   fly -t <target_name> sp \
+       -p <pipeline_name> \
+       -c <path_to_deploy_file> \
+       -l <path_to_deploy_parameters_file>
+   ```
+
+1. Browse to `https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/<pipeline_name>`
+   to status of your new pipeline

--- a/concourse/pipelines/deploy-parameters.yml
+++ b/concourse/pipelines/deploy-parameters.yml
@@ -1,0 +1,2 @@
+workspace: default
+govuk_infrastructure_branch: main

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -37,7 +37,7 @@ resources:
     icon: github
     name: govuk-infrastructure
     source: &govuk-infrastructure-source
-      branch: main
+      branch: ((govuk_infrastructure_branch))
       uri: https://github.com/alphagov/govuk-infrastructure
     type: git
 
@@ -329,9 +329,8 @@ jobs:
       trigger: true
     - file: govuk-infrastructure/concourse/pipelines/deploy.yml
       set_pipeline: self
-      vars:
-        workspace: ((workspace))
-        pipeline_name: ((pipeline_name))
+      var_files:
+        - govuk-infrastructure/concourse/pipelines/deploy-parameters.yml
 
   - name: run-terraform
     serial: true
@@ -522,7 +521,8 @@ jobs:
           app-image: frontend-image
         params:
           IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/frontend
-          S3_BUCKET_PATH: s3://govuk-test-ecs-rails-assets/assets/frontend/
+          S3_BUCKET_PATH_PATTERN: s3://govuk-test-%s-rails-assets/assets/frontend/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
+          WORKSPACE: ((workspace))
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -943,7 +943,8 @@ jobs:
           app-image: static-image
         params:
           IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/static
-          S3_BUCKET_PATH: s3://govuk-test-ecs-rails-assets/assets/static/
+          S3_BUCKET_PATH_PATTERN: s3://govuk-test-%s-rails-assets/assets/static/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
+          WORKSPACE: ((workspace))
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -427,7 +427,7 @@ jobs:
 
             terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
 
-            terraform workspace select "$WORKSPACE"
+            terraform workspace select "$WORKSPACE" || terraform workspace new "$WORKSPACE"
 
             terraform apply \
               -var "assume_role_arn=$ASSUME_ROLE_ARN" \

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -47,7 +47,7 @@ resources:
     source:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
-      versioned_file: publishing-api.json
+      versioned_file: ((workspace))/publishing-api.json
       initial_version: "0"
 
   - <<: *git-repo
@@ -63,7 +63,7 @@ resources:
     source:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
-      versioned_file: smokey.json
+      versioned_file: ((workspace))/smokey.json
       initial_version: "0"
 
   - name: deploy-slack-channel
@@ -81,7 +81,7 @@ resources:
     source:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
-      versioned_file: govuk-terraform-outputs.json
+      versioned_file: ((workspace))/govuk-terraform-outputs.json
 
   - name: content-store-terraform-outputs
     type: s3
@@ -92,7 +92,7 @@ resources:
     source:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
-      versioned_file: content-store.json
+      versioned_file: ((workspace))/content-store.json
       initial_version: "0"
 
   - name: frontend-terraform-outputs
@@ -101,7 +101,7 @@ resources:
     source:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
-      versioned_file: frontend.json
+      versioned_file: ((workspace))/frontend.json
       initial_version: "0"
 
   - name: publisher-terraform-outputs
@@ -110,7 +110,7 @@ resources:
     source:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
-      versioned_file: publisher.json
+      versioned_file: ((workspace))/publisher.json
       initial_version: "0"
 
   - name: signon-terraform-outputs
@@ -119,7 +119,7 @@ resources:
     source:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
-      versioned_file: signon.json
+      versioned_file: ((workspace))/signon.json
       initial_version: "0"
 
   - name: static-terraform-outputs
@@ -128,7 +128,7 @@ resources:
     source:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
-      versioned_file: static.json
+      versioned_file: ((workspace))/static.json
       initial_version: "0"
 
   - name: router-api-terraform-outputs
@@ -137,7 +137,7 @@ resources:
     source:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
-      versioned_file: router-api.json
+      versioned_file: ((workspace))/router-api.json
       initial_version: "0"
 
   - name: router-terraform-outputs
@@ -146,7 +146,7 @@ resources:
     source:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
-      versioned_file: router.json
+      versioned_file: ((workspace))/router.json
       initial_version: "0"
 
   - &registry-image
@@ -328,7 +328,10 @@ jobs:
     - get: govuk-infrastructure
       trigger: true
     - file: govuk-infrastructure/concourse/pipelines/deploy.yml
-      set_pipeline: deploy-apps-test
+      set_pipeline: ((pipeline_name))
+      vars:
+        workspace: ((workspace))
+        pipeline_name: ((pipeline_name))
 
   - name: run-terraform
     serial: true
@@ -403,6 +406,7 @@ jobs:
         params:
           AWS_REGION: eu-west-1
           ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+          WORKSPACE: ((workspace))
         platform: linux
         image_resource:
           type: docker-image
@@ -423,6 +427,9 @@ jobs:
             cd govuk-infrastructure/terraform/deployments/govuk-publishing-platform
 
             terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+
+            terraform workspace select "$WORKSPACE"
+
             terraform apply \
               -var "assume_role_arn=$ASSUME_ROLE_ARN" \
               -var-file ../variables/test/infrastructure.tfvars \
@@ -541,12 +548,14 @@ jobs:
          task-definition-arn: draft-task-definition-arn
         params:
          ECS_SERVICE: draft-frontend
+         WORKSPACE: ((workspace))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
          task-definition-arn: live-task-definition-arn
         params:
          ECS_SERVICE: frontend
+         WORKSPACE: ((workspace))
     serial: true
     on_failure: &notify-slack-failure
       put: deploy-slack-channel
@@ -628,12 +637,14 @@ jobs:
           task-definition-arn: web-task-definition-arn
         params:
           ECS_SERVICE: publisher-web
+          WORKSPACE: ((workspace))
       - task: update-worker-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
           task-definition-arn: worker-task-definition-arn
         params:
           ECS_SERVICE: publisher-worker
+          WORKSPACE: ((workspace))
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -685,12 +696,14 @@ jobs:
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         params:
           ECS_SERVICE: publishing-api-web
+          WORKSPACE: ((workspace))
         input_mapping:
           task-definition-arn: web-task-definition-arn
       - task: update-worker-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         params:
           ECS_SERVICE: publishing-api-worker
+          WORKSPACE: ((workspace))
         input_mapping:
             task-definition-arn: worker-task-definition-arn
     serial: true
@@ -736,12 +749,14 @@ jobs:
           task-definition-arn: live-task-definition-arn
         params:
           ECS_SERVICE: content-store
+          WORKSPACE: ((workspace))
       - task: update-draft-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
           task-definition-arn: draft-task-definition-arn
         params:
           ECS_SERVICE: draft-content-store
+          WORKSPACE: ((workspace))
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -785,12 +800,14 @@ jobs:
           task-definition-arn: draft-task-definition-arn
         params:
           ECS_SERVICE: draft-router
+          WORKSPACE: ((workspace))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
           task-definition-arn: live-task-definition-arn
         params:
           ECS_SERVICE: router
+          WORKSPACE: ((workspace))
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -834,12 +851,14 @@ jobs:
           task-definition-arn: draft-task-definition-arn
         params:
           ECS_SERVICE: draft-router-api
+          WORKSPACE: ((workspace))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
           task-definition-arn: live-task-definition-arn
         params:
           ECS_SERVICE: router-api
+          WORKSPACE: ((workspace))
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -874,6 +893,7 @@ jobs:
       params:
         ECS_SERVICE: signon
         GOVUK_ENVIRONMENT: test
+        WORKSPACE: ((workspace))
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -949,12 +969,14 @@ jobs:
           task-definition-arn: draft-task-definition-arn
         params:
           ECS_SERVICE: draft-static
+          WORKSPACE: ((workspace))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
           task-definition-arn: live-task-definition-arn
         params:
           ECS_SERVICE: static
+          WORKSPACE: ((workspace))
     serial: true
     on_failure:
       <<: *notify-slack-failure

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -328,7 +328,7 @@ jobs:
     - get: govuk-infrastructure
       trigger: true
     - file: govuk-infrastructure/concourse/pipelines/deploy.yml
-      set_pipeline: ((pipeline_name))
+      set_pipeline: self
       vars:
         workspace: ((workspace))
         pipeline_name: ((pipeline_name))

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -317,6 +317,8 @@ jobs:
 
               cd govuk-infrastructure/terraform/deployments/govuk-publishing-platform
 
+              terraform workspace select "$WORKSPACE"
+
               terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
               terraform destroy  \
               -var "assume_role_arn=$ASSUME_ROLE_ARN" \

--- a/concourse/tasks/update-ecs-service.sh
+++ b/concourse/tasks/update-ecs-service.sh
@@ -2,6 +2,12 @@
 
 set -eu
 
+if [ "${WORKSPACE}" == "default" ]; then
+  CLUSTER=govuk-ecs
+else
+  CLUSTER="govuk-$WORKSPACE"
+fi
+
 mkdir -p ~/.aws
 
 cat <<EOF > ~/.aws/config

--- a/concourse/tasks/update-ecs-service.yml
+++ b/concourse/tasks/update-ecs-service.yml
@@ -14,6 +14,6 @@ params:
   AWS_REGION: eu-west-1
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
   ECS_SERVICE:
-  CLUSTER: govuk-ecs
+  WORKSPACE:
 run:
   path: ./src/concourse/tasks/update-ecs-service.sh

--- a/concourse/tasks/upload-rails-assets.sh
+++ b/concourse/tasks/upload-rails-assets.sh
@@ -10,6 +10,12 @@ role_arn = $ASSUME_ROLE_ARN
 credential_source = Ec2InstanceMetadata
 EOF
 
+if [[ "$WORKSPACE" == "default" ]]; then
+  WORKSPACE=ecs;
+fi
+
+S3_BUCKET_PATH=$(printf "$S3_BUCKET_PATH_PATTERN" "$WORKSPACE")
+
 echo "Uploading rails assets from ${IMAGE_ASSETS_PATH} to ${S3_BUCKET_PATH} ..."
 
 aws s3 sync \

--- a/concourse/tasks/upload-rails-assets.yml
+++ b/concourse/tasks/upload-rails-assets.yml
@@ -14,6 +14,7 @@ params:
   AWS_REGION: eu-west-1
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
   IMAGE_ASSETS_PATH:
-  S3_BUCKET_PATH:
+  S3_BUCKET_PATH_PATTERN:
+  WORKSPACE:
 run:
   path: ./src/concourse/tasks/upload-rails-assets.sh

--- a/terraform/modules/app/task_definition.tf
+++ b/terraform/modules/app/task_definition.tf
@@ -2,6 +2,8 @@ locals {
   # 1337 is an arbitrary choice copied from the examples in the envoy user guide.
   user_id = "1337"
 
+  family = "${var.service_name}-${terraform.workspace}"
+
   envoy_proxy_properties = {
     AppPorts = join(",", var.ports)
 
@@ -73,7 +75,7 @@ module "task_definition" {
   ]
   cpu                = var.cpu
   execution_role_arn = var.execution_role_arn
-  family             = var.service_name
+  family             = local.family
   memory             = var.memory
   proxy_configuration = {
     type          = "APPMESH",
@@ -84,7 +86,7 @@ module "task_definition" {
 }
 
 resource "aws_ecs_task_definition" "bootstrap" {
-  family                   = var.service_name
+  family                   = local.family
   network_mode             = "awsvpc"
   cpu                      = var.cpu
   memory                   = var.memory


### PR DESCRIPTION
Terraform and concourse work together to deploy the infrastructure and the apps. Running `terraform apply` gets you most of the way there, but to get a fully working workspace you also need to upload the CSS / JS / fonts generated by the rails apps to S3. Concourse does this (amongst other things).

Workspaces are therefore much more useful if each workspace has its own concourse pipeline.

Engineers working on a branch can use the workspace to test changes to the concourse pipeline and terraform before they raise a PR, without affecting the rest of the team.

Test created was:
terraform_workspace: bob
entry_point: https://www-origin.bob.test.govuk.digital/
concourse_pipeline: https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/deploy-bob