### PR TITLE
Make Smokey workspace-aware

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -587,7 +587,7 @@ jobs:
       task: fetch-smokey-task-definition
       file: govuk-infrastructure/concourse/tasks/fetch-task-definition.yml
       params:
-        APPLICATION: smokey
+        APPLICATION: smokey-((workspace))
     - &run-smoke-test
       task: run-smoke-tests
       file: govuk-infrastructure/concourse/tasks/run-task.yml

--- a/terraform/deployments/govuk-publishing-platform/smokey.tf
+++ b/terraform/deployments/govuk-publishing-platform/smokey.tf
@@ -28,13 +28,12 @@ module "smokey_container_definition" {
   ports = []
 }
 
-# TODO: can we remove the v2?
 module "smokey_task_definition" {
   source                = "../../modules/task-definition"
   container_definitions = [module.smokey_container_definition.json_format]
   cpu                   = 512
   execution_role_arn    = aws_iam_role.execution.arn
-  family                = "smokey"
+  family                = "smokey-${terraform.workspace}"
   memory                = 1024
   task_role_arn         = aws_iam_role.task.arn
 }


### PR DESCRIPTION
This ensures that the smoke tests are run for the correct workspace.

Currently it is possible for a workspace to run smoke tests for a different workspace.

Smoke tests currently have a single task definition family called 'smokey' unlike other task definition families such as 'frontend-bill' or 'publisher-ecs'.

As you can see, each pipeline will update the smoke tests with variables such as GOVUK_APP_DOMAIN - a workspace-aware domain such as bill.test. However, since the family is not workspace-safe, the smoke tests will simply run the tests for the workspace that last updated the smokey task definition.

This resolves the described problem by creating a smokey task family for each workspace.

Symptoms:

I discovered this when debugging why the smoke tests for the default workspace had failed. In the logs I found the error "You don’t have permission to sign in to [towers] Publisher" (raised when the smoke test user tried to login to Publisher in the `towers` workspace). This indicated that the smoke tests were using the wrong workspace. 