### PR TITLE
Push infra-concourse-task image to ECR

### DIFF
--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -35,6 +35,13 @@ resources:
       uri: git@github.com:alphagov/frontend.git
 
   - <<: *git-repo
+    name: infra-concourse-task-repo
+    source:
+      <<: *git-repo-source
+      uri: git@github.com:alphagov/govuk-infrastructure.git
+      paths: [ docker/infra-concourse-task, Gemfile*, .ruby-version, concourse, lib, Rakefile ]
+
+  - <<: *git-repo
     name: publisher-repo
     source:
       <<: *git-repo-source
@@ -112,6 +119,12 @@ resources:
       tag: latest
 
   - <<: *docker-image
+    name: infra-concourse-task-image
+    source:
+      <<: *docker-image-source
+      repository: infra-concourse-task
+
+  - <<: *docker-image
     name: publisher-image
     source:
       <<: *docker-image-source
@@ -184,6 +197,12 @@ resources:
     source:
       <<: *semver-version-source
       key: frontend-version
+
+  - <<: *semver-version
+    name: infra-concourse-task-version
+    source:
+      <<: *semver-version-source
+      key: infra-concourse-task-version
 
   - <<: *semver-version
     name: publisher-version
@@ -344,6 +363,40 @@ jobs:
       - put: frontend-version
         params:
           file: frontend-version/version
+    on_failure:
+      <<: *notify-slack-failure
+
+  - name: infra-concourse-task
+    serial: true
+    plan:
+    - in_parallel:
+      - get: infra-concourse-task-repo
+        trigger: true
+      - get: infra-concourse-task-version
+        params:
+          bump: minor
+          pre_without_version: true
+          pre: release
+      - get: govuk-infrastructure
+    - task: build-image
+      privileged: true
+      file: govuk-infrastructure/concourse/tasks/build-image-definition.yml
+      input_mapping:
+        git-repo: infra-concourse-task-repo
+    - put: infra-concourse-task-image
+      params:
+        image: image/image.tar
+        additional_tags: infra-concourse-task-version/version
+    - in_parallel:
+      - put: infra-concourse-task-repo
+        params:
+          only_tag: true
+          tag_prefix: infra-concourse-task_
+          tag: infra-concourse-task-version/version
+          repository: infra-concourse-task-repo
+      - put: infra-concourse-task-version
+        params:
+          file: infra-concourse-task-version/version
     on_failure:
       <<: *notify-slack-failure
 

--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -383,6 +383,8 @@ jobs:
       file: govuk-infrastructure/concourse/tasks/build-image-definition.yml
       input_mapping:
         git-repo: infra-concourse-task-repo
+      params:
+        DOCKERFILE: git-repo/docker/images/infra-concourse-task/Dockerfile
     - put: infra-concourse-task-image
       params:
         image: image/image.tar

--- a/concourse/tasks/autogenerate-secret-key-base.yml
+++ b/concourse/tasks/autogenerate-secret-key-base.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: govuk/infra-concourse-task
-    tag: 0.0.1
+    tag: latest
     username: ((docker_hub_username))
     password: ((docker_hub_authtoken))
 inputs:

--- a/concourse/tasks/autogenerate-secret-key-base.yml
+++ b/concourse/tasks/autogenerate-secret-key-base.yml
@@ -1,11 +1,16 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: govuk/infra-concourse-task
+    repository: infra-concourse-task
     tag: latest
-    username: ((docker_hub_username))
-    password: ((docker_hub_authtoken))
+    aws_region: eu-west-1
+    aws_ecr_registry_id: ((ecr_registry_id))
+    aws_ec2_credentials: true
+    variant: release
+    aws_role_arns:
+      - ((concourse_deployer_role_arn))
+      - ((concourse_ecr_role_arn))
 inputs:
   - name: terraform-outputs
   - name: govuk-infrastructure

--- a/concourse/tasks/await-creds-in-secretsmanager.yml
+++ b/concourse/tasks/await-creds-in-secretsmanager.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: govuk/infra-concourse-task
-    tag: 0.0.1
+    tag: latest
     username: ((docker_hub_username))
     password: ((docker_hub_authtoken))
 inputs:

--- a/concourse/tasks/await-creds-in-secretsmanager.yml
+++ b/concourse/tasks/await-creds-in-secretsmanager.yml
@@ -1,11 +1,16 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: govuk/infra-concourse-task
+    repository: infra-concourse-task
     tag: latest
-    username: ((docker_hub_username))
-    password: ((docker_hub_authtoken))
+    aws_region: eu-west-1
+    aws_ecr_registry_id: ((ecr_registry_id))
+    aws_ec2_credentials: true
+    variant: release
+    aws_role_arns:
+      - ((concourse_deployer_role_arn))
+      - ((concourse_ecr_role_arn))
 inputs:
   - name: app-terraform-outputs
   - name: govuk-infrastructure

--- a/concourse/tasks/bootstrap-app-secrets.yml
+++ b/concourse/tasks/bootstrap-app-secrets.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: govuk/infra-concourse-task
-    tag: 0.0.1
+    tag: latest
     username: ((docker_hub_username))
     password: ((docker_hub_authtoken))
 inputs:

--- a/concourse/tasks/bootstrap-app-secrets.yml
+++ b/concourse/tasks/bootstrap-app-secrets.yml
@@ -1,11 +1,16 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: govuk/infra-concourse-task
+    repository: infra-concourse-task
     tag: latest
-    username: ((docker_hub_username))
-    password: ((docker_hub_authtoken))
+    aws_region: eu-west-1
+    aws_ecr_registry_id: ((ecr_registry_id))
+    aws_ec2_credentials: true
+    variant: release
+    aws_role_arns:
+      - ((concourse_deployer_role_arn))
+      - ((concourse_ecr_role_arn))
 inputs:
   - name: app-terraform-outputs
   - name: govuk-infrastructure

--- a/concourse/tasks/bootstrap-oauth-apps.yml
+++ b/concourse/tasks/bootstrap-oauth-apps.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: govuk/infra-concourse-task
-    tag: 0.0.1
+    tag: latest
     username: ((docker_hub_username))
     password: ((docker_hub_authtoken))
 inputs:

--- a/concourse/tasks/bootstrap-oauth-apps.yml
+++ b/concourse/tasks/bootstrap-oauth-apps.yml
@@ -1,11 +1,16 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: govuk/infra-concourse-task
+    repository: infra-concourse-task
     tag: latest
-    username: ((docker_hub_username))
-    password: ((docker_hub_authtoken))
+    aws_region: eu-west-1
+    aws_ecr_registry_id: ((ecr_registry_id))
+    aws_ec2_credentials: true
+    variant: release
+    aws_role_arns:
+      - ((concourse_deployer_role_arn))
+      - ((concourse_ecr_role_arn))
 inputs:
   - name: app-terraform-outputs
   - name: govuk-infrastructure

--- a/concourse/tasks/build-image-definition.yml
+++ b/concourse/tasks/build-image-definition.yml
@@ -9,5 +9,6 @@ outputs:
 - name: image
 params:
   CONTEXT: git-repo
+  DOCKERFILE: git-repo/Dockerfile
 run:
   path: build

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -24,6 +24,7 @@ locals {
   repositories = [
     "content-store",
     "frontend",
+    "infra-concourse-task",
     "publisher",
     "publishing-api",
     "router",
@@ -100,6 +101,9 @@ resource "aws_iam_role_policy_attachment" "push_to_ecr_role_attachment" {
   policy_arn = aws_iam_policy.push_image_to_ecr_policy.arn
 }
 
+# TODO: aws_ecr_repository must be created first, but this dependency is hidden
+# from Terraform. Using aws_ecr_repository.repositories rather than
+# local.repositories may resolve this.
 resource "aws_ecr_repository_policy" "pull_images_from_ecr_policy_policy" {
   for_each   = toset(local.repositories)
   repository = each.key


### PR DESCRIPTION
The infra-concourse-task image is used to run Concourse tasks in the deploy pipeline. The image contains the files and dependencies required by the concourse tasks such as ruby gems.

This creates a build job in the build-images pipeline, triggered by modifications to files required by the image on main.

You can see it running successfully at https://cd.gds-reliability.engineering/teams/govuk-ci/pipelines/build-images/jobs/infra-concourse-task.

Since this repository holds the Dockerfiles for multiple images, the git commit tag is prefixed with the ECR repository name: `infra-concourse-task_1.1.0-release`. The image tag will be `latest` or `1.2.3-release`, which is consistent with other images.