### PR TITLE
Enable control plane logging and disable writing kubeconfig.

### DIFF
--- a/terraform/deployments/eks/main.tf
+++ b/terraform/deployments/eks/main.tf
@@ -17,11 +17,17 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "17.1.0"
 
-  cluster_name    = "govuk"
-  cluster_version = "1.21"
-  subnets         = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
-  vpc_id          = data.terraform_remote_state.infra_networking.outputs.vpc_id
-  manage_aws_auth = false
+  cluster_name     = "govuk"
+  cluster_version  = "1.21"
+  subnets          = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
+  vpc_id           = data.terraform_remote_state.infra_networking.outputs.vpc_id
+  manage_aws_auth  = false
+  write_kubeconfig = false
+
+  cluster_log_retention_in_days = var.cluster_log_retention_in_days
+  cluster_enabled_log_types = [
+    "api", "audit", "authenticator", "controllerManager", "scheduler"
+  ]
 
   worker_groups = [
     {

--- a/terraform/deployments/eks/variables.tf
+++ b/terraform/deployments/eks/variables.tf
@@ -3,6 +3,11 @@ variable "govuk_aws_state_bucket" {
   description = "The name of the S3 bucket used for govuk-aws's Terraform state files."
 }
 
+variable "cluster_log_retention_in_days" {
+  type        = number
+  description = "Number of days to retain cluster log events in CloudWatch."
+}
+
 variable "workers_instance_type" {
   type        = string
   description = "Instance type for the managed node group."

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -1,6 +1,8 @@
 govuk_aws_state_bucket = "govuk-terraform-steppingstone-test"
 eks_state_bucket       = "govuk-terraform-test"
 
+cluster_log_retention_in_days = 7
+
 govuk_environment             = "test"
 ecs_default_capacity_provider = "FARGATE_SPOT"
 


### PR DESCRIPTION
We don't need the local kubeconfig file because this will normally be running from Concourse. Even on rare occasions when it might be run from a workstation, it's trivial to run `aws eks update-kubeconfig --name govuk` and that would be the normal workflow for interacting with the cluster anyway.

Tested: `terraform apply -var-file=../variables/test/common.tfvars` succeeded. No longer creates the kubeconfig file and the log group is created with the desired retention period. EKS web console shows all the log types enabled.

Relevant part of the TF plan:

```
  # module.eks.aws_cloudwatch_log_group.this[0] will be created
  + resource "aws_cloudwatch_log_group" "this" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + name              = "/aws/eks/govuk-tmp/cluster"
      + retention_in_days = 7
      + tags_all          = (known after apply)
    }

  # module.eks.aws_eks_cluster.this[0] will be updated in-place
  ~ resource "aws_eks_cluster" "this" {
      ~ enabled_cluster_log_types = [
          + "api",
          + "audit",
          + "authenticator",
          + "controllerManager",
          + "scheduler",
        ]
        id                        = "govuk-tmp"
        name                      = "govuk-tmp"
        tags                      = {}
        # (10 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }
```

[Trello card](https://trello.com/c/dqG4nXn0/591)

Pair: @karlbaker02 