### PR TITLE
Ignore changes to bootstrap task definitions

### DIFF
--- a/terraform/modules/app/task_definition.tf
+++ b/terraform/modules/app/task_definition.tf
@@ -117,6 +117,12 @@ resource "aws_ecs_task_definition" "bootstrap" {
     },
   )
 
+  lifecycle {
+    # Makes tf plan/apply diffs less verbose.
+    # This task definition is needed only for bootstrapping. We don't need
+    # to update it, so we can ignore all changes.
+    ignore_changes = all
+  }
 }
 
 output "cli_input_json" {


### PR DESCRIPTION
This change will make tf plan/apply diffs less verbose.

These task definitions are only needed during bootstrapping so don't need to be updated after the initial terraform apply.