### PR TITLE
Use manually-created Signon bearer tokens

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_content_store.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_content_store.tf
@@ -68,8 +68,10 @@ module "content_store" {
   secrets_from_arns = merge(
     local.content_store_defaults.secrets_from_arns,
     {
-      PUBLISHING_API_BEARER_TOKEN = module.content_store_to_publishing_api_bearer_token.secret_arn
-      ROUTER_API_BEARER_TOKEN     = module.content_store_to_router_api_bearer_token.secret_arn
+      # PUBLISHING_API_BEARER_TOKEN = module.content_store_to_publishing_api_bearer_token.secret_arn
+      # ROUTER_API_BEARER_TOKEN     = module.content_store_to_router_api_bearer_token.secret_arn
+      PUBLISHING_API_BEARER_TOKEN = data.aws_secretsmanager_secret.content_store_publishing_api_bearer_token.arn
+      ROUTER_API_BEARER_TOKEN     = data.aws_secretsmanager_secret.content_store_router_api_bearer_token.arn
     }
   )
   log_group          = local.log_group
@@ -113,8 +115,10 @@ module "draft_content_store" {
   secrets_from_arns = merge(
     local.content_store_defaults.secrets_from_arns,
     {
-      PUBLISHING_API_BEARER_TOKEN = module.draft_content_store_to_publishing_api_bearer_token.secret_arn
-      ROUTER_API_BEARER_TOKEN     = module.draft_content_store_to_router_api_bearer_token.secret_arn
+      # PUBLISHING_API_BEARER_TOKEN = module.draft_content_store_to_publishing_api_bearer_token.secret_arn
+      # ROUTER_API_BEARER_TOKEN     = module.draft_content_store_to_router_api_bearer_token.secret_arn
+      PUBLISHING_API_BEARER_TOKEN = data.aws_secretsmanager_secret.content_store_publishing_api_bearer_token.arn
+      ROUTER_API_BEARER_TOKEN     = data.aws_secretsmanager_secret.content_store_router_api_bearer_token.arn
     }
   )
   log_group          = local.log_group

--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -28,7 +28,8 @@ locals {
       local.defaults.secrets_from_arns,
       {
         # TODO Should frontend and draft frontend share a bearer token for publishing api?
-        PUBLISHING_API_BEARER_TOKEN = module.frontend_to_publishing_api_bearer_token.secret_arn
+        # PUBLISHING_API_BEARER_TOKEN = module.frontend_to_publishing_api_bearer_token.secret_arn
+        PUBLISHING_API_BEARER_TOKEN = data.aws_secretsmanager_secret.frontend_publishing_api_bearer_token.arn
         SECRET_KEY_BASE             = data.aws_secretsmanager_secret.frontend_secret_key_base.arn,
         SENTRY_DSN                  = data.aws_secretsmanager_secret.sentry_dsn.arn,
       }

--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -58,8 +58,9 @@ locals {
         MONGODB_URI                 = data.aws_secretsmanager_secret.publisher_mongodb_uri.arn,
         GDS_SSO_OAUTH_ID            = data.aws_secretsmanager_secret.publisher_oauth_id.arn,
         GDS_SSO_OAUTH_SECRET        = data.aws_secretsmanager_secret.publisher_oauth_secret.arn,
-        PUBLISHING_API_BEARER_TOKEN = module.publisher_to_publishing_api_bearer_token.secret_arn,
-        SECRET_KEY_BASE             = data.aws_secretsmanager_secret.publisher_secret_key_base.arn,
+        PUBLISHING_API_BEARER_TOKEN = data.aws_secretsmanager_secret.publisher_publishing_api_bearer_token.arn
+        # PUBLISHING_API_BEARER_TOKEN = module.publisher_to_publishing_api_bearer_token.secret_arn,
+        SECRET_KEY_BASE = data.aws_secretsmanager_secret.publisher_secret_key_base.arn,
       }
     )
   }

--- a/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
@@ -38,15 +38,18 @@ locals {
     secrets_from_arns = merge(
       local.defaults.secrets_from_arns,
       {
-        CONTENT_STORE_BEARER_TOKEN       = module.publishing_api_to_content_store_bearer_token.secret_arn
+        CONTENT_STORE_BEARER_TOKEN = data.aws_secretsmanager_secret.publishing_api_content_store_bearer_token.arn
+        # CONTENT_STORE_BEARER_TOKEN       = module.publishing_api_to_content_store_bearer_token.secret_arn
         DATABASE_URL                     = data.aws_secretsmanager_secret.publishing_api_database_url.arn
-        DRAFT_CONTENT_STORE_BEARER_TOKEN = module.publishing_api_to_draft_content_store_bearer_token.secret_arn
-        EVENT_LOG_AWS_SECRET_KEY         = data.aws_secretsmanager_secret.publishing_api_event_log_aws_secret_key.arn
-        GDS_SSO_OAUTH_ID                 = data.aws_secretsmanager_secret.publishing_api_oauth_id.arn
-        GDS_SSO_OAUTH_SECRET             = data.aws_secretsmanager_secret.publishing_api_oauth_secret.arn
-        RABBITMQ_PASSWORD                = data.aws_secretsmanager_secret.publishing_api_rabbitmq_password.arn
-        ROUTER_API_BEARER_TOKEN          = module.publishing_api_to_router_api_bearer_token.secret_arn
-        SECRET_KEY_BASE                  = data.aws_secretsmanager_secret.publishing_api_secret_key_base.arn
+        DRAFT_CONTENT_STORE_BEARER_TOKEN = data.aws_secretsmanager_secret.publishing_api_draft_content_store_bearer_token.arn
+        # DRAFT_CONTENT_STORE_BEARER_TOKEN = module.publishing_api_to_draft_content_store_bearer_token.secret_arn
+        EVENT_LOG_AWS_SECRET_KEY = data.aws_secretsmanager_secret.publishing_api_event_log_aws_secret_key.arn
+        GDS_SSO_OAUTH_ID         = data.aws_secretsmanager_secret.publishing_api_oauth_id.arn
+        GDS_SSO_OAUTH_SECRET     = data.aws_secretsmanager_secret.publishing_api_oauth_secret.arn
+        RABBITMQ_PASSWORD        = data.aws_secretsmanager_secret.publishing_api_rabbitmq_password.arn
+        ROUTER_API_BEARER_TOKEN  = data.aws_secretsmanager_secret.publishing_api_router_api_bearer_token.arn
+        # ROUTER_API_BEARER_TOKEN          = module.publishing_api_to_router_api_bearer_token.secret_arn
+        SECRET_KEY_BASE = data.aws_secretsmanager_secret.publishing_api_secret_key_base.arn
       }
     )
   }

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -31,9 +31,8 @@ locals {
 }
 
 module "signon" {
-  registry                         = "govuk"
+  registry                         = var.registry
   image_name                       = "signon"
-  image_tag                        = "bilbof_boostrapping" # TODO: Remove once Signon PR #1617 is merged
   service_name                     = "signon"
   backend_virtual_service_names    = local.signon_defaults.backend_services
   mesh_name                        = aws_appmesh_mesh.govuk.id

--- a/terraform/deployments/govuk-publishing-platform/signon_secrets.tf
+++ b/terraform/deployments/govuk-publishing-platform/signon_secrets.tf
@@ -16,6 +16,40 @@ resource "random_password" "signon_admin_password" {
 }
 
 #
+# Signon secrets
+#
+
+# TODO: Remove these once Signon PRs #1617 and #1623 are merged
+
+data "aws_secretsmanager_secret" "frontend_publishing_api_bearer_token" {
+  name = "frontend_app_PUBLISHING_API_BEARER_TOKEN" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "content_store_publishing_api_bearer_token" {
+  name = "content-store_PUBLISHING_API_BEARER_TOKEN" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "content_store_router_api_bearer_token" {
+  name = "content-store_ROUTER_API_BEARER_TOKEN" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "publisher_publishing_api_bearer_token" {
+  name = "publisher_app-PUBLISHING_API_BEARER_TOKEN" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "publishing_api_content_store_bearer_token" {
+  name = "publishing_api_app-CONTENT_STORE_BEARER_TOKEN" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "publishing_api_draft_content_store_bearer_token" {
+  name = "publishing_api_app-DRAFT_CONTENT_STORE_BEARER_TOKEN" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "publishing_api_router_api_bearer_token" {
+  name = "publishing_api_app-ROUTER_API_BEARER_TOKEN" # pragma: allowlist secret
+}
+
+#
 # Signon bearer tokens
 #
 


### PR DESCRIPTION
This is a partial revert of PR #202.

Before we can use the bearer tokens created by the SecretsManager Lambdas, we first need the Signon PRs https://github.com/alphagov/signon/pull/1623 (Bootstrapping task) and https://github.com/alphagov/signon/pull/1617 (Bearer token API) to be merged.

I'll revert this PR once we're ready to use the autogenerated bearer tokens.