### PR TITLE
Convert our current apps/app in to EKS usin HELM

### DIFF
--- a/helm/content-store/Chart.yaml
+++ b/helm/content-store/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: content-store
+description: A Helm chart for GOV.UK Content-Store
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/content-store/templates/NOTES.txt
+++ b/helm/content-store/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "content-store.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "content-store.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "content-store.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "content-store.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/content-store/templates/_helpers.tpl
+++ b/helm/content-store/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "content-store.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "content-store.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "content-store.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "content-store.labels" -}}
+helm.sh/chart: {{ include "content-store.chart" . }}
+{{ include "content-store.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "content-store.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "content-store.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "content-store.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "content-store.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/content-store/templates/deployment.yaml
+++ b/helm/content-store/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.containerPort }}
+          env:
+            - name: DEFAULT_TTL
+              value: "{{ .Values.appDefaultTtl }}"
+            - name: GOVUK_APP_DOMAIN
+              value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
+            - name: GOVUK_APP_DOMAIN_EXTERNAL
+              value: "{{ .Values.appGovukDomainExternal | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: GOVUK_APP_NAME
+              value: "{{ .Values.appGovukAppName | default .Release.Name }}"
+            - name: GOVUK_APP_TYPE
+              value: "{{ .Values.appGovukAppType }}"
+            - name: GOVUK_CONTENT_SCHEMAS_PATH
+              value: "{{ .Values.appGovukContentSchemasPath }}"
+            - name: GOVUK_WEBSITE_ROOT
+              value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: GOVUK_ENVIRONMENT
+              value: "{{ .Values.appGovukEnvironment }}"
+            - name: MONGODB_URI
+              value: "{{ .Values.appMongodbUri | default (printf "mongodb://mongo-1.%[1]s.%[2]s.%[3]s,mongo-2.%[1]s.%[2]s.%[3]s,mongo-3.%[1]s.%[2]s.%[3]s/content_store_production" .Values.govukStack .Values.govukEnvironment .Values.govukDomainInternal) }}"
+            - name: PLEK_SERVICE_PUBLISHING_API_URI
+              value: "{{ .Values.appPlekServicePublishingApiUri | default (printf "http://publishing-api-web.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+            - name: PLEK_SERVICE_ROUTER_API_URI
+              value: "{{ .Values.appPlekServiceRouterApiUri | default (printf "http://router-api.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+            - name: PLEK_SERVICE_SIGNON_URI
+              value: "{{ .Values.appPlekServiceSignonUri | default (printf "http://signon.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+            - name: PORT
+              value: "{{ .Values.containerPort }}"
+            - name: RAILS_ENV
+              value: "{{ .Values.appRailsEnv }}"
+            - name: SECRET_KEY_BASE
+              value: "secret" #TODO: fix when we know how to handle secrets
+          {{- with .Values.appExtraEnv }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthcheck/live
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthcheck/ready
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 5

--- a/helm/content-store/templates/service.yaml
+++ b/helm/content-store/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+{{ if .Values.service.annotations}}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.containerPort }}
+      protocol: TCP
+      name: https
+  selector:
+    app: {{ .Release.Name }}

--- a/helm/content-store/values.yaml
+++ b/helm/content-store/values.yaml
@@ -1,0 +1,48 @@
+# Default values for content-store.
+
+govukEnvironment: test
+govukStack: pink
+govukDomainExternal: govuk.digital
+govukDomainInternal: govuk-internal.digital
+clusterDomain: svc.cluster.local
+
+service:
+  annotations: {}
+  type: NodePort
+  port: 80
+  targetPort: 80
+
+
+replicaCount: 1
+
+image:
+  repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store
+  pullPolicy: IfNotPresent
+  tag: latest
+
+containerPort: 80
+
+resources:
+  limits:
+  # cpu:
+  # memory: 1024M
+  requests:
+  # cpu:
+  # memory: 1024M
+
+
+appDefaultTtl: "1800"
+appGovukAppDomain: # see template for how default value is computed
+appGovukDomainExternal: # see template for how default value is computed
+appGovukAppName: # see template for how default value is computed
+appGovukAppType: "rack"
+appGovukContentSchemasPath: "/govuk-content-schemas"
+appGovukWebsiteRoot: # see template for how default value is computed
+appMongodbUri: # see template for how default value is computed
+appPlekServicePublishingApiUri: # see template for how default value is computed
+appPlekServiceRouterApiUri: # see template for how default value is computed
+appPlekServiceSignonUri: # see template for how default value is computed
+appRailsEnv: "production"
+appExtraEnv: # extra envs that you to pass to the app
+ #- name: hello
+ #  value: world

--- a/helm/doc/adding-an-app.md
+++ b/helm/doc/adding-an-app.md
@@ -1,0 +1,68 @@
+# Adding an App
+
+It has been [decided](../../docs/architecture/decisions/0006-use-helm-for-application-package-management.md)
+to use [Helm v3](https://helm.sh/docs/) to package GOV.UK apps for our
+Kubernetes platform.
+
+A Helm charts for the apps are located under the [helm](../helm) directory.
+
+## Creating an App
+
+After installing [Helm v3](https://helm.sh/docs/intro/quickstart/), it is
+typical to use `helm create <app_name>` to create a template app that is then
+customized for a given GOV.UK app.
+
+For a typical non-internet facing app, the helm directory structure is:
+├── Chart.yaml
+├── templates
+│   ├── deployment.yaml
+│   ├── service.yaml
+│   ├── \_helpers.tpl
+│   ├── NOTES.txt
+└── values.yaml
+
+For an internet facing app, there will be an additional `ingress.yaml` template
+file to configure the AWS load balancer that will direct traffic to that app.
+
+## Operations
+
+After creating an app, the following operations can be done
+(note that you need to have AWS credentials loaded e.g.
+ `eval $(gds aws govuk-test-admin)`):
+
+1. test the config that Helm will generate for Kubernetes:
+```sh
+<chart_directory>$ helm template .
+```
+
+2. validate the Helm chart Kubernetes files against the Kubernetes schemas using
+a plugin such as [kubeval](https://github.com/instrumenta/helm-kubeval):
+```sh
+helm plugin install https://github.com/instrumenta/helm-kubeval
+<chart_directory>$ helm kubeval .
+```
+
+If kubeval is using a default Kubernetes schema repository that is [not updated]
+(https://github.com/instrumenta/kubeval/issues/301) promptly, you can use another [repo](https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master):
+```sh
+<chart_directory>$ helm kubeval -v 1.20.0 -s \
+ https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master .
+```
+
+3. install the app in the Kubernetes cluster:
+```sh
+<chart_directory>$ helm install <app_name> . -namespace <namespace_to_deploy_to>
+```
+
+4. check that the status of the app in the Kubernetes cluster:
+```sh
+helm list --namespace <namespace_where_app_deployed>
+```
+
+5. upgrade an existing deployed app:
+```sh
+<chart_directory>$ helm upgrade <app_name> . -namespace <namespace_to_deploy_to>
+```
+
+In the future, the charts will be hosted on a HTTP repository and Helm will
+retrieve the charts from there.

--- a/helm/frontend/Chart.yaml
+++ b/helm/frontend/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: frontend
+description: A Helm chart for GOV.UK Frontend
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/frontend/templates/NOTES.txt
+++ b/helm/frontend/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "frontend.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "frontend.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "frontend.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "content-store.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/frontend/templates/_helpers.tpl
+++ b/helm/frontend/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "frontend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "frontend.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "frontend.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "frontend.labels" -}}
+helm.sh/chart: {{ include "frontend.chart" . }}
+{{ include "frontend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "frontend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "frontend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "frontend.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "frontend.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/frontend/templates/deployment.yaml
+++ b/helm/frontend/templates/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount}}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.containerPort }}
+          env:
+            - name: ASSET_HOST
+              value: "{{ .Values.appAssetHost | default (printf "https://www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: GOVUK_APP_DOMAIN
+              value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
+            - name: GOVUK_APP_DOMAIN_EXTERNAL
+              value: "{{ .Values.appGovukDomainExternal | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: GOVUK_APP_NAME
+              value: "{{ .Values.appGovukAppName | default .Release.Name }}"
+            - name: GOVUK_APP_TYPE
+              value: "{{ .Values.appGovukAppType }}"
+            - name: GOVUK_WEBSITE_ROOT
+              value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: DEFAULT_TTL
+              value: "{{ .Values.appDefaultTtl }}"
+            - name: GOVUK_ASSET_ROOT
+              value: "{{ .Values.appGovukAssetRoot | default (printf "https://assets.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: GOVUK_CONTENT_SCHEMAS_PATH
+              value: "{{ .Values.appGovukContentSchemasPath }}"
+            - name: GOVUK_ENVIRONMENT
+              value: "{{ .Values.govukEnvironment }}"
+            - name: PLEK_SERVICE_CONTENT_STORE_URI
+              value: "{{ .Values.appPlekServiceContentStoreUri | default (printf "http://content-store.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+            - name: PLEK_SERVICE_PUBLISHING_API_URI
+              value: "{{ .Values.appPlekServicePublishingApiUri | default (printf "http://publishing-api-web.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+            - name: PLEK_SERVICE_SIGNON_URI
+              value: "{{ .Values.appPlekServiceSignonUri | default (printf "http://signon.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+            - name: PLEK_SERVICE_STATIC_URI
+              value: "{{ .Values.appPlekServiceStaticUri | default (printf "http://static.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+            - name: PORT
+              value: "{{ .Values.containerPort }}"
+            - name: RAILS_ENV
+              value: "{{ .Values.appRailsEnv }}"
+            - name: SECRET_KEY_BASE
+              value: "secret" #TODO: fix when we know how to handle secrets
+          {{- with .Values.appExtraEnv }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthcheck/live
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthcheck/ready
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 5

--- a/helm/frontend/templates/service.yaml
+++ b/helm/frontend/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+{{ if .Values.service.annotations}}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.containerPort }}
+      protocol: TCP
+      name: https
+  selector:
+    app: {{ .Release.Name }}

--- a/helm/frontend/values.yaml
+++ b/helm/frontend/values.yaml
@@ -1,0 +1,47 @@
+# Default values for frontend.
+
+govukEnvironment: test
+govukDomainExternal: govuk.digital
+govukDomainInternal: govuk-internal.digital
+clusterDomain: svc.cluster.local
+
+service:
+  type: NodePort
+  annotations: {}
+  port: 80
+
+
+replicaCount: 1
+
+image:
+  repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend
+  pullPolicy: IfNotPresent
+  tag: latest
+
+containerPort: 80
+
+resources:
+  limits:
+  # cpu:
+  # memory: 1024M
+  requests:
+  # cpu:
+  # memory: 1024M
+
+appDefaultTtl: "1800"
+appGovukAppDomain: # see template for how default value is computed
+appGovukDomainExternal: # see template for how default value is computed
+appGovukAppName: # see template for how default value is computed
+appGovukAppType: "rack"
+appGovukContentSchemasPath: "/govuk-content-schemas"
+appGovukWebsiteRoot: # see template for how default value is computed
+appPlekServicePublishingApiUri: # see template for how default value is computed
+appPlekServiceSignonUri: # see template for how default value is computed
+appPlekServiceContentStoreUri: # see template for how default value is computed
+appPlekServiceStaticUri: # see template for how default value is computed
+appRailsEnv: "production"
+appAssetHost: # see template for how default value is computed
+appGovukAssetRoot: # see template for how default value is computed
+appExtraEnv: # extra envs that you to pass to the app
+ #- name: hello
+ #  value: world

--- a/helm/router/Chart.yaml
+++ b/helm/router/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: router
+description: A Helm chart for GOV.UK router
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/router/templates/NOTES.txt
+++ b/helm/router/templates/NOTES.txt
@@ -1,0 +1,18 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host | default (printf "www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}{{ .path }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "router.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "router.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "router.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "router.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/router/templates/_helpers.tpl
+++ b/helm/router/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "router.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "router.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "router.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "router.labels" -}}
+helm.sh/chart: {{ include "router.chart" . }}
+{{ include "router.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "router.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "router.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "router.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "router.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/router/templates/deployment.yaml
+++ b/helm/router/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount}}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.containerPort }}
+          env:
+            - name: GOVUK_APP_DOMAIN
+              value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
+            - name: GOVUK_APP_NAME
+              value: "{{ .Values.appGovukAppName | default .Release.Name }}"
+            - name: GOVUK_APP_TYPE
+              value: "{{ .Values.appGovukAppType }}"
+            - name: ROUTER_MONGO_URL
+              value: "{{ .Values.appMongodbUri | default (printf "mongodb://router-backend-1.%[1]s.%[2]s.%[3]s,router-backend-2.%[1]s.%[2]s.%[3]s,router-backend-3.%[1]s.%[2]s.%[3]s/router" .Values.govukStack .Values.govukEnvironment .Values.govukDomainInternal) }}"
+            - name: ROUTER_MONGO_DB
+              value: "{{ .Values.appRouterMongoDb }}"
+            - name: PORT
+              value: "{{ .Values.containerPort }}"
+            - name: RAILS_ENV
+              value: "{{ .Values.appRailsEnv }}"
+            - name: BACKEND_URL_content-store
+              value: "{{ .Values.appBackendUrlContentStore | default (printf "http://content-store.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+            - name: BACKEND_URL_frontend
+              value: "{{ .Values.appBackendUrlFrontend | default (printf "http://frontend.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+            - name: BACKEND_URL_static
+              value: "{{ .Values.appBackendUrlStatic | default (printf "http://static.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+            - name: DEFAULT_TTL
+              value: "{{ .Values.appDefaultTtl }}"
+            - name: GOVUK_APP_DOMAIN_EXTERNAL
+              value: "{{ .Values.appGovukDomainExternal | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: GOVUK_APP_ROOT
+              value: "{{ .Values.appGovukAppRoot }}"
+            - name: GOVUK_ENVIRONMENT
+              value: "{{ .Values.govukEnvironment }}"
+            - name: GOVUK_WEBSITE_ROOT
+              value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: ROUTER_APIADDR
+              value: ":{{ .Values.appRouterApiAddr }}"
+            - name: ROUTER_BACKEND_HEADER_TIMEOUT
+              value: "{{ .Values.appRouterBackendHeaderTimeout }}s"
+            - name: ROUTER_PUBADDR
+              value: ":{{ .Values.containerPort }}"
+            - name: SECRET_KEY_BASE
+              value: "secret" #TODO: fix when we know how to handle secrets
+          {{- with .Values.appExtraEnv }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/helm/router/templates/ingress.yaml
+++ b/helm/router/templates/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := .Release.Name -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}
+  labels:
+    {{- include "router.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    #- host: "{{ .Values.ingress.host | default (printf "www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}" #TODO: fix when k8s DNS set up
+    -  http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+{{- end }}

--- a/helm/router/templates/service.yaml
+++ b/helm/router/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+{{ if .Values.service.annotations}}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.containerPort }}
+      protocol: TCP
+      name: https
+  selector:
+    app: {{ .Release.Name }}

--- a/helm/router/values.yaml
+++ b/helm/router/values.yaml
@@ -1,0 +1,58 @@
+# Default values for router.
+
+govukEnvironment: test
+govukStack: pink
+govukDomainExternal: govuk.digital
+govukDomainInternal: govuk-internal.digital
+clusterDomain: svc.cluster.local
+
+service:
+  type: NodePort
+  annotations: {}
+  port: 80
+
+replicaCount: 1
+
+image:
+  repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
+  pullPolicy: IfNotPresent
+  tag: latest
+
+containerPort: 80
+
+resources:
+  limits:
+  # cpu:
+  # memory: 1024M
+  requests:
+  # cpu:
+  # memory: 1024M
+  # values used to generate the environment variables for the pod
+
+appGovukAppDomain: # see template for how default value is computed
+appGovukAppName: # see template for how default value is computed
+appGovukAppType: "rack"
+appMongodbUri: # see template for how default value is computed
+appRouterMongoDb: "router"
+appRailsEnv: "production"
+appBackendUrlContentStore: # see template for how default value is computed
+appBackendUrlFrontend: # see template for how default value is computed
+appBackendUrlStatic: # see template for how default value is computed
+appDefaultTtl: "1800"
+appGovukDomainExternal: # see template for how default value is computed
+appGovukAppRoot: "/var/apps/router"
+appGovukWebsiteRoot: # see template for how default value is computed
+appRouterApiAddr: "3055"
+appRouterBackendHeaderTimeout: "20"
+
+ingress:
+  enabled: true
+  name: www-origin
+  host: # default (printf "www-origin.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal)
+  path: "/"
+  pathType: "Prefix"
+  className: alb
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme : internet-facing
+    alb.ingress.kubernetes.io/target-type: ip

--- a/helm/static/Chart.yaml
+++ b/helm/static/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: static
+description: A Helm chart for GOV.UK Static
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/static/templates/NOTES.txt
+++ b/helm/static/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "static.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "static.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "static.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "static.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/static/templates/_helpers.tpl
+++ b/helm/static/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "static.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "static.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "static.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "static.labels" -}}
+helm.sh/chart: {{ include "static.chart" . }}
+{{ include "static.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "static.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "static.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "static.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "static.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/static/templates/deployment.yaml
+++ b/helm/static/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.containerPort }}
+          env:
+            - name: GOVUK_APP_DOMAIN
+              value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
+            - name: GOVUK_APP_DOMAIN_EXTERNAL
+              value: "{{ .Values.appGovukDomainExternal | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: GOVUK_APP_NAME
+              value: "{{ .Values.appGovukAppName | default .Release.Name }}"
+            - name: GOVUK_WEBSITE_ROOT
+              value: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: DEFAULT_TTL
+              value: "{{ .Values.appDefaultTtl }}"
+            - name: GOVUK_ASSET_ROOT
+              value: "{{ .Values.appGovukAssetRoot | default (printf "https://assets.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+            - name: GOVUK_ENVIRONMENT
+              value: "{{ .Values.govukEnvironment }}"
+            - name: PORT
+              value: "{{ .Values.containerPort }}"
+            - name: RAILS_ENV
+              value: "{{ .Values.govukEnvironment }}"
+            - name: REDIS_URL
+              value: "{{ .Values.appRedisUrl | default (printf "redis://redis.ecs.%s.%s:6379" .Values.govukEnvironment .Values.govukDomainExternal) }}" #TODO: use EKS Redis cluster
+            - name: GOVUK_APP_ROOT
+              value: "{{ .Values.appGovukAppRoot }}"
+            - name: GOVUK_APP_TYPE
+              value: "{{ .Values.appGovukAppType }}"
+            - name: SECRET_KEY_BASE
+              value: "secret" #TODO: fix when we know how to handle secrets
+          {{- with .Values.appExtraEnv }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthcheck/live
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthcheck/ready
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 5

--- a/helm/static/templates/service.yaml
+++ b/helm/static/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+{{ if .Values.service.annotations}}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.containerPort}}
+      protocol: TCP
+      name: https
+  selector:
+    app: {{ .Release.Name }}

--- a/helm/static/values.yaml
+++ b/helm/static/values.yaml
@@ -1,0 +1,43 @@
+# Default values for static.
+
+govukEnvironment: test
+govukStack: pink
+govukDomainExternal: govuk.digital
+govukDomainInternal: govuk-internal.digital
+clusterDomain: svc.cluster.local
+
+service:
+  type: NodePort
+  annotations: {}
+  port: 80
+  targetPort: 80
+
+replicaCount: 1
+
+image:
+  repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
+  pullPolicy: IfNotPresent
+  tag: latest
+
+containerPort: 80
+
+resources:
+  limits:
+  # cpu:
+  # memory: 1024M
+  requests:
+  # cpu:
+  # memory: 1024M
+
+appGovukAppDomain: # see template for how default value is computed
+appGovukDomainExternal: # see template for how default value is computed
+appGovukAppName: # see template for how default value is computed
+appGovukWebsiteRoot: # see template for how default value is computed
+appDefaultTtl: "1800"
+appGovukAssetRoot: # see template for how default value is computed
+appRedisUrl: # see template for how default value is computed
+appGovukAppRoot: "/var/apps/static"
+appGovukAppType: "rack"
+appExtraEnv: # extra envs that you to pass to the app
+ #- name: hello
+ #  value: world


### PR DESCRIPTION
Used Helm v3 and created the following apps:
- (e42b7ac823d21b727a3529c41838793a3ef5879f) Content store
- (ffc19aa12bddedcd1f8229af88755201ef86476a) Frontend
- (90391410b69272b5cb1cb74adc60a181bf29f963) Router
- (291589f83f58fb011a2f489161ca545276cf10fe) Static

Documentations on how to install/upgrade the apps are located in 1f6a7678a6d7c86f90f0be65d6340375feb14a87

The approach used is to use a minimal set of helm files needed to deploy the above apps:
- values.yaml (variables used)
- template/deployment.yaml (k8s deployment config)
- template/service.yaml (k8s service config)

Testing:
1. You can follow the documentation and load each app to your namespace.
2. Since router includes an ingress, you can do `kubectl get ingress -n <namespaces>`,
    to get the address of the ingress. You can browse to `http://<ingress_address>` to 
    see a basic webpage of gov.uk

Future work:
- Storing of secrets (can use Kubernetes secrets and add template/secrets.yaml file which will create the secrecy key used in the app)
- Rollout strategy (adding strategy to deployment)