### PR TITLE
concourse iam for integration

### DIFF
--- a/terraform/deployments/concourse-iam/variables.tf
+++ b/terraform/deployments/concourse-iam/variables.tf
@@ -2,3 +2,13 @@ variable "govuk_environment" {
   type        = string
   description = "One of test, integration, staging, production."
 }
+
+variable "production_aws_account_id" {
+  type        = string
+  description = "AWS account ID where Amazon Elastic Container Registry is hosted"
+}
+
+variable "concourse_aws_account_id" {
+  type        = string
+  description = "AWS account ID where Concourse is hosted"
+}

--- a/terraform/deployments/variables/integration/iam.tfvars
+++ b/terraform/deployments/variables/integration/iam.tfvars
@@ -1,3 +1,3 @@
-govuk_environment         = "test"
+govuk_environment         = "integration"
 production_aws_account_id = "172025368201"
 concourse_aws_account_id  = "047969882937"


### PR DESCRIPTION
Parametise the `concourse-iam` terraform deployment and add the variables for integration.

Refs:
1. [trello card](https://trello.com/c/L70eZe2A/471-create-a-concourse-team-with-sufficient-access-to-aws-in-integration)