### PR TITLE
 Provide content schemas to apps

### DIFF
--- a/concourse/pipelines/content-schemas.yml
+++ b/concourse/pipelines/content-schemas.yml
@@ -1,0 +1,34 @@
+groups:
+  - name: content-schemas
+    jobs:
+      - upload-to-s3
+
+resources:
+  - &git-repo
+    name: content-schemas-repo
+    type: git
+    icon: github
+    source:
+      uri: https://github.com/alphagov/govuk-content-schemas
+      branch: main
+
+  - <<: *git-repo
+    name: govuk-infrastructure
+    source:
+      uri: https://github.com/alphagov/govuk-infrastructure
+      branch: ((govuk_infrastructure_branch))
+
+jobs:
+- name: upload-to-s3
+  plan:
+    - get: content-schemas-repo
+      trigger: true
+    - get: govuk-infrastructure
+    - task: upload-rails-assets
+      file: govuk-infrastructure/concourse/tasks/upload-rails-assets.yml
+      input_mapping:
+        app-image: content-schemas-repo
+      params:
+        IMAGE_ASSETS_PATH: app-image
+        S3_BUCKET_PATH_PATTERN: s3://govuk-content-schemas-test
+        WORKSPACE: ((workspace))

--- a/concourse/pipelines/content-schemas.yml
+++ b/concourse/pipelines/content-schemas.yml
@@ -30,5 +30,5 @@ jobs:
         app-image: content-schemas-repo
       params:
         IMAGE_ASSETS_PATH: app-image
-        S3_BUCKET_PATH_PATTERN: s3://govuk-content-schemas-test
+        S3_BUCKET_PATH_PATTERN: s3://govuk-((environment))-((workspace))-1-content-schema
         WORKSPACE: ((workspace))

--- a/concourse/pipelines/deploy-parameters.yml
+++ b/concourse/pipelines/deploy-parameters.yml
@@ -1,3 +1,0 @@
-workspace: baker
-govuk_infrastructure_branch: pull-content-schemas
-disable_slack_channel_alerts: true

--- a/concourse/pipelines/deploy-parameters.yml
+++ b/concourse/pipelines/deploy-parameters.yml
@@ -1,0 +1,3 @@
+workspace: baker
+govuk_infrastructure_branch: pull-content-schemas
+disable_slack_channel_alerts: true

--- a/terraform/deployments/govuk-publishing-platform/backends_content_schema.tf
+++ b/terraform/deployments/govuk-publishing-platform/backends_content_schema.tf
@@ -1,0 +1,35 @@
+resource "aws_s3_bucket" "backends_content_schema" {
+  bucket = "govuk-${var.govuk_environment}-${local.workspace}-content-schema"
+
+  # Unless we're in staging or production, it's okay to delete this bucket
+  # even if it still contains objects.
+  #
+  # In the lower environments, we want to be able to run `terraform destroy`
+  # without having to manually delete all the assets from the bucket.
+  force_destroy = contains(["staging", "production"], var.govuk_environment) ? false : true
+
+  tags = {
+    name            = "govuk-${var.govuk_environment}-${local.workspace}-1-content-schema"
+    aws_environment = var.govuk_environment
+  }
+}
+
+data "aws_iam_policy_document" "backends_cloudfront_access_s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.backends_content_schema.arn}/*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        module.backends_origin.cloudfront_access_identity_iam_arn,
+        module.backends_origin.cloudfront_access_identity_iam_arn
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "backends_cloudfront_access_s3_policy" {
+  bucket = aws_s3_bucket.backends_rails_assets.id
+  policy = data.aws_iam_policy_document.backends_cloudfront_access_s3_policy.json
+}

--- a/terraform/deployments/govuk-publishing-platform/backends_content_schema.tf
+++ b/terraform/deployments/govuk-publishing-platform/backends_content_schema.tf
@@ -14,22 +14,7 @@ resource "aws_s3_bucket" "backends_content_schema" {
   }
 }
 
-data "aws_iam_policy_document" "backends_cloudfront_access_s3_policy" {
-  statement {
-    actions   = ["s3:GetObject"]
-    resources = ["${aws_s3_bucket.backends_content_schema.arn}/*"]
-
-    principals {
-      type = "AWS"
-      identifiers = [
-        module.backends_origin.cloudfront_access_identity_iam_arn,
-        module.backends_origin.cloudfront_access_identity_iam_arn
-      ]
-    }
-  }
-}
-
 resource "aws_s3_bucket_policy" "backends_cloudfront_access_s3_policy" {
-  bucket = aws_s3_bucket.backends_rails_assets.id
+  bucket = aws_s3_bucket.backends_content_schema.id
   policy = data.aws_iam_policy_document.backends_cloudfront_access_s3_policy.json
 }

--- a/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
@@ -160,6 +160,11 @@ resource "aws_iam_role_policy_attachment" "ecs_exec_access" {
   policy_arn = aws_iam_policy.ecs_exec_access.arn
 }
 
+resource "aws_iam_role_policy_attachment" "s3_read_access" {
+  role       = aws_iam_role.task.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
+
 resource "aws_iam_policy" "ecs_exec_access" {
   name        = "ecs_exec_access-${local.workspace}"
   path        = "/ecsExecAccessPolicy/"

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -25,6 +25,8 @@ resource "aws_ecs_service" "service" {
 
   health_check_grace_period_seconds = length(var.load_balancers) > 0 ? var.health_check_grace_period_seconds : null
 
+  enable_execute_command = true
+
   dynamic "load_balancer" {
     for_each = var.load_balancers
     iterator = lb

--- a/terraform/modules/container-definition/main.tf
+++ b/terraform/modules/container-definition/main.tf
@@ -34,7 +34,13 @@ output "json_format" {
         },
       ],
     },
-    mountPoints  = [],
+    mountPoints = [
+      {
+        sourceVolume  = "content_schemas",
+        containerPath = lookup(var.environment_variables, "GOVUK_CONTENT_SCHEMAS_PATH", "/govuk-content-schemas"),
+        readOnly      = false
+      }
+    ],
     portMappings = [for port in var.ports : { containerPort = port, hostPort = port, protocol = "tcp" }],
     secrets      = [for key, value in var.secrets_from_arns : { name = key, valueFrom = value }]
     user         = var.user

--- a/terraform/modules/task-definition/main.tf
+++ b/terraform/modules/task-definition/main.tf
@@ -11,6 +11,10 @@ locals {
     proxyConfiguration      = var.proxy_configuration
     requiresCompatibilities = ["FARGATE"],
     taskRoleArn             = var.task_role_arn,
+    enableExecuteCommand    = true,
+    volumes = [
+      { "name" : "content_schemas" }
+    ]
   }
 }
 


### PR DESCRIPTION
This PR shows how we can provide content schemas to apps running in ECS, via the use of Concourse, S3 and a sidecar container. Concourse is used to ensure that the latest content schemas from the GitHub repo are synced to an S3 bucket, which provides an extra layer of redundancy should there be any issues with GitHub (currently call `git clone` to get the schemas, which can fail on the semi-frequent times when GitHub is unavailable). Next, a sidecar container (per service) spins up, pulls the content schemas from S3 and writes them to a transient volume, which is mounted to both the sidecar container and the app container, at the path that the app expects content schemas to reside at. Finally, the app container spins up and can access the content schemas.