### PR TITLE
Add missing region to ecs command

### DIFF
--- a/concourse/tasks/update-ecs-service.sh
+++ b/concourse/tasks/update-ecs-service.sh
@@ -46,6 +46,7 @@ container_id=$(aws ecs describe-tasks \
   --cluster "$CLUSTER" \
   --tasks $task_arn \
   --query 'tasks[0] | containers[?name==`app`].runtimeId' \
+  --region "$AWS_REGION" \
   --output text
 )
 


### PR DESCRIPTION
This PR adds the missing `region` to the call to `ecs describe-tasks`.