### PR TITLE
Make the govuk-publishing-platform environment agnostic

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -356,7 +356,7 @@ jobs:
 
               cd govuk-infrastructure/terraform/deployments/govuk-publishing-platform
 
-              terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+              terraform init -backend-config=./test.backend -backend-config "role_arn=$ASSUME_ROLE_ARN"
 
               terraform workspace select "$WORKSPACE"
 
@@ -473,7 +473,7 @@ jobs:
 
             cd govuk-infrastructure/terraform/deployments/govuk-publishing-platform
 
-            terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+            terraform init -backend-config=./test.backend -backend-config "role_arn=$ASSUME_ROLE_ARN"
 
             terraform workspace select "$WORKSPACE" || terraform workspace new "$WORKSPACE"
 

--- a/concourse/tasks/terraform-plan-govuk-deployment.yml
+++ b/concourse/tasks/terraform-plan-govuk-deployment.yml
@@ -19,7 +19,7 @@ run:
   - '-c'
   - |
     set -eu
-    terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+    terraform init -backend-config=./test.backend -backend-config "role_arn=$ASSUME_ROLE_ARN"
     terraform plan \
       -var "assume_role_arn=$ASSUME_ROLE_ARN" \
       -var-file ../variables/test/infrastructure.tfvars

--- a/terraform/deployments/govuk-publishing-platform/app_authenticating_proxy.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_authenticating_proxy.tf
@@ -44,7 +44,7 @@ module "authenticating_proxy" {
   source                           = "../../modules/app"
   desired_count                    = var.authenticating_proxy_desired_count
   subnets                          = local.private_subnets
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   environment_variables            = local.authenticating_proxy_defaults.environment_variables
   secrets_from_arns                = local.authenticating_proxy_defaults.secrets_from_arns
   load_balancers = [{

--- a/terraform/deployments/govuk-publishing-platform/app_content_store.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_content_store.tf
@@ -52,7 +52,6 @@ module "content_store" {
   subnets                          = local.private_subnets
   desired_count                    = var.content_store_desired_count
   extra_security_groups = [
-    local.govuk_management_access_security_group,
     aws_security_group.mesh_ecs_service.id
   ]
   environment_variables = merge(
@@ -104,7 +103,6 @@ module "draft_content_store" {
   subnets                          = local.private_subnets
   desired_count                    = var.draft_content_store_desired_count
   extra_security_groups = [
-    local.govuk_management_access_security_group,
     aws_security_group.mesh_ecs_service.id
   ]
   environment_variables = merge(

--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -58,7 +58,7 @@ module "frontend" {
   source                           = "../../modules/app"
   desired_count                    = var.frontend_desired_count
   subnets                          = local.private_subnets
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   environment_variables            = local.frontend_defaults.environment_variables
   secrets_from_arns                = local.frontend_defaults.secrets_from_arns
   splunk_url_secret_arn            = local.defaults.splunk_url_secret_arn
@@ -91,7 +91,7 @@ module "draft_frontend" {
   source                           = "../../modules/app"
   desired_count                    = var.draft_frontend_desired_count
   subnets                          = local.private_subnets
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   environment_variables = merge(
     local.frontend_defaults.environment_variables,
     {

--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -77,7 +77,6 @@ module "publisher_web" {
   vpc_id                           = local.vpc_id
   desired_count                    = var.publisher_desired_count
   extra_security_groups = [
-    local.govuk_management_access_security_group,
     aws_security_group.mesh_ecs_service.id
   ]
   load_balancers = [{
@@ -113,7 +112,6 @@ module "publisher_worker" {
   cluster_id                    = aws_ecs_cluster.cluster.id
   extra_security_groups = [
     module.publisher_web.security_group_id,
-    local.govuk_management_access_security_group,
     aws_security_group.mesh_ecs_service.id
   ]
   container_healthcheck_command    = ["/bin/sh", "-c", "exit 0"]

--- a/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
@@ -64,7 +64,7 @@ module "publishing_api_web" {
   cluster_id                       = aws_ecs_cluster.cluster.id
   source                           = "../../modules/app"
   desired_count                    = var.publishing_api_desired_count
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   subnets                          = local.private_subnets
   environment_variables            = local.publishing_api_defaults.environment_variables
   secrets_from_arns                = local.publishing_api_defaults.secrets_from_arns
@@ -95,7 +95,7 @@ module "publishing_api_worker" {
   cluster_id                       = aws_ecs_cluster.cluster.id
   source                           = "../../modules/app"
   desired_count                    = var.publishing_api_worker_desired_count
-  extra_security_groups            = [module.publishing_api_web.security_group_id, local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [module.publishing_api_web.security_group_id, aws_security_group.mesh_ecs_service.id]
   container_healthcheck_command    = ["/bin/sh", "-c", "exit 0"]
   subnets                          = local.private_subnets
   environment_variables            = local.publishing_api_defaults.environment_variables

--- a/terraform/deployments/govuk-publishing-platform/app_router.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router.tf
@@ -46,7 +46,7 @@ module "router" {
   vpc_id                           = local.vpc_id
   subnets                          = local.private_subnets
   desired_count                    = var.router_desired_count
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   container_healthcheck_command    = ["/bin/sh", "-c", "exit 0"]
   environment_variables = merge(
     local.router_defaults.environment_variables,
@@ -120,7 +120,7 @@ module "draft_router" {
   vpc_id                           = local.vpc_id
   subnets                          = local.private_subnets
   desired_count                    = var.draft_router_desired_count
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   container_healthcheck_command    = ["/bin/sh", "-c", "exit 0"]
   environment_variables = merge(
     local.router_defaults.environment_variables,

--- a/terraform/deployments/govuk-publishing-platform/app_router_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_router_api.tf
@@ -42,7 +42,7 @@ module "router_api" {
   vpc_id                           = local.vpc_id
   subnets                          = local.private_subnets
   desired_count                    = var.router_api_desired_count
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   environment_variables = merge(
     local.router_api_defaults.environment_variables,
     {
@@ -85,7 +85,7 @@ module "draft_router_api" {
   vpc_id                           = local.vpc_id
   subnets                          = local.private_subnets
   desired_count                    = var.draft_router_api_desired_count
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   environment_variables = merge(
     local.router_api_defaults.environment_variables,
     {

--- a/terraform/deployments/govuk-publishing-platform/app_signon.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_signon.tf
@@ -43,7 +43,7 @@ module "signon" {
   cluster_id                       = aws_ecs_cluster.cluster.id
   source                           = "../../modules/app"
   desired_count                    = var.signon_desired_count
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   load_balancers = [{
     target_group_arn = aws_lb_target_group.signon.arn
     container_port   = 80

--- a/terraform/deployments/govuk-publishing-platform/app_static.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_static.tf
@@ -31,7 +31,7 @@ module "static" {
   vpc_id                           = local.vpc_id
   subnets                          = local.private_subnets
   desired_count                    = var.static_desired_count
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   environment_variables = merge(
     local.static_defaults.environment_variables,
     {
@@ -73,7 +73,7 @@ module "draft_static" {
   vpc_id                           = local.vpc_id
   subnets                          = local.private_subnets
   desired_count                    = var.draft_static_desired_count
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   environment_variables = merge(
     local.static_defaults.environment_variables,
     {

--- a/terraform/deployments/govuk-publishing-platform/app_statsd.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_statsd.tf
@@ -16,7 +16,7 @@ module "statsd" {
   desired_count                    = var.statsd_desired_count
   environment_variables            = local.statsd_defaults.environment_variables
   execution_role_arn               = aws_iam_role.execution.arn
-  extra_security_groups            = [local.govuk_management_access_security_group, aws_security_group.mesh_ecs_service.id]
+  extra_security_groups            = [aws_security_group.mesh_ecs_service.id]
   container_healthcheck_command    = ["/bin/sh", "-c", "exit 0"]
   image_name                       = "statsd"
   image_tag                        = "test-0.1.3" # TODO: https://trello.com/c/nju3j7Ph/38-modify-statsd-so-that-we-can-run-it-in-ecs

--- a/terraform/deployments/govuk-publishing-platform/backends_origin.tf
+++ b/terraform/deployments/govuk-publishing-platform/backends_origin.tf
@@ -100,8 +100,8 @@ module "backends_origin" {
   public_zone_id      = aws_route53_zone.workspace_public.zone_id
   external_app_domain = aws_route53_zone.workspace_public.name
   subdomain           = "backends"
-  extra_aliases = compact([local.is_default_workspace ? "publisher.${local.workspace}.${var.publishing_service_domain}" : null,
-    local.is_default_workspace ? "signon.${local.workspace}.${var.publishing_service_domain}" : null,
+  extra_aliases = compact([local.is_default_workspace ? "publisher.${var.publishing_service_domain}" : null,
+    local.is_default_workspace ? "signon.${var.publishing_service_domain}" : null,
     "publisher.${aws_route53_zone.workspace_public.name}",
   "signon.${aws_route53_zone.workspace_public.name}"])
   load_balancer_certificate_arn        = aws_acm_certificate_validation.workspace_public.certificate_arn

--- a/terraform/deployments/govuk-publishing-platform/dns.tf
+++ b/terraform/deployments/govuk-publishing-platform/dns.tf
@@ -27,7 +27,7 @@ resource "aws_route53_zone" "internal_private" {
 resource "aws_acm_certificate" "workspace_public" {
   domain_name = "*.${local.workspace_external_domain}"
 
-  subject_alternative_names = local.is_default_workspace ? ["*.${local.workspace}.${var.publishing_service_domain}"] : null
+  subject_alternative_names = local.is_default_workspace ? ["*.${var.publishing_service_domain}"] : null
 
   validation_method = "DNS"
 

--- a/terraform/deployments/govuk-publishing-platform/dns.tf
+++ b/terraform/deployments/govuk-publishing-platform/dns.tf
@@ -1,9 +1,5 @@
-data "aws_route53_zone" "public" {
-  name = var.external_app_domain
-}
-
 resource "aws_route53_record" "workspace_public_zone_ns" {
-  zone_id = data.aws_route53_zone.public.zone_id
+  zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id
   name    = local.workspace_external_domain
   type    = "NS"
   ttl     = "300"

--- a/terraform/deployments/govuk-publishing-platform/frontends_origins.tf
+++ b/terraform/deployments/govuk-publishing-platform/frontends_origins.tf
@@ -58,7 +58,7 @@ module "www_frontends_origin" {
   public_zone_id                       = aws_route53_zone.workspace_public.zone_id
   external_app_domain                  = aws_route53_zone.workspace_public.name
   subdomain                            = "www-origin"
-  extra_aliases                        = local.is_default_workspace ? ["www.${local.workspace}.${var.publishing_service_domain}"] : []
+  extra_aliases                        = local.is_default_workspace ? ["www.${var.publishing_service_domain}"] : []
   load_balancer_certificate_arn        = aws_acm_certificate_validation.workspace_public.certificate_arn
   cloudfront_certificate_arn           = aws_acm_certificate_validation.public_north_virginia.certificate_arn
   publishing_service_domain            = var.publishing_service_domain

--- a/terraform/deployments/govuk-publishing-platform/hacks.tf
+++ b/terraform/deployments/govuk-publishing-platform/hacks.tf
@@ -1,5 +1,0 @@
-locals {
-  # TODO: don't use this security group
-  # See https://trello.com/c/v7S1lVMg/171-purge-govukmanagementaccess-from-govuk-infrastructure
-  govuk_management_access_security_group = "sg-0b873470482f6232d"
-}

--- a/terraform/deployments/govuk-publishing-platform/integration.backend
+++ b/terraform/deployments/govuk-publishing-platform/integration.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-ecs-terraform-integration"
+key     = "projects/govuk.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/deployments/govuk-publishing-platform/main.tf
+++ b/terraform/deployments/govuk-publishing-platform/main.tf
@@ -1,9 +1,5 @@
 terraform {
   backend "s3" {
-    bucket  = "govuk-terraform-test"
-    key     = "projects/govuk.tfstate"
-    region  = "eu-west-1"
-    encrypt = true
   }
 
   required_providers {

--- a/terraform/deployments/govuk-publishing-platform/origins_certificates.tf
+++ b/terraform/deployments/govuk-publishing-platform/origins_certificates.tf
@@ -2,7 +2,7 @@ resource "aws_acm_certificate" "public_north_virginia" {
   provider    = aws.us_east_1
   domain_name = "*.${local.workspace_external_domain}"
 
-  subject_alternative_names = local.is_default_workspace ? ["*.${local.workspace}.${var.publishing_service_domain}"] : null
+  subject_alternative_names = local.is_default_workspace ? ["*.${var.publishing_service_domain}"] : null
 
   validation_method = "DNS"
 

--- a/terraform/deployments/govuk-publishing-platform/remote_state.tf
+++ b/terraform/deployments/govuk-publishing-platform/remote_state.tf
@@ -38,6 +38,16 @@ data "terraform_remote_state" "infra_security_groups" {
   }
 }
 
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+  config = {
+    bucket   = var.govuk_aws_state_bucket
+    key      = "govuk/infra-root-dns-zones.tfstate"
+    region   = data.aws_region.current.name
+    role_arn = var.assume_role_arn
+  }
+}
+
 data "fastly_ip_ranges" "fastly" {}
 
 locals {

--- a/terraform/deployments/govuk-publishing-platform/test.backend
+++ b/terraform/deployments/govuk-publishing-platform/test.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-test"
+key     = "projects/govuk.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/deployments/variables/integration/infrastructure.tfvars
+++ b/terraform/deployments/variables/integration/infrastructure.tfvars
@@ -11,6 +11,19 @@ external_app_domain       = "integration.govuk.digital"
 registry = "172025368201.dkr.ecr.eu-west-1.amazonaws.com"
 
 #--------------------------------------------------------------
+# App
+#--------------------------------------------------------------
+
+# Apps that have workers and that we can spin down to avoid potential conflict
+# with EC2-based workers
+publisher_worker_desired_count      = 1
+publishing_api_worker_desired_count = 0
+
+# Only specific config supported. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
+content_store_cpu    = 2048
+content_store_memory = 4096
+
+#--------------------------------------------------------------
 # Network
 #--------------------------------------------------------------
 

--- a/terraform/deployments/variables/integration/infrastructure.tfvars
+++ b/terraform/deployments/variables/integration/infrastructure.tfvars
@@ -1,0 +1,21 @@
+ecs_default_capacity_provider = "FARGATE_SPOT"
+
+govuk_aws_state_bucket = "govuk-terraform-steppingstone-integration"
+
+govuk_environment = "integration"
+
+publishing_service_domain = "integration.publishing.service.gov.uk"
+internal_app_domain       = "integration.govuk-internal.digital"
+external_app_domain       = "integration.govuk.digital"
+
+registry = "172025368201.dkr.ecr.eu-west-1.amazonaws.com"
+
+#--------------------------------------------------------------
+# Network
+#--------------------------------------------------------------
+
+# TODO: When it becomes possible, pull these from Terraform "data" type
+office_cidrs_list = ["213.86.153.212/32", "213.86.153.213/32", "213.86.153.214/32", "213.86.153.235/32", "213.86.153.236/32", "213.86.153.237/32", "85.133.67.244/32"]
+
+# TODO: Move into a monitoring tfvars file.
+concourse_cidrs_list = ["35.178.226.106/32", "18.130.168.3/32"]


### PR DESCRIPTION
As we plan to build govuk-publishing-platform in integration we need to make the terraform code usable in any environment
Main things to be aware of:
Backends are now defined per environment in a file named \<env\>.backend, to initialise you now have to run terraform init with the -backend-config=env.backend option. Also you will need to delete the .terraform/terraform.tfstate file which caches your backend config.
The way we use publishing.service.gov.uk has been modified, we never try to deal with workspaces with this domain now.