### PR TITLE
Exclude smoke tests not for current environment

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -618,7 +618,7 @@ jobs:
         ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         APPLICATION: smokey
         VARIANT: default
-        COMMAND: bundle exec cucumber --profile test --strict-undefined -t @replatforming -t \"not @notreplatforming\"
+        COMMAND: bundle exec cucumber --profile test --strict-undefined -t @replatforming -t \"not @notreplatforming and not @not((govuk_environment))\"
     on_failure:
       <<: *notify-slack-failure
 
@@ -882,7 +882,7 @@ jobs:
     - <<: *run-smoke-test
       params:
         <<: *smoke-tests-params
-        COMMAND: bundle exec cucumber --profile test --strict-undefined -t @app-publisher -t \"not @notreplatforming\"
+        COMMAND: bundle exec cucumber --profile test --strict-undefined -t @app-publisher -t \"not @notreplatforming and not @not((govuk_environment))\"
     on_failure:
       <<: *notify-slack-failure
 


### PR DESCRIPTION
This PR excludes smoke tests not meant for the current environment when they're run by Concourse. To facilitate this, any tests not meant for a particular environment should be marked up as `@replatformingnot<environment>` in Smokey, where `<environment>` is to be replaced with the name of the environment in which they should not be run.

The reason for this change is to allow us to run smoke tests for publishing content, ensuring that they do not run in production.

Trello: https://trello.com/c/9QipS0X0