### PR TITLE
Add environment variable GOVUK_ENVIRONMENT_NAME for apps

### DIFF
--- a/terraform/deployments/govuk-publishing-platform/defaults.tf
+++ b/terraform/deployments/govuk-publishing-platform/defaults.tf
@@ -13,6 +13,7 @@ locals {
       GOVUK_APP_DOMAIN_EXTERNAL = local.workspace_external_domain,
       GOVUK_APP_TYPE            = "rack",
       GOVUK_ENVIRONMENT         = var.govuk_environment
+      GOVUK_ENVIRONMENT_NAME    = var.govuk_environment # For setting environment label in apps - see https://github.com/alphagov/govuk-puppet/commit/5fc81d2e5eace5d36358aa3f5b6d6c84a982ea9c
       GOVUK_STATSD_HOST         = "statsd.${local.mesh_domain}"
       GOVUK_STATSD_PROTOCOL     = "tcp"
       GOVUK_WEBSITE_ROOT        = local.public_entry_url


### PR DESCRIPTION
This PR adds the new environment variable `GOVUK_ENVIRONMENT_NAME`, which will be used as the canonical source of truth to determine an app's environment for the purposes of setting the `environment_label` and `environment_style` properties which are used by apps still requiring the deprecated `govuk_admin_template` gem.

Once this change is in, apps using said deprecated gem in the `test` account will correctly show the current environment and display the correct colour scheme relating to this environment (currently this is missing because we (correctly) [don't create a specific initializer file during app deploy for `test`](https://github.com/alphagov/govuk-app-deployment/blob/c52a9c767dff658a912aa62cea5adde6d28ea94d/recipes/govuk_admin_template.rb)).

Trello: https://trello.com/c/0Z2F9lKU