### PR TITLE
Remove the Concourse deployer IAM role from the aws-auth ConfigMap.

### DIFF
--- a/terraform/deployments/eks-stage2/aws_auth_configmap.tf
+++ b/terraform/deployments/eks-stage2/aws_auth_configmap.tf
@@ -19,11 +19,7 @@ locals {
     },
   ]
 
-  concourse_worker_role = {
-    "govuk-concourse-deployer" = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/govuk-concourse-deployer"
-  }
-
-  admin_roles_and_arns = merge(data.terraform_remote_state.infra_security.outputs.admin_roles_and_arns, local.concourse_worker_role)
+  admin_roles_and_arns = data.terraform_remote_state.infra_security.outputs.admin_roles_and_arns
   admin_configmap_roles = [
     for user, arn in local.admin_roles_and_arns : {
       rolearn  = arn


### PR DESCRIPTION
Including this was necessary in order for Concourse to manage objects in a cluster which Concourse didn't originally create, but it introduces a risk of locking ourselves out of the cluster entirely if we break the aws-auth ConfigMap.

If we ever did need Concourse to "adopt" a cluster which it didn't create, we could still do this by adding its role to the ConfigMap at that time. Unless/until that's needed, it's safer to omit it so that we can always access the cluster via the cluster creator IAM role (which from this point on will be the govuk-concourse-deployer role).

See also this Amazon knowledge centre article which mentions the issue: https://aws.amazon.com/premiumsupport/knowledge-center/amazon-eks-cluster-access/