### PR TITLE
rename EKS cluster

### DIFF
--- a/terraform/deployments/eks/main.tf
+++ b/terraform/deployments/eks/main.tf
@@ -21,7 +21,7 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "17.1.0"
 
-  cluster_name    = "govuk-tmp" # TODO: name
+  cluster_name    = "govuk"
   cluster_version = "1.21"
   subnets         = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
   vpc_id          = data.terraform_remote_state.infra_networking.outputs.vpc_id


### PR DESCRIPTION
Now that the Proof-of-Concept `govuk` cluster has been deleted, we can
reuse this name for our cluster here rather than use `govuk-tmp`

**Deployment**: applying this PR will destroy the current `govuk-tmp`
cluster and replace it with a new one.