### PR TITLE
fix destroy_terraform task

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -318,9 +318,10 @@ jobs:
 
               cd govuk-infrastructure/terraform/deployments/govuk-publishing-platform
 
+              terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+
               terraform workspace select "$WORKSPACE"
 
-              terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
               terraform destroy  \
               -var "assume_role_arn=$ASSUME_ROLE_ARN" \
               -var-file ../variables/test/infrastructure.tfvars \


### PR DESCRIPTION
terraform init should happen before the other terraform cmds

Refs: #205 and #214