### PR TITLE
Add outbound traffic to draft content store security group

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
+++ b/terraform/deployments/govuk-publishing-platform/security_group_rules.tf
@@ -65,6 +65,16 @@ resource "aws_security_group_rule" "content_store_from_router_tcp" {
 # Content Store (Draft)
 #
 
+resource "aws_security_group_rule" "draft_content_store_to_any_any" {
+  description       = "Draft Content Store sends requests to anywhere over any protocol"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = module.draft_content_store.security_group_id
+}
+
 resource "aws_security_group_rule" "draft_content_store_from_publishing_api_http" {
   description              = "Draft Content Store accepts requests from Publishing API over HTTP"
   type                     = "ingress"


### PR DESCRIPTION
This PR allows all outbound traffic to the draft content store security group. This rule already exists for the (origin) content store security group, and without it draft content store is unable to talk to MongoDB, resulting in timeouts which propagate up the stack to CloudFront serving an `upstream request timeout` error.