### PR TITLE
Add Concourse pipeline for terraforming EKS

### DIFF
--- a/concourse/parameters/test/eks.yml
+++ b/concourse/parameters/test/eks.yml
@@ -1,0 +1,3 @@
+aws_region: eu-west-1
+concourse_deployer_role_arn: arn:aws:iam::430354129336:role/govuk-concourse-deployer
+govuk_infrastructure_branch: main

--- a/concourse/pipelines/eks.yml
+++ b/concourse/pipelines/eks.yml
@@ -1,0 +1,84 @@
+---
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest # TODO - don't use latest (once we've worked out a policy for third party images)
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
+
+resources:
+  - icon: github
+    name: govuk-infrastructure
+    source:
+      branch: ((govuk_infrastructure_branch))
+      uri: https://github.com/alphagov/govuk-infrastructure
+    type: git
+
+  - name: deploy-slack-channel
+    type: slack-notification
+    icon: bell-ring
+    source:
+      url: https://hooks.slack.com/services/((deploy_apps_slack_webhook))
+      disable: ((disable_slack_channel_alerts))
+
+jobs:
+  - name: update-pipeline
+    plan:
+    - get: govuk-infrastructure
+      trigger: true
+    - file: govuk-infrastructure/concourse/pipelines/eks.yml
+      set_pipeline: self
+      var_files:
+        - govuk-infrastructure/concourse/parameters/((govuk_environment))/eks.yml
+
+  - name: terraform-eks-cluster
+    plan:
+    - get: govuk-infrastructure
+      trigger: true
+      passed:
+      - update-pipeline
+    - task: terraform-cluster
+      config: &terraform-cluster-config
+        inputs:
+        - name: govuk-infrastructure
+        params: &terraform-cluster-params
+          ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
+          AWS_REGION: ((aws_region))
+          DEPLOYMENT_PATH: govuk-infrastructure/terraform/deployments/eks
+          ENVIRONMENT: ((govuk_environment))
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: digiticketsgroup/terraforming
+            tag: tf-1.0.1-aws-2.2.18-jq-1.5-git-2.32.0 #TODO: build our own image instead.
+            username: ((docker_hub_username))
+            password: ((docker_hub_authtoken))
+        run: 
+          path: govuk-infrastructure/concourse/tasks/terraform-apply.sh
+    on_failure: &notify-slack-failure
+      put: deploy-slack-channel
+      params:
+        channel: "#govuk-deploy-alerts" # TODO: Alert owner Slack channels in future
+        username: ((govuk_environment)) $BUILD_JOB_NAME
+        icon_emoji: ":concourse:"
+        silent: true
+        text: |
+          :red_circle: Failed deploy: https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+  - name: terraform-eks-cluster-addons
+    plan:
+    - get: govuk-infrastructure
+      trigger: true
+      passed:
+      - terraform-eks-cluster
+    - task: terraform-cluster-addons
+      config: 
+        <<: *terraform-cluster-config
+        params: 
+          <<: *terraform-cluster-params
+          DEPLOYMENT_PATH: govuk-infrastructure/terraform/deployments/eks-stage2
+    on_failure:
+      <<: *notify-slack-failure

--- a/concourse/tasks/terraform-apply.sh
+++ b/concourse/tasks/terraform-apply.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eu
+
+export TF_IN_AUTOMATION=1
+
+# Assume role once here, rather than configuring the same thing (via different
+# options) in each Terraform provider in every root module.
+#
+# TODO: If this ends up being used elsewhere, factor it out into a script and
+# build it into the image.
+creds="$(aws sts assume-role \
+  --role-session-name "concourse-$(date +%d-%m-%y_%H-%M-%S)" \
+  --role-arn "${ASSUME_ROLE_ARN}" \
+  | jq .Credentials)"
+export AWS_ACCESS_KEY_ID="$(echo $creds | jq -r .AccessKeyId)"
+export AWS_SECRET_ACCESS_KEY="$(echo $creds | jq -r .SecretAccessKey)"
+export AWS_SESSION_TOKEN="$(echo $creds | jq -r .SessionToken)"
+
+cd "${DEPLOYMENT_PATH}"
+
+terraform init -input=false -backend-config "${ENVIRONMENT}.backend"
+
+terraform apply -input=false \
+  -var-file "../variables/${ENVIRONMENT}/common.tfvars" \
+  -auto-approve

--- a/terraform/deployments/eks-stage2/aws_auth_configmap.tf
+++ b/terraform/deployments/eks-stage2/aws_auth_configmap.tf
@@ -19,7 +19,11 @@ locals {
     },
   ]
 
-  admin_roles_and_arns = data.terraform_remote_state.infra_security.outputs.admin_roles_and_arns
+  concourse_worker_role = {
+    "govuk-concourse-deployer" = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/govuk-concourse-deployer"
+  }
+
+  admin_roles_and_arns = merge(data.terraform_remote_state.infra_security.outputs.admin_roles_and_arns, local.concourse_worker_role)
   admin_configmap_roles = [
     for user, arn in local.admin_roles_and_arns : {
       rolearn  = arn

--- a/terraform/deployments/eks-stage2/main.tf
+++ b/terraform/deployments/eks-stage2/main.tf
@@ -20,8 +20,4 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
-
-  assume_role {
-    role_arn = var.assume_role_arn
-  }
 }

--- a/terraform/deployments/eks-stage2/remote.tf
+++ b/terraform/deployments/eks-stage2/remote.tf
@@ -5,19 +5,17 @@ data "aws_caller_identity" "current" {}
 data "terraform_remote_state" "eks" {
   backend = "s3"
   config = {
-    bucket   = var.eks_state_bucket
-    key      = "projects/eks.tfstate"
-    region   = data.aws_region.current.name
-    role_arn = var.assume_role_arn
+    bucket = var.eks_state_bucket
+    key    = "projects/eks.tfstate"
+    region = data.aws_region.current.name
   }
 }
 
 data "terraform_remote_state" "infra_security" {
   backend = "s3"
   config = {
-    bucket   = var.govuk_aws_state_bucket
-    key      = "govuk/infra-security.tfstate"
-    region   = data.aws_region.current.name
-    role_arn = var.assume_role_arn
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-security.tfstate"
+    region = data.aws_region.current.name
   }
 }

--- a/terraform/deployments/eks-stage2/variables.tf
+++ b/terraform/deployments/eks-stage2/variables.tf
@@ -1,9 +1,3 @@
-variable "assume_role_arn" {
-  type        = string
-  description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
-  default     = null
-}
-
 variable "govuk_aws_state_bucket" {
   type        = string
   description = "Name of the S3 bucket used for govuk-aws's Terraform state."

--- a/terraform/deployments/eks/main.tf
+++ b/terraform/deployments/eks/main.tf
@@ -11,10 +11,6 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
-
-  assume_role {
-    role_arn = var.assume_role_arn
-  }
 }
 
 module "eks" {

--- a/terraform/deployments/eks/remote.tf
+++ b/terraform/deployments/eks/remote.tf
@@ -5,9 +5,8 @@ data "aws_caller_identity" "current" {}
 data "terraform_remote_state" "infra_networking" {
   backend = "s3"
   config = {
-    bucket   = var.govuk_aws_state_bucket
-    key      = "govuk/infra-networking.tfstate"
-    region   = data.aws_region.current.name
-    role_arn = var.assume_role_arn
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-networking.tfstate"
+    region = data.aws_region.current.name
   }
 }

--- a/terraform/deployments/eks/variables.tf
+++ b/terraform/deployments/eks/variables.tf
@@ -1,9 +1,3 @@
-variable "assume_role_arn" {
-  type        = string
-  description = "(optional) AWS IAM role to assume. Uses the role from the environment by default."
-  default     = null
-}
-
 variable "govuk_aws_state_bucket" {
   type        = string
   description = "The name of the S3 bucket used for govuk-aws's Terraform state files."


### PR DESCRIPTION
This PR creates a pipeline for terraforming EKS, consisting of two jobs `terraform-eks-cluster` and `terraform-eks-cluster-addons`, which terraforms the EKS cluster and the addons respectively. This is necessary for the reasons as detailed in commit c228db6.

We also change the way we assume the `govuk-concourse-deployer` role.  Instead of configuring the role once per Terraform provider per top-level module (`deployments/*`), we do the assume-role as part of the terraform-apply.sh script (by running aws sts assume-role). This results in less overall complexity. (Config for the k8s TF provider to assume a role is different from the equivalent config for the AWS provider.)

An alternative would be to keep all the existing assume-role configs and pass `--role-arn` to the `aws` command from the k8s TF provider config. Our approach however means we have one place and one way of assuming the role, rather than two different ways and multiple places (one per provider per top-level module).

We also add the `govuk-concourse-deployer` role to the `aws-auth` configmap so that Concourse can apply changes to the Kubernetes cluster via the Kubernetes Terraform provider. This is only strictly necessary when Concourse is modifying an existing cluster _not_ created by Concourse (i.e. not created by the `govuk-concourse-deployer` role), but we're including this for robustness and to make the required permissions explicit.

We're running Terraform in automation mode per the best practices described in https://learn.hashicorp.com/tutorials/terraform/automate-terraform

Pair: @sengi 

Trello: https://trello.com/c/dqG4nXn0

Tested: successfully updates the existing govuk-tmp cluster (see [Concourse pipeline](https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/eks)).

![Screenshot 2021-08-12 at 14 37 45](https://user-images.githubusercontent.com/5422487/129206660-a8f03e3c-a40e-4b87-a76f-b9c8eac7ed99.png)