### PR TITLE
Wait for secrets to be set before deploying

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -596,8 +596,6 @@ jobs:
     - in_parallel:
       - get: govuk-infrastructure
         resource: govuk-infrastructure-concourse-tasks
-        passed:
-        - deploy-signon
         trigger: true
       - get: app-terraform-outputs
         resource: frontend-terraform-outputs
@@ -606,6 +604,18 @@ jobs:
         trigger: true
       - get: frontend-image
         trigger: true
+    - in_parallel:
+      - &await-secretsmanager-creds
+        task: await-creds-in-secrets-manager
+        file: govuk-infrastructure/concourse/tasks/await-creds-in-secretsmanager.yml
+        attempts: 3
+        params:
+          APPLICATION: frontend
+          VARIANT: live
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: frontend
+          VARIANT: draft
     - in_parallel:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
@@ -690,8 +700,6 @@ jobs:
     - in_parallel:
       - get: govuk-infrastructure
         resource: govuk-infrastructure-concourse-tasks
-        passed:
-        - deploy-signon
         trigger: true
       - get: app-terraform-outputs
         resource: publisher-terraform-outputs
@@ -700,6 +708,15 @@ jobs:
         trigger: true
       - get: publisher-image
         trigger: true
+    - in_parallel:
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: publisher
+          VARIANT: web
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: publisher
+          VARIANT: worker
     - in_parallel:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
@@ -791,8 +808,6 @@ jobs:
     - in_parallel:
       - get: govuk-infrastructure
         resource: govuk-infrastructure-concourse-tasks
-        passed:
-        - deploy-signon
         trigger: true
       - get: app-terraform-outputs
         resource: publishing-api-terraform-outputs
@@ -801,6 +816,15 @@ jobs:
         trigger: true
       - get: publishing-api-image
         trigger: true
+    - in_parallel:
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: publishing-api
+          VARIANT: web
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: publishing-api
+          VARIANT: worker
     - in_parallel:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
@@ -870,8 +894,6 @@ jobs:
     - in_parallel:
       - get: govuk-infrastructure
         resource: govuk-infrastructure-concourse-tasks
-        passed:
-        - deploy-signon
         trigger: true
       - get: app-terraform-outputs
         resource: content-store-terraform-outputs
@@ -880,6 +902,16 @@ jobs:
         trigger: true
       - get: content-store-image
         trigger: true
+    - in_parallel:
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: content-store
+          VARIANT: live
+      - task: await-creds-in-secrets-manager
+        file: govuk-infrastructure/concourse/tasks/await-creds-in-secretsmanager.yml
+        params:
+          APPLICATION: content-store
+          VARIANT: draft
     - in_parallel:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
@@ -1007,7 +1039,6 @@ jobs:
       - get: govuk-infrastructure
         resource: govuk-infrastructure-concourse-tasks
         passed:
-        - deploy-signon
         trigger: true
       - get: app-terraform-outputs
         resource: router-api-terraform-outputs
@@ -1017,6 +1048,10 @@ jobs:
       - get: router-api-image
         trigger: true
     - in_parallel:
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: router-api
+          VARIANT: live
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:

--- a/concourse/tasks/await-creds-in-secretsmanager.yml
+++ b/concourse/tasks/await-creds-in-secretsmanager.yml
@@ -1,0 +1,20 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: govuk/infra-concourse-task
+    tag: 0.0.0-wip
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
+inputs:
+  - name: app-terraform-outputs
+  - name: govuk-infrastructure
+params:
+  AWS_REGION: eu-west-1
+  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  APPLICATION:
+  VARIANT:
+run:
+  dir: govuk-infrastructure
+  path: bundle
+  args: ["exec", "rake", "secretsmanager:wait_for_secrets"]

--- a/lib/tasks/secretsmanager.rake
+++ b/lib/tasks/secretsmanager.rake
@@ -1,0 +1,52 @@
+namespace :secretsmanager do
+  desc "Wait for secrets to be set in SecretsManager"
+  task :wait_for_secrets do
+    application = ENV["APPLICATION"]
+    variant = ENV["VARIANT"]
+    app_config = JSON.parse(File.read("../app-terraform-outputs/#{application}.json"))
+
+    credentials = Aws::AssumeRoleCredentials.new(
+      client: Aws::STS::Client.new,
+      role_arn: ENV["ASSUME_ROLE_ARN"],
+      role_session_name: "wait-for-#{application}-#{variant}-secrets",
+    )
+    secrets_client = Aws::SecretsManager::Client.new(
+      region: ENV["AWS_REGION"],
+      credentials: credentials,
+    )
+
+    required_secrets = app_config.dig(variant, "required_secrets")
+    secrets = required_secrets.to_h { |arn| [arn, false] }
+    attempts = 0
+    max_attempts = 8
+
+    until secrets.values.all? || attempts == max_attempts
+      attempts += 1
+
+      secrets.each do |secret_arn, set|
+        next if set
+
+        metadata = secrets_client.describe_secret(secret_id: secret_arn)
+        versions = metadata.version_ids_to_stages
+        next if versions.nil?
+
+        has_current_version = versions.values.any? do |stages|
+          stages.include?("AWSCURRENT")
+        end
+
+        secrets[secret_arn] = true if has_current_version
+      end
+      sleep(2**attempts) unless attempts == max_attempts
+    end
+
+    if secrets.values.all?
+      puts "All secrets for #{application}:#{variant} are set."
+    else
+      unset = secrets.reject { |_secret, set| set }.keys
+      puts "Timed out!"
+      puts "The following secrets are unset:"
+      unset.each { |secret| puts " • #{secret}" }
+      exit 1
+    end
+  end
+end

--- a/terraform/deployments/govuk-publishing-platform/outputs.tf
+++ b/terraform/deployments/govuk-publishing-platform/outputs.tf
@@ -12,6 +12,7 @@ output "content-store" {
     draft = {
       task_definition_cli_input_json = module.draft_content_store.cli_input_json,
       network_config                 = module.draft_content_store.network_config
+      required_secrets               = module.draft_content_store.required_secrets
       signon_secrets = {
         bearer_tokens = [
           module.content_store_to_publishing_api_bearer_token.token_data,
@@ -25,6 +26,7 @@ output "content-store" {
     live = {
       task_definition_cli_input_json = module.content_store.cli_input_json,
       network_config                 = module.content_store.network_config
+      required_secrets               = module.content_store.required_secrets
       signon_secrets = {
         bearer_tokens = [
           module.draft_content_store_to_publishing_api_bearer_token.token_data,
@@ -43,6 +45,7 @@ output "publisher" {
     web = {
       task_definition_cli_input_json = module.publisher_web.cli_input_json,
       network_config                 = module.publisher_web.network_config
+      required_secrets               = module.publisher_web.required_secrets
       signon_secrets = {
         bearer_tokens = [
           module.publisher_to_publishing_api_bearer_token.token_data,
@@ -53,6 +56,7 @@ output "publisher" {
       }
     },
     worker = {
+      required_secrets               = module.publisher_worker.required_secrets
       task_definition_cli_input_json = module.publisher_worker.cli_input_json,
       network_config                 = module.publisher_worker.network_config
     },
@@ -85,6 +89,7 @@ output "publishing-api" {
     web = {
       task_definition_cli_input_json = module.publishing_api_web.cli_input_json,
       network_config                 = module.publishing_api_web.network_config
+      required_secrets               = module.publishing_api_web.required_secrets
       signon_secrets = {
         bearer_tokens = [
           module.publishing_api_to_router_api_bearer_token.token_data,
@@ -97,6 +102,7 @@ output "publishing-api" {
       }
     },
     worker = {
+      required_secrets               = module.publishing_api_worker.required_secrets
       task_definition_cli_input_json = module.publishing_api_worker.cli_input_json,
       network_config                 = module.publishing_api_worker.network_config
     },
@@ -181,10 +187,12 @@ output "router-api" {
     draft = {
       task_definition_cli_input_json = module.draft_router_api.cli_input_json,
       network_config                 = module.draft_router_api.network_config
+      required_secrets               = module.draft_router_api.required_secrets
     },
     live = {
       task_definition_cli_input_json = module.router_api.cli_input_json,
       network_config                 = module.router_api.network_config
+      required_secrets               = module.router_api.required_secrets
     },
   }
 }

--- a/terraform/modules/app/outputs.tf
+++ b/terraform/modules/app/outputs.tf
@@ -1,3 +1,8 @@
+output "required_secrets" {
+  value       = values(var.secrets_from_arns)
+  description = "ARNs of SecretsManager secrets required by this app."
+}
+
 output "security_group_id" {
   value       = aws_security_group.service.id
   description = "ID of the security group created by the module, containing the app."


### PR DESCRIPTION
Ensures that apps will wait for SecretsManager credentials to be set before attempting to deploy the app or use the task definition for ad-hoc tasks such as running db migrations.

Will retry 8 times with an exponential backoff in Ruby. Uses 3 attempts in Concourse by default, which is configurable per deployment.

This will mostly be useful during bootstrapping. We'll also see benefit when we add credentials but forget to add them to SecretsManager - it'll make the failure more obvious in Concourse without needing to dig into the AWS console.