### PR TITLE
Temporary hack to authenticate to DockerHub.

### DIFF
--- a/terraform/modules/app/task_definition.tf
+++ b/terraform/modules/app/task_definition.tf
@@ -33,6 +33,7 @@ locals {
 module "app_container_definition" {
   source                = "../../modules/container-definition"
   image                 = "govuk/${var.image_name}:deployed-to-production"
+  registry_creds        = "arn:aws:secretsmanager:eu-west-1:430354129336:secret:dockerhub-SlzTmx" # TODO: remove once images are on ECR.
   aws_region            = var.aws_region
   command               = var.command
   environment_variables = var.environment_variables

--- a/terraform/modules/container-definition/main.tf
+++ b/terraform/modules/container-definition/main.tf
@@ -12,6 +12,8 @@ output "json_format" {
     linuxParameters = {
       initProcessEnabled = true
     }
+    # TODO: remove this hack once images are on ECR.
+    repositoryCredentials = var.registry_creds == null ? null : { "credentialsParameter" : var.registry_creds }
     logConfiguration = {
       logDriver = "awslogs",
       options = {

--- a/terraform/modules/container-definition/variables.tf
+++ b/terraform/modules/container-definition/variables.tf
@@ -35,6 +35,12 @@ variable "image" {
   default = null
 }
 
+variable "registry_creds" {
+  type        = string
+  default     = null
+  description = "ARN of Secrets Manager secret for container registry login, if authentication is needed to pull the image."
+}
+
 variable "log_group" {
   type = string
 }


### PR DESCRIPTION
Authenticate to DockerHub when pulling images, so that we don't get severely rate-limited.

I had to set the secret manually. Since it's just a temporary workaround for the test account until we're up and running with ECR, I think that's ok.

Briefly considered passing the ARN in as a var, but this workaround needs to be reverted before we deploy anything outside the test account anyway, so I decided it would just lend this a false air of legitimacy 😅