### PR TITLE
Fixup bearer token bootstrapping

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -612,18 +612,6 @@ jobs:
       - get: frontend-image
         trigger: true
     - in_parallel:
-      - &await-secretsmanager-creds
-        task: await-creds-in-secrets-manager
-        file: govuk-infrastructure/concourse/tasks/await-creds-in-secretsmanager.yml
-        attempts: 3
-        params:
-          APPLICATION: frontend
-          VARIANT: live
-      - <<: *await-secretsmanager-creds
-        params:
-          APPLICATION: frontend
-          VARIANT: draft
-    - in_parallel:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
         params:
@@ -670,6 +658,18 @@ jobs:
         params:
          ECS_SERVICE: frontend
          WORKSPACE: ((workspace))
+    - in_parallel:
+      - &await-secretsmanager-creds
+        task: await-creds-in-secrets-manager
+        file: govuk-infrastructure/concourse/tasks/await-creds-in-secretsmanager.yml
+        attempts: 3
+        params:
+          APPLICATION: frontend
+          VARIANT: live
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: frontend
+          VARIANT: draft
     - in_parallel:
       - &await-deploy-complete
         task: await-deploy-complete-live
@@ -722,15 +722,6 @@ jobs:
       - get: publisher-image
         trigger: true
     - in_parallel:
-      - <<: *await-secretsmanager-creds
-        params:
-          APPLICATION: publisher
-          VARIANT: web
-      - <<: *await-secretsmanager-creds
-        params:
-          APPLICATION: publisher
-          VARIANT: worker
-    - in_parallel:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
         params:
@@ -764,6 +755,15 @@ jobs:
           APPLICATION: publisher
           VARIANT: worker
           GOVUK_ENVIRONMENT: test
+    - in_parallel:
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: publisher
+          VARIANT: web
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: publisher
+          VARIANT: worker
     - task: run-db-migrations
       file: govuk-infrastructure/concourse/tasks/run-task.yml
       input_mapping:
@@ -837,15 +837,6 @@ jobs:
       - get: publishing-api-image
         trigger: true
     - in_parallel:
-      - <<: *await-secretsmanager-creds
-        params:
-          APPLICATION: publishing-api
-          VARIANT: web
-      - <<: *await-secretsmanager-creds
-        params:
-          APPLICATION: publishing-api
-          VARIANT: worker
-    - in_parallel:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
         params:
@@ -871,6 +862,15 @@ jobs:
           APPLICATION: publishing-api
           VARIANT: worker
           GOVUK_ENVIRONMENT: test
+    - in_parallel:
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: publishing-api
+          VARIANT: web
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: publishing-api
+          VARIANT: worker
     - task: run-db-migrations
       file: govuk-infrastructure/concourse/tasks/run-task.yml
       input_mapping:
@@ -924,16 +924,6 @@ jobs:
       - get: content-store-image
         trigger: true
     - in_parallel:
-      - <<: *await-secretsmanager-creds
-        params:
-          APPLICATION: content-store
-          VARIANT: live
-      - task: await-creds-in-secrets-manager
-        file: govuk-infrastructure/concourse/tasks/await-creds-in-secretsmanager.yml
-        params:
-          APPLICATION: content-store
-          VARIANT: draft
-    - in_parallel:
       - task: bootstrap-secrets
         file: govuk-infrastructure/concourse/tasks/bootstrap-app-secrets.yml
         params:
@@ -962,6 +952,16 @@ jobs:
         params:
           APPLICATION: content-store
           VARIANT: live
+    - in_parallel:
+      - <<: *await-secretsmanager-creds
+        params:
+          APPLICATION: content-store
+          VARIANT: live
+      - task: await-creds-in-secrets-manager
+        file: govuk-infrastructure/concourse/tasks/await-creds-in-secretsmanager.yml
+        params:
+          APPLICATION: content-store
+          VARIANT: draft
     - in_parallel:
       - task: update-live-ecs-service
         file: govuk-infrastructure/concourse/tasks/update-ecs-service.yml

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -58,7 +58,7 @@ resources:
     icon: concourse-ci
     source:
       <<: *govuk-infrastructure-source
-      paths: [ concourse/tasks, lib/signon, lib/tasks/secretsmanager.rake, lib/tasks/app_secrets.rake ]
+      paths: [ concourse/tasks, lib/signon, lib/tasks/secretsmanager.rake, lib/tasks/bootstrap.rake ]
 
   - name: smokey-terraform-outputs
     type: s3

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -54,6 +54,7 @@ def signon_client(secretsmanager, api_token_arn, api_url)
   Signon::Client.new(
     api_url: api_url,
     auth_token: admin_secret.secret_string,
+    max_retries: 10,
   )
 end
 


### PR DESCRIPTION
This fixes an issue seen in the `deploy-apps-towers` pipeline: https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/deploy-apps-towers/jobs/deploy-publisher/builds/1.2.

For some deploy jobs the `await-creds-in-secrets-manager` task blocks the `bootstrap-secrets` task that would actually
create the remaining secrets. Therefore these deploys would stall forever.

The two extra commits fix another issue: since the `bootstrap-secrets` task can occur before the signon API it relies on is ready, it needs to retry for a longer period. Now this task will retry for an extra 17 minutes until it bails. This should be enough additional time for Signon to come up.

I tested this change against the `towers` workspace using the same pipeline and verified this problem was fixed: https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/deploy-apps-towers/jobs/deploy-content-store/builds/4. The build failed for an unrelated reason (commit cf1c27d2 seems to have broken the update-ecs-service script)