### PR TITLE
Add Backend URL env vars to router

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_router.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router.tf
@@ -3,6 +3,8 @@ locals {
     cpu    = 512  # TODO parameterize this
     memory = 1024 # TODO parameterize this
 
+    backend_services = local.defaults.virtual_service_backends
+
     environment_variables = merge(
       local.defaults.environment_variables,
       {
@@ -28,10 +30,15 @@ locals {
 module "router" {
   source = "../../modules/app"
 
-  registry                         = var.registry
-  image_name                       = "router"
-  service_name                     = "router"
-  backend_virtual_service_names    = module.frontend.virtual_service_names
+  registry     = var.registry
+  image_name   = "router"
+  service_name = "router"
+  backend_virtual_service_names = flatten([
+    local.router_defaults.backend_services,
+    module.static.virtual_service_names,
+    module.content_store.virtual_service_names,
+    module.frontend.virtual_service_names,
+  ])
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
@@ -47,6 +54,32 @@ module "router" {
   environment_variables = merge(
     local.router_defaults.environment_variables,
     {
+      # BACKEND_URL_calculators             = module.calculators.virtual_service_names[0]
+      # BACKEND_URL_canary-frontend         = module.canary-frontend.virtual_service_names[0]
+      # BACKEND_URL_collections             = module.collections.virtual_service_names[0]
+      # BACKEND_URL_contacts-frontend       = module.contacts-frontend.virtual_service_names[0]
+      BACKEND_URL_content-store = module.content_store.virtual_service_names[0]
+      # BACKEND_URL_designprinciples        = module.designprinciples.virtual_service_names[0]
+      # BACKEND_URL_email-alert-frontend    = module.email-alert-frontend.virtual_service_names[0]
+      # BACKEND_URL_email-campaign-frontend = module.email-campaign-frontend.virtual_service_names[0]
+      # BACKEND_URL_external-link-tracker   = module.external-link-tracker.virtual_service_names[0]
+      # BACKEND_URL_feedback                = module.feedback.virtual_service_names[0]
+      # BACKEND_URL_finder-frontend         = module.finder-frontend.virtual_service_names[0]
+      BACKEND_URL_frontend = module.frontend.virtual_service_names[0]
+      # BACKEND_URL_government-frontend     = module.government-frontend.virtual_service_names[0]
+      # BACKEND_URL_info-frontend           = module.info-frontend.virtual_service_names[0]
+      # BACKEND_URL_licencefinder           = module.licencefinder.virtual_service_names[0]
+      # BACKEND_URL_licensify               = module.licensify.virtual_service_names[0]
+      # BACKEND_URL_manuals-frontend        = module.manuals-frontend.virtual_service_names[0]
+      # BACKEND_URL_multipage-frontend      = module.multipage-frontend.virtual_service_names[0]
+      # BACKEND_URL_publicapi               = module.publicapi.virtual_service_names[0]
+      # BACKEND_URL_search-api              = module.search-api.virtual_service_names[0]
+      # BACKEND_URL_service-manual-frontend = module.service-manual-frontend.virtual_service_names[0]
+      # BACKEND_URL_smartanswers            = module.smartanswers.virtual_service_names[0]
+      # BACKEND_URL_spotlight               = module.spotlight.virtual_service_names[0]
+      BACKEND_URL_static = module.static.virtual_service_names[0]
+      # BACKEND_URL_tariff                  = module.tariff.virtual_service_names[0]
+      # BACKEND_URL_whitehall-frontend      = module.whitehall-frontend.virtual_service_names[0]
       ROUTER_MONGO_DB  = "router"
       ROUTER_MONGO_URL = "${local.router_defaults.mongodb_url}/router",
     },
@@ -61,11 +94,16 @@ module "router" {
 }
 
 module "draft_router" {
-  source                           = "../../modules/app"
-  registry                         = var.registry
-  image_name                       = "router"
-  service_name                     = "draft-router"
-  backend_virtual_service_names    = module.draft_frontend.virtual_service_names
+  source       = "../../modules/app"
+  registry     = var.registry
+  image_name   = "router"
+  service_name = "draft-router"
+  backend_virtual_service_names = flatten([
+    local.router_defaults.backend_services,
+    module.draft_static.virtual_service_names,
+    module.draft_content_store.virtual_service_names,
+    module.draft_frontend.virtual_service_names,
+  ])
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
@@ -81,6 +119,32 @@ module "draft_router" {
   environment_variables = merge(
     local.router_defaults.environment_variables,
     {
+      # BACKEND_URL_calculators             = module.draft_calculators.virtual_service_names[0]
+      # BACKEND_URL_canary-frontend         = module.draft_canary-frontend.virtual_service_names[0]
+      # BACKEND_URL_collections             = module.draft_collections.virtual_service_names[0]
+      # BACKEND_URL_contacts-frontend       = module.draft_contacts-frontend.virtual_service_names[0]
+      BACKEND_URL_content-store = module.draft_content_store.virtual_service_names[0]
+      # BACKEND_URL_designprinciples        = module.draft_designprinciples.virtual_service_names[0]
+      # BACKEND_URL_email-alert-frontend    = module.draft_email-alert-frontend.virtual_service_names[0]
+      # BACKEND_URL_email-campaign-frontend = module.draft_email-campaign-frontend.virtual_service_names[0]
+      # BACKEND_URL_external-link-tracker   = module.draft_external-link-tracker.virtual_service_names[0]
+      # BACKEND_URL_feedback                = module.draft_feedback.virtual_service_names[0]
+      # BACKEND_URL_finder-frontend         = module.draft_finder-frontend.virtual_service_names[0]
+      BACKEND_URL_frontend = module.draft_frontend.virtual_service_names[0]
+      # BACKEND_URL_government-frontend     = module.draft_government-frontend.virtual_service_names[0]
+      # BACKEND_URL_info-frontend           = module.draft_info-frontend.virtual_service_names[0]
+      # BACKEND_URL_licencefinder           = module.draft_licencefinder.virtual_service_names[0]
+      # BACKEND_URL_licensify               = module.draft_licensify.virtual_service_names[0]
+      # BACKEND_URL_manuals-frontend        = module.draft_manuals-frontend.virtual_service_names[0]
+      # BACKEND_URL_multipage-frontend      = module.draft_multipage-frontend.virtual_service_names[0]
+      # BACKEND_URL_publicapi               = module.draft_publicapi.virtual_service_names[0]
+      # BACKEND_URL_search-api              = module.draft_search-api.virtual_service_names[0]
+      # BACKEND_URL_service-manual-frontend = module.draft_service-manual-frontend.virtual_service_names[0]
+      # BACKEND_URL_smartanswers            = module.draft_smartanswers.virtual_service_names[0]
+      # BACKEND_URL_spotlight               = module.draft_spotlight.virtual_service_names[0]
+      BACKEND_URL_static = module.draft_static.virtual_service_names[0]
+      # BACKEND_URL_tariff                  = module.tariff.virtual_service_names[0]
+      # BACKEND_URL_whitehall-frontend      = module.whitehall-frontend.virtual_service_names[0]
       ROUTER_MONGO_DB  = "draft_router"
       ROUTER_MONGO_URL = "${local.router_defaults.mongodb_url}/draft_router",
     },


### PR DESCRIPTION
This will enable router to route requests to instances in its own mesh. This follows on from this PR: https://github.com/alphagov/router/pull/188

I've added the other backends in as placeholders, acquired using this RouterAPI query:

```ruby
Route.collection.aggregate([
    {"$group" => {"_id" => "$backend_id", "count" => {"$sum" => 1}}}
]).each { |res|
    puts "#{res["_id"]}: #{res["count"]}"
}
```