### PR TITLE
Enable Concourse to create bearer tokens during bootstrapping

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/backends_origin.tf
+++ b/terraform/deployments/govuk-publishing-platform/backends_origin.tf
@@ -4,7 +4,7 @@ resource "aws_wafv2_ip_set" "waf_ipv4_set_signon_api" {
   description        = "access to backends origin ${local.workspace} cloudfront"
   scope              = "CLOUDFRONT"
   ip_address_version = "IPV4"
-  addresses          = concat(var.office_cidrs_list, local.aws_nat_gateways_cidrs)
+  addresses          = concat(var.concourse_cidrs_list, var.office_cidrs_list, local.aws_nat_gateways_cidrs)
 }
 
 resource "aws_wafv2_web_acl" "backends_origin_cloudfront_web_acl" {

--- a/terraform/deployments/govuk-publishing-platform/signon_secrets.tf
+++ b/terraform/deployments/govuk-publishing-platform/signon_secrets.tf
@@ -20,7 +20,7 @@ resource "random_password" "signon_admin_password" {
 #
 
 locals {
-  signon_api_url = "signon.${local.workspace}.${var.govuk_environment}.govuk.digital/api/v1"
+  signon_api_url = "https://signon.${local.workspace}.${var.govuk_environment}.govuk.digital/api/v1"
 
   api_user_prefix = terraform.workspace == "default" ? null : local.workspace
   signon_app = {

--- a/terraform/deployments/govuk-publishing-platform/variables.tf
+++ b/terraform/deployments/govuk-publishing-platform/variables.tf
@@ -1,3 +1,7 @@
+variable "concourse_cidrs_list" {
+  type = list(string)
+}
+
 variable "content_store_cpu" {
   type = number
 }

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -25,5 +25,4 @@ content_store_memory = 4096
 # TODO: When it becomes possible, pull these from Terraform "data" type
 office_cidrs_list = ["213.86.153.212/32", "213.86.153.213/32", "213.86.153.214/32", "213.86.153.235/32", "213.86.153.236/32", "213.86.153.237/32", "85.133.67.244/32"]
 
-# TODO: Move into a monitoring tfvars file.
 concourse_cidrs_list = ["35.178.226.106/32", "18.130.168.3/32"]


### PR DESCRIPTION
This fixes two bugs that slipped through in #236:

- Adds scheme (https) to Signon's API URL
- Allow Concourse CIDRs to send requests to Signon's API