### PR TITLE
Use content-store main image

### DIFF
--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -26,7 +26,7 @@ resources:
     source:
       <<: *git-repo-source
       uri: git@github.com:alphagov/content-store.git
-      branch: master
+      branch: main
 
   - <<: *git-repo
     name: frontend-repo


### PR DESCRIPTION
Main has replaced master as content-store's default branch.