### PR TITLE
Add ability to swith on/off DB migrations for specific GOV.UK environment

### DIFF
--- a/concourse/README.md
+++ b/concourse/README.md
@@ -1,0 +1,57 @@
+# Configuring Concourse
+
+Our Concourse pipelines are hosted in Big Concourse located at:
+https://cd.gds-reliability.engineering/. You have access to it (and specific
+Concourse teams) by being a member of the appropriate GitHub organisation.
+
+To configure Concourse, you need a Concourse CLI client called `fly` that you
+can download by clicking on the appropriate platform icon at the bottom right of
+the [page](https://cd.gds-reliability.engineering/). You should ideally install
+it in directory `/usr/local/bin/`.
+
+Our Concourse is configured so that each GOV.UK environment (e.g.
+`test` and `staging`) having its own Concourse team, e.g. `govuk-test` concourse
+team for `test` GOV.UK environment.
+
+`fly` uses the concept of `target` to refer to a specific Concourse team. To
+register a new target with `fly`, you do:
+
+```shell
+fly --target <target_name> \
+    login \
+    --team-name <concourse_team> \
+    --concourse-url https://cd.gds-reliability.engineering
+```
+
+where:
+1. `<target_name>` is the name that you want to give to the target. By convention,
+   we use `govuk-<govuk_environment>`, e.g. `govuk_test` for `test` GOV.UK
+   environment
+1. `concourse_team` is the name of an existing Concourse team, which usually
+   follows the same format as `target_name` 
+
+## Deploying Pipelines
+
+Pipelines are deployed in Concourse teams with each GOV.UK environment (e.g.
+`test` and `staging`) having their own team with default variables/secrets
+(see `gds cd secrets ls`).
+
+### Pipeline Deployment
+
+To deploy a [pipeline](./pipelines), you need to run the following commands:
+
+```shell
+cd govuk-infrastructure
+
+fly sp -t <concourse_target> \
+       -p <pipeline_name>
+       -c concourse/pipelines/<pipeline_filename> \
+       -l concourse/parameters/<govuk_environment>/parameters.yml
+```
+
+where:
+1. `<concourse_target>` is the Concourse target that points to the relevant
+   Concourse team for the GOV.UK environment that we want to deploy to
+1. `<pipeline_name>` is the name of the pipeline in Concourse
+2. `<pipeline_filename>` is the filename which contains the pipeline configuration
+3. `<govuk_environment>` is the GOV.UK environment that we want to deploy to

--- a/concourse/parameters/integration/parameters.yml
+++ b/concourse/parameters/integration/parameters.yml
@@ -1,4 +1,4 @@
-workspace: default
 govuk_infrastructure_branch: main
 disable_slack_channel_alerts: false
+skip_db_migrations: true
 background_image: "https://live.staticflickr.com/7486/15537665259_a2d796c7d4_k_d.jpg"

--- a/concourse/parameters/test/parameters.yml
+++ b/concourse/parameters/test/parameters.yml
@@ -1,0 +1,4 @@
+govuk_infrastructure_branch: main
+disable_slack_channel_alerts: false
+skip_db_migrations: false
+background_image: "https://live.staticflickr.com/7486/15537665259_a2d796c7d4_k_d.jpg"

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -377,7 +377,7 @@ jobs:
     - file: govuk-infrastructure/concourse/pipelines/deploy.yml
       set_pipeline: self
       var_files:
-        - govuk-infrastructure/concourse/pipelines/deploy-parameters.yml
+        - govuk-infrastructure/concourse/parameters/((govuk_environment))/parameters.yml
 
   - name: run-terraform
     serial: true
@@ -772,6 +772,7 @@ jobs:
         APPLICATION: publisher
         COMMAND: "bundle exec rails db:migrate"
         VARIANT: web
+        DISABLE: ((skip_db_migrations))
     - in_parallel:
       - task: update-web-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
@@ -878,6 +879,7 @@ jobs:
         APPLICATION: publishing-api
         COMMAND: "bundle exec rails db:migrate"
         VARIANT: web
+        DISABLE: ((skip_db_migrations))
     - in_parallel:
       - task: update-web-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml

--- a/concourse/tasks/run-task.sh
+++ b/concourse/tasks/run-task.sh
@@ -30,6 +30,11 @@ COMMAND=${COMMAND:-"$(cat "run-task-command/run-task-command")"}
 : "${CLUSTER:?CLUSTER not set}"
 : "${VARIANT:?VARIANT not set}"
 
+if [[ "${DISABLE:-false}" == "true" ]]; then
+  echo "Skipping Task"
+  exit 0
+fi
+
 mkdir -p ~/.aws
 
 cat <<EOF > ~/.aws/config

--- a/concourse/tasks/run-task.yml
+++ b/concourse/tasks/run-task.yml
@@ -20,5 +20,6 @@ params:
   CLUSTER: task_runner
   COMMAND: # Place command in run-task-command file or use COMMAND param
   VARIANT:
+  DISABLE: false
 run:
   path: ./src/concourse/tasks/run-task.sh


### PR DESCRIPTION
We do not want DB migrations to be enabled for all GOV.UK environments
in specific scenarios, e.g. testing in integration.  This PR allows us
to toggle that at the environment level via a setting in a parameter
file.

Ref:
1. [trello task](https://trello.com/c/CQ1CdfZV/470-ability-to-turn-off-database-migrations-needed-before-we-point-concourse-at-integration)