### PR TITLE
Relax container health check

### DIFF
--- a/terraform/modules/container-definition/main.tf
+++ b/terraform/modules/container-definition/main.tf
@@ -6,7 +6,9 @@ output "json_format" {
     environment = [for key, value in var.environment_variables : { name : key, value : tostring(value) }],
     dependsOn   = var.dependsOn
     healthCheck = {
-      command = var.healthcheck_command
+      command     = var.healthcheck_command
+      startPeriod = 30
+      retries     = 5
     }
     image = var.image
     linuxParameters = {


### PR DESCRIPTION
We're seeing new containers get stopped due to
failed health checks. We think could be because
the app web servers are slow to start.

This gives a grace period of 30 seconds to an
app when it starts up, before a failed health
check will count towards the threshold at which
the container will be stopped.

This also increases the number of times we will
retry a failed health check from 3 to 5.