### PR TITLE
fix backends origin aliases

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/backends_origin.tf
+++ b/terraform/deployments/govuk-publishing-platform/backends_origin.tf
@@ -91,16 +91,19 @@ resource "aws_wafv2_web_acl" "backends_origin_cloudfront_web_acl" {
 module "backends_origin" {
   source = "../../modules/origin"
 
-  providers                            = { aws = aws, random = random }
-  name                                 = "backends"
-  vpc_id                               = local.vpc_id
-  aws_region                           = data.aws_region.current.name
-  assume_role_arn                      = var.assume_role_arn
-  public_subnets                       = local.public_subnets
-  public_zone_id                       = aws_route53_zone.workspace_public.zone_id
-  external_app_domain                  = aws_route53_zone.workspace_public.name
-  subdomain                            = "backends"
-  extra_aliases                        = compact([local.is_default_workspace ? "publisher.${var.publishing_service_domain}" : null, "publisher.${aws_route53_zone.workspace_public.name}", "signon.${aws_route53_zone.workspace_public.name}"])
+  providers           = { aws = aws, random = random }
+  name                = "backends"
+  vpc_id              = local.vpc_id
+  aws_region          = data.aws_region.current.name
+  assume_role_arn     = var.assume_role_arn
+  public_subnets      = local.public_subnets
+  public_zone_id      = aws_route53_zone.workspace_public.zone_id
+  external_app_domain = aws_route53_zone.workspace_public.name
+  subdomain           = "backends"
+  extra_aliases = compact([local.is_default_workspace ? "publisher.${local.workspace}.${var.publishing_service_domain}" : null,
+    local.is_default_workspace ? "signon.${local.workspace}.${var.publishing_service_domain}" : null,
+    "publisher.${aws_route53_zone.workspace_public.name}",
+  "signon.${aws_route53_zone.workspace_public.name}"])
   load_balancer_certificate_arn        = aws_acm_certificate_validation.workspace_public.certificate_arn
   cloudfront_certificate_arn           = aws_acm_certificate_validation.public_north_virginia.certificate_arn
   publishing_service_domain            = var.publishing_service_domain

--- a/terraform/deployments/govuk-publishing-platform/frontends_origins.tf
+++ b/terraform/deployments/govuk-publishing-platform/frontends_origins.tf
@@ -58,7 +58,7 @@ module "www_frontends_origin" {
   public_zone_id                       = aws_route53_zone.workspace_public.zone_id
   external_app_domain                  = aws_route53_zone.workspace_public.name
   subdomain                            = "www-origin"
-  extra_aliases                        = local.is_default_workspace ? ["www.ecs.${var.publishing_service_domain}"] : []
+  extra_aliases                        = local.is_default_workspace ? ["www.${local.workspace}.${var.publishing_service_domain}"] : []
   load_balancer_certificate_arn        = aws_acm_certificate_validation.workspace_public.certificate_arn
   cloudfront_certificate_arn           = aws_acm_certificate_validation.public_north_virginia.certificate_arn
   publishing_service_domain            = var.publishing_service_domain


### PR DESCRIPTION
fix backends origin aliases for default workspace that uses the `ecs.test.publishing.service.gov.uk` domain. This was introduced in #221.

Additional changes:
1. interpolate default workspace into the frontends origin extra aliases