### PR TITLE
Run smokey builds serially

### DIFF
--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -242,6 +242,7 @@ jobs:
       set_pipeline: build-images
 
   - name: smokey
+    serial: true
     plan:
     - in_parallel:
       - get: smokey-repo


### PR DESCRIPTION
We saw the error:
Updates were rejected because the tag already exists in the remote

This happened because two smokey jobs ran in parallel. Running the builds serially will prevent this happening again.