### PR TITLE
Skip unnecessary image downloads

### DIFF
--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -1001,6 +1001,8 @@ jobs:
         trigger: true
       - get: publishing-api-image
         trigger: true
+        params:
+         skip_download: true
       - try:
           get: publishing-api-deploy-event-trigger
           trigger: true
@@ -1099,6 +1101,8 @@ jobs:
         trigger: true
       - get: content-store-image
         trigger: true
+        params:
+         skip_download: true
       - try:
           get: content-store-deploy-event-trigger
           trigger: true
@@ -1195,6 +1199,8 @@ jobs:
         trigger: true
       - get: router-image
         trigger: true
+        params:
+         skip_download: true
       - try:
           get: router-deploy-event-trigger
           trigger: true
@@ -1265,6 +1271,8 @@ jobs:
         trigger: true
       - get: router-api-image
         trigger: true
+        params:
+         skip_download: true
       - try:
           get: router-api-deploy-event-trigger
           trigger: true
@@ -1439,6 +1447,8 @@ jobs:
         trigger: true
       - get: smokey-image
         trigger: true
+        params:
+         skip_download: true
     - task: update-task-definition
       file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
       input_mapping:
@@ -1543,6 +1553,8 @@ jobs:
         trigger: true
       - get: authenticating-proxy-image
         trigger: true
+        params:
+         skip_download: true
       - try:
           get: authenticating-proxy-deploy-event-trigger
           trigger: true


### PR DESCRIPTION
It is often not necessary to download the full images in Concourse since we only want to get the latest tag/digest to pass to ECS task definition.

The only time that we want to download the full image is when we want to extract files, e.g. static assets to be uploaded to S3 bucket. This applies only to a small subset of apps currently: frontend, static, signon and publisher.
