### PR TITLE
Log from ECS to Splunk

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_content_store.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_content_store.tf
@@ -74,12 +74,15 @@ module "content_store" {
       ROUTER_API_BEARER_TOKEN     = data.aws_secretsmanager_secret.content_store_router_api_bearer_token.arn
     }
   )
-  log_group          = local.log_group
-  aws_region         = data.aws_region.current.name
-  cpu                = local.content_store_defaults.cpu
-  memory             = local.content_store_defaults.memory
-  task_role_arn      = aws_iam_role.task.arn
-  execution_role_arn = aws_iam_role.execution.arn
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  aws_region              = data.aws_region.current.name
+  cpu                     = local.content_store_defaults.cpu
+  memory                  = local.content_store_defaults.memory
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
 }
 
 module "draft_content_store" {
@@ -121,10 +124,13 @@ module "draft_content_store" {
       ROUTER_API_BEARER_TOKEN     = data.aws_secretsmanager_secret.content_store_router_api_bearer_token.arn
     }
   )
-  log_group          = local.log_group
-  aws_region         = data.aws_region.current.name
-  cpu                = local.content_store_defaults.cpu
-  memory             = local.content_store_defaults.memory
-  task_role_arn      = aws_iam_role.task.arn
-  execution_role_arn = aws_iam_role.execution.arn
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  aws_region              = data.aws_region.current.name
+  cpu                     = local.content_store_defaults.cpu
+  memory                  = local.content_store_defaults.memory
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
 }

--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -62,7 +62,10 @@ module "frontend" {
   extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
   environment_variables            = local.frontend_defaults.environment_variables
   secrets_from_arns                = local.frontend_defaults.secrets_from_arns
-  log_group                        = local.log_group
+  splunk_url_secret_arn            = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn          = local.defaults.splunk_token_secret_arn
+  splunk_index                     = local.defaults.splunk_index
+  splunk_sourcetype                = local.defaults.splunk_sourcetype
   aws_region                       = data.aws_region.current.name
   cpu                              = local.frontend_defaults.cpu
   memory                           = local.frontend_defaults.memory
@@ -95,11 +98,14 @@ module "draft_frontend" {
       PLEK_SERVICE_STATIC_URI        = local.defaults.draft_static_uri
     }
   )
-  secrets_from_arns  = local.frontend_defaults.secrets_from_arns
-  log_group          = local.log_group
-  aws_region         = data.aws_region.current.name
-  cpu                = local.frontend_defaults.cpu
-  memory             = local.frontend_defaults.memory
-  task_role_arn      = aws_iam_role.task.arn
-  execution_role_arn = aws_iam_role.execution.arn
+  secrets_from_arns       = local.frontend_defaults.secrets_from_arns
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  aws_region              = data.aws_region.current.name
+  cpu                     = local.frontend_defaults.cpu
+  memory                  = local.frontend_defaults.memory
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
 }

--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -87,15 +87,18 @@ module "publisher_web" {
     target_group_arn = module.publisher_public_alb.target_group_arn
     container_port   = 80
   }]
-  command               = ["foreman", "run", "web"]
-  environment_variables = local.publisher_defaults.environment_variables
-  secrets_from_arns     = local.publisher_defaults.secrets_from_arns
-  log_group             = local.log_group
-  aws_region            = data.aws_region.current.name
-  cpu                   = local.publisher_defaults.cpu
-  memory                = local.publisher_defaults.memory
-  task_role_arn         = aws_iam_role.task.arn
-  execution_role_arn    = aws_iam_role.execution.arn
+  command                 = ["foreman", "run", "web"]
+  environment_variables   = local.publisher_defaults.environment_variables
+  secrets_from_arns       = local.publisher_defaults.secrets_from_arns
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  aws_region              = data.aws_region.current.name
+  cpu                     = local.publisher_defaults.cpu
+  memory                  = local.publisher_defaults.memory
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
 }
 
 #
@@ -148,7 +151,10 @@ module "publisher_worker" {
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
   source                           = "../../modules/app"
   secrets_from_arns                = local.publisher_defaults.secrets_from_arns
-  log_group                        = local.log_group
+  splunk_url_secret_arn            = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn          = local.defaults.splunk_token_secret_arn
+  splunk_index                     = local.defaults.splunk_index
+  splunk_sourcetype                = local.defaults.splunk_sourcetype
   aws_region                       = data.aws_region.current.name
   cpu                              = local.publisher_defaults.cpu
   memory                           = local.publisher_defaults.memory

--- a/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
@@ -17,7 +17,7 @@ locals {
         CONTENT_API_PROTOTYPE    = "yes"
         CONTENT_STORE            = local.defaults.content_store_uri
         DRAFT_CONTENT_STORE      = local.defaults.draft_content_store_uri
-        EVENT_LOG_AWS_ACCESS_ID  = "AKIAJE6VSW25CYBUMQJA" # TODO: hardcoded
+        EVENT_LOG_AWS_ACCESS_ID  = "AKIAJE6VSW25CYBUMQJA" # pragma: allowlist secret
         EVENT_LOG_AWS_BUCKETNAME = "govuk-publishing-api-event-log-test"
         EVENT_LOG_AWS_USERNAME   = "govuk-publishing-api-event-log_user"
         GOVUK_APP_NAME           = "publishing-api"
@@ -71,7 +71,10 @@ module "publishing_api_web" {
   subnets                          = local.private_subnets
   environment_variables            = local.publishing_api_defaults.environment_variables
   secrets_from_arns                = local.publishing_api_defaults.secrets_from_arns
-  log_group                        = local.log_group
+  splunk_url_secret_arn            = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn          = local.defaults.splunk_token_secret_arn
+  splunk_index                     = local.defaults.splunk_index
+  splunk_sourcetype                = local.defaults.splunk_sourcetype
   aws_region                       = data.aws_region.current.name
   cpu                              = local.publishing_api_defaults.cpu
   memory                           = local.publishing_api_defaults.memory
@@ -95,7 +98,10 @@ module "publishing_api_worker" {
   subnets                          = local.private_subnets
   environment_variables            = local.publishing_api_defaults.environment_variables
   secrets_from_arns                = local.publishing_api_defaults.secrets_from_arns
-  log_group                        = local.log_group
+  splunk_url_secret_arn            = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn          = local.defaults.splunk_token_secret_arn
+  splunk_index                     = local.defaults.splunk_index
+  splunk_sourcetype                = local.defaults.splunk_sourcetype
   aws_region                       = data.aws_region.current.name
   cpu                              = local.publishing_api_defaults.cpu
   memory                           = local.publishing_api_defaults.memory

--- a/terraform/deployments/govuk-publishing-platform/app_router.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router.tf
@@ -81,12 +81,15 @@ module "router" {
       ROUTER_MONGO_URL = "${local.router_defaults.mongodb_url}/router",
     },
   )
-  secrets_from_arns = local.router_defaults.secrets_from_arns
+  secrets_from_arns       = local.router_defaults.secrets_from_arns
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
   load_balancers = [{
     target_group_arn = module.www_origin.origin_target_group_arn
     container_port   = 80
   }]
-  log_group          = local.log_group
   aws_region         = data.aws_region.current.name
   cpu                = local.router_defaults.cpu
   memory             = local.router_defaults.memory
@@ -147,12 +150,15 @@ module "draft_router" {
       ROUTER_MONGO_URL = "${local.router_defaults.mongodb_url}/draft_router",
     },
   )
-  secrets_from_arns = local.router_defaults.secrets_from_arns
+  secrets_from_arns       = local.router_defaults.secrets_from_arns
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
   load_balancers = [{
     target_group_arn = module.draft_origin.origin_target_group_arn
     container_port   = 80
   }]
-  log_group          = local.log_group
   aws_region         = data.aws_region.current.name
   cpu                = local.router_defaults.cpu
   memory             = local.router_defaults.memory

--- a/terraform/deployments/govuk-publishing-platform/app_router_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router_api.tf
@@ -57,12 +57,15 @@ module "router_api" {
       SECRET_KEY_BASE      = data.aws_secretsmanager_secret.router_api_secret_key_base.arn,
     },
   )
-  log_group          = local.log_group
-  aws_region         = data.aws_region.current.name
-  cpu                = local.router_api_defaults.cpu
-  memory             = local.router_api_defaults.memory
-  task_role_arn      = aws_iam_role.task.arn
-  execution_role_arn = aws_iam_role.execution.arn
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  aws_region              = data.aws_region.current.name
+  cpu                     = local.router_api_defaults.cpu
+  memory                  = local.router_api_defaults.memory
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
 }
 
 module "draft_router_api" {
@@ -94,10 +97,13 @@ module "draft_router_api" {
       SECRET_KEY_BASE      = data.aws_secretsmanager_secret.draft_router_api_secret_key_base.arn,
     },
   )
-  log_group          = local.log_group
-  aws_region         = data.aws_region.current.name
-  cpu                = local.router_api_defaults.cpu
-  memory             = local.router_api_defaults.memory
-  task_role_arn      = aws_iam_role.task.arn
-  execution_role_arn = aws_iam_role.execution.arn
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  aws_region              = data.aws_region.current.name
+  cpu                     = local.router_api_defaults.cpu
+  memory                  = local.router_api_defaults.memory
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
 }

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -48,14 +48,17 @@ module "signon" {
     target_group_arn = module.signon_public_alb.target_group_arn
     container_port   = 80
   }]
-  environment_variables = local.signon_defaults.environment_variables
-  secrets_from_arns     = local.signon_defaults.secrets_from_arns
-  log_group             = local.log_group
-  aws_region            = data.aws_region.current.name
-  cpu                   = 512
-  memory                = 1024
-  task_role_arn         = aws_iam_role.task.arn
-  execution_role_arn    = aws_iam_role.execution.arn
+  environment_variables   = local.signon_defaults.environment_variables
+  secrets_from_arns       = local.signon_defaults.secrets_from_arns
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  aws_region              = data.aws_region.current.name
+  cpu                     = 512
+  memory                  = 1024
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
 }
 
 module "signon_public_alb" {

--- a/terraform/deployments/govuk-publishing-platform/app_static.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_static.tf
@@ -45,12 +45,15 @@ module "static" {
       SECRET_KEY_BASE = data.aws_secretsmanager_secret.static_secret_key_base.arn,
     },
   )
-  log_group          = local.log_group
-  aws_region         = data.aws_region.current.name
-  cpu                = local.static_defaults.cpu
-  memory             = local.static_defaults.memory
-  task_role_arn      = aws_iam_role.task.arn
-  execution_role_arn = aws_iam_role.execution.arn
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  aws_region              = data.aws_region.current.name
+  cpu                     = local.static_defaults.cpu
+  memory                  = local.static_defaults.memory
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
 }
 
 module "draft_static" {
@@ -81,10 +84,13 @@ module "draft_static" {
       SECRET_KEY_BASE = data.aws_secretsmanager_secret.draft_static_secret_key_base.arn,
     },
   )
-  log_group          = local.log_group
-  aws_region         = data.aws_region.current.name
-  cpu                = local.static_defaults.cpu
-  memory             = local.static_defaults.memory
-  task_role_arn      = aws_iam_role.task.arn
-  execution_role_arn = aws_iam_role.execution.arn
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  aws_region              = data.aws_region.current.name
+  cpu                     = local.static_defaults.cpu
+  memory                  = local.static_defaults.memory
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
 }

--- a/terraform/deployments/govuk-publishing-platform/app_statsd.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_statsd.tf
@@ -19,7 +19,6 @@ module "statsd" {
   extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
   image_name                       = "statsd"
   image_tag                        = "test-0.1.3" # TODO: https://trello.com/c/nju3j7Ph/38-modify-statsd-so-that-we-can-run-it-in-ecs
-  log_group                        = local.log_group
   memory                           = local.statsd_defaults.memory
   mesh_name                        = aws_appmesh_mesh.govuk.id
   registry                         = var.registry
@@ -31,4 +30,8 @@ module "statsd" {
   subnets                          = local.private_subnets
   task_role_arn                    = aws_iam_role.task.arn
   vpc_id                           = local.vpc_id
+  splunk_url_secret_arn            = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn          = local.defaults.splunk_token_secret_arn
+  splunk_index                     = local.defaults.splunk_index
+  splunk_sourcetype                = local.defaults.splunk_sourcetype
 }

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -40,5 +40,9 @@ locals {
     virtual_service_backends = [
       module.statsd.virtual_service_name
     ]
+    splunk_url_secret_arn   = data.aws_secretsmanager_secret.splunk_url.arn
+    splunk_token_secret_arn = data.aws_secretsmanager_secret.splunk_token.arn
+    splunk_index            = "govuk_replatforming"
+    splunk_sourcetype       = "log"
   }
 }

--- a/terraform/deployments/govuk-publishing-platform/secrets_manager.tf
+++ b/terraform/deployments/govuk-publishing-platform/secrets_manager.tf
@@ -6,6 +6,12 @@ data "aws_secretsmanager_secret" "sentry_dsn" {
 data "aws_secretsmanager_secret" "ga_universal_id" {
   name = "GA_UNIVERSAL_ID"
 }
+data "aws_secretsmanager_secret" "splunk_url" {
+  name = "SPLUNK_HEC_URL"
+}
+data "aws_secretsmanager_secret" "splunk_token" {
+  name = "SPLUNK_TOKEN"
+}
 
 # Frontend app secrets
 

--- a/terraform/deployments/govuk-publishing-platform/smokey.tf
+++ b/terraform/deployments/govuk-publishing-platform/smokey.tf
@@ -18,8 +18,10 @@ module "smokey_container_definition" {
   environment_variables = {
     ENVIRONMENT = var.govuk_environment
   }
-  log_group         = local.log_group
-  log_stream_prefix = "smokey"
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
   secrets_from_arns = {
     AUTH_USERNAME = data.aws_secretsmanager_secret.smokey_auth_username.arn
     AUTH_PASSWORD = data.aws_secretsmanager_secret.smokey_auth_password.arn

--- a/terraform/deployments/monitoring-test/infra/main.tf
+++ b/terraform/deployments/monitoring-test/infra/main.tf
@@ -57,6 +57,11 @@ module "monitoring" {
   external_app_domain       = var.external_app_domain
   publishing_service_domain = var.publishing_service_domain
 
+  splunk_url_secret_arn   = ""
+  splunk_token_secret_arn = ""
+  splunk_sourcetype       = "log"
+  splunk_index            = "govuk_replatforming"
+
   vpc_id                        = data.terraform_remote_state.infra_networking.outputs.vpc_id
   private_subnets               = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
   public_subnets                = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids

--- a/terraform/modules/app/task_definition.tf
+++ b/terraform/modules/app/task_definition.tf
@@ -33,18 +33,20 @@ locals {
 }
 
 module "app_container_definition" {
-  source                = "../../modules/container-definition"
-  image                 = "${var.registry}/${var.image_name}:${var.image_tag}"
-  aws_region            = var.aws_region
-  command               = var.command
-  healthcheck_command   = var.container_healthcheck_command
-  environment_variables = var.environment_variables
-  dependsOn             = [{ containerName : "envoy", condition : "HEALTHY" }]
-  log_group             = var.log_group
-  log_stream_prefix     = var.service_name
-  name                  = "app"
-  ports                 = [var.port]
-  secrets_from_arns     = var.secrets_from_arns
+  source                  = "../../modules/container-definition"
+  image                   = "${var.registry}/${var.image_name}:${var.image_tag}"
+  aws_region              = var.aws_region
+  command                 = var.command
+  healthcheck_command     = var.container_healthcheck_command
+  environment_variables   = var.environment_variables
+  dependsOn               = [{ containerName : "envoy", condition : "HEALTHY" }]
+  splunk_url_secret_arn   = var.splunk_url_secret_arn
+  splunk_token_secret_arn = var.splunk_token_secret_arn
+  splunk_sourcetype       = var.splunk_sourcetype
+  splunk_index            = var.splunk_index
+  name                    = "app"
+  ports                   = [var.port]
+  secrets_from_arns       = var.secrets_from_arns
 }
 
 # See the user guide at
@@ -59,13 +61,15 @@ module "envoy_container_definition" {
   healthcheck_command = ["/bin/bash", "-c", "curl -f http://localhost:9901 || exit 1"]
   # TODO: don't hardcode the version; track stable Envoy
   # TODO: control when Envoy updates happen (but still needs to be automatic)
-  image             = "840364872350.dkr.ecr.${var.aws_region}.amazonaws.com/aws-appmesh-envoy:v1.16.1.0-prod"
-  log_group         = var.log_group
-  log_stream_prefix = "awslogs-${var.service_name}-envoy"
-  name              = "envoy"
-  secrets_from_arns = {}
-  ports             = []
-  user              = local.user_id
+  image                   = "840364872350.dkr.ecr.${var.aws_region}.amazonaws.com/aws-appmesh-envoy:v1.16.1.0-prod"
+  splunk_url_secret_arn   = var.splunk_url_secret_arn
+  splunk_token_secret_arn = var.splunk_token_secret_arn
+  splunk_sourcetype       = var.splunk_sourcetype
+  splunk_index            = var.splunk_index
+  name                    = "envoy"
+  secrets_from_arns       = {}
+  ports                   = []
+  user                    = local.user_id
 }
 
 # TODO: Can we remove the v2?

--- a/terraform/modules/app/variables.tf
+++ b/terraform/modules/app/variables.tf
@@ -113,9 +113,28 @@ variable "secrets_from_arns" {
   A map of secrets to AWS SecretsManager ARNs. For example { OAUTH_SECRET = "arn:aws:secretsmanager:eu-west-1:..." } # pragma: allowlist secret
 DESC
 }
-variable "log_group" {
-  type = string
+
+variable "splunk_url_secret_arn" {
+  type        = string
+  description = "ARN to the secret containing the URL for the Splunk instance (of the form `https://http-inputs-XXXXXXXX.splunkcloud.com:PORT`)."
 }
+
+variable "splunk_token_secret_arn" {
+  type        = string
+  description = "ARN to the secret containing the HTTP Event Collector (HEC) token."
+}
+
+variable "splunk_index" {
+  type        = string
+  description = "Splunk index to log events to (which HEC token must have access to write to)."
+}
+
+variable "splunk_sourcetype" {
+  type        = string
+  default     = null
+  description = "The source type of the logs being sent to Splunk i.e. `log4j`."
+}
+
 variable "aws_region" {
   type = string
 }

--- a/terraform/modules/container-definition/main.tf
+++ b/terraform/modules/container-definition/main.tf
@@ -13,13 +13,24 @@ output "json_format" {
       initProcessEnabled = true
     }
     logConfiguration = {
-      logDriver = "awslogs",
+      logDriver = "splunk",
       options = {
-        awslogs-create-group  = "true", # TODO create the log group in terraform so we can configure the retention policy
-        awslogs-group         = var.log_group,
-        awslogs-region        = var.aws_region,
-        awslogs-stream-prefix = var.log_stream_prefix,
+        env               = "GOVUK_APP_NAME",
+        tag               = "image_name={{.ImageName}} container_name={{.Name}} container_id={{.FullID}}",
+        splunk-sourcetype = var.splunk_sourcetype,
+        splunk-index      = var.splunk_index,
+        splunk-format     = "raw"
       }
+      secretOptions = [
+        {
+          name      = "splunk-token",
+          valueFrom = var.splunk_token_secret_arn
+        },
+        {
+          name      = "splunk-url",
+          valueFrom = var.splunk_url_secret_arn
+        },
+      ],
     },
     mountPoints  = [],
     portMappings = [for port in var.ports : { containerPort = port, hostPort = port, protocol = "tcp" }],

--- a/terraform/modules/container-definition/variables.tf
+++ b/terraform/modules/container-definition/variables.tf
@@ -35,13 +35,25 @@ variable "image" {
   default = null
 }
 
-variable "log_group" {
-  type = string
+variable "splunk_url_secret_arn" {
+  type        = string
+  description = "ARN to the secret containing the URL for the Splunk instance (of the form `https://http-inputs-XXXXXXXX.splunkcloud.com:PORT`)."
 }
 
-variable "log_stream_prefix" {
+variable "splunk_token_secret_arn" {
   type        = string
-  description = "Set log_stream_prefix to an ECS Service name, if applicable. A prefix makes it easier to associate a log with a service."
+  description = "ARN to the secret containing the HTTP Event Collector (HEC) token."
+}
+
+variable "splunk_index" {
+  type        = string
+  description = "Splunk index to log events to (which HEC token must have access to write to)."
+}
+
+variable "splunk_sourcetype" {
+  type        = string
+  default     = null
+  description = "The source type of the logs being sent to Splunk i.e. `log4j`."
 }
 
 variable "name" {

--- a/terraform/modules/envoy-configuration/main.tf
+++ b/terraform/modules/envoy-configuration/main.tf
@@ -41,14 +41,23 @@ output "container_definition" {
     ],
     "essential" : true,
     "logConfiguration" : {
-      "logDriver" : "awslogs",
+      "logDriver" : "splunk",
       "options" : {
-        "awslogs-create-group" : "true",
-        "awslogs-group" : var.log_group,
-        "awslogs-region" : var.aws_region,
-        "awslogs-stream-prefix" : "awslogs-${var.service_name}-envoy"
-      }
-    }
+        "tag" : "image_name={{.ImageName}} container_name={{.Name}} container_id={{.FullID}}",
+        "splunk-index" : local.defaults.splunk_index,
+        "splunk-format" : "raw"
+      },
+      "secretOptions" : [
+        {
+          "name"      = "splunk-token",
+          "valueFrom" = local.defaults.splunk_token_secret_arn
+        },
+        {
+          "name"      = "splunk-url",
+          "valueFrom" = local.defaults.splunk_url_secret_arn
+        },
+      ]
+    },
   }
 }
 

--- a/terraform/modules/monitoring/grafana.tf
+++ b/terraform/modules/monitoring/grafana.tf
@@ -17,15 +17,18 @@ module "grafana_app" {
     target_group_arn = module.grafana_public_alb.target_group_arn
     container_port   = 3000
   }]
-  environment_variables = {} # TODO
-  secrets_from_arns     = {} # TODO
-  log_group             = "monitoring"
-  aws_region            = data.aws_region.current.name
-  cpu                   = 512
-  memory                = 1024
-  port                  = 3000
-  task_role_arn         = aws_iam_role.monitoring_execution.arn # TODO - use a separate role for this?
-  execution_role_arn    = aws_iam_role.monitoring_execution.arn
+  environment_variables   = {} # TODO
+  secrets_from_arns       = {} # TODO
+  splunk_url_secret_arn   = var.splunk_url_secret_arn
+  splunk_token_secret_arn = var.splunk_token_secret_arn
+  splunk_sourcetype       = var.splunk_sourcetype
+  splunk_index            = var.splunk_index
+  aws_region              = data.aws_region.current.name
+  cpu                     = 512
+  memory                  = 1024
+  port                    = 3000
+  task_role_arn           = aws_iam_role.monitoring_execution.arn # TODO - use a separate role for this?
+  execution_role_arn      = aws_iam_role.monitoring_execution.arn
 }
 
 data "aws_acm_certificate" "public_lb_alternate" {

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -43,3 +43,25 @@ variable "grafana_cidrs_allow_list" {
   description = "List of CIDRs that can access Grafana"
   type        = list(any)
 }
+
+variable "splunk_url_secret_arn" {
+  type        = string
+  description = "ARN to the secret containing the URL for the Splunk instance (of the form `https://http-inputs-XXXXXXXX.splunkcloud.com:PORT`)."
+}
+
+variable "splunk_token_secret_arn" {
+  type        = string
+  description = "ARN to the secret containing the HTTP Event Collector (HEC) token."
+}
+
+variable "splunk_index" {
+  type        = string
+  description = "Splunk index to log events to (which HEC token must have access to write to)."
+}
+
+variable "splunk_sourcetype" {
+  type        = string
+  default     = null
+  description = "The source type of the logs being sent to Splunk i.e. `log4j`."
+}
+


### PR DESCRIPTION
This PR changes logging for ECS so that logs from both `app` and `envoy` containers move from AWS CloudWatch Logs to Splunk. [Splunk is the recommended tool for storing infrastructure, application and audit logs](https://gds-way.cloudapps.digital/standards/logging.html#how-to-store-and-query-logs).

Splunk has been set-up so that it logs to a new `govuk_replatforming` index, which will need to change as and when we move the new platform into any real environments. As we're using the Splunk Docker driver and aren't changing the logging of individual applications in this commit, we're using the `tag` option in the logging configuration to specify some additional metadata which will be useful for debugging, such as the image name, container name and container ID. The `splunk-sourcetype` option is currently being hard-coded to the value `log`, and the `splunk-format` option is being set to `raw` which enables us to query the values that were specified earlier with the `tag` option from within the Splunk interface.

Finally, the `splunk-url` and `splunk-token` options are set from values stored using AWS Secrets Manager.

Trello: https://trello.com/c/Y4aLvX2n