### PR TITLE
Wait longer for deploys to complete

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -674,7 +674,7 @@ jobs:
       - &await-deploy-complete
         task: await-deploy-complete-live
         file: govuk-infrastructure/concourse/tasks/await-deploy-complete.yml
-        attempts: 4
+        attempts: 5
         timeout: 5m
         params: &await-deploy-complete-params
           ECS_SERVICE: frontend


### PR DESCRIPTION
This adds an extra 5 minutes to the max wait time on deploy completions. This should resolve the issues we've seen where a deploy waiter times out, but the deploy was successful a minute or so later.

For example, this morning this task failed: https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/deploy-apps/jobs/deploy-authenticating-proxy/builds/42.

We're learning that it takes up to 25 minutes for ECS to do a rolling deployment of just one task with almost no traffic.