### PR TITLE
Modify Smokey loop schedule

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -244,7 +244,7 @@ resources:
   - name: every-10-minutes-in-daytime
     type: cron-resource
     source:
-      expression: "*/10 8-22 * * 1-5"
+      expression: "*/10 8-20 * * 1-5"
       location: "Europe/London"
       fire_immediately: true
 


### PR DESCRIPTION
This is to prevent a smoke test starting within
2 hours of the destroy-infrastructure job running
(which cannot complete if a smoke test is in progress).

Yesterday the smoke tests were run at 2021-05-13T22:51:59.583075938+01:00

I misunderstood the cron expression - I thought
8-22 was exclusive, not inclusive! I presumed the
jobs would not be run after the 22nd hour. In
fact, they are run until the 23rd hour.

This changes the smoke tests so they will run
until 9pm on weekdays.