### PR TITLE
Link to Splunk for logs when updating ECS service

### DIFF
--- a/concourse/tasks/run-task.sh
+++ b/concourse/tasks/run-task.sh
@@ -62,7 +62,8 @@ aws ecs wait tasks-stopped --tasks $task_id --cluster $CLUSTER
 echo "task finished."
 task_results=$(aws ecs describe-tasks --tasks $task_id --cluster $CLUSTER)
 
-ecs-cli logs --cluster $CLUSTER --task-id $task_id --since "60" | head -n 5000
+container_id=$(echo $task_results | jq .tasks[0].containers[]  | select(.name=="app") | .runtimeId)
+echo "Check Splunk for logs: https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/search?q=search%20index%3D%22govuk_replatforming%22%20container_id%3D$container_id"
 
 exit_code=$(echo $task_results | jq [.tasks[0].containers[].exitCode] | jq add)
 echo "Exiting with code $exit_code"

--- a/concourse/tasks/update-ecs-service.sh
+++ b/concourse/tasks/update-ecs-service.sh
@@ -30,17 +30,34 @@ aws ecs update-service \
   --task-definition "$new_task_definition_arn" \
   --region "$AWS_REGION" > /dev/null
 
-# Get the ID of the latest task so we can stream its logs.
-# ecs-cli just wants the numeric ID of the task, not the whole ARN.
-# So we have to use `awk` to fish that out.
-task_id=$(aws ecs list-tasks \
+# Get the ID of the latest task.
+task_arn=$(aws ecs list-tasks \
   --cluster "$CLUSTER" \
   --service-name "$ECS_SERVICE" \
   --region "$AWS_REGION" \
   --query 'taskArns | [0]' \
-  --output text \
-  | awk -F / '{print $NF}'
+  --output text
 )
-echo "Task ID: $task_id"
+
+echo "Task ARN: $task_arn"
+
+# Pull the container ID from the task's associated `app` container
+container_id=$(aws ecs describe-tasks \
+  --cluster "$CLUSTER" \
+  --tasks $task_arn \
+  --query 'tasks[0] | containers[?name==`app`].runtimeId' \
+  --output text
+)
+
+echo "App container ID: $container_id"
+
+echo "Waiting for $ECS_SERVICE ECS service to reach steady state..."
+
+echo "Check Splunk for logs: https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/search?q=search%20index%3D%22govuk_replatforming%22%20container_id%3D$container_id"
+
+aws ecs wait services-stable \
+  --cluster "$CLUSTER" \
+  --services "$ECS_SERVICE" \
+  --region "$AWS_REGION"
 
 echo "Updated $ECS_SERVICE to task definition $new_task_definition_arn."


### PR DESCRIPTION
This PR links to Splunk for logs when updating an ECS service. This change is necessary as we're no longer logging to AWS CloudWatch Logs, so the call to `ecs-cli logs` is failing. As we have the `runtimeId` of ECS containers logged to Splunk (via the `container_id` property) we can instead track ECS updates there.