### PR TITLE
add backend config files for concourse-iam deployment

### DIFF
--- a/terraform/deployments/concourse-iam/README.md
+++ b/terraform/deployments/concourse-iam/README.md
@@ -7,7 +7,13 @@ Apply once per GOV.UK environment.
 ## Applying
 
 ```shell
+terraform init -backend-config <govuk_environment>.backend -reconfigure
+
 terraform apply \
  -var-file ../variables/common.tfvars \
- -var-file ../variables/test/common.tfvars
+ -var-file ../variables/<govuk_environment>/common.tfvars
 ```
+
+where:
+`<govuk_environment>` is the GOV.UK environment where you want the changes to be
+applied.

--- a/terraform/deployments/concourse-iam/integration.backend
+++ b/terraform/deployments/concourse-iam/integration.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-ecs-terraform-integration"
+key     = "projects/concourse-iam.tfstate"
+region  = "eu-west-1"
+encrypt = true

--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -7,12 +7,7 @@
 # do.
 
 terraform {
-  backend "s3" {
-    bucket  = "govuk-terraform-test"
-    key     = "projects/concourse-iam.tfstate"
-    region  = "eu-west-1"
-    encrypt = true
-  }
+  backend "s3" {}
 
   required_providers {
     aws = {

--- a/terraform/deployments/concourse-iam/test.backend
+++ b/terraform/deployments/concourse-iam/test.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-test"
+key     = "projects/concourse-iam.tfstate"
+region  = "eu-west-1"
+encrypt = true


### PR DESCRIPTION
As part of the spin-up of integration, we need to supply a different backend config for the concourse-iam deployment when applied to integration.

This follows on #288

Refs:
1. [trello card](https://trello.com/c/L70eZe2A/471-create-a-concourse-team-with-sufficient-access-to-aws-in-integration)