### PR TITLE
use IAM roles with registry-image Concourse resource

### DIFF
--- a/concourse/parameters/integration/deploy.yml
+++ b/concourse/parameters/integration/deploy.yml
@@ -1,5 +1,7 @@
 govuk_infrastructure_branch: main
+ecr_registry_id: "172025368201"
 concourse_deployer_role_arn: arn:aws:iam::210287912431:role/govuk-concourse-deployer
+concourse_ecr_role_arn: arn:aws:iam::172025368201:role/pull_images_from_ecr_role
 workspace: default
 disable_slack_channel_alerts: false
 skip_db_migrations: true

--- a/concourse/parameters/test/deploy.yml
+++ b/concourse/parameters/test/deploy.yml
@@ -1,5 +1,7 @@
 govuk_infrastructure_branch: main
+ecr_registry_id: "172025368201"
 concourse_deployer_role_arn: arn:aws:iam::430354129336:role/govuk-concourse-deployer
+concourse_ecr_role_arn: arn:aws:iam::172025368201:role/pull_images_from_ecr_role
 workspace: default
 disable_slack_channel_alerts: false
 skip_db_migrations: false

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -29,8 +29,8 @@ resource_types:
   - name: registry-image
     type: docker-image
     source:
-      repository: concourse/registry-image-resource
-      tag: 1.2.1
+      repository: govuk/registry-image
+      tag: f0.0.1
       username: ((docker_hub_username))
       password: ((docker_hub_authtoken))
 
@@ -267,12 +267,13 @@ resources:
     icon: docker
     source: &registry-source
       repository: frontend
-      aws_role_arn: arn:aws:iam::172025368201:role/pull_images_from_ecr_role
       aws_region: eu-west-1
-      aws_access_key_id: ((concourse-ecr-readonly-user_aws-access-key))
-      aws_secret_access_key: ((concourse-ecr-readonly-user_aws-secret-access-key))
-      aws_ecr_registry_id: "172025368201"
+      aws_ecr_registry_id: ((ecr_registry_id))
+      aws_ec2_credentials: true
       variant: release
+      aws_role_arns:
+        - ((concourse_deployer_role_arn))
+        - ((concourse_ecr_role_arn))
 
   - <<: *registry-image
     name: static-image

--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -39,6 +39,21 @@ resource "aws_iam_role" "govuk_concourse_deployer" {
       }
     ]
   })
+
+  inline_policy {
+    name = "assume_production_ECR_role"
+
+    policy = jsonencode({
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Action" : "sts:AssumeRole",
+          "Resource" : "arn:aws:iam::${var.production_aws_account_id}:role/pull_images_from_ecr_role"
+        }
+      ]
+    })
+  }
 }
 
 # TODO - this policy is overly permissive - concourse doesn't need to be able


### PR DESCRIPTION
Currently, the Concourse `registry-image` resource is using long life
credentials of an IAM user that has been created to read from the GOV.UK
production ECR. We want to switch to IAM role and get the
credentials from the role attached to the EC2 instance that
runs the Concourse pipeline.

This will brings us the 2 main benefits:
1. short live credentials are used and less likely to be useful if
compromised.
2. there is no need to create credentials in the AWS console and add it
to the Concourse team secrets for every new team/GOV.UK environment that
we create.

Unfortunately, the Concourse `registry-image` resource does support
(i) getting AWS credentials from EC2 metadata and (ii) following a IAM
roles chain: this is required since the EC2 instances have the
credentials of the Concourse worker role which needs to be used to
assume the Concourse deployer role. The deployer role is then used to
assume a role in the GOV.UK production ECR to pull images.

A fork for the Concourse `registry-image` resource is available
[here](https://github.com/alphagov/registry-image-resource)
