### PR TITLE
Add draft-origin rather than draft-frontend in publisher

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_publisher.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publisher.tf
@@ -31,11 +31,10 @@ locals {
         PLEK_SERVICE_PUBLISHING_API_URI = local.defaults.publishing_api_uri
         PLEK_SERVICE_SIGNON_URI         = local.defaults.signon_uri
         PLEK_SERVICE_STATIC_URI         = local.defaults.static_uri
-        # TODO: remove PLEK_SERVICE_DRAFT_ORIGIN_URI once we have the draft origin properly set up with multiple frontends
-        PLEK_SERVICE_DRAFT_ORIGIN_URI = local.defaults.draft_frontends_origin_uri
-        ASSETS_PREFIX                 = "/assets/publisher"
-        REDIS_URL                     = module.shared_redis_cluster.uri
-        WEBSITE_ROOT                  = local.defaults.website_root
+        PLEK_SERVICE_DRAFT_ORIGIN_URI   = local.defaults.draft_origin_uri
+        ASSETS_PREFIX                   = "/assets/publisher"
+        REDIS_URL                       = module.shared_redis_cluster.uri
+        WEBSITE_ROOT                    = local.defaults.website_root
       }
     )
 

--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -27,7 +27,6 @@ locals {
     assets_draft_frontends_origin = "https://${module.draft_frontends_origin.fqdn}"
     content_store_uri             = "http://content-store.${local.mesh_domain}",
     draft_content_store_uri       = "http://draft-content-store.${local.mesh_domain}",
-    draft_frontends_origin_uri    = "https://draft-frontend.${local.workspace_external_domain}",
     draft_static_uri              = "http://draft-static.${local.mesh_domain}"
     publishing_api_uri            = "http://publishing-api-web.${local.mesh_domain}",
     rabbitmq_hosts                = "rabbitmq.${var.internal_app_domain}" # TODO: Make workspace-aware
@@ -36,6 +35,7 @@ locals {
     signon_uri                    = "https://signon.${local.workspace_external_domain}",
     static_uri                    = "http://static.${local.mesh_domain}",
     website_root                  = local.public_entry_url,
+    draft_origin_uri              = "https://draft-origin.${local.workspace_external_domain}",
 
     virtual_service_backends = [
       module.statsd.virtual_service_name


### PR DESCRIPTION
Since draft-router (##225) and draft-origin(#192) are now active in
the draft stack of the publishing platform, publisher should direct
draft-stack views to the the draft-origin.