### PR TITLE
Ensure apps are deployed in correct order during bootstrapping

### DIFF
--- a/concourse/parameters/test/deploy.yml
+++ b/concourse/parameters/test/deploy.yml
@@ -1,8 +1,8 @@
-govuk_infrastructure_branch: main
+govuk_infrastructure_branch: bilbof/deploy-dependencies
 ecr_registry_id: "172025368201"
 concourse_deployer_role_arn: arn:aws:iam::430354129336:role/govuk-concourse-deployer
 concourse_ecr_role_arn: arn:aws:iam::172025368201:role/pull_images_from_ecr_role
-workspace: default
-disable_slack_channel_alerts: false
-skip_db_migrations: false
+workspace: bill
+disable_slack_channel_alerts: true
+skip_db_migrations: true
 background_image: "https://live.staticflickr.com/7486/15537665259_a2d796c7d4_k_d.jpg"

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -3,6 +3,12 @@ display:
   background_image: ((background_image))
 
 definitions:
+- &bootstrap-trigger
+  get: bootstrap-event
+  trigger: true
+  passed: [run-terraform]
+  params:
+   skip_download: true
 
 resource_types:
   - name: slack-notification
@@ -748,6 +754,12 @@ jobs:
         get: govuk-infrastructure
         resource: govuk-infrastructure-concourse-tasks
         trigger: true
+      - <<: *bootstrap-trigger
+        passed:
+        - deploy-frontend
+        - deploy-publisher
+        - deploy-signon
+        - deploy-authenticating-proxy
       - &get-smokey-app-tf-outputs
         get: app-terraform-outputs
         resource: smokey-terraform-outputs
@@ -781,6 +793,8 @@ jobs:
         passed:
         - run-terraform
         trigger: true
+      - <<: *bootstrap-trigger
+        passed: [run-terraform]
     - task: secret_key_base
       file: govuk-infrastructure/concourse/tasks/autogenerate-secret-key-base.yml
       input_mapping:
@@ -806,6 +820,8 @@ jobs:
         passed:
         - run-terraform
         trigger: true
+      - <<: *bootstrap-trigger
+        passed: [deploy-signon,deploy-static,deploy-content-store]
       - get: frontend-image
         trigger: true
       - try:
@@ -940,6 +956,8 @@ jobs:
         passed:
         - run-terraform
         trigger: true
+      - <<: *bootstrap-trigger
+        passed: [deploy-signon,deploy-frontend,deploy-publishing-api]
       - get: publisher-image
         trigger: true
       - try:
@@ -1058,12 +1076,8 @@ jobs:
   - name: deploy-content-schemas
     plan:
     - in_parallel:
-      - get: bootstrap-event
-        trigger: true
-        passed:
-        - run-terraform
-        params:
-         skip_download: true
+      - <<: *bootstrap-trigger
+        passed: [run-terraform]
       - get: govuk-infrastructure
         resource: govuk-infrastructure-concourse-tasks
       - get: content-schemas
@@ -1090,12 +1104,8 @@ jobs:
         passed:
         - run-terraform
         trigger: true
-      - get: bootstrap-event
-        trigger: true
-        passed:
-        - deploy-content-schemas
-        params:
-         skip_download: true
+      - <<: *bootstrap-trigger
+        passed: [deploy-signon,deploy-content-schemas,deploy-content-store]
       - get: content-schemas
         trigger: true
         passed: [deploy-content-schemas]
@@ -1200,6 +1210,8 @@ jobs:
         passed:
         - run-terraform
         trigger: true
+      - <<: *bootstrap-trigger
+        passed: [deploy-signon,deploy-router-api]
       - get: content-store-image
         trigger: true
         params:
@@ -1372,6 +1384,8 @@ jobs:
         passed:
         - run-terraform
         trigger: true
+      - <<: *bootstrap-trigger
+        passed: [deploy-signon]
       - get: router-api-image
         trigger: true
         params:
@@ -1451,6 +1465,8 @@ jobs:
         passed:
         - run-terraform
         trigger: true
+      - <<: *bootstrap-trigger
+        passed: [run-terraform,autogenerate-secrets]
       - get: signon-image
         trigger: true
     - in_parallel:
@@ -1529,6 +1545,8 @@ jobs:
         - get: signon-terraform-outputs
           passed: [deploy-signon]
           trigger: true
+        - <<: *bootstrap-trigger
+          passed: [deploy-signon]
         - get: signon-image
           passed: [deploy-signon]
           trigger: true
@@ -1580,6 +1598,8 @@ jobs:
         passed:
         - run-terraform
         trigger: true
+      - <<: *bootstrap-trigger
+        passed: [run-terraform]
       - get: static-image
         trigger: true
       - try:
@@ -1658,6 +1678,8 @@ jobs:
         passed:
         - run-terraform
         trigger: true
+      - <<: *bootstrap-trigger
+        passed: [deploy-signon]
       - get: authenticating-proxy-image
         trigger: true
         params:

--- a/concourse/pipelines/deploy.yml
+++ b/concourse/pipelines/deploy.yml
@@ -406,13 +406,26 @@ groups:
     jobs:
       - update-pipeline
 
+  - name: content-store
+    jobs:
+      - deploy-signon
+      - deploy-router-api
+      - deploy-content-store
+
   - name: frontend
     jobs:
+      - deploy-signon
+      - deploy-static
+      - deploy-content-store
       - deploy-frontend
       - smoke-test-frontend
 
   - name: publisher
     jobs:
+      - deploy-signon
+      - deploy-static
+      - deploy-content-store
+      - deploy-frontend
       - deploy-publisher
       - smoke-test-publisher
 
@@ -420,6 +433,8 @@ groups:
     jobs:
       - deploy-publishing-api
       - deploy-content-schemas
+      - deploy-signon
+      - deploy-content-store
 
   - name: router
     jobs:
@@ -427,10 +442,12 @@ groups:
 
   - name: router-api
     jobs:
+      - deploy-signon
       - deploy-router-api
 
   - name: signon
     jobs:
+      - autogenerate-secrets
       - deploy-signon
       - smoke-test-signon
 
@@ -448,6 +465,7 @@ groups:
 
   - name: authenticating-proxy
     jobs:
+      - deploy-signon
       - deploy-authenticating-proxy
 
 jobs:


### PR DESCRIPTION
### Problem and context

We've seen the `frontend-smoke-test` job fail when bootstrapping the infrastructure daily ([example]()). The error message is usually something like "503 Service Unavailable". The job fails because frontend cannot reach content-store, which is still to finish deploying when the smoke test job runs.

The root cause of the problem is that we deploy applications before their dependencies are available.

We saw the same problem when bootstrapping apps dependent on Signon. Signon generates credentials for other apps and has an API required by other apps (both during deployment and at runtime). Our solution was the `await-credentials` job. Currently we start all deploy-app jobs more or less simultaneously and have some jobs poll secretsmanager for their required secrets.

This is works okay, but it feels like a Concourse anti-pattern. A secretsmanager Concourse resource might be useful here, but that wouldn't capture all of the dependencies between apps.

### Solution

I've added the bootstrap trigger to apps, so that apps will be bootstrapped after their dependencies have been deployed.

For example, frontend won't be deployed until signon, static, and content-store are deployed (fixing the above issue):

```yaml
  - name: deploy-frontend
    plan:
    - in_parallel:
      ...
      - <<: *bootstrap-trigger
        passed: [deploy-signon,deploy-static,deploy-content-store]
```

I've also modified the pipeline [groups](https://concourse-ci.org/pipelines.html#schema.pipeline.groups) to include the dependencies of apps, which should make it easier to debug an app.

<img width="1781" alt="Frontend group" src="https://user-images.githubusercontent.com/8124374/127145741-90feaa54-0be5-40ab-accb-3862dabbeab6.png">

### Reflections

The bootstrapping process should be more robust, but it will probably take longer to complete.

The pipeline also looks messier (see whole pipeline: https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/deploy-apps-bill?group=all). There are more lines (showing dependencies) which can make it harder to follow the pipeline as a whole. I think this is OK given we're going to have at least 40 more deploy-<app> jobs which will make the pipeline extremely difficult to look at in its entirety. I've added dependencies to groups to make it a bit easier to view parts of the pipeline.