### PR TITLE
Add default background_image of the GOV.UK cake

### DIFF
--- a/concourse/pipelines/deploy-parameters.yml
+++ b/concourse/pipelines/deploy-parameters.yml
@@ -1,3 +1,4 @@
 workspace: default
 govuk_infrastructure_branch: main
 disable_slack_channel_alerts: false
+background_image: "https://live.staticflickr.com/7486/15537665259_a2d796c7d4_k_d.jpg"

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -1,4 +1,7 @@
 ---
+display:
+  background_image: ((background_image))
+
 definitions:
 
 resource_types:


### PR DESCRIPTION
The idea here is that people's individual pipelines can use different
background images, to make them a bit more visually distinct. This should
hopefully avoid someone accidentally doing something in the wrong pipeline, and
also adds fun.

I've use a picture of some cake from GOV.UK's launch (from GDS' Flickr account)
as the default image. Obviously my workspaces will use Doge.

![image](https://user-images.githubusercontent.com/1696784/119017063-84d75380-b992-11eb-8e2c-dace52419a57.png)
