### PR TITLE
Move provider config to root module

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/main.tf
+++ b/terraform/deployments/govuk-publishing-platform/main.tf
@@ -17,6 +17,11 @@ terraform {
       source  = "hashicorp/random"
       version = "3.0.0"
     }
+
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.2"
+    }
   }
 }
 
@@ -43,6 +48,8 @@ provider "fastly" {
 }
 
 provider "random" {}
+
+provider "archive" {}
 
 locals {
   vpc_id                       = data.terraform_remote_state.infra_networking.outputs.vpc_id

--- a/terraform/modules/signon_bearer_token/lambda.tf
+++ b/terraform/modules/signon_bearer_token/lambda.tf
@@ -4,8 +4,6 @@ locals {
   permissions          = "signin"
 }
 
-provider "archive" {}
-
 data "archive_file" "bearer_token_rotater" {
   type        = "zip"
   source_file = "${path.module}/../../../lambdas/signon_bearer_token_rotater.rb"

--- a/terraform/modules/signon_bearer_token/main.tf
+++ b/terraform/modules/signon_bearer_token/main.tf
@@ -1,16 +1,3 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 3.30"
-    }
-    archive = {
-      source  = "hashicorp/archive"
-      version = ">= 2.2"
-    }
-  }
-}
-
 locals {
   secret_name = "${var.name}_bearer_token_${var.workspace}"
 }


### PR DESCRIPTION
It's recommended that providers are only defined in root modules, to avoid issues around provider versions.

This should be a no-op.

The motivation for this change is I want to refactor the client of the signon_bearer_token module to use `for_each` on the `module` block. To do this I need to explicitly pass in the parent module's providers to the child module.

https://www.terraform.io/docs/language/modules/develop/providers.html