### PR TITLE
Add some default tags to the AWS resources for the EKS cluster.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -11,6 +11,13 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
+  default_tags {
+    tags = {
+      project              = "replatforming"
+      repository           = "govuk-infrastructure"
+      terraform_deployment = basename(abspath(path.root))
+    }
+  }
 }
 
 module "eks" {

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -31,6 +31,13 @@ module "eks" {
   manage_aws_auth  = false
   write_kubeconfig = false
 
+  # TODO: Tag the node pool ASG once
+  # https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1455 is
+  # addressed. This may or may not involve passing additional args here.
+  # Ideally the default_tags above would propagate automatically to the ASG but
+  # that isn't possible yet because of the above bug and
+  # https://github.com/hashicorp/terraform-provider-aws/issues/19204.
+
   cluster_log_retention_in_days = var.cluster_log_retention_in_days
   cluster_enabled_log_types = [
     "api", "audit", "authenticator", "controllerManager", "scheduler"


### PR DESCRIPTION
This adds some of the tags from the [tagging guide] from the previous ECS project. I've omitted `chargeable_entity` and `environment` for now because those might need a bit of a rethink in light of the switch to Kubernetes. (For example is the "environment" the same thing from an infrastructure perspective as it is from the cluster-user/developer/application perspective?)

The idea here is really just to define a place to put the common tags so that we continue to set them in the right way. Using [provider default tags] (relatively new feature) is now the cleanest way to do this.

Thanks to @kerin for the suggestion of using provider default tags.

One caveat is that the default tags aren't propagated to ASGs, so this doesn't currently tag the node pool ASG. Passing the same set of tags to the `eks` module in order to tag the ASG doesn't work, because the TF provider unhelpfully forbids individual resources from overriding provider-specific tags because of a design limitation of TF. (See issue 19204 in [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/issues/).)

[tagging guide]: https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/docs/tagging-guide.md
[provider default tags]: https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider

Tested: `tf apply -var-file=../variables/test/common.tfvars`

TF plan in the test account:

```
  # module.eks.aws_cloudwatch_log_group.this[0] will be updated in-place
  ~ resource "aws_cloudwatch_log_group" "this" {
        id                = "/aws/eks/govuk/cluster"
        name              = "/aws/eks/govuk/cluster"
        tags              = {}
      ~ tags_all          = {
          + "project"              = "replatforming"
          + "repository"           = "govuk-infrastructure"
          + "terraform_deployment" = "cluster-infrastructure"
        }
        # (2 unchanged attributes hidden)
    }

  # module.eks.aws_eks_cluster.this[0] will be updated in-place
  ~ resource "aws_eks_cluster" "this" {
        id                        = "govuk"
        name                      = "govuk"
        tags                      = {}
      ~ tags_all                  = {
          + "project"              = "replatforming"
          + "repository"           = "govuk-infrastructure"
          + "terraform_deployment" = "cluster-infrastructure"
        }
        # (10 unchanged attributes hidden)
        # (3 unchanged blocks hidden)
    }

  # module.eks.aws_iam_instance_profile.workers[0] will be updated in-place
  ~ resource "aws_iam_instance_profile" "workers" {
        id          = "govuk20210816(redacted)"
        name        = "govuk20210816(redacted)"
        tags        = {}
      ~ tags_all    = {
          + "project"              = "replatforming"
          + "repository"           = "govuk-infrastructure"
          + "terraform_deployment" = "cluster-infrastructure"
        }
        # (6 unchanged attributes hidden)
    }

  # module.eks.aws_iam_policy.cluster_elb_sl_role_creation[0] will be updated in-place
  ~ resource "aws_iam_policy" "cluster_elb_sl_role_creation" {
        id          = "arn:aws:iam::(redacted):policy/govuk-elb-sl-role-creation20210816(redacted)"
        name        = "govuk-elb-sl-role-creation20210816(redacted)"
        tags        = {}
      ~ tags_all    = {
          + "project"              = "replatforming"
          + "repository"           = "govuk-infrastructure"
          + "terraform_deployment" = "cluster-infrastructure"
        }
        # (6 unchanged attributes hidden)
    }

  # module.eks.aws_iam_role.cluster[0] will be updated in-place
  ~ resource "aws_iam_role" "cluster" {
        id                    = "govuk20210816(redacted)"
        name                  = "govuk20210816(redacted)"
        tags                  = {}
      ~ tags_all              = {
          + "project"              = "replatforming"
          + "repository"           = "govuk-infrastructure"
          + "terraform_deployment" = "cluster-infrastructure"
        }
        # (9 unchanged attributes hidden)
        # (1 unchanged block hidden)
    }

  # module.eks.aws_iam_role.workers[0] will be updated in-place
  ~ resource "aws_iam_role" "workers" {
        id                    = "govuk20210816(redacted)"
        name                  = "govuk202108(redacted)"
        tags                  = {}
      ~ tags_all              = {
          + "project"              = "replatforming"
          + "repository"           = "govuk-infrastructure"
          + "terraform_deployment" = "cluster-infrastructure"
        }
        # (9 unchanged attributes hidden)
        # (1 unchanged block hidden)
    }

  # module.eks.aws_security_group.cluster[0] will be updated in-place
  ~ resource "aws_security_group" "cluster" {
        id                     = "sg-(redacted)"
        name                   = "govuk20210816(redacted)"
        tags                   = {
            "Name" = "govuk-eks_cluster_sg"
        }
      ~ tags_all               = {
          + "project"              = "replatforming"
          + "repository"           = "govuk-infrastructure"
          + "terraform_deployment" = "cluster-infrastructure"
            # (1 unchanged element hidden)
        }
        # (8 unchanged attributes hidden)
    }

  # module.eks.aws_security_group.workers[0] will be updated in-place
  ~ resource "aws_security_group" "workers" {
        id                     = "sg-(redacted)"
        name                   = "govuk20210816(redacted)"
        tags                   = {
            "Name"                        = "govuk-eks_worker_sg"
            "kubernetes.io/cluster/govuk" = "owned"
        }
      ~ tags_all               = {
          + "project"                     = "replatforming"
          + "repository"                  = "govuk-infrastructure"
          + "terraform_deployment"        = "cluster-infrastructure"
            # (2 unchanged elements hidden)
        }
        # (8 unchanged attributes hidden)
    }

Plan: 0 to add, 8 to change, 0 to destroy.
```