### PR TITLE
Add dependabot for Docker images and Ruby gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,13 @@ updates:
     directory: "/terraform"
     schedule:
       interval: "weekly"
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    ignore:
+      - dependency-name: ruby
+    directory: /docker/images/
+    schedule:
+      interval: weekly


### PR DESCRIPTION
We'll get notified when our gems / images need to be updated.