### PR TITLE
export dns and cert info

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/outputs.tf
+++ b/terraform/deployments/govuk-publishing-platform/outputs.tf
@@ -209,3 +209,11 @@ output "authenticating-proxy" {
 output "cluster_name" {
   value = aws_ecs_cluster.cluster.name
 }
+
+output "dns_public_zone_id" {
+  value = aws_route53_zone.workspace_public.zone_id
+}
+
+output "public_certificate_arn" {
+  value = aws_acm_certificate.workspace_public.arn
+}


### PR DESCRIPTION
Export DNS and cert info for use by the monitoring deployment.

Ref:
1. [Trello task](https://trello.com/c/twpFac1c/499-fix-grafana-deploy)
2. #254