### PR TITLE
Be more explicit about which tests to run

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -856,7 +856,7 @@ jobs:
     - <<: *run-smoke-test
       params:
         <<: *smoke-tests-params
-        COMMAND: bundle exec cucumber --profile test --strict-undefined -t @app-frontend -t \"not @notreplatforming\"
+        COMMAND: bundle exec cucumber --profile test --strict-undefined -t @app-frontend -t @replatforming -t \"not @notreplatforming\"
     on_failure:
       <<: *notify-slack-failure
 
@@ -983,7 +983,7 @@ jobs:
     - <<: *run-smoke-test
       params:
         <<: *smoke-tests-params
-        COMMAND: bundle exec cucumber --profile test --strict-undefined -t @app-publisher -t \"not @notreplatforming and not @not((govuk_environment))\"
+        COMMAND: bundle exec cucumber --profile test --strict-undefined -t @app-publisher -t @replatforming -t \"not @notreplatforming and not @not((govuk_environment))\"
     on_failure:
       <<: *notify-slack-failure
 
@@ -1421,7 +1421,7 @@ jobs:
     - <<: *run-smoke-test
       params:
         <<: *smoke-tests-params
-        COMMAND: bundle exec cucumber --profile test --strict-undefined -t @app-signon -t \"not @notreplatforming\"
+        COMMAND: bundle exec cucumber --profile test --strict-undefined -t @app-signon -t @replatforming -t \"not @notreplatforming\"
     on_failure:
       <<: *notify-slack-failure
 


### PR DESCRIPTION
There are some new accounts tests which are relevant to @app-frontend,
but don't pass in the replatforming subset of apps (yet). We could mark
these as `@notreplatforming`, but it probably makes more sense for us to
only run tests which have been explicitly marked as okay for
`@replatforming`.

The tests we actually want to run in smokey are already marked
explicitly:

```
smokey ▶ main ▶ % ▶ git grep '@replatforming'
features/frontend.feature:@aws @replatforming @app-frontend
features/publisher.feature:@app-publisher @replatforming
features/publishing_tools.feature:  @app-publisher @replatforming
features/signon.feature:@app-signon @replatforming
```