### PR TITLE
Add support for ECS exec-command

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
@@ -138,3 +138,31 @@ resource "aws_iam_role_policy_attachment" "appmesh_envoy_access" {
   role       = aws_iam_role.task.id
   policy_arn = "arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess"
 }
+
+resource "aws_iam_role_policy_attachment" "ecs_exec_access" {
+  role       = aws_iam_role.task.id
+  policy_arn = aws_iam_policy.ecs_exec_access.arn
+}
+
+resource "aws_iam_policy" "ecs_exec_access" {
+  name        = "ecs_exec_access-${local.workspace}"
+  path        = "/ecsExecAccessPolicy/"
+  description = "Permits developers to access a running container"
+  policy      = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+       {
+       "Effect": "Allow",
+       "Action": [
+            "ssmmessages:CreateControlChannel",
+            "ssmmessages:CreateDataChannel",
+            "ssmmessages:OpenControlChannel",
+            "ssmmessages:OpenDataChannel"
+       ],
+      "Resource": "*"
+      }
+   ]
+}
+EOF
+}

--- a/terraform/modules/container-definition/main.tf
+++ b/terraform/modules/container-definition/main.tf
@@ -9,6 +9,9 @@ output "json_format" {
       command = ["/bin/bash", "-c", var.health_check]
     }
     image = var.image
+    linuxParameters = {
+      initProcessEnabled = true
+    }
     logConfiguration = {
       logDriver = "awslogs",
       options = {

--- a/tools/run-task.sh
+++ b/tools/run-task.sh
@@ -70,6 +70,7 @@ echo "Starting task:
 task=$(aws ecs run-task --cluster $cluster \
 --task-definition $task_definition_arn --launch-type FARGATE --count 1 \
 --network-configuration $network_config \
+--enable-execute-command \
 --started-by $(whoami) \
 --overrides '{
   "containerOverrides": [{


### PR DESCRIPTION
The AWS ECS team recently released ECS Exec Command which permits us to run an interactive shell in a
running container: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html

This change introduces the policies to enable the feature. We won't be enabling this feature on our ECS Services, only on tasks in the `task_runner` cluster - as we don't want to give developers access to containers serving user requests.

Further work is required to improve the tooling - currently one needs to run a task and then use `aws ecs exec-command` to start an SSM session.

The workflow currently will look like this:

```
cd govuk-infrastructure
./tools/run-task.sh -a publisher -v web sleep 1800
# get task id from output of task
aws ecs execute-command --cluster task_runner --container app --command /bin/bash --interactive --task <task-id>
```