### PR TITLE
fix grafana dns conflict

### DIFF
--- a/concourse/pipelines/monitoring.yml
+++ b/concourse/pipelines/monitoring.yml
@@ -5,7 +5,7 @@ resources:
   - icon: github
     name: govuk-infrastructure
     source:
-      branch: fix_grafana
+      branch: fix_grafana_zone_conflict
       uri: https://github.com/alphagov/govuk-infrastructure
     type: git
 

--- a/concourse/pipelines/monitoring.yml
+++ b/concourse/pipelines/monitoring.yml
@@ -5,7 +5,7 @@ resources:
   - icon: github
     name: govuk-infrastructure
     source:
-      branch: fix_grafana_zone_conflict
+      branch: main
       uri: https://github.com/alphagov/govuk-infrastructure
     type: git
 

--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -90,7 +90,8 @@ resource "aws_iam_role_policy" "concourse_terraform_planner_test" {
         "Sid" : "TerraformPlannerReadsNonSensitiveTestSecrets",
         "Effect" : "Allow",
         "Action" : "secretsmanager:GetSecretValue",
-        "Resource" : "arn:aws:secretsmanager:eu-west-1:430354129336:secret:signon_admin_password_ecs-*"
+        "Resource" : ["arn:aws:secretsmanager:eu-west-1:430354129336:secret:signon_admin_password_ecs-*",
+        "arn:aws:secretsmanager:eu-west-1:430354129336:secret:grafana_password-*"]
       }
     ]
   })

--- a/terraform/deployments/monitoring/infra/main.tf
+++ b/terraform/deployments/monitoring/infra/main.tf
@@ -91,4 +91,5 @@ module "monitoring" {
   workspace                     = local.workspace
   additional_tags               = local.additional_tags
   capacity_provider             = var.ecs_default_capacity_provider
+  grafana_image_tag             = "7.5.6"
 }

--- a/terraform/deployments/monitoring/infra/main.tf
+++ b/terraform/deployments/monitoring/infra/main.tf
@@ -90,7 +90,5 @@ module "monitoring" {
   govuk_environment             = var.govuk_environment
   workspace                     = local.workspace
   additional_tags               = local.additional_tags
-  dns_public_zone_id            = data.terraform_remote_state.govuk.outputs.dns_public_zone_id
-  certificate_arn               = data.terraform_remote_state.govuk.outputs.public_certificate_arn
   capacity_provider             = var.ecs_default_capacity_provider
 }

--- a/terraform/modules/monitoring/grafana_defaults.tf
+++ b/terraform/modules/monitoring/grafana_defaults.tf
@@ -12,7 +12,7 @@ locals {
     GF_AUTH_GITHUB_ALLOW_SIGN_UP         = true,
     GF_AUTH_GITHUB_ALLOWED_ORGANIZATIONS = "alphagov",
     GF_AUTH_GITHUB_TEAM_IDS              = "3279243",
-    GF_SERVER_DOMAIN                     = "grafana.${local.workspace_external_domain}",
+    GF_SERVER_DOMAIN                     = "grafana.${local.monitoring_external_domain}",
     GF_SERVER_ROOT_URL                   = "https://%(domain)s",
     GF_SERVER_HTTP_PORT                  = var.grafana_port
   }

--- a/terraform/modules/monitoring/grafana_public_alb.tf
+++ b/terraform/modules/monitoring/grafana_public_alb.tf
@@ -3,11 +3,11 @@ module "grafana_public_alb" {
 
   app_name                  = "grafana"
   vpc_id                    = var.vpc_id
-  public_zone_id            = var.dns_public_zone_id
+  public_zone_id            = aws_route53_zone.monitoring_public.zone_id
   dns_a_record_name         = local.grafana_service_name
   public_subnets            = var.public_subnets
-  external_app_domain       = var.external_app_domain
-  certificate               = aws_acm_certificate_validation.public.certificate_arn
+  external_app_domain       = local.monitoring_external_domain
+  certificate               = aws_acm_certificate_validation.monitoring_public.certificate_arn
   publishing_service_domain = var.publishing_service_domain
   workspace                 = var.workspace
   service_security_group_id = aws_security_group.grafana.id

--- a/terraform/modules/monitoring/grafana_task_definition.tf
+++ b/terraform/modules/monitoring/grafana_task_definition.tf
@@ -4,7 +4,7 @@ locals {
     essential   = true,
     environment = [for key, value in local.grafana_environment_variables : { name : key, value : tostring(value) }],
     healthCheck = {
-      command     = ["/bin/bash", "-c", "curl -f http://localhost:${var.grafana_port} || exit 1"]
+      command     = ["/bin/bash", "-c", "wget -q -O - http://localhost:3000/api/health || exit 1"]
       startPeriod = 30
       retries     = 5
     }

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -8,5 +8,5 @@ locals {
     terraform_workspace  = var.workspace
   }
 
-  workspace_external_domain = "${var.workspace}.${var.external_app_domain}"
+  monitoring_external_domain = "monitoring.${var.external_app_domain}"
 }

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -1,5 +1,5 @@
 output "grafana_fqdn" {
-  value       = "grafana.${local.workspace_external_domain}"
+  value       = "grafana.${local.monitoring_external_domain}"
   description = "Public Fully Qualified Domain Name for Grafana"
 }
 

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -106,11 +106,3 @@ variable "grafana_image_tag" {
   type    = string
   default = "latest"
 }
-
-variable "dns_public_zone_id" {
-  type = string
-}
-
-variable "certificate_arn" {
-  type = string
-}


### PR DESCRIPTION
**1. fix DNS conflict**

Previously in #254, we imported the DNS zone `ecs.test.govuk.digital`
from `govuk-publishing-platform` to then add the `grafana` CNAME DNS
record. This creates a conflict when `govuk-publishing-platform` is
destroyed nightly before `monitoring`

As a workaround, we create the `grafana` domain in a dns zone
`monitoring.test.govuk.digital`.

So grafana url will be: https://grafana.monitoring.test.govuk.digital

**2. Fix Concourse plan role access to grafana_password**

**3. Fix container healthcheck and image tag**

**4. Fix branch of monitoring pipeline**



