### PR TITLE
Integration pipelines

### DIFF
--- a/concourse/parameters/ci/ci.yml
+++ b/concourse/parameters/ci/ci.yml
@@ -1,0 +1,2 @@
+govuk_infrastructure_branch: main
+concourse_ci_role_arn: arn:aws:iam::430354129336:role/govuk-ci-concourse

--- a/concourse/parameters/integration/deploy.yml
+++ b/concourse/parameters/integration/deploy.yml
@@ -1,4 +1,5 @@
 govuk_infrastructure_branch: main
+concourse_deployer_role_arn: arn:aws:iam::210287912431:role/govuk-concourse-deployer
 workspace: default
 disable_slack_channel_alerts: false
 skip_db_migrations: true

--- a/concourse/parameters/integration/monitoring.yml
+++ b/concourse/parameters/integration/monitoring.yml
@@ -1,0 +1,2 @@
+govuk_infrastructure_branch: main
+concourse_deployer_role_arn: arn:aws:iam::210287912431:role/govuk-concourse-deployer

--- a/concourse/parameters/test/deploy.yml
+++ b/concourse/parameters/test/deploy.yml
@@ -1,4 +1,5 @@
 govuk_infrastructure_branch: main
+concourse_deployer_role_arn: arn:aws:iam::430354129336:role/govuk-concourse-deployer
 workspace: default
 disable_slack_channel_alerts: false
 skip_db_migrations: false

--- a/concourse/parameters/test/monitoring.yml
+++ b/concourse/parameters/test/monitoring.yml
@@ -1,0 +1,2 @@
+govuk_infrastructure_branch: main
+concourse_deployer_role_arn: arn:aws:iam::430354129336:role/govuk-concourse-deployer

--- a/concourse/pipelines/ci.yml
+++ b/concourse/pipelines/ci.yml
@@ -41,6 +41,8 @@ jobs:
       params: {status: pending, context: terraform-plan-govuk-deployment}
     - task: terraform-plan
       file: govuk-infrastructure-commit/repo/concourse/tasks/terraform-plan-govuk-deployment.yml
+      params:
+        ASSUME_ROLE_ARN: ((concourse_ci_role_arn))
       on_success:
         put: govuk-infrastructure-commit
         params: {status: success, context: terraform-plan-govuk-deployment}
@@ -62,6 +64,8 @@ jobs:
       params: {status: pending, context: terraform-plan-govuk-deployment}
     - task: terraform-plan
       file: govuk-infrastructure-commit/repo/concourse/tasks/terraform-plan-monitoring.yml
+      params:
+        ASSUME_ROLE_ARN: ((concourse_ci_role_arn))
       on_success:
         put: govuk-infrastructure-commit
         params: {status: success, context: terraform-plan-monitoring}

--- a/concourse/pipelines/ci.yml
+++ b/concourse/pipelines/ci.yml
@@ -21,7 +21,7 @@ resources:
   - icon: github
     name: govuk-infrastructure
     source:
-      branch: main
+      branch: ((govuk_infrastructure_branch))
       uri: https://github.com/alphagov/govuk-infrastructure
     type: git
 
@@ -32,6 +32,8 @@ jobs:
       trigger: true
     - file: govuk-infrastructure/concourse/pipelines/ci.yml
       set_pipeline: ci-govuk-infrastructure-main
+      var_files:
+        - govuk-infrastructure/concourse/parameters/ci/ci.yml
 
   - name: terraform-plan-govuk-deployment
     plan:

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -639,6 +639,7 @@ jobs:
         params:
          APPLICATION: frontend
          VARIANT: draft
+         ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -648,6 +649,7 @@ jobs:
         params:
          APPLICATION: frontend
          VARIANT: live
+         ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - task: update-draft-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
@@ -757,6 +759,7 @@ jobs:
           APPLICATION: publisher
           VARIANT: web
           GOVUK_ENVIRONMENT: ((govuk_environment))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-worker-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -767,6 +770,7 @@ jobs:
           APPLICATION: publisher
           VARIANT: worker
           GOVUK_ENVIRONMENT: ((govuk_environment))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-secretsmanager-creds
         params:
@@ -870,6 +874,7 @@ jobs:
           APPLICATION: publishing-api
           VARIANT: web
           GOVUK_ENVIRONMENT: ((govuk_environment))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-worker-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -880,6 +885,7 @@ jobs:
           APPLICATION: publishing-api
           VARIANT: worker
           GOVUK_ENVIRONMENT: ((govuk_environment))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-secretsmanager-creds
         params:
@@ -968,6 +974,7 @@ jobs:
         params:
           APPLICATION: content-store
           VARIANT: draft
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -977,6 +984,7 @@ jobs:
         params:
           APPLICATION: content-store
           VARIANT: live
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-secretsmanager-creds
         params:
@@ -1044,6 +1052,7 @@ jobs:
         params:
           APPLICATION: router
           VARIANT: draft
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -1053,6 +1062,7 @@ jobs:
         params:
           APPLICATION: router
           VARIANT: live
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - task: update-draft-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
@@ -1114,6 +1124,7 @@ jobs:
         params:
           APPLICATION: router-api
           VARIANT: draft
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -1123,6 +1134,7 @@ jobs:
         params:
           APPLICATION: router-api
           VARIANT: live
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - task: update-draft-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
@@ -1184,6 +1196,7 @@ jobs:
           APPLICATION: signon
           GOVUK_ENVIRONMENT: ((govuk_environment))
           VARIANT: web
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         input_mapping:
           app-image: signon-image
         output_mapping:
@@ -1272,6 +1285,7 @@ jobs:
         APPLICATION: smokey
         GOVUK_ENVIRONMENT: ((govuk_environment))
         VARIANT: default
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -1308,6 +1322,7 @@ jobs:
         params:
           APPLICATION: static
           VARIANT: draft
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -1317,6 +1332,7 @@ jobs:
         params:
           APPLICATION: static
           VARIANT: live
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - task: update-draft-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
@@ -1371,6 +1387,7 @@ jobs:
       params:
         APPLICATION: authenticating-proxy
         VARIANT: web
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       input_mapping:

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -337,8 +337,8 @@ jobs:
         inputs:
         - name: govuk-infrastructure
         params:
-          AWS_REGION: eu-west-1
           ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          AWS_REGION: eu-west-1
           WORKSPACE: ((workspace))
           GOVUK_ENVIRONMENT: ((govuk_environment))
         platform: linux
@@ -378,7 +378,7 @@ jobs:
     - file: govuk-infrastructure/concourse/pipelines/deploy.yml
       set_pipeline: self
       var_files:
-        - govuk-infrastructure/concourse/parameters/((govuk_environment))/parameters.yml
+        - govuk-infrastructure/concourse/parameters/((govuk_environment))/deploy.yml
 
   - name: run-terraform
     serial: true
@@ -626,47 +626,47 @@ jobs:
         input_mapping:
           app-image: frontend-image
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/frontend
           S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-frontends-rails-assets/assets/frontend/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
           WORKSPACE: ((workspace))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
           app-image: frontend-image
         output_mapping:
-         task-definition-arn: draft-task-definition-arn
+          task-definition-arn: draft-task-definition-arn
         params:
-         APPLICATION: frontend
-         VARIANT: draft
-         ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          APPLICATION: frontend
+          VARIANT: draft
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
           app-image: frontend-image
         output_mapping:
-         task-definition-arn: live-task-definition-arn
+          task-definition-arn: live-task-definition-arn
         params:
-         APPLICATION: frontend
-         VARIANT: live
-         ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          APPLICATION: frontend
+          VARIANT: live
     - in_parallel:
       - task: update-draft-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
-         task-definition-arn: draft-task-definition-arn
+          task-definition-arn: draft-task-definition-arn
         params:
-         ECS_SERVICE: draft-frontend
-         WORKSPACE: ((workspace))
-         ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          ECS_SERVICE: draft-frontend
+          WORKSPACE: ((workspace))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
-         task-definition-arn: live-task-definition-arn
+          task-definition-arn: live-task-definition-arn
         params:
-         ECS_SERVICE: frontend
-         WORKSPACE: ((workspace))
-         ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          ECS_SERVICE: frontend
+          WORKSPACE: ((workspace))
     - in_parallel:
       - &await-secretsmanager-creds
         task: await-creds-in-secrets-manager
@@ -688,9 +688,9 @@ jobs:
         attempts: 4
         timeout: 5m
         params: &await-deploy-complete-params
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           ECS_SERVICE: frontend
           WORKSPACE: ((workspace))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - <<: *await-deploy-complete
         task: await-deploy-complete-draft
         params:
@@ -745,10 +745,10 @@ jobs:
         input_mapping:
           app-image: publisher-image
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/publisher
           S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-backends-rails-assets/assets/publisher/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
           WORKSPACE: ((workspace))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-web-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -756,10 +756,10 @@ jobs:
         output_mapping:
           task-definition-arn: web-task-definition-arn
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: publisher
           VARIANT: web
           GOVUK_ENVIRONMENT: ((govuk_environment))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-worker-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -767,10 +767,10 @@ jobs:
         output_mapping:
           task-definition-arn: worker-task-definition-arn
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: publisher
           VARIANT: worker
           GOVUK_ENVIRONMENT: ((govuk_environment))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-secretsmanager-creds
         params:
@@ -1122,9 +1122,9 @@ jobs:
         output_mapping:
           task-definition-arn: draft-task-definition-arn
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: router-api
           VARIANT: draft
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -1132,26 +1132,26 @@ jobs:
         output_mapping:
           task-definition-arn: live-task-definition-arn
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: router-api
           VARIANT: live
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - task: update-draft-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
           task-definition-arn: draft-task-definition-arn
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           ECS_SERVICE: draft-router-api
           WORKSPACE: ((workspace))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
           task-definition-arn: live-task-definition-arn
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           ECS_SERVICE: router-api
           WORKSPACE: ((workspace))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-deploy-complete
         task: await-deploy-complete-draft
@@ -1186,17 +1186,17 @@ jobs:
         input_mapping:
           app-image: signon-image
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/signon
           S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-backends-rails-assets/assets/signon/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
           WORKSPACE: ((workspace))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: signon
           GOVUK_ENVIRONMENT: ((govuk_environment))
           VARIANT: web
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         input_mapping:
           app-image: signon-image
         output_mapping:
@@ -1205,9 +1205,9 @@ jobs:
     - task: make-bootstrap-command
       file: govuk-infrastructure/concourse/tasks/make-signon-bootstrap-command.yml
       params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         GOVUK_ENVIRONMENT: ((govuk_environment))
         WORKSPACE: ((workspace))
-        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - task: create-signon-resources
       file: govuk-infrastructure/concourse/tasks/run-task.yml
       input_mapping:
@@ -1222,10 +1222,10 @@ jobs:
       input_mapping:
         task-definition-arn: task-definition-arn
       params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         ECS_SERVICE: signon
         GOVUK_ENVIRONMENT: ((govuk_environment))
         WORKSPACE: ((workspace))
-        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - <<: *await-deploy-complete
       task: await-deploy-complete
       params:
@@ -1282,10 +1282,10 @@ jobs:
       input_mapping:
         app-image: smokey-image
       params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         APPLICATION: smokey
         GOVUK_ENVIRONMENT: ((govuk_environment))
         VARIANT: default
-        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     serial: true
     on_failure:
       <<: *notify-slack-failure
@@ -1309,10 +1309,10 @@ jobs:
         input_mapping:
           app-image: static-image
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/static
           S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-frontends-rails-assets/assets/static/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
           WORKSPACE: ((workspace))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -1320,9 +1320,9 @@ jobs:
         output_mapping:
           task-definition-arn: draft-task-definition-arn
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: static
           VARIANT: draft
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -1330,26 +1330,26 @@ jobs:
         output_mapping:
           task-definition-arn: live-task-definition-arn
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: static
           VARIANT: live
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - task: update-draft-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
           task-definition-arn: draft-task-definition-arn
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           ECS_SERVICE: draft-static
           WORKSPACE: ((workspace))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
           task-definition-arn: live-task-definition-arn
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           ECS_SERVICE: static
           WORKSPACE: ((workspace))
-          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-deploy-complete
         task: await-deploy-complete-live
@@ -1385,17 +1385,17 @@ jobs:
       output_mapping:
         task-definition-arn: task-definition-arn
       params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         APPLICATION: authenticating-proxy
         VARIANT: web
-        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - task: update-ecs-service
       file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
       input_mapping:
         task-definition-arn: task-definition-arn
       params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         ECS_SERVICE: authenticating-proxy
         WORKSPACE: ((workspace))
-        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - <<: *await-deploy-complete
       task: await-deploy-complete-live
       params:

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -338,8 +338,9 @@ jobs:
         - name: govuk-infrastructure
         params:
           AWS_REGION: eu-west-1
-          ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           WORKSPACE: ((workspace))
+          GOVUK_ENVIRONMENT: ((govuk_environment))
         platform: linux
         image_resource:
           type: docker-image
@@ -359,15 +360,15 @@ jobs:
 
               cd govuk-infrastructure/terraform/deployments/govuk-publishing-platform
 
-              terraform init -backend-config=./test.backend -backend-config "role_arn=$ASSUME_ROLE_ARN"
+              terraform init -backend-config "./${GOVUK_ENVIRONMENT}.backend" -backend-config "role_arn=$ASSUME_ROLE_ARN"
 
               terraform workspace select "$WORKSPACE"
 
               terraform destroy  \
               -var "assume_role_arn=$ASSUME_ROLE_ARN" \
               -var-file ../variables/common.tfvars \
-              -var-file ../variables/test/common.tfvars \
-              -var-file ../variables/test/infrastructure.tfvars \
+              -var-file "../variables/${GOVUK_ENVIRONMENT}/common.tfvars" \
+              -var-file "../variables/${GOVUK_ENVIRONMENT}/infrastructure.tfvars" \
               -auto-approve
 
   - name: update-pipeline
@@ -457,8 +458,9 @@ jobs:
           optional: true
         params:
           AWS_REGION: eu-west-1
-          ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           WORKSPACE: ((workspace))
+          GOVUK_ENVIRONMENT: ((govuk_environment))
         platform: linux
         image_resource:
           type: docker-image
@@ -478,15 +480,15 @@ jobs:
 
             cd govuk-infrastructure/terraform/deployments/govuk-publishing-platform
 
-            terraform init -backend-config=./test.backend -backend-config "role_arn=$ASSUME_ROLE_ARN"
+            terraform init -backend-config "./${GOVUK_ENVIRONMENT}.backend" -backend-config "role_arn=$ASSUME_ROLE_ARN"
 
             terraform workspace select "$WORKSPACE" || terraform workspace new "$WORKSPACE"
 
             terraform apply \
               -var "assume_role_arn=$ASSUME_ROLE_ARN" \
               -var-file ../variables/common.tfvars \
-              -var-file ../variables/test/common.tfvars \
-              -var-file ../variables/test/infrastructure.tfvars \
+              -var-file "../variables/${GOVUK_ENVIRONMENT}/common.tfvars" \
+              -var-file "../variables/${GOVUK_ENVIRONMENT}/infrastructure.tfvars" \
               -auto-approve
 
             terraform output -json > "$root_dir/govuk-terraform-outputs/govuk-terraform-outputs.json"
@@ -564,7 +566,7 @@ jobs:
       put: deploy-slack-channel
       params:
         channel: "#govuk-deploy-alerts" # TODO: Alert owner Slack channels in future, i.e. ((search_team_slack))
-        username: 'test-((workspace)) deploy-apps' # TODO: Change `test` to ((govuk_enviroment))
+        username: '((govuk_environment))-((workspace)) deploy-apps'
         icon_emoji: ':concourse:'
         silent: true
         text: |
@@ -592,6 +594,7 @@ jobs:
       task: run-smoke-tests
       file: govuk-infrastructure/concourse/tasks/run-task.yml
       params: &smoke-tests-params
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         APPLICATION: smokey
         VARIANT: default
         COMMAND: bundle exec cucumber --profile test --strict-undefined -t @replatforming -t \"not @notreplatforming\"
@@ -615,6 +618,7 @@ jobs:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: frontend
           VARIANT: live
       - task: upload-rails-assets
@@ -623,8 +627,9 @@ jobs:
           app-image: frontend-image
         params:
           IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/frontend
-          S3_BUCKET_PATH_PATTERN: s3://govuk-test-%s-frontends-rails-assets/assets/frontend/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
+          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-frontends-rails-assets/assets/frontend/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -651,6 +656,7 @@ jobs:
         params:
          ECS_SERVICE: draft-frontend
          WORKSPACE: ((workspace))
+         ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
@@ -658,16 +664,19 @@ jobs:
         params:
          ECS_SERVICE: frontend
          WORKSPACE: ((workspace))
+         ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - &await-secretsmanager-creds
         task: await-creds-in-secrets-manager
         file: govuk-infrastructure/concourse/tasks/await-creds-in-secretsmanager.yml
         attempts: 3
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: frontend
           VARIANT: live
       - <<: *await-secretsmanager-creds
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: frontend
           VARIANT: draft
     - in_parallel:
@@ -679,6 +688,7 @@ jobs:
         params: &await-deploy-complete-params
           ECS_SERVICE: frontend
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - <<: *await-deploy-complete
         task: await-deploy-complete-draft
         params:
@@ -725,6 +735,7 @@ jobs:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: publisher
           VARIANT: web
       - task: upload-rails-assets
@@ -733,8 +744,9 @@ jobs:
           app-image: publisher-image
         params:
           IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/publisher
-          S3_BUCKET_PATH_PATTERN: s3://govuk-test-%s-backends-rails-assets/assets/publisher/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
+          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-backends-rails-assets/assets/publisher/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-web-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -744,7 +756,7 @@ jobs:
         params:
           APPLICATION: publisher
           VARIANT: web
-          GOVUK_ENVIRONMENT: test
+          GOVUK_ENVIRONMENT: ((govuk_environment))
       - task: update-worker-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -754,14 +766,16 @@ jobs:
         params:
           APPLICATION: publisher
           VARIANT: worker
-          GOVUK_ENVIRONMENT: test
+          GOVUK_ENVIRONMENT: ((govuk_environment))
     - in_parallel:
       - <<: *await-secretsmanager-creds
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: publisher
           VARIANT: web
       - <<: *await-secretsmanager-creds
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: publisher
           VARIANT: worker
     - task: run-db-migrations
@@ -769,6 +783,7 @@ jobs:
       input_mapping:
         task-definition-arn: web-task-definition-arn
       params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         APPLICATION: publisher
         COMMAND: "bundle exec rails db:migrate"
         VARIANT: web
@@ -781,6 +796,7 @@ jobs:
         params:
           ECS_SERVICE: publisher-web
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-worker-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
@@ -788,6 +804,7 @@ jobs:
         params:
           ECS_SERVICE: publisher-worker
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-deploy-complete
         task: await-deploy-complete-web
@@ -840,6 +857,7 @@ jobs:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: publishing-api
           VARIANT: web
       - task: update-web-task-definition
@@ -851,7 +869,7 @@ jobs:
         params:
           APPLICATION: publishing-api
           VARIANT: web
-          GOVUK_ENVIRONMENT: test
+          GOVUK_ENVIRONMENT: ((govuk_environment))
       - task: update-worker-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -861,14 +879,16 @@ jobs:
         params:
           APPLICATION: publishing-api
           VARIANT: worker
-          GOVUK_ENVIRONMENT: test
+          GOVUK_ENVIRONMENT: ((govuk_environment))
     - in_parallel:
       - <<: *await-secretsmanager-creds
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: publishing-api
           VARIANT: web
       - <<: *await-secretsmanager-creds
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: publishing-api
           VARIANT: worker
     - task: run-db-migrations
@@ -876,6 +896,7 @@ jobs:
       input_mapping:
         task-definition-arn: web-task-definition-arn
       params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         APPLICATION: publishing-api
         COMMAND: "bundle exec rails db:migrate"
         VARIANT: web
@@ -886,6 +907,7 @@ jobs:
         params:
           ECS_SERVICE: publishing-api-web
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         input_mapping:
           task-definition-arn: web-task-definition-arn
       - task: update-worker-ecs-service
@@ -893,6 +915,7 @@ jobs:
         params:
           ECS_SERVICE: publishing-api-worker
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         input_mapping:
           task-definition-arn: worker-task-definition-arn
     - in_parallel:
@@ -927,11 +950,13 @@ jobs:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: content-store
           VARIANT: draft
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: content-store
           VARIANT: live
       - task: update-draft-task-definition
@@ -955,11 +980,13 @@ jobs:
     - in_parallel:
       - <<: *await-secretsmanager-creds
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: content-store
           VARIANT: live
       - task: await-creds-in-secrets-manager
         file: govuk-infrastructure/concourse/tasks/await-creds-in-secretsmanager.yml
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: content-store
           VARIANT: draft
     - in_parallel:
@@ -970,6 +997,7 @@ jobs:
         params:
           ECS_SERVICE: content-store
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-draft-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
@@ -977,6 +1005,7 @@ jobs:
         params:
           ECS_SERVICE: draft-content-store
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-deploy-complete
         task: await-deploy-complete-live
@@ -1032,6 +1061,7 @@ jobs:
         params:
           ECS_SERVICE: draft-router
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
@@ -1039,6 +1069,7 @@ jobs:
         params:
           ECS_SERVICE: router
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-deploy-complete
         task: await-deploy-complete-draft
@@ -1071,6 +1102,7 @@ jobs:
     - in_parallel:
       - <<: *await-secretsmanager-creds
         params:
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: router-api
           VARIANT: live
       - task: update-draft-task-definition
@@ -1099,6 +1131,7 @@ jobs:
         params:
           ECS_SERVICE: draft-router-api
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
@@ -1106,6 +1139,7 @@ jobs:
         params:
           ECS_SERVICE: router-api
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-deploy-complete
         task: await-deploy-complete-draft
@@ -1141,13 +1175,14 @@ jobs:
           app-image: signon-image
         params:
           IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/signon
-          S3_BUCKET_PATH_PATTERN: s3://govuk-test-%s-backends-rails-assets/assets/signon/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
+          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-backends-rails-assets/assets/signon/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         params:
           APPLICATION: signon
-          GOVUK_ENVIRONMENT: test
+          GOVUK_ENVIRONMENT: ((govuk_environment))
           VARIANT: web
         input_mapping:
           app-image: signon-image
@@ -1157,14 +1192,16 @@ jobs:
     - task: make-bootstrap-command
       file: govuk-infrastructure/concourse/tasks/make-signon-bootstrap-command.yml
       params:
-        GOVUK_ENVIRONMENT: test
+        GOVUK_ENVIRONMENT: ((govuk_environment))
         WORKSPACE: ((workspace))
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - task: create-signon-resources
       file: govuk-infrastructure/concourse/tasks/run-task.yml
       input_mapping:
         task-definition-arn: task-definition-arn
         run-task-command: run-task-command
       params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         APPLICATION: signon
         VARIANT: web
     - task: update-ecs-service
@@ -1173,8 +1210,9 @@ jobs:
         task-definition-arn: task-definition-arn
       params:
         ECS_SERVICE: signon
-        GOVUK_ENVIRONMENT: test
+        GOVUK_ENVIRONMENT: ((govuk_environment))
         WORKSPACE: ((workspace))
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - <<: *await-deploy-complete
       task: await-deploy-complete
       params:
@@ -1186,6 +1224,7 @@ jobs:
       input_mapping:
         app-terraform-outputs: app-terraform-outputs
       params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         APPLICATION: signon
         VARIANT: web
     serial: true
@@ -1231,7 +1270,7 @@ jobs:
         app-image: smokey-image
       params:
         APPLICATION: smokey
-        GOVUK_ENVIRONMENT: test
+        GOVUK_ENVIRONMENT: ((govuk_environment))
         VARIANT: default
     serial: true
     on_failure:
@@ -1257,8 +1296,9 @@ jobs:
           app-image: static-image
         params:
           IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/static
-          S3_BUCKET_PATH_PATTERN: s3://govuk-test-%s-frontends-rails-assets/assets/static/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
+          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-frontends-rails-assets/assets/static/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
         input_mapping:
@@ -1285,6 +1325,7 @@ jobs:
         params:
           ECS_SERVICE: draft-static
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml
         input_mapping:
@@ -1292,6 +1333,7 @@ jobs:
         params:
           ECS_SERVICE: static
           WORKSPACE: ((workspace))
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - in_parallel:
       - <<: *await-deploy-complete
         task: await-deploy-complete-live
@@ -1336,6 +1378,7 @@ jobs:
       params:
         ECS_SERVICE: authenticating-proxy
         WORKSPACE: ((workspace))
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
     - <<: *await-deploy-complete
       task: await-deploy-complete-live
       params:

--- a/concourse/pipelines/monitoring.yml
+++ b/concourse/pipelines/monitoring.yml
@@ -45,7 +45,8 @@ jobs:
         - name: govuk-infrastructure
         params:
           AWS_REGION: eu-west-1
-          ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          GOVUK_ENVIRONMENT: ((govuk_environment))
         platform: linux
         image_resource:
           type: docker-image
@@ -62,11 +63,11 @@ jobs:
           - |
             set -eu
 
-            terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+            terraform init -backend-config "./${GOVUK_ENVIRONMENT}.backend" -backend-config "role_arn=$ASSUME_ROLE_ARN"
             terraform apply \
               -var "assume_role_arn=$ASSUME_ROLE_ARN" \
               -var-file ../../variables/common.tfvars \
-              -var-file ../../variables/test/common.tfvars \
+              -var-file "../../variables/${GOVUK_ENVIRONMENT}/common.tfvars" \
               -auto-approve
 
   - name: configure-grafana
@@ -82,7 +83,8 @@ jobs:
           path: src
         params:
           AWS_REGION: eu-west-1
-          ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          GOVUK_ENVIRONMENT: ((govuk_environment))
         platform: linux
         image_resource:
           type: docker-image
@@ -107,7 +109,7 @@ jobs:
               terraform apply -var "assume_role_arn=$ASSUME_ROLE_ARN" -auto-approve
             }
 
-            terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+            terraform init -backend-config "./${GOVUK_ENVIRONMENT}.backend" -backend-config "role_arn=$ASSUME_ROLE_ARN"
 
             if ! terraform_apply; then
                 # See bug https://github.com/grafana/terraform-provider-grafana/issues/129

--- a/concourse/pipelines/monitoring.yml
+++ b/concourse/pipelines/monitoring.yml
@@ -5,7 +5,7 @@ resources:
   - icon: github
     name: govuk-infrastructure
     source:
-      branch: main
+      branch: ((govuk_infrastructure_branch))
       uri: https://github.com/alphagov/govuk-infrastructure
     type: git
 
@@ -32,6 +32,8 @@ jobs:
       trigger: true
     - file: govuk-infrastructure/concourse/pipelines/monitoring.yml
       set_pipeline: monitoring
+      var_files:
+        - govuk-infrastructure/concourse/parameters/((govuk_environment))/monitoring.yml
 
   - name: deploy-monitoring
     plan:

--- a/concourse/tasks/await-creds-in-secretsmanager.yml
+++ b/concourse/tasks/await-creds-in-secretsmanager.yml
@@ -11,7 +11,7 @@ inputs:
   - name: govuk-infrastructure
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
   APPLICATION:
   VARIANT:
 run:

--- a/concourse/tasks/await-creds-in-secretsmanager.yml
+++ b/concourse/tasks/await-creds-in-secretsmanager.yml
@@ -11,7 +11,7 @@ inputs:
   - name: govuk-infrastructure
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+  ASSUME_ROLE_ARN:
   APPLICATION:
   VARIANT:
 run:

--- a/concourse/tasks/await-deploy-complete.yml
+++ b/concourse/tasks/await-deploy-complete.yml
@@ -11,7 +11,7 @@ inputs:
     path: src
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
   ECS_SERVICE:
   WORKSPACE:
 run:

--- a/concourse/tasks/await-deploy-complete.yml
+++ b/concourse/tasks/await-deploy-complete.yml
@@ -11,7 +11,7 @@ inputs:
     path: src
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+  ASSUME_ROLE_ARN:
   ECS_SERVICE:
   WORKSPACE:
 run:

--- a/concourse/tasks/bootstrap-app-secrets.yml
+++ b/concourse/tasks/bootstrap-app-secrets.yml
@@ -11,7 +11,7 @@ inputs:
   - name: govuk-infrastructure
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
   APPLICATION:
   VARIANT:
 run:

--- a/concourse/tasks/bootstrap-app-secrets.yml
+++ b/concourse/tasks/bootstrap-app-secrets.yml
@@ -11,7 +11,7 @@ inputs:
   - name: govuk-infrastructure
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+  ASSUME_ROLE_ARN:
   APPLICATION:
   VARIANT:
 run:

--- a/concourse/tasks/bootstrap-oauth-apps.yml
+++ b/concourse/tasks/bootstrap-oauth-apps.yml
@@ -11,7 +11,7 @@ inputs:
   - name: govuk-infrastructure
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
   APPLICATION:
   VARIANT:
 run:

--- a/concourse/tasks/bootstrap-oauth-apps.yml
+++ b/concourse/tasks/bootstrap-oauth-apps.yml
@@ -11,7 +11,7 @@ inputs:
   - name: govuk-infrastructure
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+  ASSUME_ROLE_ARN:
   APPLICATION:
   VARIANT:
 run:

--- a/concourse/tasks/make-signon-bootstrap-command.yml
+++ b/concourse/tasks/make-signon-bootstrap-command.yml
@@ -12,7 +12,7 @@ inputs:
 outputs:
   - name: run-task-command
 params:
-  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+  ASSUME_ROLE_ARN:
   AWS_REGION: eu-west-1
   GOVUK_ENVIRONMENT:
   WORKSPACE:

--- a/concourse/tasks/make-signon-bootstrap-command.yml
+++ b/concourse/tasks/make-signon-bootstrap-command.yml
@@ -12,7 +12,7 @@ inputs:
 outputs:
   - name: run-task-command
 params:
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
   AWS_REGION: eu-west-1
   GOVUK_ENVIRONMENT:
   WORKSPACE:

--- a/concourse/tasks/run-task.yml
+++ b/concourse/tasks/run-task.yml
@@ -15,7 +15,7 @@ inputs:
     optional: true
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+  ASSUME_ROLE_ARN:
   APPLICATION:
   CLUSTER: task_runner
   COMMAND: # Place command in run-task-command file or use COMMAND param

--- a/concourse/tasks/run-task.yml
+++ b/concourse/tasks/run-task.yml
@@ -15,7 +15,7 @@ inputs:
     optional: true
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
   APPLICATION:
   CLUSTER: task_runner
   COMMAND: # Place command in run-task-command file or use COMMAND param

--- a/concourse/tasks/terraform-plan-govuk-deployment.yml
+++ b/concourse/tasks/terraform-plan-govuk-deployment.yml
@@ -9,7 +9,7 @@ image_resource:
 inputs:
   - name: govuk-infrastructure-commit
 params:
-  ASSUME_ROLE_ARN: ((concourse_ci_role_arn))
+  ASSUME_ROLE_ARN:
   AWS_REGION: eu-west-1
   TF_IN_AUTOMATION: true
 run:

--- a/concourse/tasks/terraform-plan-govuk-deployment.yml
+++ b/concourse/tasks/terraform-plan-govuk-deployment.yml
@@ -9,7 +9,7 @@ image_resource:
 inputs:
   - name: govuk-infrastructure-commit
 params:
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-ci-concourse'
+  ASSUME_ROLE_ARN: ((concourse_ci_role_arn))
   AWS_REGION: eu-west-1
   TF_IN_AUTOMATION: true
 run:

--- a/concourse/tasks/terraform-plan-monitoring.yml
+++ b/concourse/tasks/terraform-plan-monitoring.yml
@@ -9,7 +9,7 @@ image_resource:
 inputs:
   - name: govuk-infrastructure-commit
 params:
-  ASSUME_ROLE_ARN: ((concourse_ci_role_arn))
+  ASSUME_ROLE_ARN:
   AWS_REGION: eu-west-1
   TF_IN_AUTOMATION: true
 run:

--- a/concourse/tasks/terraform-plan-monitoring.yml
+++ b/concourse/tasks/terraform-plan-monitoring.yml
@@ -19,7 +19,7 @@ run:
   - '-c'
   - |
     set -eu
-    terraform init -backend-config "role_arn=$ASSUME_ROLE_ARN"
+    terraform init -backend-config=./test.backend -backend-config "role_arn=$ASSUME_ROLE_ARN"
     terraform plan \
       -var "assume_role_arn=$ASSUME_ROLE_ARN" \
       -var-file ../../variables/common.tfvars \

--- a/concourse/tasks/terraform-plan-monitoring.yml
+++ b/concourse/tasks/terraform-plan-monitoring.yml
@@ -9,7 +9,7 @@ image_resource:
 inputs:
   - name: govuk-infrastructure-commit
 params:
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-ci-concourse'
+  ASSUME_ROLE_ARN: ((concourse_ci_role_arn))
   AWS_REGION: eu-west-1
   TF_IN_AUTOMATION: true
 run:

--- a/concourse/tasks/update-ecs-service.yml
+++ b/concourse/tasks/update-ecs-service.yml
@@ -12,7 +12,7 @@ inputs:
   - name: task-definition-arn
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
   ECS_SERVICE:
   WORKSPACE:
 run:

--- a/concourse/tasks/update-ecs-service.yml
+++ b/concourse/tasks/update-ecs-service.yml
@@ -12,7 +12,7 @@ inputs:
   - name: task-definition-arn
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+  ASSUME_ROLE_ARN:
   ECS_SERVICE:
   WORKSPACE:
 run:

--- a/concourse/tasks/update-task-definition.yml
+++ b/concourse/tasks/update-task-definition.yml
@@ -18,7 +18,7 @@ outputs:
   - name: task-definition-arn
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
   APPLICATION:
   VARIANT:
   REGISTRY: '172025368201.dkr.ecr.eu-west-1.amazonaws.com'

--- a/concourse/tasks/update-task-definition.yml
+++ b/concourse/tasks/update-task-definition.yml
@@ -18,7 +18,7 @@ outputs:
   - name: task-definition-arn
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+  ASSUME_ROLE_ARN:
   APPLICATION:
   VARIANT:
   REGISTRY: '172025368201.dkr.ecr.eu-west-1.amazonaws.com'

--- a/concourse/tasks/upload-rails-assets.yml
+++ b/concourse/tasks/upload-rails-assets.yml
@@ -12,7 +12,7 @@ inputs:
   - name: app-image
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: 'arn:aws:iam::430354129336:role/govuk-concourse-deployer'
+  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
   IMAGE_ASSETS_PATH:
   S3_BUCKET_PATH_PATTERN:
   WORKSPACE:

--- a/concourse/tasks/upload-rails-assets.yml
+++ b/concourse/tasks/upload-rails-assets.yml
@@ -12,7 +12,7 @@ inputs:
   - name: app-image
 params:
   AWS_REGION: eu-west-1
-  ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+  ASSUME_ROLE_ARN:
   IMAGE_ASSETS_PATH:
   S3_BUCKET_PATH_PATTERN:
   WORKSPACE:

--- a/terraform/deployments/monitoring/grafana/integration.backend
+++ b/terraform/deployments/monitoring/grafana/integration.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-integration"
+key     = "projects/grafana.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/deployments/monitoring/grafana/main.tf
+++ b/terraform/deployments/monitoring/grafana/main.tf
@@ -1,10 +1,5 @@
 terraform {
-  backend "s3" {
-    bucket  = "govuk-terraform-test"
-    key     = "projects/grafana.tfstate"
-    region  = "eu-west-1"
-    encrypt = true
-  }
+  backend "s3" {}
 
   required_providers {
     aws = {

--- a/terraform/deployments/monitoring/grafana/test.backend
+++ b/terraform/deployments/monitoring/grafana/test.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-test"
+key     = "projects/grafana.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/deployments/monitoring/infra/integration.backend
+++ b/terraform/deployments/monitoring/infra/integration.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-integration"
+key     = "projects/monitoring.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/deployments/monitoring/infra/main.tf
+++ b/terraform/deployments/monitoring/infra/main.tf
@@ -1,10 +1,5 @@
 terraform {
-  backend "s3" {
-    bucket  = "govuk-terraform-test"
-    key     = "projects/monitoring.tfstate"
-    region  = "eu-west-1"
-    encrypt = true
-  }
+  backend "s3" {}
 
   required_providers {
     aws = {
@@ -27,26 +22,6 @@ data "terraform_remote_state" "infra_networking" {
   config = {
     bucket   = var.govuk_aws_state_bucket
     key      = "govuk/infra-networking.tfstate"
-    region   = "eu-west-1"
-    role_arn = var.assume_role_arn
-  }
-}
-
-data "terraform_remote_state" "infra_security_groups" {
-  backend = "s3"
-  config = {
-    bucket   = var.govuk_aws_state_bucket
-    key      = "govuk/infra-security-groups.tfstate"
-    region   = "eu-west-1"
-    role_arn = var.assume_role_arn
-  }
-}
-
-data "terraform_remote_state" "govuk" {
-  backend = "s3"
-  config = {
-    bucket   = "govuk-terraform-test"
-    key      = "projects/govuk.tfstate"
     region   = "eu-west-1"
     role_arn = var.assume_role_arn
   }
@@ -82,14 +57,13 @@ module "monitoring" {
   splunk_sourcetype       = "log"
   splunk_index            = "govuk_replatforming"
 
-  vpc_id                        = data.terraform_remote_state.infra_networking.outputs.vpc_id
-  private_subnets               = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
-  public_subnets                = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
-  govuk_management_access_sg_id = data.terraform_remote_state.infra_security_groups.outputs.sg_management_id
-  grafana_cidrs_allow_list      = concat(var.office_cidrs_list, var.concourse_cidrs_list)
-  govuk_environment             = var.govuk_environment
-  workspace                     = local.workspace
-  additional_tags               = local.additional_tags
-  capacity_provider             = var.ecs_default_capacity_provider
-  grafana_image_tag             = "7.5.6"
+  vpc_id                   = data.terraform_remote_state.infra_networking.outputs.vpc_id
+  private_subnets          = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
+  public_subnets           = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
+  grafana_cidrs_allow_list = concat(var.office_cidrs_list, var.concourse_cidrs_list)
+  govuk_environment        = var.govuk_environment
+  workspace                = local.workspace
+  additional_tags          = local.additional_tags
+  capacity_provider        = var.ecs_default_capacity_provider
+  grafana_image_tag        = "7.5.6"
 }

--- a/terraform/deployments/monitoring/infra/test.backend
+++ b/terraform/deployments/monitoring/infra/test.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-test"
+key     = "projects/monitoring.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/modules/monitoring/grafana_defaults.tf
+++ b/terraform/modules/monitoring/grafana_defaults.tf
@@ -24,5 +24,5 @@ locals {
     GF_SECURITY_ADMIN_PASSWORD   = aws_secretsmanager_secret_version.grafana_password.arn,
   }
 
-  grafana_security_groups = concat([aws_security_group.grafana.id], [var.govuk_management_access_sg_id])
+  grafana_security_groups = [aws_security_group.grafana.id]
 }

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -28,11 +28,6 @@ variable "publishing_service_domain" {
   description = "e.g. test.publishing.service.gov.uk"
 }
 
-variable "govuk_management_access_sg_id" {
-  description = "ID of security group (from the govuk-aws repo) for access from jumpboxes etc. This SG is added to all ECS instances."
-  type        = string
-}
-
 variable "grafana_desired_count" {
   description = "Desired count of Grafana instances"
   type        = number


### PR DESCRIPTION
With the spin-up of GOV.UK ECS in integration, we need to parameterize the different concourse pipelines so that they are generic enough to be used in all GOV.UK environment.

Ref:
1. [trello card](https://trello.com/c/L70eZe2A/471-create-a-concourse-team-with-sufficient-access-to-aws-in-integration)