### PR TITLE
migrate test cdn to govuk.digital domain

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -5,7 +5,7 @@ locals {
   workspace_internal_domain = "${local.workspace}.${var.internal_app_domain}"
   mesh_domain               = "mesh.${local.workspace_internal_domain}"
   # public_domain             = local.is_default_workspace ? var.publishing_service_domain : local.workspace_external_domain
-  public_entry_url = local.is_default_workspace ? "https://www.ecs.${var.publishing_service_domain}" : "https://${module.www_frontends_origin.fqdn}"
+  public_entry_url = local.is_default_workspace && var.enable_cdn ? "https://www.${local.workspace_external_domain}" : "https://${module.www_frontends_origin.fqdn}"
   defaults = {
     environment_variables = {
       DEFAULT_TTL               = 1800,

--- a/terraform/deployments/govuk-publishing-platform/variables.tf
+++ b/terraform/deployments/govuk-publishing-platform/variables.tf
@@ -139,3 +139,15 @@ variable "registry" {
   type        = string
   description = "registry from which to pull container images"
 }
+
+variable "enable_cdn" {
+  type        = bool
+  description = "enable Fastly CDN for this govuk_environment on govuk.digital domain, this applies to the default workspace only"
+  default     = false
+}
+
+variable "cdn_certificate_validation_cname" {
+  type        = map(any)
+  description = "map of name and record pair for Fastly certificate validation"
+  default     = {}
+}

--- a/terraform/deployments/variables/test/infrastructure.tfvars
+++ b/terraform/deployments/variables/test/infrastructure.tfvars
@@ -10,6 +10,9 @@ external_app_domain       = "test.govuk.digital"
 
 registry = "172025368201.dkr.ecr.eu-west-1.amazonaws.com"
 
+enable_cdn                       = true
+cdn_certificate_validation_cname = { name = "_acme-challenge.www.ecs.test.govuk.digital", record = "imu53najhaviy4ov80.fastly-validations.com" }
+
 #--------------------------------------------------------------
 # App
 #--------------------------------------------------------------


### PR DESCRIPTION
We migrate the test CDN from `publishing.service.gov.uk` to the `govuk.digital` domain so as to stop cannibalising the `publishing.service.gov.uk`. This is useful before the spin-up in integration.

We add an option to enable or not the configuration of the `govuk.digital` test CDN, there will be scenarios where we just want to use the `publishing.service.gov.uk` CDN only.