### PR TITLE
Update Signon::Client to use new status code

### DIFF
--- a/lib/signon/client.rb
+++ b/lib/signon/client.rb
@@ -106,7 +106,10 @@ module Signon
     end
 
     def already_exists(res)
-      res.code == "400" && JSON.parse(res.body).dig("error") == "Record already exists"
+      # TODO: Remove deprecated check once
+      deprecated = res.code == "400" && JSON.parse(res.body).dig("error") == "Record already exists"
+      new = res.code == "409"
+      new || deprecated
     end
   end
 end

--- a/spec/lib/signon/client_spec.rb
+++ b/spec/lib/signon/client_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe Signon::Client do
     context "when application already exists" do
       it "raises a custom error" do
         stub_req(endpoint).to_return(
-          status: 400,
-          body: JSON.generate(error: "Record already exists"),
+          status: 409,
+          body: JSON.generate(error: "ApplicationAlreadyCreated"),
         )
         expect { response }.to raise_error(Signon::Client::ApplicationAlreadyCreated)
       end


### PR DESCRIPTION
Uses the change in Signon PR #1644. Backwards compatible.