### PR TITLE
Use Envoy's /ready endpoint for healthcheck

### DIFF
--- a/terraform/modules/app/task_definition.tf
+++ b/terraform/modules/app/task_definition.tf
@@ -58,7 +58,7 @@ module "envoy_container_definition" {
   environment_variables = {
     APPMESH_RESOURCE_ARN = "mesh/${var.mesh_name}/virtualNode/${var.service_name}"
   }
-  healthcheck_command = ["/bin/bash", "-c", "curl -f http://localhost:9901 || exit 1"]
+  healthcheck_command = ["/bin/bash", "-c", "curl -f http://localhost:9901/ready || exit 1"]
   # TODO: don't hardcode the version; track stable Envoy
   # TODO: control when Envoy updates happen (but still needs to be automatic)
   image                   = "840364872350.dkr.ecr.${var.aws_region}.amazonaws.com/aws-appmesh-envoy:v1.16.1.0-prod"


### PR DESCRIPTION
This path returns a 200 when Envoy is in a LIVE state,
returns a 503 status otherwise.

This will fix some transient issues we have experienced
where Envoy was not ready to proxy a request.

https://www.envoyproxy.io/docs/envoy/latest/operations/admin#get--ready