### PR TITLE
fix publishing-api command

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_publishing_api.tf
@@ -80,6 +80,7 @@ module "publishing_api_web" {
   additional_tags                  = local.additional_tags
   environment                      = var.govuk_environment
   workspace                        = local.workspace
+  command                          = ["foreman", "run", "web"]
 }
 
 module "publishing_api_worker" {
@@ -111,4 +112,5 @@ module "publishing_api_worker" {
   additional_tags                  = local.additional_tags
   environment                      = var.govuk_environment
   workspace                        = local.workspace
+  command                          = ["foreman", "run", "worker"]
 }


### PR DESCRIPTION
Publishing-api is run into 2 modes: web and worker.

Therefore in the the app deployment, we need to specify which
mode do we want to run.

This will hopefully fix the issue where the publishing-api workers
are not processing the queue because they are in default web mode.