### PR TITLE
Trigger app smoke tests on all deploys

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -676,6 +676,12 @@ jobs:
     - in_parallel:
         - <<: *get-smokey-govuk-infrastructure
           passed: [deploy-frontend]
+        - get: frontend-terraform-outputs
+          passed: [deploy-frontend]
+          trigger: true
+        - get: frontend-image
+          passed: [deploy-frontend]
+          trigger: true
         - <<: *get-smokey-app-tf-outputs
     - <<: *get-smokey-task-definition
     - <<: *run-smoke-test
@@ -777,6 +783,12 @@ jobs:
     - in_parallel:
         - <<: *get-smokey-govuk-infrastructure
           passed: [deploy-publisher]
+        - get: publisher-terraform-outputs
+          passed: [deploy-publisher]
+          trigger: true
+        - get: publisher-image
+          passed: [deploy-publisher]
+          trigger: true
         - <<: *get-smokey-app-tf-outputs
     - <<: *get-smokey-task-definition
     - <<: *run-smoke-test
@@ -1140,6 +1152,12 @@ jobs:
     - in_parallel:
         - <<: *get-smokey-govuk-infrastructure
           passed: [deploy-signon]
+        - get: signon-terraform-outputs
+          passed: [deploy-signon]
+          trigger: true
+        - get: signon-image
+          passed: [deploy-signon]
+          trigger: true
         - <<: *get-smokey-app-tf-outputs
     - <<: *get-smokey-task-definition
     - <<: *run-smoke-test


### PR DESCRIPTION
This ensures app smoke tests are triggered when a new image or new task definition config is deployed, which I expect to be the most frequent trigger of smoke tests.

This was mistakenly omitted in PR #253.