### PR TITLE
Add missing Terraform and Concourse variables relating to EKS

### DIFF
--- a/concourse/parameters/integration/eks.yaml
+++ b/concourse/parameters/integration/eks.yaml
@@ -1,0 +1,3 @@
+aws_region: eu-west-1
+concourse_deployer_role_arn: arn:aws:iam::210287912431:role/govuk-concourse-deployer
+govuk_infrastructure_branch: main

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -1,4 +1,7 @@
-govuk_aws_state_bucket = "govuk-terraform-steppingstone-integration"
+govuk_aws_state_bucket              = "govuk-terraform-steppingstone-integration"
+cluster_infrastructure_state_bucket = "govuk-terraform-integration"
+
+cluster_log_retention_in_days = 7
 
 govuk_environment             = "integration"
 ecs_default_capacity_provider = "FARGATE_SPOT"


### PR DESCRIPTION
This PR adds:

- missing Terraform variables to integration `common.tfvars`, for our EKS cluster.
- a new Concourse `eks.yaml` variables file for EKS, to be able to deploy our EKS cluster in integration.