### PR TITLE
fix content store db name

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/app_content_store.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_content_store.tf
@@ -59,7 +59,7 @@ module "content_store" {
     {
       GOVUK_STATSD_PREFIX         = "govuk-ecs.app.content-store"
       PLEK_SERVICE_ROUTER_API_URI = local.defaults.router_api_uri
-      MONGODB_URI                 = "${local.content_store_defaults.mongodb_url}/live_content_store_production"
+      MONGODB_URI                 = "${local.content_store_defaults.mongodb_url}/content_store_production"
     },
   )
   secrets_from_arns = merge(


### PR DESCRIPTION
In `test` GOV.UK environment, we were using `live_content_store_production` as the db name for the live content store but in other environment, it is `content_store_production`. This PR resolves this unexplained anomaly.

Ref:
1. [trello card](https://trello.com/c/lZQJKP1h/485-spin-up-in-integration)