### PR TITLE
Quote arguments to jq to fix syntax error

### DIFF
--- a/concourse/tasks/run-task.sh
+++ b/concourse/tasks/run-task.sh
@@ -88,9 +88,9 @@ aws ecs wait tasks-stopped --tasks $task_id --cluster $CLUSTER
 echo "task finished."
 task_results=$(aws ecs describe-tasks --tasks $task_id --cluster $CLUSTER)
 
-container_id=$(echo $task_results | jq .tasks[0].containers[]  | select(.name=="app") | .runtimeId)
+container_id=$(echo $task_results | jq '.tasks[0].containers[]  | select(.name=="app") | .runtimeId')
 echo "Check Splunk for logs: https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/search?q=search%20index%3D%22govuk_replatforming%22%20container_id%3D$container_id"
 
-exit_code=$(echo $task_results | jq [.tasks[0].containers[].exitCode] | jq add)
+exit_code=$(echo $task_results | jq '[.tasks[0].containers[].exitCode]' | jq add)
 echo "Exiting with code $exit_code"
 exit $exit_code


### PR DESCRIPTION
I was seeing:

```
./src/concourse/tasks/run-task.sh: line 91: syntax error: unexpected word (expecting ")")
```

I think this is because the arguments to jq on line 91 aren't quoted, so the
shell is getting confused by the `)`