### PR TITLE
Fix example command for running terraform apply

### DIFF
--- a/terraform/docs/applying-terraform.md
+++ b/terraform/docs/applying-terraform.md
@@ -29,12 +29,15 @@ For example, run the following commands to update the test environment:
 
 ```sh
 cd terraform/deployments/govuk-publishing-platform
-gds aws govuk-test-admin -- terraform init
+
+gds aws govuk-test-admin -- terraform init -backend-config test.backend
+
+gds aws govuk-test-admin -- terraform workspace select default
 
 gds aws govuk-test-admin -- terraform apply \
- -var-file ../variables/common.tfvars \
- -var-file ../variables/test/common.tfvars \
- -var-file=../variables/test/infrastructure.tfvars
+  -var-file ../variables/common.tfvars \
+  -var-file ../variables/test/common.tfvars \
+  -var-file ../variables/test/infrastructure.tfvars
 ```
 
 ### Application


### PR DESCRIPTION
Now that we're using backend files, we need to specify `-backend-config` in order for tf init to work.

Also add a step for running `terraform workspace select`, as that's an easily avoidable gotcha.

Tested: copy/pasting these steps worked for me as far as running a plan.