### PR TITLE
Update docs for creating new environment

### DIFF
--- a/docs/create-a-new-environment.md
+++ b/docs/create-a-new-environment.md
@@ -15,10 +15,10 @@ See the [Glossary][] for detail on what we mean by an environment.
 ## Contents
 
 1. Prerequisites
-1. Apply `govuk-aws`
-1. Create a Concourse team
-1. Apply the `concourse-iam` deployment
-1. Create a Concourse pipeline for deployments
+1. Base Deployments
+1. Concourse
+1. `govuk-publishing-platform` Deployment
+1. `monitoring` Deployment
 
 ## Prerequisites
 
@@ -30,47 +30,113 @@ It is also assumes that you are somewhat familiar with GOV.UK architecture and
 infrastructure. If not, please see the [developer documentation][]. The
 [infrastructure manual][] has many guides for operating GOV.UK.
 
+`govuk-infrastructure` is dependent on [govuk-aws][], which creates AWS
+resources such as the VPC and the databases for apps in ECS use. Our goal is
+to move the resources managed by [govuk-aws][] to this repository. You can check
+out the [govuk-aws][] repo and then the [govuk-puppet][] for guidance on how to
+bring up the current GOV.UK platform.
+
 [developer documentation]: https://docs.publishing.service.gov.uk/#infrastructure
 [infrastructure manual]: https://docs.publishing.service.gov.uk/manual.html#infrastructure
-
-## Apply govuk-aws
-
-`govuk-infrastructure` is dependent on [govuk-aws][], which creates AWS
-resources such as the VPC and the databases apps in ECS use.
-
-See the `govuk-aws` repo and then the `govuk-puppet` for guidance on how to
-bring up the current platform.
-
-This may change in future, our goal is to move the resources managed by govuk-aws
-to this repository.
-
 [govuk-aws]: https://github.com/alphagov/govuk-aws
+[govuk-puppet]: https://github.com/alphagov/govuk-puppet
 
-## Create a Concourse team
+## Base Deployments
 
-Ask the RE Autom8 team to create a new Concourse team for you, e.g. `govuk-dev`.
+The terraform code has been structured into deployable units called
+[deployments](../terraform/deployments).
 
-You'll need to add the following team-wide secrets to the new Concourse team:
+Some of these deployments uses variables that are stored
+[here](../terraform/deployments/variables). When creating a new environment,
+you need to make a copy of one of the existing environment variables directory
+(e.g. [test](../terraform/deployments/variables/test)) and modify the files
+according to the new environment needs.
 
-* docker_hub_username
-* docker_hub_authtoken
-* deploy_apps_slack_webhook
+Before the deployment of the main
+`govuk-publishing-platform` which is the main deployment where GOV.UK apps are
+spinned up, there is a need to deployed the following base deployments:
+1. [concourse-iam](../terraform/deployments/concourse-iam): creates the IAM role
+   that Concourse uses to deploy Terraform in its pipelines
+2. [ecr](../terraform/deployments/ecr): creates AWS ECR in the GOV.UK production
+   account where container images are stored and gives permissions to other
+   AWS accounts to pull these images
+3. [terraform-lock](../terraform/deployments/terraform-lock): creates the
+   database that Terraform uses to lock the state so that there is no
+   conflicting concurrent runs of Terraform
+4. [task-runner](../terraform/deployments/task-runner): creates a ECS cluster
+   where one-off containers are run to execute a command in the infrastructure,
+   e.g. database migration.
 
-You should also set the team-wide variable (maybe as a secret):
-`govuk_environment` to `dev`.
+For each of the base deployments above (except the `ecr` one), one would have to
+create a backend file for the new environment to be spin up. You can use the
+existing backend file as a template. Once, the backend file is created, you can
+deployed the deployment by following the `Applying` section in the README.md
+file.
 
-## Apply the `concourse-iam` deployment
+## Concourse
 
-To give pipelines in the Concourse team permission to apply terraform, you'll
-first need to locally apply Terraform in the `terraform/deployments/concourse-iam`
-directory.
+### Creating a New Concourse Team
 
-## Create a Concourse pipeline for deployments
+Each GOV.UK environment needs to have its own Concourse team where the pipelines
+specific for that environment are run.
+
+A new Concourse team (e.g. `govuk-dev`) is created by requesting one from  [reliability-eng](https://reliability-engineering.cloudapps.digital/continuous-deployment.html).
+
+You'll need to add the following team-wide secrets, which are added using the [gds-cli](https://github.com/alphagov/gds-cli), to the new Concourse team:
+
+1. `docker_hub_username`: available in [2ndline password store][] under `docker`
+1. `docker_hub_authtoken`: available in [2ndline password store][] under
+   `docker`
+1. `deploy_apps_slack_webhook`: available in [2ndline password store][] under
+   `slack`
+1. `govuk_environment`: set to the name of the environment that you are created
+1. `concourse-ecr-readonly-user_aws-access-key`
+    and  `concourse-ecr-readonly-user_aws-secret-access-key`: create and
+    retrieve from the `concourse-ecr-readonly-user` IAM role in AWS console.
+    We are currently investigating how to remove the need for these 2 secrets.
+
+[2ndline password store]: https://github.com/alphagov/govuk-secrets/tree/main/pass
+
+### Creating new pipelines
+
+All pipelines are located in [here](../concourse/pipelines) along with their
+parameters [here](../concourse/parameters).
+
+When creating a new environment,
+you need to make a copy of one of the existing environment parameters directory
+(e.g. [test](../concourse/parameters/test)) and modify the files
+according to the new environment needs.
+
+## `govuk-publishing-platform` Deployment
+
+Before deploying `govuk-publishing-platform`, we need to set some secrets that
+are not generated by the platform in AWS Secrets Manager. The list of secrets
+are located [here](../terraform/deployments/govuk-publishing-platform/secrets_manager.tf)
+
+A Concourse pipeline is used to deploy the main `govuk-publishing-platform`
+deployment:
 
 ```
-fly sp -t govuk-dev -p deploy-apps -p concourse/pipelines/deploy.yml \
-  -l concourse/pipelines/deploy-parameters.yml
+fly sp -t govuk-<govuk-environment> -p deploy-apps -p concourse/pipelines/deploy.yml \
+  -l concourse/parameters/<govuk-environment>/deploy.yml
 ```
 
-This pipeline will apply the `govuk-publishing-platform` terraform deployment
-for you, and run the remaining tasks to bootstrap the environment.
+where `<govuk-environment>` is the name of the environment we are
+deploying, i.e `dev`.
+
+## Deploying `monitoring` Deployment
+
+Before deploying `monitoring`, we need to set some secrets that
+are not generated by the platform in AWS Secrets Manager. The list of secrets
+are located [here](../terraform/deployments/monitoring/infra/secrets_manager.tf) and 
+
+A Concourse pipeline is used to deploy the `monitoring`
+deployment:
+
+```
+fly sp -t govuk-<govuk-environment> -p monitoring -p concourse/pipelines/monitoring.yml \
+  -l concourse/parameters/<govuk-environment>/monitoring.yml
+```
+
+where `<govuk-environment>` is the name of the environment we are
+deploying, i.e `dev`.

--- a/terraform/deployments/ecr/README.md
+++ b/terraform/deployments/ecr/README.md
@@ -1,0 +1,11 @@
+# GOV.UK AWS ECR
+
+In the new platform, container images are stored in AWS ECR. The AWS account
+that has been chosen to host the ECR is the GOV.UK production one
+
+## Applying
+
+```shell
+gds aws govuk-production-admin -- terraform apply \
+ -var-file ../variables/common.tfvars
+```

--- a/terraform/deployments/monitoring/infra/main.tf
+++ b/terraform/deployments/monitoring/infra/main.tf
@@ -27,14 +27,6 @@ data "terraform_remote_state" "infra_networking" {
   }
 }
 
-data "aws_secretsmanager_secret" "splunk_url" {
-  name = "SPLUNK_HEC_URL"
-}
-
-data "aws_secretsmanager_secret" "splunk_token" {
-  name = "SPLUNK_TOKEN"
-}
-
 locals {
   workspace = terraform.workspace == "default" ? "ecs" : terraform.workspace #default terraform workspace mapped to ecs
   additional_tags = {
@@ -57,13 +49,15 @@ module "monitoring" {
   splunk_sourcetype       = "log"
   splunk_index            = "govuk_replatforming"
 
-  vpc_id                   = data.terraform_remote_state.infra_networking.outputs.vpc_id
-  private_subnets          = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
-  public_subnets           = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
-  grafana_cidrs_allow_list = concat(var.office_cidrs_list, var.concourse_cidrs_list)
-  govuk_environment        = var.govuk_environment
-  workspace                = local.workspace
-  additional_tags          = local.additional_tags
-  capacity_provider        = var.ecs_default_capacity_provider
-  grafana_image_tag        = "7.5.6"
+  vpc_id                          = data.terraform_remote_state.infra_networking.outputs.vpc_id
+  private_subnets                 = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
+  public_subnets                  = data.terraform_remote_state.infra_networking.outputs.public_subnet_ids
+  grafana_cidrs_allow_list        = concat(var.office_cidrs_list, var.concourse_cidrs_list)
+  govuk_environment               = var.govuk_environment
+  workspace                       = local.workspace
+  additional_tags                 = local.additional_tags
+  capacity_provider               = var.ecs_default_capacity_provider
+  grafana_image_tag               = "7.5.6"
+  github_client_id_secret_arn     = data.aws_secretsmanager_secret.github_client_id.arn
+  github_client_secret_secret_arn = data.aws_secretsmanager_secret.github_client_secret.arn
 }

--- a/terraform/deployments/monitoring/infra/secrets_manager.tf
+++ b/terraform/deployments/monitoring/infra/secrets_manager.tf
@@ -1,0 +1,15 @@
+data "aws_secretsmanager_secret" "splunk_url" {
+  name = "SPLUNK_HEC_URL"
+}
+
+data "aws_secretsmanager_secret" "splunk_token" {
+  name = "SPLUNK_TOKEN"
+}
+
+data "aws_secretsmanager_secret" "github_client_id" {
+  name = "grafana_github_client_id"
+}
+
+data "aws_secretsmanager_secret" "github_client_secret" {
+  name = "grafana_github_client_secret"
+}

--- a/terraform/deployments/task-runner/README.md
+++ b/terraform/deployments/task-runner/README.md
@@ -2,6 +2,20 @@
 
 This project enables developers to run manual and scheduled tasks in ECS.
 
+## Applying
+
+```shell
+terraform init -backend-config <govuk_environment>.backend -reconfigure
+
+terraform apply \
+ -var-file ../variables/common.tfvars \
+ -var-file ../variables/<govuk_environment>/common.tfvars
+```
+
+where:
+`<govuk_environment>` is the GOV.UK environment where you want the changes to be
+applied.
+
 ## Running a rake task
 
 To run a one-off rake task, you must do something like the following:

--- a/terraform/deployments/terraform-lock/README.md
+++ b/terraform/deployments/terraform-lock/README.md
@@ -6,12 +6,19 @@ infrastructure in a new AWS account.
 
 A DynamoDB table is created in each GOV.UK environment for Terraform locking.
 
+
+## Applying
+
 Applying:
 
 ```sh
-terraform init -backend-config=./$ENVIRONMENT.backend
+terraform init -backend-config=./<govuk_environment>.backend
 terraform apply
 ```
+
+where:
+`<govuk_environment>` is the GOV.UK environment where you want the changes to be
+applied.
 
 This creates a table `terraform-lock`.
 

--- a/terraform/modules/monitoring/grafana_defaults.tf
+++ b/terraform/modules/monitoring/grafana_defaults.tf
@@ -19,8 +19,8 @@ locals {
 
 
   grafana_secrets_from_arns = {
-    GF_AUTH_GITHUB_CLIENT_ID     = data.aws_secretsmanager_secret.github_client_id.arn,
-    GF_AUTH_GITHUB_CLIENT_SECRET = data.aws_secretsmanager_secret.github_client_secret.arn,
+    GF_AUTH_GITHUB_CLIENT_ID     = var.github_client_id_secret_arn,
+    GF_AUTH_GITHUB_CLIENT_SECRET = var.github_client_secret_secret_arn,
     GF_SECURITY_ADMIN_PASSWORD   = aws_secretsmanager_secret_version.grafana_password.arn,
   }
 

--- a/terraform/modules/monitoring/grafana_secrets.tf
+++ b/terraform/modules/monitoring/grafana_secrets.tf
@@ -1,12 +1,3 @@
-data "aws_secretsmanager_secret" "github_client_id" {
-  name = "grafana_github_client_id"
-}
-
-data "aws_secretsmanager_secret" "github_client_secret" {
-  name = "grafana_github_client_secret"
-}
-
-
 resource "random_password" "grafana_password" {
   length  = 64
   special = false

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -101,3 +101,11 @@ variable "grafana_image_tag" {
   type    = string
   default = "latest"
 }
+
+variable "github_client_id_secret_arn" {
+  type = string
+}
+
+variable "github_client_secret_secret_arn" {
+  type = string
+}


### PR DESCRIPTION
We update the documentation following the spin-up of the new Integration
GOV.UK environment. In particular, we have specified:
1. dependant deployments before the main `govuk-publishing-platform`
   can be deployed.
2. manual secrets that our Concourse teams need and where to find them
3. manual secrets that some deployments need

In addition, we refactored the secrets used in `monitoring` deployment
to make it easier to identify the secrets that need to be set manually.

Ref:
1. [trello card](https://trello.com/c/lZQJKP1h/485-spin-up-in-integration)