### PR TITLE
Add logging to CloudFront distribution to Splunk

### DIFF
--- a/terraform/modules/origin/main.tf
+++ b/terraform/modules/origin/main.tf
@@ -104,6 +104,12 @@ resource "aws_cloudfront_distribution" "origin" {
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2019"
   }
+  
+  logging_config {
+    include_cookies = false
+    bucket          = "cyber-security-cloudfront.s3.amazonaws.com"
+    prefix          = "govuk-${var.workspace}"
+  }
 }
 
 resource "aws_route53_record" "origin_cloudfront" {

--- a/terraform/modules/origin/main.tf
+++ b/terraform/modules/origin/main.tf
@@ -104,7 +104,7 @@ resource "aws_cloudfront_distribution" "origin" {
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2019"
   }
-  
+
   logging_config {
     include_cookies = false
     bucket          = "cyber-security-cloudfront.s3.amazonaws.com"


### PR DESCRIPTION
**Pending**
 https://github.com/alphagov/cyber-security-terraform/pull/356 and deployment of IAM permissions to our central CloudFront bucket

**What?** 
Adds logging from CloudFront to central S3 bucket which ends up in Splunk.
Uses prefix with `var.workspace` to align to apparent GOV.UK usage.

**Why?**
Increased visibility when CDN bypassed through direct access or failover event.

