### PR TITLE
Authenticating proxy

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -150,6 +150,15 @@ resources:
       versioned_file: ((workspace))/router.json
       initial_version: "0"
 
+  - name: authenticating-proxy-terraform-outputs
+    type: s3
+    icon: file
+    source:
+      bucket: ((readonly_private_bucket_name))
+      region_name: eu-west-2
+      versioned_file: ((workspace))/authenticating-proxy.json
+      initial_version: "0"
+
   - &registry-image
     name: frontend-image
     type: registry-image
@@ -208,6 +217,12 @@ resources:
       repository: signon
 
   - <<: *registry-image
+    name: authenticating-proxy-image
+    source:
+      <<: *registry-source
+      repository: authenticating-proxy
+
+  - <<: *registry-image
     name: smokey-image
     source:
       <<: *registry-source
@@ -242,6 +257,7 @@ groups:
       - deploy-signon
       - deploy-smokey
       - deploy-static
+      - deploy-authenticating-proxy
 
   - name: terraform
     jobs:
@@ -284,6 +300,10 @@ groups:
   - name: static
     jobs:
       - deploy-static
+
+  - name: authenticating-proxy
+    jobs:
+      - deploy-authenticating-proxy
 
 jobs:
   - name: destroy-infrastructure
@@ -356,6 +376,7 @@ jobs:
       - get: router-api-terraform-outputs
       - get: router-terraform-outputs
       - get: frontend-terraform-outputs
+      - get: authenticating-proxy-terraform-outputs
     - task: terraform-apply
       config:
         inputs:
@@ -387,6 +408,8 @@ jobs:
         - name: router-terraform-outputs
           path: old-router-terraform-outputs
           optional: true
+        - name: authenticating-proxy-terraform-outputs
+          path: old-authenticating-proxy-terraform-outputs
         outputs:
         - name: govuk-terraform-outputs
         - name: content-store-terraform-outputs
@@ -407,6 +430,9 @@ jobs:
           path: new-router-api-terraform-outputs
         - name: router-terraform-outputs
           path: new-router-terraform-outputs
+        - name: authenticating-proxy-terraform-outputs
+          path: new-authenticating-proxy-terraform-outputs
+          optional: true
         params:
           AWS_REGION: eu-west-1
           ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
@@ -464,6 +490,7 @@ jobs:
             update_terraform_outputs static
             update_terraform_outputs router-api
             update_terraform_outputs router
+            update_terraform_outputs authenticating-proxy
 
     - in_parallel:
       - put: govuk-terraform-outputs
@@ -505,6 +532,10 @@ jobs:
           put: router-terraform-outputs
           params:
             file: router-terraform-outputs/router.json
+      - try:
+          put: authenticating-proxy-terraform-outputs
+          params:
+            file: authenticating-proxy-terraform-outputs/authenticating-proxy.json
     on_failure: &notify-slack-failure
       put: deploy-slack-channel
       params:
@@ -1087,6 +1118,44 @@ jobs:
         params:
           <<: *await-deploy-complete-params
           ECS_SERVICE: draft-static
+    serial: true
+    on_failure:
+      <<: *notify-slack-failure
+
+  - name: deploy-authenticating-proxy
+    plan:
+    - in_parallel:
+      - get: govuk-infrastructure
+        resource: govuk-infrastructure-concourse-tasks
+        trigger: true
+      - get: app-terraform-outputs
+        resource: authenticating-proxy-terraform-outputs
+        passed:
+        - run-terraform
+        trigger: true
+      - get: authenticating-proxy-image
+        trigger: true
+    - task: update-task-definition
+      file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
+      input_mapping:
+        app-image: authenticating-proxy-image
+      output_mapping:
+        task-definition-arn: task-definition-arn
+      params:
+        APPLICATION: authenticating-proxy
+        VARIANT: web
+    - task: update-ecs-service
+      file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
+      input_mapping:
+        task-definition-arn: task-definition-arn
+      params:
+        ECS_SERVICE: authenticating-proxy
+        WORKSPACE: ((workspace))
+    - <<: *await-deploy-complete
+      task: await-deploy-complete-live
+      params:
+        <<: *await-deploy-complete-params
+        ECS_SERVICE: authenticating-proxy
     serial: true
     on_failure:
       <<: *notify-slack-failure

--- a/terraform/deployments/govuk-publishing-platform/app_authenticating_proxy.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_authenticating_proxy.tf
@@ -1,0 +1,66 @@
+locals {
+  authenticating_proxy_defaults = {
+    cpu    = 512  # TODO parameterize this
+    memory = 1024 # TODO parameterize this
+
+    backend_services = flatten([
+      local.defaults.virtual_service_backends,
+      module.draft_router.virtual_service_name,
+      module.signon.virtual_service_name,
+    ])
+
+    environment_variables = merge(
+      local.defaults.environment_variables,
+      {
+        GOVUK_APP_NAME          = "authenticating-proxy",
+        PLEK_SERVICE_SIGNON_URI = local.defaults.signon_uri,
+        GOVUK_UPSTREAM_URI      = "http://draft-router.${local.mesh_domain}",
+        MONGODB_URI             = "${local.router_defaults.mongodb_url}/authenticating_proxy_production",
+      }
+    )
+
+    secrets_from_arns = merge(
+      local.defaults.secrets_from_arns,
+      {
+        GDS_SSO_OAUTH_ID     = data.aws_secretsmanager_secret.authenticating_proxy_oauth_id.arn,
+        GDS_SSO_OAUTH_SECRET = data.aws_secretsmanager_secret.authenticating_proxy_oauth_secret.arn,
+        JWT_AUTH_SECRET      = data.aws_secretsmanager_secret.authenticating_proxy_jwt_auth_secret.arn,
+        SECRET_KEY_BASE      = data.aws_secretsmanager_secret.authenticating_proxy_secret_key_base.arn,
+      }
+    )
+  }
+}
+
+module "authenticating_proxy" {
+  registry                         = var.registry
+  image_name                       = "authenticating-proxy"
+  service_name                     = "authenticating-proxy"
+  mesh_name                        = aws_appmesh_mesh.govuk.id
+  backend_virtual_service_names    = local.authenticating_proxy_defaults.backend_services
+  service_discovery_namespace_id   = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.id
+  service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.govuk_publishing_platform.name
+  vpc_id                           = local.vpc_id
+  cluster_id                       = aws_ecs_cluster.cluster.id
+  source                           = "../../modules/app"
+  desired_count                    = var.authenticating_proxy_desired_count
+  subnets                          = local.private_subnets
+  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  environment_variables            = local.authenticating_proxy_defaults.environment_variables
+  secrets_from_arns                = local.authenticating_proxy_defaults.secrets_from_arns
+  load_balancers = [{
+    target_group_arn = aws_lb_target_group.authenticating_proxy.arn
+    container_port   = 80
+  }]
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  aws_region              = data.aws_region.current.name
+  cpu                     = local.authenticating_proxy_defaults.cpu
+  memory                  = local.authenticating_proxy_defaults.memory
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
+  additional_tags         = local.additional_tags
+  environment             = var.govuk_environment
+  workspace               = local.workspace
+}

--- a/terraform/deployments/govuk-publishing-platform/app_router.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router.tf
@@ -100,6 +100,8 @@ module "router" {
   workspace          = local.workspace
 }
 
+# draft_router does not have a load balancer since authenticating-proxy proxies
+# and authenticates requests to draft_router in the draft stack.
 module "draft_router" {
   source       = "../../modules/app"
   registry     = var.registry
@@ -158,16 +160,12 @@ module "draft_router" {
   splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
   splunk_index            = local.defaults.splunk_index
   splunk_sourcetype       = local.defaults.splunk_sourcetype
-  load_balancers = [{
-    target_group_arn = aws_lb_target_group.draft_router.arn
-    container_port   = 80
-  }]
-  aws_region         = data.aws_region.current.name
-  cpu                = local.router_defaults.cpu
-  memory             = local.router_defaults.memory
-  task_role_arn      = aws_iam_role.task.arn
-  execution_role_arn = aws_iam_role.execution.arn
-  additional_tags    = local.additional_tags
-  environment        = var.govuk_environment
-  workspace          = local.workspace
+  aws_region              = data.aws_region.current.name
+  cpu                     = local.router_defaults.cpu
+  memory                  = local.router_defaults.memory
+  task_role_arn           = aws_iam_role.task.arn
+  execution_role_arn      = aws_iam_role.execution.arn
+  additional_tags         = local.additional_tags
+  environment             = var.govuk_environment
+  workspace               = local.workspace
 }

--- a/terraform/deployments/govuk-publishing-platform/frontends_origins.tf
+++ b/terraform/deployments/govuk-publishing-platform/frontends_origins.tf
@@ -131,21 +131,21 @@ module "draft_frontends_origin" {
   waf_web_acl_arn                      = aws_wafv2_web_acl.all_frontends_origins_cloudfront_web_acl.arn
 
   fronted_apps = {
-    "draft-router" = { security_group_id = module.draft_router.security_group_id },
+    "authenticating-proxy" = { security_group_id = module.authenticating_proxy.security_group_id },
   }
   additional_tags = local.additional_tags
   environment     = var.govuk_environment
 }
 
-resource "aws_lb_target_group" "draft_router" {
-  name        = "draft-router-${local.workspace}"
+resource "aws_lb_target_group" "authenticating_proxy" {
+  name        = "authenticating-proxy-${local.workspace}"
   port        = 80
   protocol    = "HTTP"
   vpc_id      = local.vpc_id
   target_type = "ip"
 
   health_check {
-    path = "/"
+    path = "/healthcheck/live"
   }
 
   tags = merge(
@@ -156,13 +156,13 @@ resource "aws_lb_target_group" "draft_router" {
   )
 }
 
-resource "aws_lb_listener_rule" "draft_router" {
+resource "aws_lb_listener_rule" "authenticating_proxy" {
   listener_arn = module.draft_frontends_origin.origin_alb_listerner_arn
   priority     = 11
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.draft_router.arn
+    target_group_arn = aws_lb_target_group.authenticating_proxy.arn
   }
 
   condition {

--- a/terraform/deployments/govuk-publishing-platform/outputs.tf
+++ b/terraform/deployments/govuk-publishing-platform/outputs.tf
@@ -148,6 +148,15 @@ output "router" {
   }
 }
 
+output "authenticating-proxy" {
+  value = {
+    web = {
+      task_definition_cli_input_json = module.authenticating_proxy.cli_input_json,
+      network_config                 = module.authenticating_proxy.network_config
+    }
+  }
+}
+
 output "cluster_name" {
   value = aws_ecs_cluster.cluster.name
 }

--- a/terraform/deployments/govuk-publishing-platform/secrets_manager.tf
+++ b/terraform/deployments/govuk-publishing-platform/secrets_manager.tf
@@ -146,3 +146,18 @@ data "aws_secretsmanager_secret" "draft_router_api_oauth_secret" {
 data "aws_secretsmanager_secret" "draft_router_api_secret_key_base" {
   name = "draft-router-api_SECRET_KEY_BASE"
 }
+
+# Authenticating-proxy app
+
+data "aws_secretsmanager_secret" "authenticating_proxy_oauth_id" {
+  name = "authenticating-proxy_OAUTH_ID"
+}
+data "aws_secretsmanager_secret" "authenticating_proxy_oauth_secret" {
+  name = "authenticating-proxy_OAUTH_SECRET"
+}
+data "aws_secretsmanager_secret" "authenticating_proxy_secret_key_base" {
+  name = "authenticating-proxy_SECRET_KEY_BASE"
+}
+data "aws_secretsmanager_secret" "authenticating_proxy_jwt_auth_secret" {
+  name = "authenticating-proxy_JWT_AUTH_SECRET"
+}

--- a/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
+++ b/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
@@ -426,6 +426,17 @@ resource "aws_security_group_rule" "draft_router_from_draft_router_api_tcp" {
   source_security_group_id = module.draft_router_api.security_group_id
 }
 
+resource "aws_security_group_rule" "draft_router_from_authenticating_proxy_http" {
+  description = "Draft Router accepts requests from Authenticating Proxy over HTTP"
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+
+  security_group_id        = module.draft_router.security_group_id
+  source_security_group_id = module.authenticating_proxy.security_group_id
+}
+
 #
 # Router API
 #
@@ -494,6 +505,15 @@ resource "aws_security_group_rule" "routerdb_from_draft_router_mongodb" {
   protocol                 = "tcp"
   security_group_id        = local.routerdb_security_group_id
   source_security_group_id = module.draft_router.security_group_id
+}
+
+resource "aws_security_group_rule" "routerdb_from_authenticating_proxy_mongodb" {
+  type                     = "ingress"
+  from_port                = 27017
+  to_port                  = 27017
+  protocol                 = "tcp"
+  security_group_id        = local.routerdb_security_group_id
+  source_security_group_id = module.authenticating_proxy.security_group_id
 }
 
 #
@@ -594,6 +614,20 @@ resource "aws_security_group_rule" "statsd_from_apps_tcp" {
   protocol                 = "tcp"
   security_group_id        = module.statsd.security_group_id
   source_security_group_id = aws_security_group.mesh_ecs_service.id
+}
+
+#
+# Authenticating-proxy
+#
+
+resource "aws_security_group_rule" "authenticating-proxy_to_any_any" {
+  description       = "Authenticating-proxy send requests to anywhere"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = module.authenticating_proxy.security_group_id
 }
 
 # TODO: move the rest of the rules into this file unless there's a good reason

--- a/terraform/deployments/govuk-publishing-platform/variables.tf
+++ b/terraform/deployments/govuk-publishing-platform/variables.tf
@@ -115,6 +115,11 @@ variable "statsd_desired_count" {
   default = 1
 }
 
+variable "authenticating_proxy_desired_count" {
+  type    = number
+  default = 1
+}
+
 variable "assume_role_arn" {
   type        = string
   description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."


### PR DESCRIPTION
Add authenticating-proxy app

Adds the `authenticating-proxy` to the `govuk-publishing-platform`
which authenticates HTTP requests before it reaches the draft-router by
either authenticating with Signon or validating the token in the HTTP
requests.

Hence, the `authenticating-proxy` replaces `draft-router` as the first
app when in the draft traffic flow.

**NOTE**
authenticating-proxy is named `Content Preview` in Signon in other
environments and this has been kept this way in ECS Signon.

**Testing**

This was tested by deploying this PR in `fred` workspace and browsing
to:
https://draft-origin.fred.test.govuk.digital/ . You should be redirected
to Signon for login. Note that your user should be authorised to use
`Content Preview` app in Signon for Signon to authorise the request and
redirect you to the draft stack.

Ref:
1. [task trello card](https://trello.com/c/vYNGbJSN/493-add-authenticating-proxy-to-the-draft-stack)
2. [authenticating-proxy dockerfile](alphagov/authenticating-proxy#269)