### PR TITLE
Use main branch for frontend image

### DIFF
--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -33,7 +33,6 @@ resources:
     source:
       <<: *git-repo-source
       uri: git@github.com:alphagov/frontend.git
-      branch: master
 
   - <<: *git-repo
     name: publisher-repo


### PR DESCRIPTION
The default branch for the frontend repo has changed to main from master.