### PR TITLE
shorter target group names

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/backends_origin.tf
+++ b/terraform/deployments/govuk-publishing-platform/backends_origin.tf
@@ -121,7 +121,7 @@ module "backends_origin" {
 ## Publisher
 
 resource "aws_lb_target_group" "publisher" {
-  name        = "backends-origin-publisher-${local.workspace}"
+  name        = "publisher-${local.workspace}"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = local.vpc_id
@@ -166,7 +166,7 @@ resource "aws_route53_record" "publisher" {
 ## Signon
 
 resource "aws_lb_target_group" "signon" {
-  name        = "backends-origin-signon-${local.workspace}"
+  name        = "signon-${local.workspace}"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = local.vpc_id

--- a/terraform/deployments/govuk-publishing-platform/frontends_origins.tf
+++ b/terraform/deployments/govuk-publishing-platform/frontends_origins.tf
@@ -73,7 +73,7 @@ module "www_frontends_origin" {
 }
 
 resource "aws_lb_target_group" "router" {
-  name        = "www-f-origin-router-${local.workspace}"
+  name        = "router-${local.workspace}"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = local.vpc_id
@@ -127,7 +127,7 @@ module "draft_frontends_origin" {
 }
 
 resource "aws_lb_target_group" "draft_router" {
-  name        = "draft-f-origin-d-frontend-${local.workspace}"
+  name        = "draft-router-${local.workspace}"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = local.vpc_id


### PR DESCRIPTION
Further fix to #221 where we now use shorter target group names since they have a 32 character limit and workspace names can be long

Target groups are just named after the apps that are in them.