### PR TITLE
Add pre-commit check for merge conflict markers.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
 ---
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-merge-conflict
   - repo: git@github.com:Yelp/detect-secrets
     rev: v0.14.3
     hooks:


### PR DESCRIPTION
Does what it says on the tin (hopefully!)

Tested: ran on the commit I made on this branch and didn't block. I didn't bother testing the positive case since it's a built-in check and it's been around for ages so I'm assuming it works.