### PR TITLE
Increase content-store ECS task size

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_content_store.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_content_store.tf
@@ -1,7 +1,7 @@
 locals {
   content_store_defaults = {
-    cpu    = 512  # TODO parameterize this
-    memory = 1024 # TODO parameterize this
+    cpu    = var.content_store_cpu
+    memory = var.content_store_memory
 
     backend_services = flatten([
       local.defaults.virtual_service_backends,

--- a/terraform/deployments/govuk-publishing-platform/variables.tf
+++ b/terraform/deployments/govuk-publishing-platform/variables.tf
@@ -1,3 +1,11 @@
+variable "content_store_cpu" {
+  type = number
+}
+
+variable "content_store_memory" {
+  type = number
+}
+
 variable "external_app_domain" {
   type        = string
   description = "e.g. test.govuk.digital"

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -11,6 +11,14 @@ external_app_domain       = "test.govuk.digital"
 registry = "172025368201.dkr.ecr.eu-west-1.amazonaws.com"
 
 #--------------------------------------------------------------
+# App
+#--------------------------------------------------------------
+
+# Only specific config supported. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
+content_store_cpu    = 2048
+content_store_memory = 4096
+
+#--------------------------------------------------------------
 # Network
 #--------------------------------------------------------------
 

--- a/terraform/modules/task-definition/variables.tf
+++ b/terraform/modules/task-definition/variables.tf
@@ -4,7 +4,7 @@ variable "container_definitions" {
 }
 
 variable "cpu" {
-  description = "CPU hard limit for the ECS task (total for all containers). 1024 units = 1 vCPU. Only certain pairs of CPU/memory values are valid on Fargate. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html"
+  description = "CPU hard limit for the ECS task (total for all containers). 1024 units = 1 vCPU. Only certain pairs of CPU/memory values are valid on Fargate. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size"
   type        = string
 }
 
@@ -18,7 +18,7 @@ variable "family" {
 }
 
 variable "memory" {
-  description = "RAM hard limit for the ECS task (total for all containers) in MiB. Only certain pairs of CPU/memory values are valid on Fargate. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html"
+  description = "RAM hard limit for the ECS task (total for all containers) in MiB. Only certain pairs of CPU/memory values are valid on Fargate. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size"
   type        = string
 }
 


### PR DESCRIPTION
Increases Content Store CPU and Memory from 1 vCPU and 2GB RAM to 2 vCPU and 4GB RAM.

This change is made since we've seen spikes of CPU usage when starting content-store's container, and failing container health checks. We're interested to see whether the health check failures will be reduced if we make content-store's task beefier.

Changes to the CPU and Memory params need to consider the [permitted task sizes](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size) (e.g. you're not allowed a task with 2 CPU units and 1GB RAM).