### PR TITLE
Add missing LOG_TO_SPLUNK param to Smokey runs

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -618,6 +618,7 @@ jobs:
         ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
         APPLICATION: smokey
         VARIANT: default
+        LOG_TO_SPLUNK: false
         COMMAND: bundle exec cucumber --profile test --strict-undefined -t @replatforming -t \"not @notreplatforming and not @not((govuk_environment))\"
     on_failure:
       <<: *notify-slack-failure


### PR DESCRIPTION
This PR adds the missing `LOG_TO_SPLUNK` param to Smokey runs and sets it to `false` so that we can inspect Smokey job output in Concourse. This should have been added in https://github.com/alphagov/govuk-infrastructure/pull/328 but seems to have been missed out.