### PR TITLE
Refactor app module

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_content_store.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_content_store.tf
@@ -5,7 +5,7 @@ locals {
 
     backend_services = flatten([
       local.defaults.virtual_service_backends,
-      module.signon.virtual_service_names
+      module.signon.virtual_service_name
     ])
 
     environment_variables = merge(
@@ -43,7 +43,7 @@ module "content_store" {
   source = "../../modules/app"
   backend_virtual_service_names = flatten([
     local.content_store_defaults.backend_services,
-    module.router_api.virtual_service_names,
+    module.router_api.virtual_service_name,
   ])
   registry                         = var.registry
   image_name                       = "content-store"
@@ -82,7 +82,7 @@ module "draft_content_store" {
   service_name = "draft-content-store"
   backend_virtual_service_names = flatten([
     local.content_store_defaults.backend_services,
-    module.draft_router_api.virtual_service_names,
+    module.draft_router_api.virtual_service_name,
   ])
   registry                         = var.registry
   image_name                       = "content-store"

--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -5,8 +5,8 @@ locals {
 
     backend_services = flatten([
       local.defaults.virtual_service_backends,
-      module.static.virtual_service_names,
-      module.signon.virtual_service_names,
+      module.static.virtual_service_name,
+      module.signon.virtual_service_name,
     ])
 
     environment_variables = merge(
@@ -48,7 +48,7 @@ module "frontend" {
   mesh_name    = aws_appmesh_mesh.govuk.id
   backend_virtual_service_names = flatten([
     local.frontend_defaults.backend_services,
-    module.content_store.virtual_service_names,
+    module.content_store.virtual_service_name,
   ])
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
@@ -79,7 +79,7 @@ module "draft_frontend" {
   mesh_name    = aws_appmesh_mesh.govuk.id
   backend_virtual_service_names = flatten([
     local.frontend_defaults.backend_services,
-    module.draft_content_store.virtual_service_names,
+    module.draft_content_store.virtual_service_name,
   ])
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name

--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -7,8 +7,8 @@ locals {
 
     backend_services = flatten([
       local.defaults.virtual_service_backends,
-      module.signon.virtual_service_names,
-      module.publishing_api_web.virtual_service_names,
+      module.signon.virtual_service_name,
+      module.publishing_api_web.virtual_service_name,
     ])
 
     environment_variables = merge(

--- a/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
@@ -5,9 +5,9 @@ locals {
 
     backend_services = flatten([
       local.defaults.virtual_service_backends,
-      module.signon.virtual_service_names,
-      module.content_store.virtual_service_names,
-      module.draft_content_store.virtual_service_names,
+      module.signon.virtual_service_name,
+      module.content_store.virtual_service_name,
+      module.draft_content_store.virtual_service_name,
     ])
 
     environment_variables = merge(

--- a/terraform/deployments/govuk-publishing-platform/app_router.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router.tf
@@ -47,10 +47,6 @@ module "router" {
   subnets                          = local.private_subnets
   desired_count                    = var.router_desired_count
   extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
-  custom_container_services = [
-    { container_service = "router", port = 80, protocol = "tcp" },
-    { container_service = "router-reload", port = 3055, protocol = "tcp" },
-  ]
   environment_variables = merge(
     local.router_defaults.environment_variables,
     {
@@ -112,10 +108,6 @@ module "draft_router" {
   subnets                          = local.private_subnets
   desired_count                    = var.draft_router_desired_count
   extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
-  custom_container_services = [
-    { container_service = "draft-router", port = 80, protocol = "tcp" },
-    { container_service = "draft-router-reload", port = 3055, protocol = "tcp" },
-  ]
   environment_variables = merge(
     local.router_defaults.environment_variables,
     {

--- a/terraform/deployments/govuk-publishing-platform/app_router.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router.tf
@@ -35,9 +35,9 @@ module "router" {
   service_name = "router"
   backend_virtual_service_names = flatten([
     local.router_defaults.backend_services,
-    module.static.virtual_service_names,
-    module.content_store.virtual_service_names,
-    module.frontend.virtual_service_names,
+    module.static.virtual_service_name,
+    module.content_store.virtual_service_name,
+    module.frontend.virtual_service_name,
   ])
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
@@ -50,32 +50,32 @@ module "router" {
   environment_variables = merge(
     local.router_defaults.environment_variables,
     {
-      # BACKEND_URL_calculators             = module.calculators.virtual_service_names[0]
-      # BACKEND_URL_canary-frontend         = module.canary-frontend.virtual_service_names[0]
-      # BACKEND_URL_collections             = module.collections.virtual_service_names[0]
-      # BACKEND_URL_contacts-frontend       = module.contacts-frontend.virtual_service_names[0]
-      BACKEND_URL_content-store = module.content_store.virtual_service_names[0]
-      # BACKEND_URL_designprinciples        = module.designprinciples.virtual_service_names[0]
-      # BACKEND_URL_email-alert-frontend    = module.email-alert-frontend.virtual_service_names[0]
-      # BACKEND_URL_email-campaign-frontend = module.email-campaign-frontend.virtual_service_names[0]
-      # BACKEND_URL_external-link-tracker   = module.external-link-tracker.virtual_service_names[0]
-      # BACKEND_URL_feedback                = module.feedback.virtual_service_names[0]
-      # BACKEND_URL_finder-frontend         = module.finder-frontend.virtual_service_names[0]
-      BACKEND_URL_frontend = module.frontend.virtual_service_names[0]
-      # BACKEND_URL_government-frontend     = module.government-frontend.virtual_service_names[0]
-      # BACKEND_URL_info-frontend           = module.info-frontend.virtual_service_names[0]
-      # BACKEND_URL_licencefinder           = module.licencefinder.virtual_service_names[0]
-      # BACKEND_URL_licensify               = module.licensify.virtual_service_names[0]
-      # BACKEND_URL_manuals-frontend        = module.manuals-frontend.virtual_service_names[0]
-      # BACKEND_URL_multipage-frontend      = module.multipage-frontend.virtual_service_names[0]
-      # BACKEND_URL_publicapi               = module.publicapi.virtual_service_names[0]
-      # BACKEND_URL_search-api              = module.search-api.virtual_service_names[0]
-      # BACKEND_URL_service-manual-frontend = module.service-manual-frontend.virtual_service_names[0]
-      # BACKEND_URL_smartanswers            = module.smartanswers.virtual_service_names[0]
-      # BACKEND_URL_spotlight               = module.spotlight.virtual_service_names[0]
-      BACKEND_URL_static = module.static.virtual_service_names[0]
-      # BACKEND_URL_tariff                  = module.tariff.virtual_service_names[0]
-      # BACKEND_URL_whitehall-frontend      = module.whitehall-frontend.virtual_service_names[0]
+      # BACKEND_URL_calculators             = module.calculators.virtual_service_name
+      # BACKEND_URL_canary-frontend         = module.canary-frontend.virtual_service_name
+      # BACKEND_URL_collections             = module.collections.virtual_service_name
+      # BACKEND_URL_contacts-frontend       = module.contacts-frontend.virtual_service_name
+      BACKEND_URL_content-store = module.content_store.virtual_service_name
+      # BACKEND_URL_designprinciples        = module.designprinciples.virtual_service_name
+      # BACKEND_URL_email-alert-frontend    = module.email-alert-frontend.virtual_service_name
+      # BACKEND_URL_email-campaign-frontend = module.email-campaign-frontend.virtual_service_name
+      # BACKEND_URL_external-link-tracker   = module.external-link-tracker.virtual_service_name
+      # BACKEND_URL_feedback                = module.feedback.virtual_service_name
+      # BACKEND_URL_finder-frontend         = module.finder-frontend.virtual_service_name
+      BACKEND_URL_frontend = module.frontend.virtual_service_name
+      # BACKEND_URL_government-frontend     = module.government-frontend.virtual_service_name
+      # BACKEND_URL_info-frontend           = module.info-frontend.virtual_service_name
+      # BACKEND_URL_licencefinder           = module.licencefinder.virtual_service_name
+      # BACKEND_URL_licensify               = module.licensify.virtual_service_name
+      # BACKEND_URL_manuals-frontend        = module.manuals-frontend.virtual_service_name
+      # BACKEND_URL_multipage-frontend      = module.multipage-frontend.virtual_service_name
+      # BACKEND_URL_publicapi               = module.publicapi.virtual_service_name
+      # BACKEND_URL_search-api              = module.search-api.virtual_service_name
+      # BACKEND_URL_service-manual-frontend = module.service-manual-frontend.virtual_service_name
+      # BACKEND_URL_smartanswers            = module.smartanswers.virtual_service_name
+      # BACKEND_URL_spotlight               = module.spotlight.virtual_service_name
+      BACKEND_URL_static = module.static.virtual_service_name
+      # BACKEND_URL_tariff                  = module.tariff.virtual_service_name
+      # BACKEND_URL_whitehall-frontend      = module.whitehall-frontend.virtual_service_name
       ROUTER_MONGO_DB  = "router"
       ROUTER_MONGO_URL = "${local.router_defaults.mongodb_url}/router",
     },
@@ -96,9 +96,9 @@ module "draft_router" {
   service_name = "draft-router"
   backend_virtual_service_names = flatten([
     local.router_defaults.backend_services,
-    module.draft_static.virtual_service_names,
-    module.draft_content_store.virtual_service_names,
-    module.draft_frontend.virtual_service_names,
+    module.draft_static.virtual_service_name,
+    module.draft_content_store.virtual_service_name,
+    module.draft_frontend.virtual_service_name,
   ])
   mesh_name                        = aws_appmesh_mesh.govuk.id
   service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
@@ -111,32 +111,32 @@ module "draft_router" {
   environment_variables = merge(
     local.router_defaults.environment_variables,
     {
-      # BACKEND_URL_calculators             = module.draft_calculators.virtual_service_names[0]
-      # BACKEND_URL_canary-frontend         = module.draft_canary-frontend.virtual_service_names[0]
-      # BACKEND_URL_collections             = module.draft_collections.virtual_service_names[0]
-      # BACKEND_URL_contacts-frontend       = module.draft_contacts-frontend.virtual_service_names[0]
-      BACKEND_URL_content-store = module.draft_content_store.virtual_service_names[0]
-      # BACKEND_URL_designprinciples        = module.draft_designprinciples.virtual_service_names[0]
-      # BACKEND_URL_email-alert-frontend    = module.draft_email-alert-frontend.virtual_service_names[0]
-      # BACKEND_URL_email-campaign-frontend = module.draft_email-campaign-frontend.virtual_service_names[0]
-      # BACKEND_URL_external-link-tracker   = module.draft_external-link-tracker.virtual_service_names[0]
-      # BACKEND_URL_feedback                = module.draft_feedback.virtual_service_names[0]
-      # BACKEND_URL_finder-frontend         = module.draft_finder-frontend.virtual_service_names[0]
-      BACKEND_URL_frontend = module.draft_frontend.virtual_service_names[0]
-      # BACKEND_URL_government-frontend     = module.draft_government-frontend.virtual_service_names[0]
-      # BACKEND_URL_info-frontend           = module.draft_info-frontend.virtual_service_names[0]
-      # BACKEND_URL_licencefinder           = module.draft_licencefinder.virtual_service_names[0]
-      # BACKEND_URL_licensify               = module.draft_licensify.virtual_service_names[0]
-      # BACKEND_URL_manuals-frontend        = module.draft_manuals-frontend.virtual_service_names[0]
-      # BACKEND_URL_multipage-frontend      = module.draft_multipage-frontend.virtual_service_names[0]
-      # BACKEND_URL_publicapi               = module.draft_publicapi.virtual_service_names[0]
-      # BACKEND_URL_search-api              = module.draft_search-api.virtual_service_names[0]
-      # BACKEND_URL_service-manual-frontend = module.draft_service-manual-frontend.virtual_service_names[0]
-      # BACKEND_URL_smartanswers            = module.draft_smartanswers.virtual_service_names[0]
-      # BACKEND_URL_spotlight               = module.draft_spotlight.virtual_service_names[0]
-      BACKEND_URL_static = module.draft_static.virtual_service_names[0]
-      # BACKEND_URL_tariff                  = module.tariff.virtual_service_names[0]
-      # BACKEND_URL_whitehall-frontend      = module.whitehall-frontend.virtual_service_names[0]
+      # BACKEND_URL_calculators             = module.draft_calculators.virtual_service_name
+      # BACKEND_URL_canary-frontend         = module.draft_canary-frontend.virtual_service_name
+      # BACKEND_URL_collections             = module.draft_collections.virtual_service_name
+      # BACKEND_URL_contacts-frontend       = module.draft_contacts-frontend.virtual_service_name
+      BACKEND_URL_content-store = module.draft_content_store.virtual_service_name
+      # BACKEND_URL_designprinciples        = module.draft_designprinciples.virtual_service_name
+      # BACKEND_URL_email-alert-frontend    = module.draft_email-alert-frontend.virtual_service_name
+      # BACKEND_URL_email-campaign-frontend = module.draft_email-campaign-frontend.virtual_service_name
+      # BACKEND_URL_external-link-tracker   = module.draft_external-link-tracker.virtual_service_name
+      # BACKEND_URL_feedback                = module.draft_feedback.virtual_service_name
+      # BACKEND_URL_finder-frontend         = module.draft_finder-frontend.virtual_service_name
+      BACKEND_URL_frontend = module.draft_frontend.virtual_service_name
+      # BACKEND_URL_government-frontend     = module.draft_government-frontend.virtual_service_name
+      # BACKEND_URL_info-frontend           = module.draft_info-frontend.virtual_service_name
+      # BACKEND_URL_licencefinder           = module.draft_licencefinder.virtual_service_name
+      # BACKEND_URL_licensify               = module.draft_licensify.virtual_service_name
+      # BACKEND_URL_manuals-frontend        = module.draft_manuals-frontend.virtual_service_name
+      # BACKEND_URL_multipage-frontend      = module.draft_multipage-frontend.virtual_service_name
+      # BACKEND_URL_publicapi               = module.draft_publicapi.virtual_service_name
+      # BACKEND_URL_search-api              = module.draft_search-api.virtual_service_name
+      # BACKEND_URL_service-manual-frontend = module.draft_service-manual-frontend.virtual_service_name
+      # BACKEND_URL_smartanswers            = module.draft_smartanswers.virtual_service_name
+      # BACKEND_URL_spotlight               = module.draft_spotlight.virtual_service_name
+      BACKEND_URL_static = module.draft_static.virtual_service_name
+      # BACKEND_URL_tariff                  = module.tariff.virtual_service_name
+      # BACKEND_URL_whitehall-frontend      = module.whitehall-frontend.virtual_service_name
       ROUTER_MONGO_DB  = "draft_router"
       ROUTER_MONGO_URL = "${local.router_defaults.mongodb_url}/draft_router",
     },

--- a/terraform/deployments/govuk-publishing-platform/app_router_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router_api.tf
@@ -5,7 +5,7 @@ locals {
 
     backend_services = flatten([
       local.defaults.virtual_service_backends,
-      module.signon.virtual_service_names,
+      module.signon.virtual_service_name,
     ])
 
     environment_variables = merge(

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -38,7 +38,7 @@ locals {
     website_root            = local.public_entry_url,
 
     virtual_service_backends = [
-      module.statsd.virtual_service_names[0]
+      module.statsd.virtual_service_name
     ]
   }
 }

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -12,10 +12,7 @@ terraform {
 }
 
 locals {
-  container_name = "app"
-  subdomain      = var.service_name
-  # TODO: Do we need container services?
-  container_services      = var.custom_container_services == null ? [{ container_service = local.subdomain, port = 80, protocol = "http" }] : var.custom_container_services
+  container_name          = "app"
   service_security_groups = concat([aws_security_group.service.id], var.extra_security_groups)
 }
 
@@ -62,16 +59,17 @@ resource "aws_ecs_service" "service" {
 }
 
 module "service_mesh_node" {
-  count = var.service_mesh ? length(local.container_services) : 0
+  # TODO: It looks like service_mesh (bool) is just a snowflake for grafana.
+  count = var.service_mesh ? 1 : 0
 
   source                           = "../service-mesh-node"
   backend_virtual_service_names    = var.backend_virtual_service_names
   mesh_name                        = var.mesh_name
-  port                             = local.container_services[count.index].port
-  protocol                         = local.container_services[count.index].protocol
+  port                             = var.port
+  protocol                         = "http"
   service_discovery_namespace_id   = var.service_discovery_namespace_id
   service_discovery_namespace_name = var.service_discovery_namespace_name
-  service_name                     = local.container_services[count.index].container_service
+  service_name                     = var.service_name
 }
 
 resource "aws_security_group" "service" {

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -40,12 +40,9 @@ resource "aws_ecs_service" "service" {
     subnets         = var.subnets
   }
 
-  dynamic "service_registries" {
-    for_each = var.service_mesh ? [1] : []
-    content {
-      registry_arn   = module.service_mesh_node[0].discovery_service_arn
-      container_name = local.container_name
-    }
+  service_registries {
+    registry_arn   = module.service_mesh_node.discovery_service_arn
+    container_name = local.container_name
   }
 
   # For bootstrapping
@@ -59,9 +56,6 @@ resource "aws_ecs_service" "service" {
 }
 
 module "service_mesh_node" {
-  # TODO: It looks like service_mesh (bool) is just a snowflake for grafana.
-  count = var.service_mesh ? 1 : 0
-
   source                           = "../service-mesh-node"
   backend_virtual_service_names    = var.backend_virtual_service_names
   mesh_name                        = var.mesh_name

--- a/terraform/modules/app/outputs.tf
+++ b/terraform/modules/app/outputs.tf
@@ -9,8 +9,7 @@ output "security_groups" {
   description = "The security groups applied to the ECS Service."
 }
 
-# TODO: Return a single virtual service name
-output "virtual_service_names" {
-  value       = module.service_mesh_node[*].virtual_service_name
-  description = "App Mesh virtual services for this app"
+output "virtual_service_name" {
+  value       = module.service_mesh_node.virtual_service_name
+  description = "App Mesh virtual service for this app"
 }

--- a/terraform/modules/app/outputs.tf
+++ b/terraform/modules/app/outputs.tf
@@ -9,6 +9,7 @@ output "security_groups" {
   description = "The security groups applied to the ECS Service."
 }
 
+# TODO: Return a single virtual service name
 output "virtual_service_names" {
   value       = module.service_mesh_node[*].virtual_service_name
   description = "App Mesh virtual services for this app"

--- a/terraform/modules/app/task_definition.tf
+++ b/terraform/modules/app/task_definition.tf
@@ -5,7 +5,7 @@ locals {
   family = "${var.service_name}-${terraform.workspace}"
 
   envoy_proxy_properties = {
-    AppPorts = join(",", var.ports)
+    AppPorts = var.port
 
     # From the user guide: "Envoy doesn't proxy traffic to these IP addresses.
     # Set this value to 169.254.170.2,169.254.169.254, which ignores the Amazon
@@ -42,7 +42,7 @@ module "app_container_definition" {
   log_group             = var.log_group
   log_stream_prefix     = var.service_name
   name                  = "app"
-  ports                 = var.ports
+  ports                 = [var.port]
   secrets_from_arns     = var.secrets_from_arns
 }
 

--- a/terraform/modules/app/variables.tf
+++ b/terraform/modules/app/variables.tf
@@ -67,12 +67,6 @@ variable "service_name" {
   type        = string
 }
 
-variable "custom_container_services" {
-  description = "list of services in map format {container_service, port, protocol} that an app container exposes."
-  type        = list(any)
-  default     = null
-}
-
 variable "extra_security_groups" {
   description = "Additional security groups to attach to the app's ECS service/tasks."
   type        = list(any)
@@ -97,10 +91,11 @@ variable "desired_count" {
   default     = 1
 }
 
-variable "ports" {
-  type        = list(any)
-  default     = [80]
-  description = "The ports the application listens on. For most apps this can be left as the default (port 80)."
+# TODO: Switch the other apps
+variable "port" {
+  type        = number
+  default     = 80
+  description = "The port the application listens on. For most apps this can be left as the default (port 80)."
 }
 
 variable "environment_variables" {

--- a/terraform/modules/app/variables.tf
+++ b/terraform/modules/app/variables.tf
@@ -39,13 +39,6 @@ variable "subnets" {
   type        = list(any)
 }
 
-
-variable "service_mesh" {
-  description = "Determines if app will be added to service mesh"
-  type        = bool
-  default     = true
-}
-
 variable "mesh_name" {
   type        = string
   default     = null

--- a/terraform/modules/monitoring/grafana.tf
+++ b/terraform/modules/monitoring/grafana.tf
@@ -14,8 +14,6 @@ module "grafana_app" {
   extra_security_groups         = [var.govuk_management_access_sg_id]
   service_mesh                  = false
   desired_count                 = var.desired_count
-  custom_container_services     = [{ container_service = local.service_name, port = 3000, protocol = "http" }]
-
   load_balancers = [{
     target_group_arn = module.grafana_public_alb.target_group_arn
     container_port   = 3000
@@ -26,6 +24,7 @@ module "grafana_app" {
   aws_region            = data.aws_region.current.name
   cpu                   = 512
   memory                = 1024
+  port                  = 3000
   task_role_arn         = aws_iam_role.monitoring_execution.arn # TODO - use a separate role for this?
   execution_role_arn    = aws_iam_role.monitoring_execution.arn
 }

--- a/terraform/modules/monitoring/grafana.tf
+++ b/terraform/modules/monitoring/grafana.tf
@@ -12,7 +12,6 @@ module "grafana_app" {
   service_name                  = local.service_name
   subnets                       = var.private_subnets
   extra_security_groups         = [var.govuk_management_access_sg_id]
-  service_mesh                  = false
   desired_count                 = var.desired_count
   load_balancers = [{
     target_group_arn = module.grafana_public_alb.target_group_arn


### PR DESCRIPTION
This removes the `custom_container_services` and `service_mesh` variables from the `app` module.

These seem to have been required by router and grafana, but are no longer needed.

The app module no longer explicitly supports apps which can serve traffic on multiple ports. If this need arises (for example, apps which have an admin port and cannot easily be modified) I'd recommend extracting the service mesh node module call from the app module, and have the clients of the app module also create the service mesh virtual services.