### PR TITLE
Fix `terraform-cluster-services` job

### DIFF
--- a/concourse/pipelines/eks.yml
+++ b/concourse/pipelines/eks.yml
@@ -74,7 +74,7 @@ jobs:
     - get: govuk-infrastructure
       trigger: true
       passed:
-      - terraform-eks-cluster
+      - terraform-cluster-infrastructure
     - task: terraform-cluster-addons
       config:
         <<: *terraform-cluster-config


### PR DESCRIPTION
This PR fixes the `terraform-cluster-services` job to reference the correct pre-requisite job `terraform-cluster-infrastructure`, which has been renamed from `terraform-eks-cluster`.