### PR TITLE
Create GOV.UK tmp EKS Cluster

### DIFF
--- a/terraform/deployments/eks/k8s_auth.tf
+++ b/terraform/deployments/eks/k8s_auth.tf
@@ -1,0 +1,13 @@
+data "aws_eks_cluster_auth" "auth" {
+  name = "govuk"
+}
+
+provider "kubernetes" {
+  host                   = aws_eks_cluster.govuk.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.govuk.certificate_authority[0].data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.govuk.name]
+    command     = "aws"
+  }
+}

--- a/terraform/deployments/eks/main.tf
+++ b/terraform/deployments/eks/main.tf
@@ -1,0 +1,72 @@
+terraform {
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.33"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.3.2"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = var.assume_role_arn
+  }
+}
+
+resource "aws_iam_role" "eks_cluster" {
+  name = "eks_cluster-tmp"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "eks_AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.eks_cluster.name
+}
+
+# Optionally, enable Security Groups for Pods
+# Reference: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html
+#resource "aws_iam_role_policy_attachment" "eks_AmazonEKSVPCResourceController" {
+#  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+#  role       = aws_iam_role.eks_cluster.name
+#}
+
+resource "aws_eks_cluster" "govuk" {
+  name     = "govuk-tmp"
+  role_arn = aws_iam_role.eks_cluster.arn
+
+  vpc_config {
+    subnet_ids = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
+  # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_AmazonEKSClusterPolicy,
+    #aws_iam_role_policy_attachment.eks_AmazonEKSVPCResourceController,
+  ]
+}
+
+

--- a/terraform/deployments/eks/remote.tf
+++ b/terraform/deployments/eks/remote.tf
@@ -1,0 +1,23 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+  config = {
+    bucket   = var.govuk_aws_state_bucket
+    key      = "govuk/infra-networking.tfstate"
+    region   = data.aws_region.current.name
+    role_arn = var.assume_role_arn
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+  config = {
+    bucket   = var.govuk_aws_state_bucket
+    key      = "govuk/infra-root-dns-zones.tfstate"
+    region   = data.aws_region.current.name
+    role_arn = var.assume_role_arn
+  }
+}

--- a/terraform/deployments/eks/test.backend
+++ b/terraform/deployments/eks/test.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-test"
+key     = "projects/tmp-govuk-eks.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/deployments/eks/users.tf
+++ b/terraform/deployments/eks/users.tf
@@ -1,0 +1,40 @@
+locals {
+  default_configmap_roles = [
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${aws_iam_role.eks_workers.name}"
+      username = "system:node:{{EC2PrivateDNSName}}"
+      groups   = ["system:bootstrappers", "system:nodes"]
+    },
+  ]
+
+  hydrated_admin_roles = [for role in var.admin_roles :
+    {
+      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${role}"
+      username = "admin"
+      groups   = ["system:masters"]
+    }
+  ]
+}
+
+resource "kubernetes_config_map" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+    labels = merge(
+      {
+        "app.kubernetes.io/managed-by" = "Terraform"
+      },
+    )
+  }
+
+  data = {
+    mapRoles = yamlencode(
+      distinct(concat(
+        local.default_configmap_roles,
+        local.hydrated_admin_roles,
+      ))
+    )
+  }
+
+  depends_on = [aws_eks_cluster.govuk]
+}

--- a/terraform/deployments/eks/variables.tf
+++ b/terraform/deployments/eks/variables.tf
@@ -1,0 +1,44 @@
+variable "assume_role_arn" {
+  type        = string
+  description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
+  default     = null
+}
+
+variable "govuk_aws_state_bucket" {
+  type        = string
+  description = "The name of the S3 bucket used for govuk-aws's terraform state files"
+  default     = "govuk-terraform-steppingstone-test"
+}
+
+variable "external_domain" {
+  type        = string
+  description = "full domain where services will be accessible publicly"
+  default     = "tmp.eks.test.govuk.digital"
+}
+
+variable "worker_node_instance_type" {
+  type        = string
+  description = "worker_node_instance_type"
+  default     = "m5.4xlarge"
+}
+
+variable "desired_workers_size" {
+  type        = number
+  description = "desired number of worker nodes"
+  default     = 1
+}
+
+#TODO: move default to variables file
+variable "admin_roles" {
+  description = "name of Additional IAM roles to add to the aws-auth configmap"
+  type        = list(string)
+  default = [
+    "frederic.francois-admin",
+    "william.franklin-admin",
+    "roch.trinque-admin",
+    "stephen.ford-admin",
+    "karl.baker-admin",
+    "chris.banks-admin",
+    "nadeem.sabri-admin",
+  ]
+}

--- a/terraform/deployments/eks/workers.tf
+++ b/terraform/deployments/eks/workers.tf
@@ -1,0 +1,54 @@
+resource "aws_iam_role" "eks_workers" {
+  name = "eks_workers-tmp"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.eks_workers.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.eks_workers.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.eks_workers.name
+}
+
+
+resource "aws_eks_node_group" "govuk" {
+  cluster_name    = aws_eks_cluster.govuk.name
+  node_group_name = "govuk"
+  node_role_arn   = aws_iam_role.eks_workers.arn
+  subnet_ids      = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
+
+  instance_types = [var.worker_node_instance_type]
+
+  scaling_config {
+    desired_size = var.desired_workers_size
+    max_size     = var.desired_workers_size
+    min_size     = var.desired_workers_size
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.eks_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.eks_AmazonEC2ContainerRegistryReadOnly,
+    kubernetes_config_map.aws_auth,
+  ]
+}


### PR DESCRIPTION
This creates a temporary EKS cluster for use by GOV.UK replatforming.
This is named govuk-tmp because there is a currently running cluster
which we are working with.  In time both of these clusters will be
cleaned up.

The PR does:
- creates an eks cluster
- creates a node group
- defines worker node sizing
- grants access to the cluster to the replatforming administrators
- grants access to the cluster to allow the k8s provider to configure
  iam role mapping to k8s users

Pair: @karlbaker02 & @smford 