### PR TITLE
Wait longer for secrets to be set

### DIFF
--- a/lib/tasks/secretsmanager.rake
+++ b/lib/tasks/secretsmanager.rake
@@ -18,7 +18,7 @@ namespace :secretsmanager do
     required_secrets = app_config.dig(variant, "required_secrets")
     secrets = required_secrets.to_h { |arn| [arn, false] }
     attempts = 0
-    max_attempts = 8
+    max_attempts = 10
 
     until secrets.values.all? || attempts == max_attempts
       attempts += 1


### PR DESCRIPTION
This change will increase the amount of time
an app waits for secrets to be set before it
attempts to deploy from ~4mins to ~17mins.

We also re-attempt per app in the deploy pipeline

This should stop those errors we saw this morning
when we destroyed and re-ran the deploy pipeline.