### PR TITLE
Fix instructions for creating workspace Concourse pipelines.

### DIFF
--- a/docs/create-a-new-workspace.md
+++ b/docs/create-a-new-workspace.md
@@ -59,12 +59,27 @@ Change the contents of `concourse/pipelines/deploy-parameters.yml` to the
 following:
 
 ```
-workspace: personal # or something else, it's your workspace
+workspace: <workspace-name>
 # so the pipeline uses your branch (crucially the set_pipeline step will use
 # this file!)
 govuk_infrastructure_branch: <githubusername>/workspace
 # so you don't create noise in the govuk-deploy-alerts channel
 disable_slack_channel_alerts: true
+```
+
+Commit the new `deploy-parameters.yml` and push your branch to GitHub.
+
+```
+git add concourse/pipelines/deploy-parameters.yml
+git commit
+git push --set-upstream origin <githubusername>/workspace
+```
+
+Log into Concourse and update the `fly` command if necessary.
+
+```
+fly -t govuk-test login --team-name govuk-test --concourse-url https://cd.gds-reliability.engineering
+fly -t govuk-test sync
 ```
 
 Finally, set the pipeline, and then unpause it

--- a/docs/create-a-new-workspace.md
+++ b/docs/create-a-new-workspace.md
@@ -55,7 +55,7 @@ Create a new branch
 git checkout -b <githubusername>/workspace
 ```
 
-Change the contents of `concourse/pipelines/deploy-parameters.yml` to the
+Change the contents of `concourse/parameters/deploy-parameters.yml` to the
 following:
 
 ```
@@ -70,7 +70,7 @@ disable_slack_channel_alerts: true
 Commit the new `deploy-parameters.yml` and push your branch to GitHub.
 
 ```
-git add concourse/pipelines/deploy-parameters.yml
+git add concourse/parameters/deploy-parameters.yml
 git commit
 git push --set-upstream origin <githubusername>/workspace
 ```
@@ -87,7 +87,7 @@ Finally, set the pipeline, and then unpause it
 ```
 fly sp -t govuk-test -p deploy-apps-<workspace-name> \
 -c concourse/pipelines/deploy.yml \
--l concourse/pipelines/deploy-parameters.yml
+-l concourse/parameters/deploy-parameters.yml
 
 fly up -t govuk-test -p deploy-apps-<workspace-name>
 ```


### PR DESCRIPTION
If you forget to commit and/or push the deploy-parameters.yml changes, the pipeline config will look correct when you create it but will update-pipeline itself back to the config from the main branch as soon as it runs.