### PR TITLE
Change from Docker Hub to AWS ECR

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -16,6 +16,14 @@ resource_types:
       repository: governmentpaas/s3-resource
       tag: latest # TODO - don't use latest (once we've worked out a policy for third party images)
 
+  - name: registry-image
+    type: docker-image
+    source:
+      repository: concourse/registry-image-resource
+      tag: 1.2.1
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
+
 resources:
   - &git-repo
     icon: github
@@ -24,20 +32,6 @@ resources:
       branch: main
       uri: https://github.com/alphagov/govuk-infrastructure
     type: git
-
-  - <<: *git-repo
-    name: publisher
-    source:
-      branch: master
-      uri: https://github.com/alphagov/publisher
-      tag_filter: release_*
-
-  - <<: *git-repo
-    name: publishing-api
-    source:
-      branch: master
-      uri: https://github.com/alphagov/publishing-api
-      tag_filter: release_*
 
   - name: publishing-api-terraform-outputs
     type: s3
@@ -49,46 +43,11 @@ resources:
       initial_version: "0"
 
   - <<: *git-repo
-    name: content-store
-    source:
-      branch: master
-      uri: https://github.com/alphagov/content-store
-      tag_filter: release_*
-
-  - <<: *git-repo
     name: govuk-infrastructure-concourse-tasks
     icon: concourse-ci
     source:
       <<: *govuk-infrastructure-source
       paths: [ concourse/tasks ]
-
-  - <<: *git-repo
-    name: router
-    source:
-      branch: master
-      uri: https://github.com/alphagov/router
-      tag_filter: release_*
-
-  - <<: *git-repo
-    name: router-api
-    source:
-      branch: master
-      uri: https://github.com/alphagov/router-api
-      tag_filter: release_*
-
-  - <<: *git-repo
-    name: signon
-    source:
-      branch: master
-      uri: https://github.com/alphagov/signon
-      tag_filter: release_*
-
-  - <<: *git-repo
-    name: smokey
-    source:
-      branch: main
-      uri: https://github.com/alphagov/smokey
-      tag_filter: "*-release"
 
   - name: smokey-terraform-outputs
     type: s3
@@ -183,23 +142,68 @@ resources:
       initial_version: "0"
 
 
-  - name: frontend-image
+  - &registry-image
+    name: frontend-image
     type: registry-image
     icon: docker
-    source:
-      repository: govuk/frontend
-      tag: release
-      username: ((docker_hub_username))
-      password: ((docker_hub_authtoken))
+    source: &registry-source
+      repository: frontend
+      aws_role_arn: arn:aws:iam::172025368201:role/pull_images_from_ecr_role
+      aws_region: eu-west-1
+      aws_access_key_id: ((concourse-ecr-readonly-user_aws-access-key))
+      aws_secret_access_key: ((concourse-ecr-readonly-user_aws-secret-access-key))
+      aws_ecr_registry_id: "172025368201"
+      variant: release
 
-  - name: static-image
-    type: registry-image
-    icon: docker
+  - <<: *registry-image
+    name: static-image
     source:
-      repository: govuk/static
-      tag: release
-      username: ((docker_hub_username))
-      password: ((docker_hub_authtoken))
+      <<: *registry-source
+      repository: static
+
+  - <<: *registry-image
+    name: publisher-image
+    source:
+      <<: *registry-source
+      repository: publisher
+
+  - <<: *registry-image
+    name: publishing-api-image
+    source:
+      <<: *registry-source
+      repository: publishing-api
+      tag: bilbof_dockerfile-fix # TODO - remove this once content-store supports content-schemas
+
+  - <<: *registry-image
+    name: content-store-image
+    source:
+      <<: *registry-source
+      repository: content-store
+      tag: bill-content-schemas # TODO - remove this once content-store supports content-schemas
+
+  - <<: *registry-image
+    name: router-image
+    source:
+      <<: *registry-source
+      repository: router
+
+  - <<: *registry-image
+    name: router-api-image
+    source:
+      <<: *registry-source
+      repository: router-api
+
+  - <<: *registry-image
+    name: signon-image
+    source:
+      <<: *registry-source
+      repository: signon
+
+  - <<: *registry-image
+    name: smokey-image
+    source:
+      <<: *registry-source
+      repository: smokey
 
 groups:
   - name: all
@@ -524,12 +528,13 @@ jobs:
         passed:
         - run-terraform
         trigger: true
-      - get: release
-        resource: publisher
+      - get: publisher-image
         trigger: true
     - in_parallel:
       - task: update-web-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: publisher-image
         output_mapping:
           task-definition-arn: web-task-definition-arn
         params:
@@ -538,6 +543,8 @@ jobs:
           GOVUK_ENVIRONMENT: test
       - task: update-worker-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: publisher-image
         output_mapping:
           task-definition-arn: worker-task-definition-arn
         params:
@@ -580,28 +587,29 @@ jobs:
         passed:
         - run-terraform
         trigger: true
-      - get: release
-        resource: publishing-api
+      - get: publishing-api-image
         trigger: true
     - in_parallel:
       - task: update-web-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: publishing-api-image
         output_mapping:
           task-definition-arn: web-task-definition-arn
         params:
           APPLICATION: publishing-api
           VARIANT: web
           GOVUK_ENVIRONMENT: test
-          PIN_IMAGE_TAG: bilbof_dockerfile-fix # TODO - remove this once content-store supports content-schemas
       - task: update-worker-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: publishing-api-image
         output_mapping:
           task-definition-arn: worker-task-definition-arn
         params:
           APPLICATION: publishing-api
           VARIANT: worker
           GOVUK_ENVIRONMENT: test
-          PIN_IMAGE_TAG: bilbof_dockerfile-fix # TODO - remove this once content-store supports content-schemas
     - task: run-db-migrations
       file: govuk-infrastructure/concourse/tasks/run-task.yml
       input_mapping:
@@ -638,27 +646,27 @@ jobs:
         passed:
         - run-terraform
         trigger: true
-      - get: release
-        resource: content-store
+      - get: content-store-image
         trigger: true
-
     - in_parallel:
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: content-store-image
         output_mapping:
           task-definition-arn: draft-task-definition-arn
         params:
           APPLICATION: content-store
           VARIANT: draft
-          PIN_IMAGE_TAG: bill-content-schemas # TODO - remove this once content-store supports content-schemas
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: content-store-image
         output_mapping:
           task-definition-arn: live-task-definition-arn
         params:
           APPLICATION: content-store
           VARIANT: live
-          PIN_IMAGE_TAG: bill-content-schemas # TODO - remove this once content-store supports content-schemas
     - in_parallel:
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
@@ -687,12 +695,13 @@ jobs:
         passed:
         - run-terraform
         trigger: true
-      - get: release
-        resource: router
+      - get: router-image
         trigger: true
     - in_parallel:
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: router-image
         output_mapping:
           task-definition-arn: draft-task-definition-arn
         params:
@@ -700,6 +709,8 @@ jobs:
           VARIANT: draft
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: router-image
         output_mapping:
           task-definition-arn: live-task-definition-arn
         params:
@@ -733,12 +744,13 @@ jobs:
         passed:
         - run-terraform
         trigger: true
-      - get: release
-        resource: router-api
+      - get: router-api-image
         trigger: true
     - in_parallel:
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: router-api-image
         output_mapping:
           task-definition-arn: draft-task-definition-arn
         params:
@@ -746,6 +758,8 @@ jobs:
           VARIANT: draft
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+        input_mapping:
+          app-image: router-api-image
         output_mapping:
           task-definition-arn: live-task-definition-arn
         params:
@@ -779,8 +793,7 @@ jobs:
         passed:
         - run-terraform
         trigger: true
-      - get: release
-        resource: signon
+      - get: signon-image
         trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
@@ -788,6 +801,8 @@ jobs:
         APPLICATION: signon
         GOVUK_ENVIRONMENT: test
         VARIANT: web
+      input_mapping:
+        app-image: signon-image
       output_mapping:
         task-definition-arn: task-definition-arn
     - task: update-ecs-service
@@ -812,11 +827,12 @@ jobs:
         passed:
         - run-terraform
         trigger: true
-      - get: release
-        resource: smokey
+      - get: smokey-image
         trigger: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+      input_mapping:
+        app-image: smokey-image
       params:
         APPLICATION: smokey
         GOVUK_ENVIRONMENT: test

--- a/concourse/tasks/update-task-definition.sh
+++ b/concourse/tasks/update-task-definition.sh
@@ -10,12 +10,7 @@ role_arn = $ASSUME_ROLE_ARN
 credential_source = Ec2InstanceMetadata
 EOF
 
-if [ -f "app-image/digest" ]; then
-  IMAGE="govuk/${APPLICATION}@$(cat app-image/digest)"
-else
-  BUILD_TAG=${PIN_IMAGE_TAG:-$(cat release/.git/ref)}
-  IMAGE="govuk/${APPLICATION}:${BUILD_TAG}"
-fi
+IMAGE="${REGISTRY}/${APPLICATION}@$(cat app-image/digest)"
 
 echo "Creating a new task definition for ${IMAGE} in ECS"
 echo "================================================="

--- a/concourse/tasks/update-task-definition.yml
+++ b/concourse/tasks/update-task-definition.yml
@@ -21,6 +21,6 @@ params:
   ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
   APPLICATION:
   VARIANT:
-  PIN_IMAGE_TAG:
+  REGISTRY: '172025368201.dkr.ecr.eu-west-1.amazonaws.com'
 run:
   path: ./src/concourse/tasks/update-task-definition.sh

--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -30,20 +30,18 @@ resource "aws_iam_role" "govuk_concourse_deployer" {
   name        = "govuk-concourse-deployer"
   description = "Deploys applications to ECS from Concourse"
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": "sts:AssumeRole",
-            "Principal": {
-              "AWS": "arn:aws:iam::047969882937:role/cd-govuk-tools-concourse-worker"
-            }
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : "sts:AssumeRole",
+        "Principal" : {
+          "AWS" : "arn:aws:iam::047969882937:role/cd-govuk-tools-concourse-worker"
         }
+      }
     ]
-}
-EOF
+  })
 }
 
 # TODO - this policy is overly permissive - concourse doesn't need to be able
@@ -58,23 +56,41 @@ resource "aws_iam_role" "govuk_concourse_terraform_planner" {
   name        = "govuk-ci-concourse"
   description = "Runs Terraform plan from Concourse"
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": "sts:AssumeRole",
-            "Principal": {
-              "AWS": "arn:aws:iam::047969882937:role/cd-govuk-ci-concourse-worker"
-            }
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : "sts:AssumeRole",
+        "Principal" : {
+          "AWS" : "arn:aws:iam::047969882937:role/cd-govuk-ci-concourse-worker"
         }
+      }
     ]
-}
-EOF
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "concourse_readonly" {
   role       = aws_iam_role.govuk_concourse_terraform_planner.id
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_user" "concourse_ecr_readonly_user" {
+  name = "concourse_ecr_readonly_user"
+}
+
+resource "aws_iam_user_policy" "concourse_ecr_readonly_user_policy" {
+  name = "concourse_ecr_readonly_user_policy"
+  user = aws_iam_user.concourse_ecr_readonly_user.name
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : "sts:AssumeRole",
+        "Resource" : "arn:aws:iam::172025368201:role/pull_images_from_ecr_role"
+      }
+    ]
+  })
 }

--- a/terraform/deployments/govuk-publishing-platform/.terraform.lock.hcl
+++ b/terraform/deployments/govuk-publishing-platform/.terraform.lock.hcl
@@ -6,6 +6,8 @@ provider "registry.terraform.io/fastly/fastly" {
   constraints = "0.24.0"
   hashes = [
     "h1:2KzSQsT1Z870qPkUTWT3xUMTCvAA9/Xqn/fUzWTyqbE=",
+    "h1:O6NSgvY6xEXO6S269CC7zSm/bGRcEZu2YHrSz704oa8=",
+    "h1:xikn4kvuDCHCypHP5p2kM13lTHYZqaaJi+HmrpRVaXo=",
     "zh:083f8f5263f133a65bbc54c5b57857a2e97491151d2d97cefc4fe90313d07c53",
     "zh:0d2371268e9e318f20011a4d25d12beb88f61589867236c303f0ed999ef24ed6",
     "zh:1edaab7a4d6400f9898ae03b7cf5c44166f8e9283278c3eef7a77d43263a17d3",
@@ -25,6 +27,8 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 3.0.0, ~> 3.33"
   hashes = [
     "h1:KL3jLlJjk3d9/IoXqDWmsBglsLIYRL8ieAEG0Zl+3fE=",
+    "h1:MA7T5ntGMjC54SGQg1YY6qeg4ouDTVdE8+fTuXbkyUQ=",
+    "h1:WlAlvuH+7ByKFNU+ZQ8Fk91jkP5a9AQYBt09TkBVunw=",
     "zh:17b1e924f1efc0084823bbcdd9565b6b7018b17e8471f65fc59c2d9617e28b60",
     "zh:1fd5dfe2d22db93c576c2f328b4a9cf28e09b88496888a54a25325c638a69bec",
     "zh:269d7e870fc86db4336ac215282ac0a97522209453ce6cc9022ab2079e4e7a3b",
@@ -43,6 +47,8 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.0.0"
   constraints = "3.0.0"
   hashes = [
+    "h1:+JUEdzBH7Od9JKdMMAIJlX9v6P8jfbMR7V4/FKXLAgY=",
+    "h1:grDzxfnOdFXi90FRIIwP/ZrCzirJ/SfsGBe6cE0Shg4=",
     "h1:yhHJpb4IfQQfuio7qjUXuUFTU/s+ensuEpm23A+VWz0=",
     "zh:0fcb00ff8b87dcac1b0ee10831e47e0203a6c46aafd76cb140ba2bab81f02c6b",
     "zh:123c984c0e04bad910c421028d18aa2ca4af25a153264aef747521f4e7c36a17",

--- a/terraform/deployments/govuk-publishing-platform/app_content_store.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_content_store.tf
@@ -45,6 +45,7 @@ module "content_store" {
     local.content_store_defaults.backend_services,
     module.router_api.virtual_service_names,
   ])
+  registry                         = var.registry
   image_name                       = "content-store"
   service_name                     = "content-store"
   mesh_name                        = aws_appmesh_mesh.govuk.id
@@ -83,6 +84,7 @@ module "draft_content_store" {
     local.content_store_defaults.backend_services,
     module.draft_router_api.virtual_service_names,
   ])
+  registry                         = var.registry
   image_name                       = "content-store"
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id

--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -42,6 +42,7 @@ locals {
 }
 
 module "frontend" {
+  registry     = var.registry
   image_name   = "frontend"
   service_name = "frontend"
   mesh_name    = aws_appmesh_mesh.govuk.id
@@ -72,6 +73,7 @@ module "frontend" {
 }
 
 module "draft_frontend" {
+  registry     = var.registry
   image_name   = "frontend"
   service_name = "draft-frontend"
   mesh_name    = aws_appmesh_mesh.govuk.id

--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -64,6 +64,7 @@ locals {
 }
 
 module "publisher_web" {
+  registry                         = var.registry
   image_name                       = "publisher"
   service_name                     = "publisher-web"
   backend_virtual_service_names    = local.publishing_api_defaults.backend_services
@@ -118,6 +119,7 @@ module "publisher_public_alb" {
 # Sidekiq Worker Service
 #
 module "publisher_worker" {
+  registry                      = var.registry
   image_name                    = "publisher"
   service_name                  = "publisher-worker"
   backend_virtual_service_names = local.publishing_api_defaults.backend_services

--- a/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
@@ -53,6 +53,7 @@ locals {
 }
 
 module "publishing_api_web" {
+  registry                         = var.registry
   image_name                       = "publishing-api"
   service_name                     = "publishing-api-web"
   backend_virtual_service_names    = local.publishing_api_defaults.backend_services
@@ -76,6 +77,7 @@ module "publishing_api_web" {
 }
 
 module "publishing_api_worker" {
+  registry                         = var.registry
   image_name                       = "publishing-api"
   service_name                     = "publishing-api-worker"
   backend_virtual_service_names    = local.publishing_api_defaults.backend_services

--- a/terraform/deployments/govuk-publishing-platform/app_router.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router.tf
@@ -28,6 +28,7 @@ locals {
 module "router" {
   source = "../../modules/app"
 
+  registry                         = var.registry
   image_name                       = "router"
   service_name                     = "router"
   backend_virtual_service_names    = module.frontend.virtual_service_names
@@ -61,6 +62,7 @@ module "router" {
 
 module "draft_router" {
   source                           = "../../modules/app"
+  registry                         = var.registry
   image_name                       = "router"
   service_name                     = "draft-router"
   backend_virtual_service_names    = module.draft_frontend.virtual_service_names

--- a/terraform/deployments/govuk-publishing-platform/app_router_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router_api.tf
@@ -31,6 +31,7 @@ locals {
 
 module "router_api" {
   source                           = "../../modules/app"
+  registry                         = var.registry
   image_name                       = "router-api"
   service_name                     = "router-api"
   backend_virtual_service_names    = local.router_api_defaults.backend_services
@@ -67,6 +68,7 @@ module "router_api" {
 module "draft_router_api" {
   source = "../../modules/app"
 
+  registry                         = var.registry
   image_name                       = "router-api"
   service_name                     = "draft-router-api"
   backend_virtual_service_names    = local.router_api_defaults.backend_services

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -30,6 +30,7 @@ locals {
 }
 
 module "signon" {
+  registry                         = var.registry
   image_name                       = "signon"
   service_name                     = "signon"
   backend_virtual_service_names    = local.signon_defaults.backend_services

--- a/terraform/deployments/govuk-publishing-platform/app_static.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_static.tf
@@ -20,6 +20,7 @@ locals {
 module "static" {
   source = "../../modules/app"
 
+  registry                         = var.registry
   image_name                       = "static"
   service_name                     = "static"
   backend_virtual_service_names    = [] # Static doesn't use any other services
@@ -56,6 +57,7 @@ module "static" {
 module "draft_static" {
   source = "../../modules/app"
 
+  registry                         = var.registry
   image_name                       = "static"
   service_name                     = "draft-static"
   backend_virtual_service_names    = [] # Static doesn't use any other services

--- a/terraform/deployments/govuk-publishing-platform/variables.tf
+++ b/terraform/deployments/govuk-publishing-platform/variables.tf
@@ -102,3 +102,8 @@ variable "assume_role_arn" {
   description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
   default     = null
 }
+
+variable "registry" {
+  type        = string
+  description = "registry from which to pull container images"
+}

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -8,6 +8,8 @@ publishing_service_domain = "test.publishing.service.gov.uk"
 internal_app_domain       = "test.govuk-internal.digital"
 external_app_domain       = "test.govuk.digital"
 
+registry = "172025368201.dkr.ecr.eu-west-1.amazonaws.com"
+
 #--------------------------------------------------------------
 # Network
 #--------------------------------------------------------------

--- a/terraform/modules/app/task_definition.tf
+++ b/terraform/modules/app/task_definition.tf
@@ -32,7 +32,7 @@ locals {
 
 module "app_container_definition" {
   source                = "../../modules/container-definition"
-  image                 = "govuk/${var.image_name}:deployed-to-production"
+  image                 = "${var.registry}/${var.image_name}:latest"
   aws_region            = var.aws_region
   command               = var.command
   environment_variables = var.environment_variables

--- a/terraform/modules/app/variables.tf
+++ b/terraform/modules/app/variables.tf
@@ -23,6 +23,11 @@ variable "image_name" {
   description = "Used only for bootstrapping. Provide only the image name, not the tag."
 }
 
+variable "registry" {
+  type        = string
+  description = "registry from which to pull container images"
+}
+
 variable "subnets" {
   description = "IDs of the subnets where the ECS task will run."
   type        = list(any)

--- a/terraform/modules/monitoring/grafana.tf
+++ b/terraform/modules/monitoring/grafana.tf
@@ -4,7 +4,8 @@ locals {
 
 module "grafana_app" {
   source                        = "../app"
-  image_name                    = "grafana/grafana"
+  image_name                    = "grafana"
+  registry                      = "grafana"
   vpc_id                        = var.vpc_id
   backend_virtual_service_names = []
   cluster_id                    = aws_ecs_cluster.cluster.id

--- a/terraform/modules/origin/main.tf
+++ b/terraform/modules/origin/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.33"
+      version = "~> 3.36"
     }
 
     random = {


### PR DESCRIPTION
GOV.UK containers are already being built and pushed into our own AWS
ECR (see #149 and #158).

This PR involves changing the code base so that the task definitions
refer to the images in the AWS ECR rather than Docker Hub.

Other work include:
1. giving permission to the test environment to pull from the AWS ECR in
production
2. creating a concourse user which is able to pull from AWS ECR so that
concourse can monitor new container versions and automatically deploy
them

Some caveats:
1. for content-store and publishing-api, we were using special versions
for our ECS environment. Therefore, we have pushed these container
versions from Docker Hub to AWS ECR. Hence, if these versions are
modified, these container images will have to be updated manually.
(see
[ecr manual](https://docs.aws.amazon.com/AmazonECR/latest/userguide/getting-started-cli.html))

Ref:
1. [trello card](https://trello.com/c/PcU9eVue/461-migrate-from-docker-hub-to-aws-ecr)