### PR TITLE
Ignore pending rotations when bootstrapping signon tokens

### DIFF
--- a/lib/signon/bootstrap.rb
+++ b/lib/signon/bootstrap.rb
@@ -40,7 +40,8 @@ module Signon
       end
 
       versions = metadata.version_ids_to_stages
-      if versions.any?
+      has_current_version = versions.values.any? { |stages| stages.include?("AWSCURRENT") }
+      if has_current_version
         logger.info "Secret #{secret_arn} already bootstrapped."
         return
       end

--- a/spec/lib/signon/bootstrap_spec.rb
+++ b/spec/lib/signon/bootstrap_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe Signon::Bootstrap do
   end
 
   context "when secret has already been created" do
+    let(:versions) { { "version1" => %w[AWSCURRENT] } }
+
     it "does not create a new token" do
       signon_request = stub_request(:post, /signon.example.org/)
 
@@ -72,8 +74,8 @@ RSpec.describe Signon::Bootstrap do
     end
   end
 
-  context "when no secret versions exist yet" do
-    let(:versions) { {} }
+  context "when no AWSCURRENT secret version exist yet" do
+    let(:versions) { { "version1" => %w[AWSPENDING] } }
 
     it "creates a secret in signon" do
       stub = stub_request(:post, /signon.example.org/)


### PR DESCRIPTION
This resolves a race condition which would prevent a SecretsManager secret value being set for a signon bearer token during bootstrapping. A lambda rotation can start before the secret has been set during bootstrapping.

If a secret rotation has started and failed (i.e. the lambda will try again tomorrow) we still want to set a current version of the secret during bootstrapping, regardless of any pending rotations.

Between the bootstrap check for an AWSCURRENT version and the bootstrap set command, the rotation could complete. This would not cause an error, since we need either of the working secrets to be set for the initial run of the pipeline. It doesn't matter which token gets set.

