### PR TITLE
Wait 15minutes for ECS deploy to complete

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -560,6 +560,20 @@ jobs:
         params:
          ECS_SERVICE: frontend
          WORKSPACE: ((workspace))
+    - in_parallel:
+      - &await-deploy-complete
+        task: await-deploy-complete-live
+        file: govuk-infrastructure/concourse/tasks/await-deploy-complete.yml
+        attempts: 4
+        timeout: 5m
+        params: &await-deploy-complete-params
+          ECS_SERVICE: frontend
+          WORKSPACE: ((workspace))
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-draft
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: draft-frontend
     serial: true
     on_failure: &notify-slack-failure
       put: deploy-slack-channel
@@ -657,6 +671,17 @@ jobs:
         params:
           ECS_SERVICE: publisher-worker
           WORKSPACE: ((workspace))
+    - in_parallel:
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-web
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: publisher-web
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-worker
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: publisher-worker
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -718,6 +743,17 @@ jobs:
           WORKSPACE: ((workspace))
         input_mapping:
             task-definition-arn: worker-task-definition-arn
+    - in_parallel:
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-web
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: publishing-api-web
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-worker
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: publishing-api-worker
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -769,6 +805,17 @@ jobs:
         params:
           ECS_SERVICE: draft-content-store
           WORKSPACE: ((workspace))
+    - in_parallel:
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-live
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: content-store
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-draft
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: draft-content-store
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -820,6 +867,17 @@ jobs:
         params:
           ECS_SERVICE: router
           WORKSPACE: ((workspace))
+    - in_parallel:
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-draft
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: draft-router
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-live
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: router
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -871,6 +929,17 @@ jobs:
         params:
           ECS_SERVICE: router-api
           WORKSPACE: ((workspace))
+    - in_parallel:
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-draft
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: draft-router-api
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-live
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: router-api
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -915,6 +984,11 @@ jobs:
         ECS_SERVICE: signon
         GOVUK_ENVIRONMENT: test
         WORKSPACE: ((workspace))
+    - <<: *await-deploy-complete
+      task: await-deploy-complete
+      params:
+        <<: *await-deploy-complete-params
+        ECS_SERVICE: signon
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -999,6 +1073,17 @@ jobs:
         params:
           ECS_SERVICE: static
           WORKSPACE: ((workspace))
+    - in_parallel:
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-live
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: static
+      - <<: *await-deploy-complete
+        task: await-deploy-complete-draft
+        params:
+          <<: *await-deploy-complete-params
+          ECS_SERVICE: draft-static
     serial: true
     on_failure:
       <<: *notify-slack-failure

--- a/concourse/tasks/await-deploy-complete.sh
+++ b/concourse/tasks/await-deploy-complete.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+
+set -eu
+
+if [ "${WORKSPACE}" == "default" ]; then
+  CLUSTER=govuk-ecs
+else
+  CLUSTER="govuk-$WORKSPACE"
+fi
+
+mkdir -p ~/.aws
+
+cat <<EOF > ~/.aws/config
+[profile default]
+role_arn = $ASSUME_ROLE_ARN
+credential_source = Ec2InstanceMetadata
+EOF
+
+echo "Waiting for $ECS_SERVICE ECS service to reach steady state..."
+
+aws ecs wait services-stable \
+  --cluster "$CLUSTER" \
+  --services "$ECS_SERVICE" \
+  --region "$AWS_REGION"
+
+echo "ECS Service $ECS_SERVICE deployment complete. Service is now stable."

--- a/concourse/tasks/await-deploy-complete.yml
+++ b/concourse/tasks/await-deploy-complete.yml
@@ -1,0 +1,19 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: govuk/ecs-cli
+    tag: latest # TODO - manage image versions ourselves instead of using latest
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
+inputs:
+  - name: govuk-infrastructure
+    path: src
+  - name: task-definition-arn
+params:
+  AWS_REGION: eu-west-1
+  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  ECS_SERVICE:
+  WORKSPACE:
+run:
+  path: ./src/concourse/tasks/await-deploy-complete.sh

--- a/concourse/tasks/update-ecs-service.sh
+++ b/concourse/tasks/update-ecs-service.sh
@@ -43,13 +43,4 @@ task_id=$(aws ecs list-tasks \
 )
 echo "Task ID: $task_id"
 
-echo "Waiting for $ECS_SERVICE ECS service to reach steady state..."
-
-ecs-cli logs --region "$AWS_REGION" --cluster "$CLUSTER" --task-id "$task_id" --container-name "app" --follow | head -n 5000 &
-
-aws ecs wait services-stable \
-  --cluster "$CLUSTER" \
-  --services "$ECS_SERVICE" \
-  --region "$AWS_REGION"
-
-echo "Finished updating $ECS_SERVICE to task definition $new_task_definition_arn."
+echo "Updated $ECS_SERVICE to task definition $new_task_definition_arn."


### PR DESCRIPTION
Motivation:

This should make deploy jobs fail less frequently due to the following error:

```
Waiter ServicesStable failed: Max attempts exceeded
```

I would expect this job to succeed after this change: https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/deploy-apps/jobs/deploy-publisher/builds/6.

Implementation:

This change will make the deploy job wait for 20mins for an ECS deployment to complete. This feels excessive, but as seen in our deploy job logs, it's unfortunately necessary.

If we find this is too long to wait for success, we can now configure the timeout/attempts per deployment with this change.

Waiting a longer time for a deploy to complete could mask a bigger problem. For example, the ECS error `CouldNotPullContainerError` can occur when ECS is unable to pull an image from a registry. After this change we would not discover this problem for an extra 10 minutes. I think this is acceptable, since the change won't cause additional problems or make them worse, and it will fix an existing problem.

Explanation:

An ECS service is stable when `service.deployments == 0 and runningCount == desiredCount` ([source](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecs/wait/services-stable.html)). In other words, when
there are no active deployments associated with the service and the desired number of tasks are running.

The [`ecs wait service-stable` command](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecs/wait/services-stable.html) is used to wait for a deployment to complete.

However, the polling time for the wait command is not configurable: it polls every 15s for 40 attempts (10m).

A deploy can take longer than this. For example the publisher-web deployment this morning was started at 10:01:37 and completed at 10:16:26.

This change allows us to configure the timeout on a deploy.