### PR TITLE
Fixup bootstrapping

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -55,7 +55,7 @@ resources:
     icon: concourse-ci
     source:
       <<: *govuk-infrastructure-source
-      paths: [ concourse/tasks, lib/signon, tasks/app_secrets.rake ]
+      paths: [ concourse/tasks, lib/signon, tasks/secretsmanager.rake, tasks/app_secrets.rake ]
 
   - name: smokey-terraform-outputs
     type: s3

--- a/terraform/modules/signon_bearer_token/lambda.tf
+++ b/terraform/modules/signon_bearer_token/lambda.tf
@@ -35,6 +35,7 @@ resource "aws_lambda_function" "bearer_token" {
     }
   }
 
+  # As recommended in Terraform docs
   depends_on = [
     aws_iam_role_policy_attachment.lambda_logs,
     aws_iam_role_policy_attachment.vpc,

--- a/terraform/modules/signon_bearer_token/main.tf
+++ b/terraform/modules/signon_bearer_token/main.tf
@@ -28,4 +28,7 @@ resource "aws_secretsmanager_secret_rotation" "bearer_token" {
     automatically_after_days = 30
   }
 
+  # Secrets Manager cannot invoke the specified Lambda function
+  # without the lambda permission being created first.
+  depends_on = [aws_lambda_permission.allow_secretsmanager]
 }


### PR DESCRIPTION
Paired with @nsabri1 on this one.

Two changes to prevent the deploy-apps pipeline from raising errors in the morning when we recreate the test environment:

- Fixup lambda rotation dependency
- Add secretsmanager waiter task to the concourse tasks (so the change in #287 will have an effect)