### PR TITLE
Move aws-auth ConfigMap generation into a separate root module.

### DIFF
--- a/terraform/deployments/eks-stage2/aws_auth_configmap.tf
+++ b/terraform/deployments/eks-stage2/aws_auth_configmap.tf
@@ -1,0 +1,48 @@
+# Generate the aws-auth ConfigMap, which defines the mapping between AWS IAM
+# roles and k8s RBAC. The authoritative ACLs are defined in
+# https://github.com/alphagov/govuk-aws-data/blob/master/data/infra-security/
+# and read here via Terraform remote state.
+#
+# The aws-auth ConfigMap is documented at
+# https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+#
+# Generally, it is unwise to manage k8s objects directly from Terraform (as
+# opposed to using Helm or kubectl or other tooling designed to work with
+# k8s). This is a rare exception to that rule of thumb.
+
+locals {
+  default_configmap_roles = [
+    {
+      rolearn  = data.terraform_remote_state.eks.outputs.worker_iam_role_arn
+      username = "system:node:{{EC2PrivateDNSName}}"
+      groups   = ["system:bootstrappers", "system:nodes"]
+    },
+  ]
+
+  admin_roles_and_arns = data.terraform_remote_state.infra_security.outputs.admin_roles_and_arns
+  admin_configmap_roles = [
+    for user, arn in local.admin_roles_and_arns : {
+      rolearn  = arn
+      username = user
+      # TODO: don't use system:masters.
+      groups = ["system:masters"]
+    }
+  ]
+}
+
+resource "kubernetes_config_map" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+    labels    = { "app.kubernetes.io/managed-by" = "Terraform" }
+  }
+
+  data = {
+    mapRoles = yamlencode(
+      distinct(concat(
+        local.default_configmap_roles,
+        local.admin_configmap_roles,
+      ))
+    )
+  }
+}

--- a/terraform/deployments/eks-stage2/k8s_auth.tf
+++ b/terraform/deployments/eks-stage2/k8s_auth.tf
@@ -1,0 +1,13 @@
+data "aws_eks_cluster_auth" "auth" {
+  name = data.terraform_remote_state.eks.outputs.cluster_id
+}
+
+provider "kubernetes" {
+  host                   = data.terraform_remote_state.eks.outputs.cluster_endpoint
+  cluster_ca_certificate = base64decode(data.terraform_remote_state.eks.outputs.cluster_certificate_authority_data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", data.terraform_remote_state.eks.outputs.cluster_id]
+  }
+}

--- a/terraform/deployments/eks-stage2/main.tf
+++ b/terraform/deployments/eks-stage2/main.tf
@@ -1,0 +1,27 @@
+# The eks-stage2 module is responsible for Kubernetes objects within the EKS
+# cluster.
+#
+# It has to be a separate root module (aka deployment/project) because
+# Terraform does not handle dependencies in provider configurations, which
+# means the Kubernetes and Helm providers cannot reliably be initialised in the
+# same root module which creates the EKS cluster (see warning in
+# https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#stacking-with-managed-kubernetes-cluster-resources).
+
+terraform {
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.33"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = var.assume_role_arn
+  }
+}

--- a/terraform/deployments/eks-stage2/remote.tf
+++ b/terraform/deployments/eks-stage2/remote.tf
@@ -1,0 +1,23 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "terraform_remote_state" "eks" {
+  backend = "s3"
+  config = {
+    bucket   = var.eks_state_bucket
+    key      = "projects/eks.tfstate"
+    region   = data.aws_region.current.name
+    role_arn = var.assume_role_arn
+  }
+}
+
+data "terraform_remote_state" "infra_security" {
+  backend = "s3"
+  config = {
+    bucket   = var.govuk_aws_state_bucket
+    key      = "govuk/infra-security.tfstate"
+    region   = data.aws_region.current.name
+    role_arn = var.assume_role_arn
+  }
+}

--- a/terraform/deployments/eks-stage2/test.backend
+++ b/terraform/deployments/eks-stage2/test.backend
@@ -1,0 +1,4 @@
+bucket  = "govuk-terraform-test"
+key     = "projects/eks-stage2.tfstate"
+encrypt = true
+region  = "eu-west-1"

--- a/terraform/deployments/eks-stage2/variables.tf
+++ b/terraform/deployments/eks-stage2/variables.tf
@@ -1,0 +1,15 @@
+variable "assume_role_arn" {
+  type        = string
+  description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
+  default     = null
+}
+
+variable "govuk_aws_state_bucket" {
+  type        = string
+  description = "Name of the S3 bucket used for govuk-aws's Terraform state."
+}
+
+variable "eks_state_bucket" {
+  type        = string
+  description = "Name of the S3 bucket for the (first-stage) 'eks' module's Terraform state. Must match the name of the bucket specified in the backend config file."
+}

--- a/terraform/deployments/eks/outputs.tf
+++ b/terraform/deployments/eks/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_certificate_authority_data" {
+  description = "Base64-encoded certificate data required to communicate with the cluster."
+  value       = module.eks.cluster_certificate_authority_data
+}
+
+output "worker_iam_role_arn" {
+  description = "IAM role ARN for EKS worker node groups"
+  value       = module.eks.worker_iam_role_arn
+}
+
+output "cluster_id" {
+  description = "The name (also known as the ID) of the EKS cluster."
+  value       = module.eks.cluster_id
+}
+
+output "cluster_endpoint" {
+  description = "The endpoint for the EKS cluster's kube-apiserver."
+  value       = module.eks.cluster_endpoint
+}

--- a/terraform/deployments/eks/variables.tf
+++ b/terraform/deployments/eks/variables.tf
@@ -6,9 +6,7 @@ variable "assume_role_arn" {
 
 variable "govuk_aws_state_bucket" {
   type        = string
-  description = "The name of the S3 bucket used for govuk-aws's terraform state files"
-  # TODO: this probably should not have a default
-  default = "govuk-terraform-steppingstone-test"
+  description = "The name of the S3 bucket used for govuk-aws's Terraform state files."
 }
 
 variable "workers_instance_type" {

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -1,4 +1,5 @@
 govuk_aws_state_bucket = "govuk-terraform-steppingstone-test"
+eks_state_bucket       = "govuk-terraform-test"
 
 govuk_environment             = "test"
 ecs_default_capacity_provider = "FARGATE_SPOT"


### PR DESCRIPTION
Terraform cannot reliably manage Kubernetes objects in the same run as creating the cluster. This is because Terraform does not handle dependencies between provider configurations: see https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#stacking-with-managed-kubernetes-cluster-resources

We therefore need a separate deployment in order to reliably deploy k8s objects into the cluster. Configuration about the EKS cluster is passed from the first-stage deployment to the second-stage deployment via Terraform remote state.

Also clean up the variables, e.g. remove some defaults which were specific to the test environment.

Based on some earlier proof-of-concept work by @fredericfran-gds and @bilbof.

[Trello card](https://trello.com/c/dqG4nXn0/591)

#### Alternatives considered

Considered generating the aws-auth ConfigMap outside Terraform using a simple script (run terraform output from govuk-aws, pipe into transformation script to output the configmap, pipe into kubectl apply) and CDing it from Concourse. Decided against this because we're going to need this second-stage Terraform deployment anyway because we want to use the Helm provider to install/manage the cluster addons and therefore it makes sense to use the same setup for this.

#### Testing

Successfully applied the `eks` module followed by the `eks-stage2` module in the test account. Resulting aws-auth configmap looks good and a user other than the creator of the cluster was able to authenticate to the apiserver.

How to test:
```
cd eks
terraform init -backend-config test.backend -reconfigure
terraform apply -var-file=../variables/test/common.tfvars
cd ../eks-stage2
terraform init -backend-config test.backend -reconfigure
terraform apply -var-file=../variables/test/common.tfvars
aws eks update-kubeconfig --name govuk-tmp
kubectl auth can-i \* \*
kubectl describe cm aws-auth -n kube-system
```

#### Rollout

Depends on alphagov/govuk-aws#1465.

#### Caveats / follow-up work

We're currently just assigning `system:masters` to all the users. This is not good practice and we'll need to improve on that very soon. It's tolerable for just getting us going in the test environment for now.

Co-authored-by: Karl Baker <karl.baker@digital.cabinet-office.gov.uk>