### PR TITLE
Use app domains for backend apps

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -4,8 +4,8 @@ locals {
   workspace_external_domain = "${local.workspace}.${var.external_app_domain}"
   workspace_internal_domain = "${local.workspace}.${var.internal_app_domain}"
   mesh_domain               = "mesh.${local.workspace_internal_domain}"
-  public_domain             = local.is_default_workspace ? var.publishing_service_domain : local.workspace_external_domain
-  public_entry_url          = local.is_default_workspace ? "https://www.ecs.${var.publishing_service_domain}" : "https://${module.www_frontends_origin.fqdn}"
+  # public_domain             = local.is_default_workspace ? var.publishing_service_domain : local.workspace_external_domain
+  public_entry_url = local.is_default_workspace ? "https://www.ecs.${var.publishing_service_domain}" : "https://${module.www_frontends_origin.fqdn}"
   defaults = {
     environment_variables = {
       DEFAULT_TTL               = 1800,

--- a/terraform/deployments/govuk-publishing-platform/signon_bearer_tokens.tf
+++ b/terraform/deployments/govuk-publishing-platform/signon_bearer_tokens.tf
@@ -20,7 +20,9 @@ resource "random_password" "signon_admin_password" {
 #
 
 locals {
-  signon_api_url  = "https://signon.${local.public_domain}/api/v1"
+  # TODO Change this to local.public_domain once publishing.service domains
+  # for backend apps are working.
+  signon_api_url  = "https://signon.${local.workspace_external_domain}/api/v1"
   api_user_prefix = local.is_default_workspace ? null : local.workspace
   signon_api_user = {
     content_store       = join("-", compact([local.api_user_prefix, "content-store@${var.publishing_service_domain}"]))

--- a/terraform/deployments/govuk-publishing-platform/signon_oauth_apps.tf
+++ b/terraform/deployments/govuk-publishing-platform/signon_oauth_apps.tf
@@ -77,9 +77,11 @@ module "oauth_applications" {
   app_name        = each.value.name
   description     = each.value.description
   environment     = var.govuk_environment
-  home_uri        = "https://${each.value.subdomain}.${local.public_domain}"
-  permissions     = each.value.permissions
-  app_shortname   = each.value.shortname
-  redirect_path   = each.value.redirect_path
-  workspace       = local.workspace
+  # TODO Change this to local.public_domain once publishing.service domains
+  # for backend apps are working.
+  home_uri      = "https://${each.value.subdomain}.${local.workspace_external_domain}"
+  permissions   = each.value.permissions
+  app_shortname = each.value.shortname
+  redirect_path = each.value.redirect_path
+  workspace     = local.workspace
 }


### PR DESCRIPTION
This changes the domains we'll use for backend apps in signon OAuth app config and when making requests to signon in the default workspace from the public domain publishing.service.gov.uk to the app domain ecs.test.govuk.digital.

This is because we've not yet set up the backend apps on publishing.service.gov.uk subdomains.