### PR TITLE
Enable Terraform statefile locking.

### DIFF
--- a/terraform/deployments/eks-stage2/test.backend
+++ b/terraform/deployments/eks-stage2/test.backend
@@ -2,3 +2,4 @@ bucket  = "govuk-terraform-test"
 key     = "projects/eks-stage2.tfstate"
 encrypt = true
 region  = "eu-west-1"
+dynamodb_table = "terraform-lock"

--- a/terraform/deployments/eks/test.backend
+++ b/terraform/deployments/eks/test.backend
@@ -2,3 +2,4 @@ bucket  = "govuk-terraform-test"
 key     = "projects/eks.tfstate"
 encrypt = true
 region  = "eu-west-1"
+dynamodb_table = "terraform-lock"


### PR DESCRIPTION
This is the same arrangement that we've been using with our ECS Terraform.  The Dynamo table is owned by the [terraform-lock](/alphagov/govuk-infrastructure/blob/main/terraform/deployments/terraform-lock) root module.

[Trello card](https://trello.com/c/dqG4nXn0/591-use-terraform-to-deploy-an-eks-cluster)

Tested: reinitialised Terraform and tried applying a small change to the cluster logging options and then reverting it. (`tf init -backend-config test.backend -reconfigure && tf apply -var-file=../variables/test/common.tfvars`)