### PR TITLE
Autogenerate secret_key_base for Frontend app

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -87,6 +87,15 @@ resources:
       region_name: eu-west-2
       versioned_file: ((workspace))/govuk-terraform-outputs.json
 
+  - name: secret_key_bases-terraform-outputs
+    type: s3
+    icon: file
+    source:
+      bucket: ((readonly_private_bucket_name))
+      region_name: eu-west-2
+      versioned_file: ((workspace))/secret_key_bases.json
+      initial_version: "0"
+
   - name: content-store-terraform-outputs
     type: s3
     icon: file
@@ -271,6 +280,7 @@ groups:
       - smoke-test-frontend
       - smoke-test-publisher
       - smoke-test-signon
+      - autogenerate-secrets
 
   - name: terraform
     jobs:
@@ -400,6 +410,7 @@ jobs:
       - get: router-terraform-outputs
       - get: frontend-terraform-outputs
       - get: authenticating-proxy-terraform-outputs
+      - get: secret_key_bases-terraform-outputs
     - task: terraform-apply
       config:
         inputs:
@@ -409,6 +420,9 @@ jobs:
           optional: true
         - name: frontend-terraform-outputs
           path: old-frontend-terraform-outputs
+          optional: true
+        - name: secret_key_bases-terraform-outputs
+          path: old-secret_key_bases-terraform-outputs
           optional: true
         - name: publisher-terraform-outputs
           path: old-publisher-terraform-outputs
@@ -453,6 +467,8 @@ jobs:
           path: new-router-api-terraform-outputs
         - name: router-terraform-outputs
           path: new-router-terraform-outputs
+        - name: secret_key_bases-terraform-outputs
+          path: new-secret_key_bases-terraform-outputs
         - name: authenticating-proxy-terraform-outputs
           path: new-authenticating-proxy-terraform-outputs
           optional: true
@@ -494,16 +510,16 @@ jobs:
             terraform output -json > "$root_dir/govuk-terraform-outputs/govuk-terraform-outputs.json"
 
             update_terraform_outputs() {
-              app="$1"
-              terraform output -json "${app}" > "$root_dir/new-${app}-terraform-outputs/${app}.json"
+              output="$1"
+              terraform output -json "${output}" > "$root_dir/new-${output}-terraform-outputs/${output}.json"
 
               if cmp \
-                "$root_dir/old-${app}-terraform-outputs/${app}.json" \
-                "$root_dir/new-${app}-terraform-outputs/${app}.json"
+                "$root_dir/old-${output}-terraform-outputs/${output}.json" \
+                "$root_dir/new-${output}-terraform-outputs/${output}.json"
               then
                 # If the new terraform outputs are the same as the old ones
                 # delete them to avoid unnecessarily creating a new resource version
-                rm "$root_dir/new-${app}-terraform-outputs/${app}.json"
+                rm "$root_dir/new-${output}-terraform-outputs/${output}.json"
               fi
             }
 
@@ -517,11 +533,16 @@ jobs:
             update_terraform_outputs router-api
             update_terraform_outputs router
             update_terraform_outputs authenticating-proxy
+            update_terraform_outputs secret_key_bases
 
     - in_parallel:
       - put: govuk-terraform-outputs
         params:
           file: govuk-terraform-outputs/govuk-terraform-outputs.json
+      - try:
+          put: secret_key_bases-terraform-outputs
+          params:
+            file: secret_key_bases-terraform-outputs/secret_key_bases.json
       - try:
           put: content-store-terraform-outputs
           params:
@@ -598,6 +619,27 @@ jobs:
         APPLICATION: smokey
         VARIANT: default
         COMMAND: bundle exec cucumber --profile test --strict-undefined -t @replatforming -t \"not @notreplatforming\"
+    on_failure:
+      <<: *notify-slack-failure
+
+  - name: autogenerate-secrets
+    plan:
+    - in_parallel:
+      - get: govuk-infrastructure
+        resource: govuk-infrastructure-concourse-tasks
+        trigger: true
+      - get: secret_key_bases
+        resource: secret_key_bases-terraform-outputs
+        passed:
+        - run-terraform
+        trigger: true
+    - task: secret_key_base
+      file: govuk-infrastructure/concourse/tasks/autogenerate-secret-key-base.yml
+      input_mapping:
+        terraform-outputs: secret_key_bases
+      params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+    serial: true
     on_failure:
       <<: *notify-slack-failure
 

--- a/concourse/tasks/autogenerate-secret-key-base.yml
+++ b/concourse/tasks/autogenerate-secret-key-base.yml
@@ -1,0 +1,18 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: govuk/infra-concourse-task
+    tag: 0.0.0-wip
+    username: ((docker_hub_username))
+    password: ((docker_hub_authtoken))
+inputs:
+  - name: terraform-outputs
+  - name: govuk-infrastructure
+params:
+  AWS_REGION: eu-west-1
+  ASSUME_ROLE_ARN:
+run:
+  dir: govuk-infrastructure
+  path: bundle
+  args: ["exec", "rake", "secretsmanager:autogenerate_secret_key_base"]

--- a/lib/tasks/secretsmanager.rake
+++ b/lib/tasks/secretsmanager.rake
@@ -67,11 +67,11 @@ namespace :secretsmanager do
     config.fetch("arns").each do |secret_arn|
       metadata = secrets_client.describe_secret(secret_id: secret_arn)
       versions = metadata.version_ids_to_stages
-      is_unset = versions.nil? || versions.values.none? do |stages|
+      already_set = !versions.nil? && versions.values.any? do |stages|
         stages.include?("AWSCURRENT")
       end
 
-      unless is_unset
+      if already_set
         puts "Secret #{secret_arn} already set; skipping. 🔒"
         next
       end

--- a/lib/tasks/secretsmanager.rake
+++ b/lib/tasks/secretsmanager.rake
@@ -49,4 +49,42 @@ namespace :secretsmanager do
       exit 1
     end
   end
+
+  desc "Autogenerate secret_key_base for Rails apps"
+  task :autogenerate_secret_key_base do
+    config = JSON.parse(File.read("../terraform-outputs/secret_key_bases.json"))
+
+    credentials = Aws::AssumeRoleCredentials.new(
+      client: Aws::STS::Client.new,
+      role_arn: ENV["ASSUME_ROLE_ARN"],
+      role_session_name: "create-rails-app-secret_key_base",
+    )
+    secrets_client = Aws::SecretsManager::Client.new(
+      region: ENV["AWS_REGION"],
+      credentials: credentials,
+    )
+
+    config.fetch("arns").each do |secret_arn|
+      metadata = secrets_client.describe_secret(secret_id: secret_arn)
+      versions = metadata.version_ids_to_stages
+      is_unset = versions.nil? || versions.values.none? do |stages|
+        stages.include?("AWSCURRENT")
+      end
+
+      unless is_unset
+        puts "Secret #{secret_arn} already set; skipping. 🔒"
+        next
+      end
+
+      secrets_client.put_secret_value(
+        secret_id: secret_arn,
+        secret_string: SecureRandom.hex(64),
+        version_stages: %w[AWSCURRENT],
+      )
+
+      puts "Generated secret_key_base for #{secret_arn} 🔑"
+    end
+
+    puts "Done! All secrets generated. 🔐"
+  end
 end

--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -29,8 +29,7 @@ locals {
       {
         # TODO Should frontend and draft frontend share a bearer token for publishing api?
         PUBLISHING_API_BEARER_TOKEN = module.signon_bearer_tokens.frontend_to_pub_api.secret_arn
-        SECRET_KEY_BASE             = data.aws_secretsmanager_secret.frontend_secret_key_base.arn,
-        SENTRY_DSN                  = data.aws_secretsmanager_secret.sentry_dsn.arn,
+        SECRET_KEY_BASE             = aws_secretsmanager_secret.secret_key_base["frontend"].arn
       }
     )
 

--- a/terraform/deployments/govuk-publishing-platform/outputs.tf
+++ b/terraform/deployments/govuk-publishing-platform/outputs.tf
@@ -208,3 +208,10 @@ output "authenticating-proxy" {
 output "cluster_name" {
   value = aws_ecs_cluster.cluster.name
 }
+
+output "secret_key_bases" {
+  value = {
+    arns = [for k, v in aws_secretsmanager_secret.secret_key_base : v.arn]
+  }
+  description = "ARNs of SecretsManager secrets for secret_key_base creds"
+}

--- a/terraform/deployments/govuk-publishing-platform/secret_key_base.tf
+++ b/terraform/deployments/govuk-publishing-platform/secret_key_base.tf
@@ -1,0 +1,39 @@
+data "aws_secretsmanager_secret" "authenticating_proxy_secret_key_base" {
+  name = "authenticating-proxy_SECRET_KEY_BASE" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "content_store_secret_key_base" {
+  name = "content-store_SECRET_KEY_BASE" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "frontend_secret_key_base" {
+  name = "frontend_app-SECRET_KEY_BASE" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "publisher_secret_key_base" {
+  name = "publisher_app-SECRET_KEY_BASE" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "publishing_api_secret_key_base" {
+  name = "publishing_api_app-SECRET_KEY_BASE" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "signon_secret_key_base" {
+  name = "signon_app-SECRET_KEY_BASE" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "static_secret_key_base" {
+  name = "static_SECRET_KEY_BASE" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "draft_static_secret_key_base" {
+  name = "draft-static_SECRET_KEY_BASE" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "router_api_secret_key_base" {
+  name = "router-api_SECRET_KEY_BASE" # pragma: allowlist secret
+}
+
+data "aws_secretsmanager_secret" "draft_router_api_secret_key_base" {
+  name = "draft-router-api_SECRET_KEY_BASE" # pragma: allowlist secret
+}

--- a/terraform/deployments/govuk-publishing-platform/secret_key_base.tf
+++ b/terraform/deployments/govuk-publishing-platform/secret_key_base.tf
@@ -1,13 +1,39 @@
+resource "aws_secretsmanager_secret" "secret_key_base" {
+  for_each = toset([
+    # "authenticating_proxy",
+    # "content_store",
+    # "draft_content_store", # new
+    # "draft_frontend", # new
+    # "draft_static",
+    # "draft_router_api",
+    "frontend",
+    # "publisher",
+    # "publishing_api",
+    # "signon",
+    # "static",
+    # "router_api",
+  ])
+
+  name = "${each.key}-${local.workspace}-SECRET_KEY_BASE"
+
+  # HACK: Fixes a bug where Terraform can't handle secrets scheduled for deletion:
+  # https://github.com/hashicorp/terraform-provider-aws/issues/5127
+  recovery_window_in_days = 0
+
+  tags = merge(
+    local.additional_tags,
+    {
+      Name = "${each.key}-secret_key_base-${var.govuk_environment}-${local.workspace}"
+    },
+  )
+}
+
 data "aws_secretsmanager_secret" "authenticating_proxy_secret_key_base" {
   name = "authenticating-proxy_SECRET_KEY_BASE" # pragma: allowlist secret
 }
 
 data "aws_secretsmanager_secret" "content_store_secret_key_base" {
   name = "content-store_SECRET_KEY_BASE" # pragma: allowlist secret
-}
-
-data "aws_secretsmanager_secret" "frontend_secret_key_base" {
-  name = "frontend_app-SECRET_KEY_BASE" # pragma: allowlist secret
 }
 
 data "aws_secretsmanager_secret" "publisher_secret_key_base" {

--- a/terraform/deployments/govuk-publishing-platform/secrets_manager.tf
+++ b/terraform/deployments/govuk-publishing-platform/secrets_manager.tf
@@ -15,15 +15,7 @@ data "aws_secretsmanager_secret" "splunk_token" {
 
 # Frontend app secrets
 
-data "aws_secretsmanager_secret" "frontend_secret_key_base" {
-  name = "frontend_app-SECRET_KEY_BASE" # pragma: allowlist secret
-}
-
 # Content store app secrets
-
-data "aws_secretsmanager_secret" "content_store_secret_key_base" {
-  name = "content-store_SECRET_KEY_BASE" # pragma: allowlist secret
-}
 
 # Publisher app secrets
 
@@ -57,9 +49,6 @@ data "aws_secretsmanager_secret" "publisher_link_checker_api_secret_token" {
 data "aws_secretsmanager_secret" "publisher_mongodb_uri" {
   name = "publisher_app-MONGODB_URI"
 }
-data "aws_secretsmanager_secret" "publisher_secret_key_base" {
-  name = "publisher_app-SECRET_KEY_BASE" # pragma: allowlist secret
-}
 
 # Publishing API app
 
@@ -75,10 +64,6 @@ data "aws_secretsmanager_secret" "publishing_api_rabbitmq_password" {
   name = "publishing_api_app-RABBITMQ_PASSWORD"
 }
 
-data "aws_secretsmanager_secret" "publishing_api_secret_key_base" {
-  name = "publishing_api_app-SECRET_KEY_BASE"
-}
-
 # Signon app
 
 data "aws_secretsmanager_secret" "signon_devise_pepper" {
@@ -87,10 +72,6 @@ data "aws_secretsmanager_secret" "signon_devise_pepper" {
 
 data "aws_secretsmanager_secret" "signon_devise_secret_key" {
   name = "signon_app-DEVISE_SECRET_KEY" # pragma: allowlist secret
-}
-
-data "aws_secretsmanager_secret" "signon_secret_key_base" {
-  name = "signon_app-SECRET_KEY_BASE" # pragma: allowlist secret
 }
 
 data "aws_secretsmanager_secret" "signon_database_url" {
@@ -113,27 +94,10 @@ data "aws_secretsmanager_secret" "smokey_signon_password" {
 
 # Static app
 
-data "aws_secretsmanager_secret" "static_secret_key_base" {
-  name = "static_SECRET_KEY_BASE" # pragma: allowlist secret
-}
-data "aws_secretsmanager_secret" "draft_static_secret_key_base" {
-  name = "draft-static_SECRET_KEY_BASE" # pragma: allowlist secret
-}
-
 # Router-api app
-
-data "aws_secretsmanager_secret" "router_api_secret_key_base" {
-  name = "router-api_SECRET_KEY_BASE"
-}
-data "aws_secretsmanager_secret" "draft_router_api_secret_key_base" {
-  name = "draft-router-api_SECRET_KEY_BASE"
-}
 
 # Authenticating-proxy app
 
-data "aws_secretsmanager_secret" "authenticating_proxy_secret_key_base" {
-  name = "authenticating-proxy_SECRET_KEY_BASE"
-}
 data "aws_secretsmanager_secret" "authenticating_proxy_jwt_auth_secret" {
   name = "authenticating-proxy_JWT_AUTH_SECRET"
 }


### PR DESCRIPTION
Trello: https://trello.com/c/HQxqvue6/505-autogenerate-secretkeybase-when-bootstrapping

This autogenerates the `secret_key_base` secret for Rails apps (used for [cookie signing](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Cookies/ChainedCookieJars.html#method-i-signed)). This job is idempotent and will not attempt to create a secret if one already exists in SecretsManager.

I've started with the `frontend` app, it'll be trivial to update the other apps later.

See my pipeline for an example of this running: https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/deploy-apps-bill.