### PR TITLE
Create EKS cluster

### DIFF
--- a/helm/govuk-charts/content-store/app.yml
+++ b/helm/govuk-charts/content-store/app.yml
@@ -1,0 +1,72 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: content-store
+spec:
+  type: NodePort
+  selector:
+    app: content-store
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: content-store
+  labels:
+    app: content-store
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: content-store
+  template:
+    metadata:
+      labels:
+        app: content-store
+    spec:
+      containers:
+      - name: content-store
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store:bill-content-schemas
+        ports:
+        - containerPort: 80
+        env:
+          - name: DEFAULT_TTL
+            value: "1800"
+          - name: GOVUK_APP_DOMAIN
+            value: "default.svc.cluster.local"
+          - name: GOVUK_APP_DOMAIN_EXTERNAL
+            value: "fred.eks.test.govuk.digital"
+          - name: GOVUK_APP_NAME
+            value: "content-store"
+          - name: GOVUK_APP_TYPE
+            value: "rack"
+          - name: GOVUK_CONTENT_SCHEMAS_PATH
+            value: "/govuk-content-schemas"
+          - name: GOVUK_ENVIRONMENT
+            value: "test"
+          - name: GOVUK_WEBSITE_ROOT
+            value: "https://www.fred.eks.test.govuk.digital"
+          - name: GOVUK_WORKSPACE
+            value: "fred"
+          - name: MONGODB_URI
+            value: "mongodb://mongo-1.pink.test.govuk-internal.digital,mongo-2.pink.test.govuk-internal.digital,mongo-3.pink.test.govuk-internal.digital/content_store_production"
+          - name: PLEK_SERVICE_PUBLISHING_API_URI
+            value: "http://publishing-api-web.default.svc.cluster.local"
+          - name: PLEK_SERVICE_ROUTER_API_URI
+            value: "http://router-api.default.svc.cluster.local"
+          - name: PLEK_SERVICE_SIGNON_URI
+            value: "https://signon.fred.eks.test.govuk.digital"
+          - name: PORT
+            value: "80"
+          - name: RAILS_ENV
+            value: "production"
+          - name: SENTRY_ENVIRONMENT
+            value: "test-ecsplatform-ecs"
+          - name: UNICORN_WORKER_PROCESSES
+            value: "12"
+          - name: SECRET_KEY_BASE
+            value: "123456789"

--- a/helm/govuk-charts/frontend/app.yml
+++ b/helm/govuk-charts/frontend/app.yml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: NodePort
+  selector:
+    app: frontend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend@sha256:46d607f5762451052db0e2dbaa55b1d54a8dc441778ec35642d4cb6fce433658
+        ports:
+        - containerPort: 80
+        env:
+          - name: ASSET_HOST
+            value: "https://www-origin.fred.eks.test.govuk.digital"
+          - name: DEFAULT_TTL
+            value: "1800"
+          - name: GOVUK_APP_DOMAIN
+            value: "default.svc.cluster.local"
+          - name: GOVUK_APP_DOMAIN_EXTERNAL
+            value: "fred.eks.test.govuk.digital"
+          - name: GOVUK_APP_NAME
+            value: "frontend"
+          - name: GOVUK_APP_TYPE
+            value: "rack"
+          - name: GOVUK_ASSET_ROOT
+            value: "https://assets.test.publishing.service.gov.uk"
+          - name: GOVUK_CONTENT_SCHEMAS_PATH
+            value: "/govuk-content-schemas"
+          - name: GOVUK_ENVIRONMENT
+            value: "test"
+          - name: GOVUK_WEBSITE_ROOT
+            value: "https://www.fred.eks.test.govuk.digital"
+          - name: GOVUK_WORKSPACE
+            value: "fred"
+          - name: PLEK_SERVICE_CONTENT_STORE_URI
+            value: "http://content-store.default.svc.cluster.local"
+          - name: PLEK_SERVICE_PUBLISHING_API_URI
+            value: "http://publishing-api-web.default.svc.cluster.local"
+          - name: PLEK_SERVICE_SIGNON_URI
+            value: "https://signon.fred.eks.test.govuk.digital"
+          - name: PLEK_SERVICE_STATIC_URI
+            value: "http://static.default.svc.cluster.local"
+          - name: PORT
+            value: "80"
+          - name: RAILS_ENV
+            value: "production"
+          - name: SENTRY_ENVIRONMENT
+            value: "test-ecsplatform-ecs"
+          - name: UNICORN_WORKER_PROCESSES
+            value: "12"
+          - name: SECRET_KEY_BASE
+            value: "123456789"

--- a/helm/govuk-charts/static/app.yml
+++ b/helm/govuk-charts/static/app.yml
@@ -1,0 +1,68 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: static
+spec:
+  type: NodePort
+  selector:
+    app: static
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static
+  labels:
+    app: static
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: static
+  template:
+    metadata:
+      labels:
+        app: static
+    spec:
+      containers:
+      - name: static
+        image: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static@sha256:08c32c52ea59862893287a6701a0f24db2c792aa36f28036122f3462bd8520f9
+        ports:
+        - containerPort: 80
+        env:
+          - name: ASSET_HOST
+            value: "https://www-origin.fred.eks.test.govuk.digital"
+          - name: DEFAULT_TTL
+            value: "1800"
+          - name: GOVUK_APP_DOMAIN
+            value: "default.svc.cluster.local"
+          - name: GOVUK_APP_DOMAIN_EXTERNAL
+            value: "fred.eks.test.govuk.digital"
+          - name: GOVUK_APP_NAME
+            value: "static"
+          - name: GOVUK_APP_ROOT
+            value: "/var/apps/static"
+          - name: GOVUK_APP_TYPE
+            value: "rack"
+          - name: GOVUK_ENVIRONMENT
+            value: "test"
+          - name: GOVUK_WEBSITE_ROOT
+            value: "https://www.fred.eks.test.govuk.digital"
+          - name: GOVUK_WORKSPACE
+            value: "fred"
+          - name: REDIS_URL
+            value: "redis://redis.fred.test.govuk-internal.digital:6379"
+          - name: PORT
+            value: "80"
+          - name: RAILS_ENV
+            value: "production"
+          - name: SENTRY_ENVIRONMENT
+            value: "test-ecsplatform-ecs"
+          - name: UNICORN_WORKER_PROCESSES
+            value: "12"
+          - name: SECRET_KEY_BASE
+            value: "123456789"

--- a/terraform/deployments/govuk-eks/README.md
+++ b/terraform/deployments/govuk-eks/README.md
@@ -1,0 +1,34 @@
+# AWS EKS
+
+## Procedure
+
+1. Create cluster
+
+```sh
+gds aws govuk-test-admin -- terraform init -backend-config test.backend
+gds aws govuk-test-admin -- terraform apply
+```
+
+2. Update kubeconfig
+
+```sh
+gds aws govuk-test-admin -- aws eks --region eu-west-1 update-kubeconfig --name govuk
+```
+
+test by:
+
+```sh
+gds aws govuk-test-admin -- kubectl get nodes
+```
+
+3. Add all the apps: frontend, static, content-store
+
+```sh
+gds aws govuk-test-admin -- kubectl apply -f <repository_home>/helm/govuk-charts/<app_name>/app.yml
+```
+
+4. Get ingress address, i.e load balancer
+
+```sh
+gds aws govuk-test-admin -- kubectl get ingress
+```

--- a/terraform/deployments/govuk-eks/cert.tf
+++ b/terraform/deployments/govuk-eks/cert.tf
@@ -1,0 +1,44 @@
+resource "aws_route53_zone" "public" {
+  name = var.external_domain
+}
+
+resource "aws_route53_record" "workspace_public_zone_ns" {
+  zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id
+  name    = var.external_domain
+  type    = "NS"
+  ttl     = "300"
+
+  records = aws_route53_zone.public.name_servers
+}
+
+resource "aws_acm_certificate" "public" {
+  domain_name = "*.${var.external_domain}"
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "public" {
+  for_each = {
+    for dvo in aws_acm_certificate.public.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.public.zone_id
+}
+
+resource "aws_acm_certificate_validation" "public" {
+  certificate_arn         = aws_acm_certificate.public.arn
+  validation_record_fqdns = [for record in aws_route53_record.public : record.name]
+}

--- a/terraform/deployments/govuk-eks/helm_auth.tf
+++ b/terraform/deployments/govuk-eks/helm_auth.tf
@@ -1,0 +1,11 @@
+provider "helm" {
+  kubernetes {
+    host                   = aws_eks_cluster.govuk.endpoint
+    cluster_ca_certificate = base64decode(aws_eks_cluster.govuk.certificate_authority[0].data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1alpha1"
+      args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.govuk.name]
+      command     = "aws"
+    }
+  }
+}

--- a/terraform/deployments/govuk-eks/ingress.tf
+++ b/terraform/deployments/govuk-eks/ingress.tf
@@ -1,0 +1,319 @@
+resource "kubernetes_cluster_role" "ingress" {
+  metadata {
+    name = "ingress"
+    labels = {
+      "app.kubernetes.io/name" = "alb-ingress-controller"
+    }
+  }
+
+  rule {
+    api_groups = ["", "extensions"]
+    resources  = ["configmaps", "endpoints", "events", "ingresses", "ingresses/status", "services"]
+    verbs      = ["create", "get", "list", "update", "watch", "patch"]
+  }
+
+  rule {
+    api_groups = ["", "extensions"]
+    resources  = ["nodes", "pods", "secrets", "services", "namespaces"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
+resource "kubernetes_service_account" "ingress" {
+  metadata {
+    name = "ingress"
+    labels = {
+      "app.kubernetes.io/name"       = "alb-ingress-controller",
+      "app.kubernetes.io/managed-by" = "Helm"
+    }
+    annotations = {
+      "eks.amazonaws.com/role-arn"     = "${aws_iam_role.ingress.arn}"
+      "meta.helm.sh/release-name"      = "aws-alb-controller"
+      "meta.helm.sh/release-namespace" = "kube-system"
+    }
+    namespace = "kube-system"
+  }
+
+}
+
+resource "kubernetes_cluster_role_binding" "ingress" {
+  metadata {
+    name = "ingress"
+    labels = {
+      "app.kubernetes.io/name" = "alb-ingress-controller"
+    }
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.ingress.metadata.0.name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.ingress.metadata.0.name
+    namespace = "kube-system"
+  }
+}
+
+resource "aws_iam_policy" "ingress" {
+  name = "ingress"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "iam:CreateServiceLinkedRole",
+          "ec2:DescribeAccountAttributes",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeInstances",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeTags",
+          "ec2:GetCoipPoolUsage",
+          "ec2:DescribeCoipPools",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeListenerCertificates",
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTags"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "cognito-idp:DescribeUserPoolClient",
+          "acm:ListCertificates",
+          "acm:DescribeCertificate",
+          "iam:ListServerCertificates",
+          "iam:GetServerCertificate",
+          "waf-regional:GetWebACL",
+          "waf-regional:GetWebACLForResource",
+          "waf-regional:AssociateWebACL",
+          "waf-regional:DisassociateWebACL",
+          "wafv2:GetWebACL",
+          "wafv2:GetWebACLForResource",
+          "wafv2:AssociateWebACL",
+          "wafv2:DisassociateWebACL",
+          "shield:GetSubscriptionState",
+          "shield:DescribeProtection",
+          "shield:CreateProtection",
+          "shield:DeleteProtection"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateSecurityGroup"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateTags"
+        ],
+        "Resource" : "arn:aws:ec2:*:*:security-group/*",
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:CreateAction" : "CreateSecurityGroup"
+          },
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateTags",
+          "ec2:DeleteTags"
+        ],
+        "Resource" : "arn:aws:ec2:*:*:security-group/*",
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DeleteSecurityGroup"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "Null" : {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:DeleteRule"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ],
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ],
+        "Condition" : {
+          "Null" : {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" : "true",
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ],
+        "Resource" : [
+          "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+          "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:DeleteTargetGroup"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "Null" : {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" : "false"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets"
+        ],
+        "Resource" : "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "elasticloadbalancing:SetWebAcl",
+          "elasticloadbalancing:ModifyListener",
+          "elasticloadbalancing:AddListenerCertificates",
+          "elasticloadbalancing:RemoveListenerCertificates",
+          "elasticloadbalancing:ModifyRule"
+        ],
+        "Resource" : "*"
+      }
+    ]
+    }
+  )
+}
+
+resource "aws_iam_role" "ingress" {
+  name = "ingress"
+
+  assume_role_policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Principal" : {
+            "Federated" : aws_iam_openid_connect_provider.govuk.arn
+          },
+          "Action" : "sts:AssumeRoleWithWebIdentity",
+          "Condition" : {
+            "StringEquals" : {
+              "${replace(aws_iam_openid_connect_provider.govuk.url, "https://", "")}:sub" : "system:serviceaccount:kube-system:ingress"
+            }
+          }
+        }
+      ]
+    }
+  )
+
+  managed_policy_arns = [aws_iam_policy.ingress.arn]
+}
+
+resource "helm_release" "aws_alb_controller" {
+  name       = "aws-alb-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  version    = "1.1.6"
+  namespace  = "kube-system"
+
+  set {
+    name  = "clusterName"
+    value = aws_iam_role.eks_cluster.name
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "false"
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = kubernetes_service_account.ingress.metadata.0.name
+  }
+
+  depends_on = [kubernetes_cluster_role_binding.ingress]
+}

--- a/terraform/deployments/govuk-eks/k8s_auth.tf
+++ b/terraform/deployments/govuk-eks/k8s_auth.tf
@@ -1,0 +1,23 @@
+data "aws_eks_cluster_auth" "auth" {
+  name = "govuk"
+}
+
+provider "kubernetes" {
+  host                   = aws_eks_cluster.govuk.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.govuk.certificate_authority[0].data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.govuk.name]
+    command     = "aws"
+  }
+}
+
+data "tls_certificate" "govuk" {
+  url = aws_eks_cluster.govuk.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "govuk" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.govuk.certificates[0].sha1_fingerprint]
+  url             = aws_eks_cluster.govuk.identity[0].oidc[0].issuer
+}

--- a/terraform/deployments/govuk-eks/main.tf
+++ b/terraform/deployments/govuk-eks/main.tf
@@ -1,0 +1,70 @@
+terraform {
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.33"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.3.2"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = var.assume_role_arn
+  }
+}
+
+resource "aws_iam_role" "eks_cluster" {
+  name = "eks_cluster"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "eks_AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.eks_cluster.name
+}
+
+# Optionally, enable Security Groups for Pods
+# Reference: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html
+resource "aws_iam_role_policy_attachment" "eks_AmazonEKSVPCResourceController" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+  role       = aws_iam_role.eks_cluster.name
+}
+
+resource "aws_eks_cluster" "govuk" {
+  name     = "govuk"
+  role_arn = aws_iam_role.eks_cluster.arn
+
+  vpc_config {
+    subnet_ids = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
+  # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.eks_AmazonEKSVPCResourceController,
+  ]
+}

--- a/terraform/deployments/govuk-eks/outputs.tf
+++ b/terraform/deployments/govuk-eks/outputs.tf
@@ -1,0 +1,3 @@
+output "endpoint" {
+  value = aws_eks_cluster.govuk.endpoint
+}

--- a/terraform/deployments/govuk-eks/remote.tf
+++ b/terraform/deployments/govuk-eks/remote.tf
@@ -1,0 +1,23 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+  config = {
+    bucket   = var.govuk_aws_state_bucket
+    key      = "govuk/infra-networking.tfstate"
+    region   = data.aws_region.current.name
+    role_arn = var.assume_role_arn
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+  config = {
+    bucket   = var.govuk_aws_state_bucket
+    key      = "govuk/infra-root-dns-zones.tfstate"
+    region   = data.aws_region.current.name
+    role_arn = var.assume_role_arn
+  }
+}

--- a/terraform/deployments/govuk-eks/secrets.tf
+++ b/terraform/deployments/govuk-eks/secrets.tf
@@ -1,0 +1,33 @@
+resource "kubernetes_service_account" "signon-secrets-management" {
+  metadata {
+    name = "signon-secrets-management"
+  }
+}
+
+resource "kubernetes_cluster_role" "signon-secrets-management-role" {
+  metadata {
+    name = "signon-secrets-management"
+  }
+
+  rule {
+    api_groups = ["", ]
+    resources  = ["secrets"]
+    verbs      = ["create", "get", "list", "update", "watch", "patch"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "signon-secrets-management-role-binding" {
+  metadata {
+    name = "signon-secrets-management"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.signon-secrets-management-role.metadata.0.name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.signon-secrets-management.metadata.0.name
+    namespace = "default"
+  }
+}

--- a/terraform/deployments/govuk-eks/test.backend
+++ b/terraform/deployments/govuk-eks/test.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-test"
+key     = "projects/govuk-eks.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/deployments/govuk-eks/users_auth.tf
+++ b/terraform/deployments/govuk-eks/users_auth.tf
@@ -1,0 +1,40 @@
+locals {
+  default_configmap_roles = [
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${aws_iam_role.eks_workers.name}"
+      username = "system:node:{{EC2PrivateDNSName}}"
+      groups   = ["system:bootstrappers", "system:nodes"]
+    },
+  ]
+
+  hydrated_admin_roles = [for role in var.admin_roles :
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${role}"
+      username = "admin"
+      groups   = ["system:masters"]
+    }
+  ]
+}
+
+resource "kubernetes_config_map" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+    labels = merge(
+      {
+        "app.kubernetes.io/managed-by" = "Terraform"
+      },
+    )
+  }
+
+  data = {
+    mapRoles = yamlencode(
+      distinct(concat(
+        local.default_configmap_roles,
+        local.hydrated_admin_roles,
+      ))
+    )
+  }
+
+  depends_on = [aws_eks_cluster.govuk]
+}

--- a/terraform/deployments/govuk-eks/variables.tf
+++ b/terraform/deployments/govuk-eks/variables.tf
@@ -1,0 +1,44 @@
+variable "assume_role_arn" {
+  type        = string
+  description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
+  default     = null
+}
+
+variable "govuk_aws_state_bucket" {
+  type        = string
+  description = "The name of the S3 bucket used for govuk-aws's terraform state files"
+  default     = "govuk-terraform-steppingstone-test"
+}
+
+variable "external_domain" {
+  type        = string
+  description = "full domain where services will be accessible publicly"
+  default     = "eks.test.govuk.digital"
+}
+
+variable "worker_node_instance_type" {
+  type        = string
+  description = "worker_node_instance_type"
+  default     = "m5.4xlarge"
+}
+
+variable "desired_workers_size" {
+  type        = number
+  description = "desired number of worker nodes"
+  default     = 1
+}
+
+#TODO: move default to variables file
+variable "admin_roles" {
+  description = "name of Additional IAM roles to add to the aws-auth configmap"
+  type        = list(string)
+  default = [
+    "frederic.francois-admin",
+    "william.franklin-admin",
+    "roch.trinque-admin",
+    "stephen.ford-admin",
+    "karl.baker-admin",
+    "chris.banks-admin",
+    "nadeem.sabri-admin",
+  ]
+}

--- a/terraform/deployments/govuk-eks/workers.tf
+++ b/terraform/deployments/govuk-eks/workers.tf
@@ -1,0 +1,54 @@
+resource "aws_iam_role" "eks_workers" {
+  name = "eks_workers"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.eks_workers.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.eks_workers.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.eks_workers.name
+}
+
+
+resource "aws_eks_node_group" "govuk" {
+  cluster_name    = aws_eks_cluster.govuk.name
+  node_group_name = "govuk"
+  node_role_arn   = aws_iam_role.eks_workers.arn
+  subnet_ids      = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
+
+  instance_types = [var.worker_node_instance_type]
+
+  scaling_config {
+    desired_size = var.desired_workers_size
+    max_size     = var.desired_workers_size
+    min_size     = var.desired_workers_size
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.eks_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.eks_AmazonEC2ContainerRegistryReadOnly,
+    kubernetes_config_map.aws_auth,
+  ]
+}

--- a/terraform/deployments/govuk-eks/www_origin.tf
+++ b/terraform/deployments/govuk-eks/www_origin.tf
@@ -1,0 +1,76 @@
+# TODO: This is a placeholder service that will be replaced by `router` service.
+# The service will still be deployed later by using `kubectl` or `helm`.
+# The k8s ingress needs the service(s) to be present before creation or else
+# it will stuck in creation.
+# It is easier to have k8s ingress created in terraform since we can add a CNAME
+# to the "random" FQDN of the AWS ALB created to represent the k8s ingress.
+
+
+resource "kubernetes_service" "frontend" {
+  metadata {
+    name = "frontend"
+  }
+  spec {
+    selector = {
+      app = "frontend"
+    }
+
+    port {
+      port        = 80
+      target_port = 80
+    }
+
+    type = "NodePort"
+  }
+}
+
+
+resource "kubernetes_ingress" "www_origin_ingress" {
+  metadata {
+    name = "www-origin-ingress"
+    annotations = {
+      "kubernetes.io/ingress.class" : "alb"
+      "alb.ingress.kubernetes.io/scheme" : "internet-facing"
+      "alb.ingress.kubernetes.io/subnets" : join(",", data.terraform_remote_state.infra_networking.outputs.public_subnet_ids)
+      "alb.ingress.kubernetes.io/listen-ports" : "[{\"HTTPS\": 443}]"
+      "alb.ingress.kubernetes.io/certificate-arn" : aws_acm_certificate_validation.public.certificate_arn
+    }
+  }
+
+  spec {
+    backend {
+      service_name = kubernetes_service.frontend.metadata.0.name
+      service_port = 80
+    }
+
+    rule {
+      http {
+        path {
+          backend {
+            service_name = kubernetes_service.frontend.metadata.0.name
+            service_port = 80
+          }
+
+          path = "/*"
+        }
+      }
+    }
+
+  }
+
+  wait_for_load_balancer = true
+
+  depends_on = [helm_release.aws_alb_controller]
+}
+
+resource "aws_route53_record" "www_origin" {
+  zone_id = aws_route53_zone.public.zone_id
+  name    = "www-origin"
+  type    = "CNAME"
+  ttl     = 300
+  records = [kubernetes_ingress.www_origin_ingress.status.0.load_balancer.0.ingress.0.hostname]
+}
+
+output "www_ingress_fqdn" {
+  value = "${aws_route53_record.www_origin.name}.${aws_route53_zone.public.name}"
+}


### PR DESCRIPTION
This PR does the following:
1. create a `govuk` EKS cluster
2. create necessary resources for AWS ALB ingress controllers
3. install some apps using basic k8s yaml using kubectl (not yet
converted into helm chart). You can access frontend
via: https://www-origin.eks.test.govuk.digital/
4. add our team members as admin so they can use their AWS admin role to
interact with the cluster using kubectl

Ref:
1. [trello
tasks](https://trello.com/c/9PWkSvuN/589-reconfigure-govuk-infrastructure-to-support-eks)

Co-authored-by: William Flanklin <william.franklin@digital.cabinet-office.gov.uk>