### PR TITLE
Disable refresh on CI plan

### DIFF
--- a/concourse/tasks/terraform-plan-govuk-deployment.yml
+++ b/concourse/tasks/terraform-plan-govuk-deployment.yml
@@ -25,4 +25,5 @@ run:
       -var-file ../variables/common.tfvars \
       -var-file ../variables/test/common.tfvars \
       -var-file ../variables/test/infrastructure.tfvars \
-      -lock=false
+      -lock=false \
+      -refresh=false


### PR DESCRIPTION
This disables the default behavior of synchronizing the
local Terraform state with remote objects before checking
for configuration changes.

This will make the CI planner test faster, since it reduces
the number of API requests from refreshing the state.

However, it makes the test less reliable since it ignores
changes that have been made outside of Terraform, therefore
risks the plan not being complete or correct.