### PR TITLE
Don't wait for ECS service stable in update-ecs-service task

### DIFF
--- a/concourse/tasks/update-ecs-service.sh
+++ b/concourse/tasks/update-ecs-service.sh
@@ -51,14 +51,6 @@ container_id=$(aws ecs describe-tasks \
 )
 
 echo "App container ID: $container_id"
-
-echo "Waiting for $ECS_SERVICE ECS service to reach steady state..."
-
 echo "Check Splunk for logs: https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/search?q=search%20index%3D%22govuk_replatforming%22%20container_id%3D$container_id"
 
-aws ecs wait services-stable \
-  --cluster "$CLUSTER" \
-  --services "$ECS_SERVICE" \
-  --region "$AWS_REGION"
-
-echo "Updated $ECS_SERVICE to task definition $new_task_definition_arn."
+echo "Deploy started."


### PR DESCRIPTION
We wait for the deploy to complete in the await-deploy-complete task, which is retried with n attempts. The update-ecs-task job is merely for setting the new task definition on the ECS service and thereby triggering the deploy.

This waiter was removed but was re-added accidentally in https://github.com/alphagov/govuk-infrastructure/pull/237/files#diff-32213ce85db7c49f7f2026f29e45a96e298f80b7c85c69e028d666c72971439cR58-R61.