### PR TITLE
Make concourse-iam environment-agnostic

### DIFF
--- a/terraform/deployments/concourse-iam/README.md
+++ b/terraform/deployments/concourse-iam/README.md
@@ -1,0 +1,11 @@
+# Concourse IAM
+
+Enables Concourse pipelines to make changes in an AWS account, e.g. to deploy.
+
+Apply once per GOV.UK environment.
+
+## Applying
+
+```shell
+terraform apply -var-file=../variables/<govuk_environment>/iam.tfvars
+```

--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -37,7 +37,7 @@ resource "aws_iam_role" "govuk_concourse_deployer" {
         "Effect" : "Allow",
         "Action" : "sts:AssumeRole",
         "Principal" : {
-          "AWS" : "arn:aws:iam::047969882937:role/cd-govuk-tools-concourse-worker"
+          "AWS" : "arn:aws:iam::047969882937:role/cd-govuk-${var.govuk_environment}-concourse-worker"
         }
       }
     ]

--- a/terraform/deployments/concourse-iam/variables.tf
+++ b/terraform/deployments/concourse-iam/variables.tf
@@ -1,0 +1,4 @@
+variable "govuk_environment" {
+  type        = string
+  description = "One of test, integration, staging, production."
+}

--- a/terraform/deployments/variables/test/iam.tfvars
+++ b/terraform/deployments/variables/test/iam.tfvars
@@ -1,0 +1,1 @@
+govuk_environment = "test"


### PR DESCRIPTION
This will enable the concourse team govuk-integration to deploy apps to integration.

As [in RE Autom8's docs](https://reliability-engineering.cloudapps.digital/continuous-deployment.html#services):

> Each Concourse team’s worker instances have a specific AWS IAM role, this allows Concourse to assume roles in other AWS accounts, if those accounts have a role which Concourse is permitted to assume.

Since we now have a Concourse team `govuk-<env>` for each environment, we need to trust a team-specific Concourse worker IAM role.