### PR TITLE
Rename steps within EKS pipeline

### DIFF
--- a/concourse/pipelines/eks.yml
+++ b/concourse/pipelines/eks.yml
@@ -39,11 +39,11 @@ jobs:
       trigger: true
       passed:
       - update-pipeline
-    - task: terraform-cluster
-      config: &terraform-cluster-config
+    - task: terraform-apply
+      config: &terraform-apply-config
         inputs:
         - name: govuk-infrastructure
-        params: &terraform-cluster-params
+        params: &terraform-apply-params
           ASSUME_ROLE_ARN: ((concourse_deployer_role_arn))
           AWS_REGION: ((aws_region))
           DEPLOYMENT_PATH: govuk-infrastructure/terraform/deployments/cluster-infrastructure
@@ -75,11 +75,11 @@ jobs:
       trigger: true
       passed:
       - terraform-cluster-infrastructure
-    - task: terraform-cluster-addons
+    - task: terraform-apply
       config:
-        <<: *terraform-cluster-config
+        <<: *terraform-apply-config
         params:
-          <<: *terraform-cluster-params
+          <<: *terraform-apply-params
           DEPLOYMENT_PATH: govuk-infrastructure/terraform/deployments/cluster-services
     on_failure:
       <<: *notify-slack-failure


### PR DESCRIPTION
This PR renames the steps (which apply the Terraform) within the `terraform-cluster-infrastructure` and `terraform-cluster-services` jobs of the `eks` pipeline to be called `terraform-apply`. This removes the duplication between the job and step name that currently exists and also makes our naming consistent with the existing `deploy` pipeline that we have been using to deploy to ECS.