### PR TITLE
Update Concourse bootstrap tasks on code change

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -56,7 +56,7 @@ resources:
     icon: concourse-ci
     source:
       <<: *govuk-infrastructure-source
-      paths: [ concourse/tasks ]
+      paths: [ concourse/tasks, lib/signon, tasks/app_secrets.rake ]
 
   - name: smokey-terraform-outputs
     type: s3


### PR DESCRIPTION
This will ensure that the bootstrapping tasks that are part of the deploy app jobs will run when the code for the bootstrapping jobs changes. Crucially, the bootstrapping tasks will use the latest code when running.

From the [Concourse git resource docs](https://github.com/concourse/git-resource):

> paths: Optional. If specified (as a list of glob patterns), only changes to the specified files will yield new versions from check.