### PR TITLE
pull statsd from ecr

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_statsd.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_statsd.tf
@@ -17,11 +17,11 @@ module "statsd" {
   environment_variables            = local.statsd_defaults.environment_variables
   execution_role_arn               = aws_iam_role.execution.arn
   extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
-  image_name                       = "statsd:test-0.1.3" # TODO: hardcoded image tag
+  image_name                       = "statsd:test-0.1.3" # TODO: https://trello.com/c/nju3j7Ph/38-modify-statsd-so-that-we-can-run-it-in-ecs
   log_group                        = local.log_group
   memory                           = local.statsd_defaults.memory
   mesh_name                        = aws_appmesh_mesh.govuk.id
-  registry                         = "govuk"
+  registry                         = var.registry
   secrets_from_arns                = local.statsd_defaults.secrets_from_arns
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name


### PR DESCRIPTION
Following on from #208 where we pull images from ECR rather than Dockerhub, we also do this for our modified version of statsd since it is failing to pull and [prevents Signon from working](https://github.com/alphagov/signon/blob/21620a87881d7db51daa87f732961b4684908103/config/initializers/devise.rb#L277).

For now, we have only manually uploaded the specific statsd image to our ECR but there is a [trello card](https://trello.com/c/nju3j7Ph/38-modify-statsd-so-that-we-can-run-it-in-ecs) for a permanent fix.