### PR TITLE
Limit log lines for Concourse job to 5000

### DIFF
--- a/concourse/tasks/run-task.sh
+++ b/concourse/tasks/run-task.sh
@@ -55,7 +55,7 @@ aws ecs wait tasks-stopped --tasks $task_id --cluster $CLUSTER
 echo "task finished."
 task_results=$(aws ecs describe-tasks --tasks $task_id --cluster $CLUSTER)
 
-ecs-cli logs --cluster $CLUSTER --task-id $task_id --since "60"
+ecs-cli logs --cluster $CLUSTER --task-id $task_id --since "60" | head -n 5000
 
 exit_code=$(echo $task_results | jq [.tasks[0].containers[].exitCode] | jq add)
 echo "Exiting with code $exit_code"

--- a/concourse/tasks/update-ecs-service.sh
+++ b/concourse/tasks/update-ecs-service.sh
@@ -45,7 +45,7 @@ echo "Task ID: $task_id"
 
 echo "Waiting for $ECS_SERVICE ECS service to reach steady state..."
 
-ecs-cli logs --region "$AWS_REGION" --cluster "$CLUSTER" --task-id "$task_id" --container-name "app" --follow &
+ecs-cli logs --region "$AWS_REGION" --cluster "$CLUSTER" --task-id "$task_id" --container-name "app" --follow | head -n 5000 &
 
 aws ecs wait services-stable \
   --cluster "$CLUSTER" \


### PR DESCRIPTION
It's not possible to view the output for the update-ecs-service
job if the task outputs too many log lines.

For example, during a deploy Router generates 45k log lines
in about 200 seconds, causing the Concourse UI to crash.

https://trello.com/c/L7pANVwe/463-router-over-logging