### PR TITLE
Permit integration AWS account to pull from prod ECR

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -138,6 +138,7 @@ resource "aws_iam_role" "pull_images_from_ecr_role" {
         "Effect" : "Allow",
         "Action" : "sts:AssumeRole",
         "Principal" : {
+          "AWS" : "arn:aws:iam::${var.integration_aws_account_id}:root",
           "AWS" : "arn:aws:iam::${var.test_aws_account_id}:root"
         }
       }


### PR DESCRIPTION
This change should enable the integration concourse deployer to pull images from production ECR.