### PR TITLE
Commit workspace params files to main branch

### DIFF
--- a/concourse/parameters/test/default.yml
+++ b/concourse/parameters/test/default.yml
@@ -1,0 +1,5 @@
+govuk_infrastructure_branch: steve/workspace
+workspace: steve
+disable_slack_channel_alerts: true
+skip_db_migrations: false
+background_image: "https://miro.medium.com/max/2960/0*xJEt4-dCPp9L03fi.jpg"

--- a/concourse/parameters/test/parameters.yml
+++ b/concourse/parameters/test/parameters.yml
@@ -1,5 +1,0 @@
-govuk_infrastructure_branch: main
-workspace: default
-disable_slack_channel_alerts: false
-skip_db_migrations: false
-background_image: "https://live.staticflickr.com/7486/15537665259_a2d796c7d4_k_d.jpg"

--- a/concourse/parameters/test/steve.yml
+++ b/concourse/parameters/test/steve.yml
@@ -1,0 +1,5 @@
+govuk_infrastructure_branch: main
+workspace: steve
+disable_slack_channel_alerts: true
+skip_db_migrations: false
+background_image: "https://images.unsplash.com/photo-1494022299300-899b96e49893?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80"

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -377,7 +377,7 @@ jobs:
     - file: govuk-infrastructure/concourse/pipelines/deploy.yml
       set_pipeline: self
       var_files:
-        - govuk-infrastructure/concourse/parameters/((govuk_environment))/parameters.yml
+        - govuk-infrastructure/concourse/parameters/((govuk_environment))/((workspace)).yml
 
   - name: run-terraform
     serial: true


### PR DESCRIPTION
Props to @smford for this - he implemented this in an earlier PR.

This includes the pipeline file in the main branch. The benefit is that we can keep our workspaces up to date without needing to rebase frequently. This will reduce the amount of time we need to spend repairing workspaces that fell too far behind.

If we want to work on a separate branch, we can create a new branch and point our pipeline at that branch briefly.

The effect of this PR is that Steve's workspace will be up to date with `main` when he returns from vacation, and won't need to spend time repairing it.