### PR TITLE
fix Production ECR role

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -138,8 +138,10 @@ resource "aws_iam_role" "pull_images_from_ecr_role" {
         "Effect" : "Allow",
         "Action" : "sts:AssumeRole",
         "Principal" : {
-          "AWS" : "arn:aws:iam::${var.integration_aws_account_id}:root",
-          "AWS" : "arn:aws:iam::${var.test_aws_account_id}:root"
+          "AWS" : [
+            "arn:aws:iam::${var.integration_aws_account_id}:root",
+            "arn:aws:iam::${var.test_aws_account_id}:root"
+          ]
         }
       }
     ]


### PR DESCRIPTION
This fixes #364 where the format for setting the multiple principals for
the assume role policy was incorrect.

Now Concourse `deploy` pipeline in
[integration](https://cd.gds-reliability.engineering/teams/govuk-integration/pipelines/deploy-apps)
is pulling images successfully.