### PR TITLE
allow default bootstrap image tag to be overridden

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_statsd.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_statsd.tf
@@ -17,7 +17,8 @@ module "statsd" {
   environment_variables            = local.statsd_defaults.environment_variables
   execution_role_arn               = aws_iam_role.execution.arn
   extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
-  image_name                       = "statsd:test-0.1.3" # TODO: https://trello.com/c/nju3j7Ph/38-modify-statsd-so-that-we-can-run-it-in-ecs
+  image_name                       = "statsd"
+  image_tag                        = "test-0.1.3" # TODO: https://trello.com/c/nju3j7Ph/38-modify-statsd-so-that-we-can-run-it-in-ecs
   log_group                        = local.log_group
   memory                           = local.statsd_defaults.memory
   mesh_name                        = aws_appmesh_mesh.govuk.id

--- a/terraform/modules/app/task_definition.tf
+++ b/terraform/modules/app/task_definition.tf
@@ -34,7 +34,7 @@ locals {
 
 module "app_container_definition" {
   source                = "../../modules/container-definition"
-  image                 = "${var.registry}/${var.image_name}:latest"
+  image                 = "${var.registry}/${var.image_name}:${var.image_tag}"
   aws_region            = var.aws_region
   command               = var.command
   environment_variables = var.environment_variables

--- a/terraform/modules/app/variables.tf
+++ b/terraform/modules/app/variables.tf
@@ -23,6 +23,12 @@ variable "image_name" {
   description = "Used only for bootstrapping. Provide only the image name, not the tag."
 }
 
+variable "image_tag" {
+  type        = string
+  default     = "latest"
+  description = "Used only for bootstrapping. Override default tag latest."
+}
+
 variable "registry" {
   type        = string
   description = "registry from which to pull container images"


### PR DESCRIPTION
This PR allows the default bootstrap image tag `latest` to be overridden. This is useful in the case of statsd where we want to use the tag `test-0.1.3` for now