### PR TITLE
Enable DynamoDB Terraform state locking

### DIFF
--- a/concourse/tasks/terraform-plan-govuk-deployment.yml
+++ b/concourse/tasks/terraform-plan-govuk-deployment.yml
@@ -24,4 +24,5 @@ run:
       -var "assume_role_arn=$ASSUME_ROLE_ARN" \
       -var-file ../variables/common.tfvars \
       -var-file ../variables/test/common.tfvars \
-      -var-file ../variables/test/infrastructure.tfvars
+      -var-file ../variables/test/infrastructure.tfvars \
+      -lock=false

--- a/terraform/deployments/govuk-publishing-platform/integration.backend
+++ b/terraform/deployments/govuk-publishing-platform/integration.backend
@@ -2,3 +2,4 @@ bucket  = "govuk-ecs-terraform-integration"
 key     = "projects/govuk.tfstate"
 encrypt = true
 region  = "eu-west-1"
+dynamodb_table = "terraform-lock"

--- a/terraform/deployments/terraform-lock/README.md
+++ b/terraform/deployments/terraform-lock/README.md
@@ -1,0 +1,24 @@
+# Terraform state lock
+
+This provides [DynamoDB State Locking][] for other Terraform deployments. It should
+usually be the first Terraform deployment you apply when bringing up the
+infrastructure in a new AWS account.
+
+A DynamoDB table is created in each GOV.UK environment for Terraform locking.
+
+Applying:
+
+```sh
+terraform init -backend-config=./$ENVIRONMENT.backend
+terraform apply
+```
+
+This creates a table `terraform-lock`.
+
+The table is then used by the S3 backend of `govuk-publishing-platform`,
+in the backend config `dynamodb_table = "terraform-lock"`.
+
+State locking happens automatically.
+See the docs for more detail: https://www.terraform.io/docs/language/state/locking.html
+
+[DynamoDB State Locking]: https://www.terraform.io/docs/language/settings/backends/s3.html#dynamodb-state-locking

--- a/terraform/deployments/terraform-lock/main.tf
+++ b/terraform/deployments/terraform-lock/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  # Backend config in ./<env>.backend file
+  backend "s3" {
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.33"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "aws_dynamodb_table" "terraform_state_lock" {
+  name         = "terraform-lock"
+  hash_key     = "LockID"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    chargeable_entity    = "terraform-lock"
+    project              = "replatforming"
+    repository           = "govuk-infrastructure"
+    terraform_deployment = "terraform-lock"
+    terraform_workspace  = terraform.workspace
+  }
+}

--- a/terraform/deployments/terraform-lock/test.backend
+++ b/terraform/deployments/terraform-lock/test.backend
@@ -1,5 +1,4 @@
 bucket  = "govuk-terraform-test"
-key     = "projects/govuk.tfstate"
+key     = "projects/terraform-lock.tfstate"
 encrypt = true
 region  = "eu-west-1"
-dynamodb_table = "terraform-lock"


### PR DESCRIPTION
This enables locking on our Terraform state files.

The effect of this will be that one cannot perform concurrent operations on a Terraform statefile, such as applying and destroying concurrently.

https://www.terraform.io/docs/language/state/locking.html

You'll see an error when attempting to apply terraform if a lock has already been taken:

```
Error: Error locking state: Error acquiring the state lock: ConditionalCheckFailedException: The conditional request failed
Lock Info:
  ID:        12345
  Path:      govuk-terraform-test/env:/bill/projects/govuk.tfstate
  Operation: OperationTypeApply
  Who:       bill
  Version:   0.14.6
  Created:   2021-05-21 10:22:00.72746 +0000 UTC
  Info:      
```

https://trello.com/c/dR54Lh1c/518-enable-locking-on-our-terraform-statefiles