### PR TITLE
Fixup container_id in run-task

### DIFF
--- a/concourse/tasks/run-task.sh
+++ b/concourse/tasks/run-task.sh
@@ -88,7 +88,7 @@ aws ecs wait tasks-stopped --tasks $task_id --cluster $CLUSTER
 echo "task finished."
 task_results=$(aws ecs describe-tasks --tasks $task_id --cluster $CLUSTER)
 
-container_id=$(echo $task_results | jq .tasks[0].containers[]  | select(.name=="app") | .runtimeId)
+container_id=$(echo $task_results | jq .tasks[0].containers[]  | jq 'select(.name=="app") | .runtimeId')
 echo "Check Splunk for logs: https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/search?q=search%20index%3D%22govuk_replatforming%22%20container_id%3D$container_id"
 
 exit_code=$(echo $task_results | jq [.tasks[0].containers[].exitCode] | jq add)


### PR DESCRIPTION
Fixes a small issue with the run-task script.

Verified it works in my pipeline: https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/deploy-apps-bill/jobs/all-smoke-tests/builds/1207