### PR TITLE
monitoring cert should use the root publishing domain

### DIFF
--- a/terraform/modules/monitoring/certs.tf
+++ b/terraform/modules/monitoring/certs.tf
@@ -19,7 +19,7 @@ resource "aws_route53_zone" "monitoring_public" {
 resource "aws_acm_certificate" "monitoring_public" {
   domain_name = "*.${local.monitoring_external_domain}"
 
-  subject_alternative_names = ["*.${var.workspace}.${var.publishing_service_domain}"]
+  subject_alternative_names = ["*.${var.publishing_service_domain}"]
 
   validation_method = "DNS"
 


### PR DESCRIPTION
This change is needed because we keep the root publishing domain because we switch between ECS and EC2 at this level.