### PR TITLE
Associate admin users with `cluster-admins` group

### DIFF
--- a/terraform/deployments/eks-stage2/aws_auth_configmap.tf
+++ b/terraform/deployments/eks-stage2/aws_auth_configmap.tf
@@ -46,9 +46,9 @@ resource "kubernetes_config_map" "aws_auth" {
   }
 }
 
-resource "kubernetes_cluster_role_binding" "cluster_admin" {
+resource "kubernetes_cluster_role_binding" "cluster_admins" {
   metadata {
-    name = "cluster-admin"
+    name = "cluster-admins"
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"

--- a/terraform/deployments/eks-stage2/aws_auth_configmap.tf
+++ b/terraform/deployments/eks-stage2/aws_auth_configmap.tf
@@ -24,8 +24,7 @@ locals {
     for user, arn in local.admin_roles_and_arns : {
       rolearn  = arn
       username = user
-      # TODO: don't use system:masters.
-      groups = ["system:masters"]
+      groups   = ["cluster-admins"]
     }
   ]
 }
@@ -44,5 +43,21 @@ resource "kubernetes_config_map" "aws_auth" {
         local.admin_configmap_roles,
       ))
     )
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "cluster_admin" {
+  metadata {
+    name = "cluster-admin"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+  subject {
+    kind      = "Group"
+    name      = "cluster-admins"
+    api_group = "rbac.authorization.k8s.io"
   }
 }


### PR DESCRIPTION
This PR associates all current admin users with the existing in-built `cluster-admin` role via a new ClusterRoleBinding. By making this association, we can remove the direct association between these users and the `system:masters` group, meaning that we have greater visibility over users' permissions as well as laying some groundwork for when we more tightly scope user roles.

Trello: https://trello.com/c/dqG4nXn0