### PR TITLE
Make Deploy Event bucket environment specific

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -184,7 +184,7 @@ resources:
     icon: file
     source: &deploy-event-trigger-source
       aws_role_arn: ((concourse_deployer_role_arn))
-      bucket: deploy-event-((workspace))
+      bucket: deploy-event-((govuk_environment))-((workspace))
       region_name: eu-west-1
       private: true
       skip_download: true

--- a/terraform/deployments/govuk-publishing-platform/deploy-events.tf
+++ b/terraform/deployments/govuk-publishing-platform/deploy-events.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "deploy_event_bucket" {
-  bucket = "deploy-event-${terraform.workspace}"
+  bucket = "deploy-event-${var.govuk_environment}-${terraform.workspace}"
   acl    = "private"
 
   tags = merge(


### PR DESCRIPTION
The deploy event bucket is used for triggering deploys.
It enables us to put an event object into the bucket
whenever we want to trigger a deploy. Who needs Kafka
when you have S3.

However the bucket must be environment-specific. I forgot
that S3 bucket names are global (not scoped to an account).

This fixes the problem by putting the govuk_environment into
the name of the event bucket.