### PR TITLE
use new default `main` GitHub branch to build govuk apps

### DIFF
--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -31,7 +31,6 @@ resources:
     source:
       <<: *git-repo-source
       uri: git@github.com:alphagov/publisher.git
-      branch: master
 
   - <<: *git-repo
     name: publishing-api-repo
@@ -52,21 +51,18 @@ resources:
     source:
       <<: *git-repo-source
       uri: git@github.com:alphagov/router-api.git
-      branch: master
 
   - <<: *git-repo
     name: signon-repo
     source:
       <<: *git-repo-source
       uri: git@github.com:alphagov/signon.git
-      branch: master
 
   - <<: *git-repo
     name: static-repo
     source:
       <<: *git-repo-source
       uri: git@github.com:alphagov/static.git
-      branch: master
 
   - <<: *git-repo
     name: govuk-infrastructure


### PR DESCRIPTION
Some govuk apps have switched to the new default `main` GitHub branch so we modify the relevant concourse resources for these apps:
1. publisher
1. router-api
1. signon
1. static