### PR TITLE
Re-enable logging for concourse/run-task

### DIFF
--- a/concourse/tasks/run-task.sh
+++ b/concourse/tasks/run-task.sh
@@ -55,15 +55,7 @@ aws ecs wait tasks-stopped --tasks $task_id --cluster $CLUSTER
 echo "task finished."
 task_results=$(aws ecs describe-tasks --tasks $task_id --cluster $CLUSTER)
 
-# TODO - for some reason, this no longer works.
-#
-# ```
-# Error executing 'logs': ResourceNotFoundException: The specified log stream does not exist.
-# ```
-#
-# Commenting it out to make the tests green while we investigate:
-
-# ecs-cli logs --cluster $CLUSTER --task-id $task_id --since "60"
+ecs-cli logs --cluster $CLUSTER --task-id $task_id --since "60"
 
 exit_code=$(echo $task_results | jq [.tasks[0].containers[].exitCode] | jq add)
 echo "Exiting with code $exit_code"


### PR DESCRIPTION
We saw intermittent failures with esc-cli logs, but they seem to have gone away.

Run-task shouldn't fail if fetching logs fails, though, so if this keeps happening perhaps we should trap the error.