### PR TITLE
Fix intermittent failures affecting update-ecs-service task

### DIFF
--- a/concourse/tasks/update-ecs-service.sh
+++ b/concourse/tasks/update-ecs-service.sh
@@ -30,27 +30,4 @@ aws ecs update-service \
   --task-definition "$new_task_definition_arn" \
   --region "$AWS_REGION" > /dev/null
 
-# Get the ID of the latest task.
-task_arn=$(aws ecs list-tasks \
-  --cluster "$CLUSTER" \
-  --service-name "$ECS_SERVICE" \
-  --region "$AWS_REGION" \
-  --query 'taskArns | [0]' \
-  --output text
-)
-
-echo "Task ARN: $task_arn"
-
-# Pull the container ID from the task's associated `app` container
-container_id=$(aws ecs describe-tasks \
-  --cluster "$CLUSTER" \
-  --tasks $task_arn \
-  --query 'tasks[0] | containers[?name==`app`].runtimeId' \
-  --region "$AWS_REGION" \
-  --output text
-)
-
-echo "App container ID: $container_id"
-echo "Check Splunk for logs: https://gds.splunkcloud.com/en-GB/app/gds-006-govuk/search?q=search%20index%3D%22govuk_replatforming%22%20container_id%3D$container_id"
-
 echo "Deploy started."


### PR DESCRIPTION
This remove the Splunk logs link from update-ecs-service job in order to fix an intermittent issue when deploying. Sometimes `aws ecs list-tasks` does not return any Task ARNs. This can happen if the task has not yet started, or if the task has been stopped after failing health checks (as seems to have happened for router).

The error symptoms:

```
Updating draft-router-api service...
Task ARN: None

An error occurred (InvalidParameterException) when calling the DescribeTasks operation: taskId length should be one of [32,36]
```

Link to failed job: https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/deploy-apps/jobs/deploy-router-api/builds/52.

We don't have a good way to see the logs for all tasks on an ECS Service at the moment. One way would be to feed in `GOVUK_APP_NAME` to the update-ecs-service job, for the purpose of linking to logs filtered by the relevant `GOVUK_APP_NAME`. This seems a bit pointless though, since we'll be able to filter easily in Splunk, provided we know what index to filter by.

Removing this since sometimes we can't retrieve the task id (and the fix would be to re-attempt this) but don't actually need it here.