### PR TITLE
Use main branch for Publishing API

### DIFF
--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -37,7 +37,7 @@ resources:
     source:
       <<: *git-repo-source
       uri: git@github.com:alphagov/publishing-api.git
-      branch: master
+      branch: main
 
   - <<: *git-repo
     name: router-repo


### PR DESCRIPTION
Publishing API now uses the main branch for its default branch.