### PR TITLE
Provide Content Schemas to Publishing API in ECS

### DIFF
--- a/concourse/parameters/test/deploy.yml
+++ b/concourse/parameters/test/deploy.yml
@@ -1,8 +1,8 @@
-govuk_infrastructure_branch: main
+govuk_infrastructure_branch: bilbof/content-schemas
 ecr_registry_id: "172025368201"
 concourse_deployer_role_arn: arn:aws:iam::430354129336:role/govuk-concourse-deployer
 concourse_ecr_role_arn: arn:aws:iam::172025368201:role/pull_images_from_ecr_role
-workspace: default
-disable_slack_channel_alerts: false
+workspace: bill
+disable_slack_channel_alerts: true
 skip_db_migrations: false
 background_image: "https://live.staticflickr.com/7486/15537665259_a2d796c7d4_k_d.jpg"

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -309,14 +309,12 @@ resources:
     source:
       <<: *registry-source
       repository: publishing-api
-      tag: bilbof_dockerfile-fix # TODO - remove this once content-store supports content-schemas
 
   - <<: *registry-image
     name: content-store-image
     source:
       <<: *registry-source
       repository: content-store
-      tag: bill-content-schemas # TODO - remove this once content-store supports content-schemas
 
   - <<: *registry-image
     name: router-image

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -51,6 +51,12 @@ resources:
       uri: https://github.com/alphagov/govuk-infrastructure
     type: git
 
+  - <<: *git-repo
+    name: content-schemas
+    source:
+      branch: main
+      uri: https://github.com/alphagov/govuk-content-schemas
+
   - name: publishing-api-terraform-outputs
     type: s3
     icon: file
@@ -176,6 +182,17 @@ resources:
       bucket: ((readonly_private_bucket_name))
       region_name: eu-west-2
       versioned_file: ((workspace))/authenticating-proxy.json
+      initial_version: "0"
+
+  # This S3 bucket resource triggers a bootstrap event, which eventually
+  # triggers all jobs in the pipeline necessary to spin up a namespace.
+  - name: bootstrap-event
+    type: s3
+    icon: file
+    source:
+      bucket: ((readonly_private_bucket_name))
+      region_name: eu-west-2
+      versioned_file: ((workspace))/event.json
       initial_version: "0"
 
   - &deploy-event-trigger
@@ -355,8 +372,10 @@ groups:
   - name: all
     jobs:
       - update-pipeline
+      - create-infrastructure
       - run-terraform
       - deploy-content-store
+      - deploy-content-schemas
       - deploy-frontend
       - destroy-infrastructure
       - deploy-publisher
@@ -376,6 +395,7 @@ groups:
   - name: terraform
     jobs:
       - destroy-infrastructure
+      - create-infrastructure
       - run-terraform
 
   - name: admin
@@ -395,6 +415,7 @@ groups:
   - name: publishing-api
     jobs:
       - deploy-publishing-api
+      - deploy-content-schemas
 
   - name: router
     jobs:
@@ -426,6 +447,41 @@ groups:
       - deploy-authenticating-proxy
 
 jobs:
+  # create-infrastructure triggers the creation of all resources in a GOV.UK
+  # namespace by placing a file in an S3 bucket.
+  # TODO: Do we need to remove the object when we destroy infra?
+  - name: create-infrastructure
+    serial: true
+    plan:
+    - try:
+        get: everyday-at-6am
+        trigger: true
+    - task: create-bootstrap-trigger
+      config:
+        outputs:
+        - name: bootstrap-event
+        params:
+          WORKSPACE: ((workspace))
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            # TODO: Use ECR
+            repository: govuk/infra-concourse-task
+            tag: 0.0.2
+            username: ((docker_hub_username))
+            password: ((docker_hub_authtoken))
+        run:
+          path: sh
+          args:
+            - '-c'
+            - |
+              set -eu
+              echo "{\"date\":\"$(date '+%Y-%m-%d %H:%M:%S')\"}" > bootstrap-event/event.json
+    - put: bootstrap-event
+      params:
+        file: bootstrap-event/event.json
+
   - name: destroy-infrastructure
     plan:
     - get: everyday-at-11pm
@@ -489,8 +545,9 @@ jobs:
         passed:
         - update-pipeline
         trigger: true
-      - get: everyday-at-6am
+      - get: bootstrap-event
         trigger: true
+        passed: [create-infrastructure]
       - get: content-store-terraform-outputs
       - get: publisher-terraform-outputs
       - get: publishing-api-terraform-outputs
@@ -762,14 +819,14 @@ jobs:
           ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: frontend
           VARIANT: live
-      - task: upload-rails-assets
-        file: govuk-infrastructure/concourse/tasks/upload-rails-assets.yml
+      - task: push-dir-to-s3
+        file: govuk-infrastructure/concourse/tasks/push-dir-to-s3.yml
         input_mapping:
-          app-image: frontend-image
+          src: frontend-image
         params:
           ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
-          IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/frontend
-          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-frontends-rails-assets/assets/frontend/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
+          SOURCE_PATH: src/rootfs/app/public/assets/frontend
+          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-frontends-rails-assets/assets/frontend/ # %s will be replaced by interpolated workspace in push-dir-to-s3.yml
           WORKSPACE: ((workspace))
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
@@ -884,14 +941,14 @@ jobs:
           ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           APPLICATION: publisher
           VARIANT: web
-      - task: upload-rails-assets
-        file: govuk-infrastructure/concourse/tasks/upload-rails-assets.yml
+      - task: push-dir-to-s3
+        file: govuk-infrastructure/concourse/tasks/push-dir-to-s3.yml
         input_mapping:
-          app-image: publisher-image
+          src: publisher-image
         params:
           ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
-          IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/publisher
-          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-backends-rails-assets/assets/publisher/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
+          SOURCE_PATH: src/rootfs/app/public/assets/publisher
+          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-backends-rails-assets/assets/publisher/ # %s will be replaced by interpolated workspace in push-dir-to-s3.yml
           WORKSPACE: ((workspace))
       - task: update-web-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
@@ -988,6 +1045,30 @@ jobs:
     on_failure:
       <<: *notify-slack-failure
 
+  - name: deploy-content-schemas
+    plan:
+    - in_parallel:
+      - get: bootstrap-event
+        trigger: true
+        passed:
+        - run-terraform
+        params:
+         skip_download: true
+      - get: govuk-infrastructure
+        resource: govuk-infrastructure-concourse-tasks
+      - get: content-schemas
+        # TODO: Set to false to prevent continuous deployment
+        trigger: true
+    - task: push-content-schemas-to-s3
+      file: govuk-infrastructure/concourse/tasks/push-dir-to-s3.yml
+      input_mapping:
+        src: content-schemas
+      params:
+        ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+        SOURCE_PATH: src
+        S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-content-schemas/
+        WORKSPACE: ((workspace))
+
   - name: deploy-publishing-api
     plan:
     - in_parallel:
@@ -999,6 +1080,17 @@ jobs:
         passed:
         - run-terraform
         trigger: true
+      - get: bootstrap-event
+        trigger: true
+        passed:
+        - deploy-content-schemas
+        params:
+         skip_download: true
+      - get: content-schemas
+        trigger: true
+        passed: [deploy-content-schemas]
+        params:
+         skip_download: true
       - get: publishing-api-image
         trigger: true
         params:
@@ -1351,14 +1443,14 @@ jobs:
       - get: signon-image
         trigger: true
     - in_parallel:
-      - task: upload-rails-assets
-        file: govuk-infrastructure/concourse/tasks/upload-rails-assets.yml
+      - task: push-dir-to-s3
+        file: govuk-infrastructure/concourse/tasks/push-dir-to-s3.yml
         input_mapping:
-          app-image: signon-image
+          src: signon-image
         params:
           ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
-          IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/signon
-          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-backends-rails-assets/assets/signon/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
+          SOURCE_PATH: src/rootfs/app/public/assets/signon
+          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-backends-rails-assets/assets/signon/ # %s will be replaced by interpolated workspace in push-dir-to-s3.yml
           WORKSPACE: ((workspace))
       - task: update-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml
@@ -1479,14 +1571,14 @@ jobs:
           get: static-deploy-event-trigger
           trigger: true
     - in_parallel:
-      - task: upload-rails-assets
-        file: govuk-infrastructure/concourse/tasks/upload-rails-assets.yml
+      - task: push-dir-to-s3
+        file: govuk-infrastructure/concourse/tasks/push-dir-to-s3.yml
         input_mapping:
-          app-image: static-image
+          src: static-image
         params:
           ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
-          IMAGE_ASSETS_PATH: app-image/rootfs/app/public/assets/static
-          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-frontends-rails-assets/assets/static/ # %s will be replaced by interpolated workspace in upload-rails-assets.yml
+          SOURCE_PATH: src/rootfs/app/public/assets/static
+          S3_BUCKET_PATH_PATTERN: s3://govuk-((govuk_environment))-%s-frontends-rails-assets/assets/static/ # %s will be replaced by interpolated workspace in push-dir-to-s3.yml
           WORKSPACE: ((workspace))
       - task: update-draft-task-definition
         file: govuk-infrastructure/concourse/tasks/update-task-definition.yml

--- a/concourse/tasks/push-dir-to-s3.sh
+++ b/concourse/tasks/push-dir-to-s3.sh
@@ -16,10 +16,10 @@ fi
 
 S3_BUCKET_PATH=$(printf "$S3_BUCKET_PATH_PATTERN" "$WORKSPACE")
 
-echo "Uploading rails assets from ${IMAGE_ASSETS_PATH} to ${S3_BUCKET_PATH} ..."
+echo "Uploading files from ${SOURCE_PATH} to ${S3_BUCKET_PATH} ..."
 
 aws s3 sync \
-  "${IMAGE_ASSETS_PATH}" \
+  "${SOURCE_PATH}" \
   "${S3_BUCKET_PATH}"
 
-echo "Finished uploading rails assets from ${IMAGE_ASSETS_PATH} to ${S3_BUCKET_PATH}"
+echo "Finished uploading files from ${SOURCE_PATH} to ${S3_BUCKET_PATH}"

--- a/concourse/tasks/push-dir-to-s3.yml
+++ b/concourse/tasks/push-dir-to-s3.yml
@@ -2,19 +2,18 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: governmentpaas/awscli
-    tag: latest # TODO - manage image versions ourselves instead of using latest
+    repository: govuk/ecs-cli
+    tag: latest
     username: ((docker_hub_username))
     password: ((docker_hub_authtoken))
 inputs:
   - name: govuk-infrastructure
-    path: src
-  - name: app-image
+  - name: src
 params:
   AWS_REGION: eu-west-1
   ASSUME_ROLE_ARN:
-  IMAGE_ASSETS_PATH:
+  SOURCE_PATH: src
   S3_BUCKET_PATH_PATTERN:
   WORKSPACE:
 run:
-  path: ./src/concourse/tasks/upload-rails-assets.sh
+  path: ./govuk-infrastructure/concourse/tasks/push-dir-to-s3.sh

--- a/terraform/deployments/govuk-publishing-platform/app_content_store.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_content_store.tf
@@ -12,7 +12,6 @@ locals {
       local.defaults.environment_variables,
       {
         GOVUK_APP_NAME                  = "content-store",
-        GOVUK_CONTENT_SCHEMAS_PATH      = local.content_schemas.mount_point.containerPath,
         PLEK_SERVICE_PUBLISHING_API_URI = local.defaults.publishing_api_uri
         PLEK_SERVICE_SIGNON_URI         = local.defaults.signon_uri
         UNICORN_WORKER_PROCESSES        = 12,

--- a/terraform/deployments/govuk-publishing-platform/app_content_store.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_content_store.tf
@@ -12,7 +12,7 @@ locals {
       local.defaults.environment_variables,
       {
         GOVUK_APP_NAME                  = "content-store",
-        GOVUK_CONTENT_SCHEMAS_PATH      = "/govuk-content-schemas",
+        GOVUK_CONTENT_SCHEMAS_PATH      = local.content_schemas.mount_point.containerPath,
         PLEK_SERVICE_PUBLISHING_API_URI = local.defaults.publishing_api_uri
         PLEK_SERVICE_SIGNON_URI         = local.defaults.signon_uri
         UNICORN_WORKER_PROCESSES        = 12,

--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -13,7 +13,6 @@ locals {
       local.defaults.environment_variables,
       {
         GOVUK_APP_NAME                  = "frontend",
-        GOVUK_CONTENT_SCHEMAS_PATH      = local.content_schemas.mount_point.containerPath,
         PLEK_SERVICE_PUBLISHING_API_URI = local.defaults.publishing_api_uri
         PLEK_SERVICE_SIGNON_URI         = local.defaults.signon_uri
         UNICORN_WORKER_PROCESSES        = 12,

--- a/terraform/deployments/govuk-publishing-platform/app_frontend.tf
+++ b/terraform/deployments/govuk-publishing-platform/app_frontend.tf
@@ -13,7 +13,7 @@ locals {
       local.defaults.environment_variables,
       {
         GOVUK_APP_NAME                  = "frontend",
-        GOVUK_CONTENT_SCHEMAS_PATH      = "/govuk-content-schemas",
+        GOVUK_CONTENT_SCHEMAS_PATH      = local.content_schemas.mount_point.containerPath,
         PLEK_SERVICE_PUBLISHING_API_URI = local.defaults.publishing_api_uri
         PLEK_SERVICE_SIGNON_URI         = local.defaults.signon_uri
         UNICORN_WORKER_PROCESSES        = 12,

--- a/terraform/deployments/govuk-publishing-platform/content_schemas.tf
+++ b/terraform/deployments/govuk-publishing-platform/content_schemas.tf
@@ -1,5 +1,18 @@
+locals {
+  content_schemas = {
+    mount_point = {
+      sourceVolume  = "content_schemas",
+      containerPath = "/govuk-content-schemas",
+      readOnly      = false
+    }
+
+    s3_bucket = "govuk-${var.govuk_environment}-${local.workspace}-content-schemas"
+    volume    = { name = "content_schemas" }
+  }
+}
+
 resource "aws_s3_bucket" "content_schemas" {
-  bucket = "govuk-${var.govuk_environment}-${local.workspace}-content-schemas"
+  bucket = local.content_schemas.s3_bucket
 
   # Unless we're in staging or production, it's okay to delete this bucket
   # even if it still contains objects.
@@ -9,9 +22,53 @@ resource "aws_s3_bucket" "content_schemas" {
   force_destroy = contains(["staging", "production"], var.govuk_environment) ? false : true
 
   tags = {
-    name            = "govuk-${var.govuk_environment}-${local.workspace}-content-schemas"
+    name            = local.content_schemas.s3_bucket
     aws_environment = var.govuk_environment
   }
 }
 
-# TODO: ECS must be able to cp objects in this bucket.
+module "content_schemas_container_definition" {
+  source              = "../../modules/container-definition"
+  image               = "430354129336.dkr.ecr.eu-west-1.amazonaws.com/govuk/ecs-cli:latest"
+  aws_region          = data.aws_region.current.name
+  command             = ["/bin/sh", "-c", "aws s3 cp s3://${local.content_schemas.s3_bucket} $GOVUK_CONTENT_SCHEMAS_PATH --recursive"]
+  essential           = false
+  healthcheck_command = ["/bin/sh", "-c", "ls $GOVUK_CONTENT_SCHEMAS_PATH"]
+  environment_variables = {
+    GOVUK_CONTENT_SCHEMAS_PATH = local.content_schemas.mount_point.containerPath,
+  }
+  splunk_url_secret_arn   = local.defaults.splunk_url_secret_arn
+  splunk_token_secret_arn = local.defaults.splunk_token_secret_arn
+  splunk_index            = local.defaults.splunk_index
+  splunk_sourcetype       = local.defaults.splunk_sourcetype
+  name                    = "content_schemas_downloader"
+  ports                   = []
+  mount_points            = [local.content_schemas.mount_point]
+}
+
+resource "aws_iam_policy" "content_schemas_read_access_policy" {
+  name        = "read_content_schemas-${terraform.workspace}"
+  path        = "/readContentSchemas/"
+  description = "Read Content Schemas S3 bucket"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : ["s3:ListBucket"],
+        "Effect" : "Allow",
+        "Resource" : [
+          "arn:aws:s3:::${local.content_schemas.s3_bucket}"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : ["s3:GetObject"],
+        "Resource" : [
+          "arn:aws:s3:::${local.content_schemas.s3_bucket}/*"
+        ]
+      }
+    ]
+  })
+}

--- a/terraform/deployments/govuk-publishing-platform/content_schemas.tf
+++ b/terraform/deployments/govuk-publishing-platform/content_schemas.tf
@@ -1,0 +1,17 @@
+resource "aws_s3_bucket" "content_schemas" {
+  bucket = "govuk-${var.govuk_environment}-${local.workspace}-content-schemas"
+
+  # Unless we're in staging or production, it's okay to delete this bucket
+  # even if it still contains objects.
+  #
+  # In the lower environments, we want to be able to run `terraform destroy`
+  # without having to manually delete all the assets from the bucket.
+  force_destroy = contains(["staging", "production"], var.govuk_environment) ? false : true
+
+  tags = {
+    name            = "govuk-${var.govuk_environment}-${local.workspace}-content-schemas"
+    aws_environment = var.govuk_environment
+  }
+}
+
+# TODO: ECS must be able to cp objects in this bucket.

--- a/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
+++ b/terraform/deployments/govuk-publishing-platform/ecs_cluster.tf
@@ -182,3 +182,8 @@ resource "aws_iam_policy" "ecs_exec_access" {
 }
 EOF
 }
+
+resource "aws_iam_role_policy_attachment" "content_schemas_read_access" {
+  role       = aws_iam_role.task.id
+  policy_arn = aws_iam_policy.content_schemas_read_access_policy.arn
+}

--- a/terraform/modules/app/variables.tf
+++ b/terraform/modules/app/variables.tf
@@ -1,3 +1,9 @@
+variable "additional_containers" {
+  default     = []
+  description = "Additional containers in the ECS service task, i.e. extra init containers"
+  type        = list(any)
+}
+
 variable "backend_virtual_service_names" {
   type        = list(any)
   description = "aws_appmesh_virtual_service names called by this app"
@@ -18,6 +24,12 @@ variable "command" {
   default     = null
 }
 
+variable "container_dependencies" {
+  default     = []
+  description = "Additional container dependencies on the app container"
+  type        = list(object({ containerName = string, condition = string }))
+}
+
 variable "image_name" {
   type        = string
   description = "Used only for bootstrapping. Provide only the image name, not the tag."
@@ -27,6 +39,12 @@ variable "image_tag" {
   type        = string
   default     = "latest"
   description = "Used only for bootstrapping. Override default tag latest."
+}
+
+variable "mount_points" {
+  default     = []
+  description = "Mount points on the app container"
+  type        = list(object({ sourceVolume = string, containerPath = string, readOnly = bool }))
 }
 
 variable "registry" {
@@ -163,4 +181,9 @@ variable "additional_tags" {
   default     = {}
   description = "Additional resource tags"
   type        = map(string)
+}
+
+variable "volumes" {
+  type    = list(object({ name = string }))
+  default = []
 }

--- a/terraform/modules/container-definition/main.tf
+++ b/terraform/modules/container-definition/main.tf
@@ -36,7 +36,7 @@ output "json_format" {
   value = {
     name        = var.name,
     command     = var.command,
-    essential   = true,
+    essential   = var.essential,
     environment = [for key, value in var.environment_variables : { name : key, value : tostring(value) }],
     dependsOn   = var.dependsOn
     healthCheck = {
@@ -49,9 +49,13 @@ output "json_format" {
       initProcessEnabled = true
     }
     logConfiguration = var.log_to_splunk ? local.log_configuration_splunk : local.log_configuration_aws
-    mountPoints      = [],
+    mountPoints      = var.mount_points,
     portMappings     = [for port in var.ports : { containerPort = port, hostPort = port, protocol = "tcp" }],
     secrets          = [for key, value in var.secrets_from_arns : { name = key, valueFrom = value }]
     user             = var.user
   }
+}
+
+output "name" {
+  value = var.name
 }

--- a/terraform/modules/container-definition/variables.tf
+++ b/terraform/modules/container-definition/variables.tf
@@ -18,6 +18,11 @@ variable "environment_variables" {
 DESC
 }
 
+variable "essential" {
+  type    = bool
+  default = true
+}
+
 variable "dependsOn" {
   type        = list(object({ containerName = string, condition = string }))
   default     = []
@@ -33,6 +38,11 @@ variable "healthcheck_command" {
 variable "image" {
   type    = string
   default = null
+}
+
+variable "mount_points" {
+  type    = list(object({ sourceVolume = string, containerPath = string, readOnly = bool }))
+  default = []
 }
 
 variable "splunk_url_secret_arn" {

--- a/terraform/modules/task-definition/main.tf
+++ b/terraform/modules/task-definition/main.tf
@@ -11,6 +11,7 @@ locals {
     proxyConfiguration      = var.proxy_configuration
     requiresCompatibilities = ["FARGATE"],
     taskRoleArn             = var.task_role_arn,
+    volumes                 = var.volumes
   }
 }
 

--- a/terraform/modules/task-definition/variables.tf
+++ b/terraform/modules/task-definition/variables.tf
@@ -51,3 +51,8 @@ variable "proxy_configuration" {
 variable "task_role_arn" {
   type = string
 }
+
+variable "volumes" {
+  type    = list(object({ name = string }))
+  default = []
+}


### PR DESCRIPTION
The Publishing API app depends on [content-schemas](https://github.com/alphagov/govuk-content-schemas) being available at the path `/govuk-content-schemas`.

We use Capistrano to copy the content-schema files to EC2. As a temporary fix in ECS we have baked the content schemas into the publishing-api image. However, publishing-api releases should continue to be decoupled from content schemas versions in ECS.

In ECS we will push content-schemas to S3, trigger redeployments of publishing-api when new content-schemas versions are pushed to S3, and have publishing-api ECS Tasks copy content-schemas from S3 to the task file system for use by the publishing-api without requiring changes to the app.

This solution implements @karlbaker02's [design doc](https://docs.google.com/document/d/1nxJzdbTK__jWDFjUj9C5sH4yP0caIHhXp6fx1yKGHwE/edit) (internal-only).

Changes:

- Push content-schemas to S3 bucket in a Concourse job
- Updates to content-schemas triggers a deploy of publishing-api
- Publishing API can still be deployed without updating content-schemas
- Content Schemas will be deployed during bootstrapping but do not need to be deployed after every run-terraform job
- Added create-infrastructure job (inverse of destroy-terraform) to be run at 6am daily - triggers run-terraform, and enables us to run some jobs when bootstrapping but not on every run-terraform job.

The pipeline is available to view at https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/deploy-apps-bill.
https://trello.com/c/6PvcoCAE/540-implement-content-schemas