### PR TITLE
Give the EKS cluster its own subnets and associated resources.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
@@ -233,7 +233,7 @@ locals {
 }
 
 resource "aws_iam_role" "aws_lb_controller" {
-  name        = "AmazonEKSLoadBalancerController-${var.cluster_name}"
+  name        = "AWSLoadBalancerController-${var.cluster_name}"
   description = "Role for the AWS Load Balancer Controller. Corresponds to ${local.aws_lb_controller_service_account_name} k8s ServiceAccount."
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",

--- a/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
@@ -6,7 +6,7 @@
 
 locals {
   cluster_autoscaler_service_account_namespace = "kube-system"
-  cluster_autoscaler_service_account_name      = "cluster-autoscaler"
+  cluster_autoscaler_service_account_name      = "cluster-autoscaler-${var.cluster_name}"
 }
 
 # The rest of this file is taken from

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -43,7 +43,8 @@ module "eks" {
   manage_aws_auth  = false
   write_kubeconfig = false
 
-  cluster_log_retention_in_days = var.cluster_log_retention_in_days
+  cluster_endpoint_private_access = true
+  cluster_log_retention_in_days   = var.cluster_log_retention_in_days
   cluster_enabled_log_types = [
     "api", "audit", "authenticator", "controllerManager", "scheduler"
   ]

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -31,18 +31,14 @@ provider "aws" {
   default_tags { tags = local.default_tags }
 }
 
-locals {
-  cluster_name = "govuk"
-}
-
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "17.1.0"
 
   cluster_name     = var.cluster_name
   cluster_version  = "1.21"
-  subnets          = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
-  vpc_id           = data.terraform_remote_state.infra_networking.outputs.vpc_id
+  subnets          = [for s in aws_subnet.eks_control_plane : s.id]
+  vpc_id           = data.terraform_remote_state.infra_vpc.outputs.vpc_id
   enable_irsa      = true
   manage_aws_auth  = false
   write_kubeconfig = false
@@ -72,16 +68,17 @@ module "eks" {
       asg_max_size         = var.workers_size_max
       asg_min_size         = var.workers_size_min
       instance_type        = var.workers_instance_type
+      subnets              = [for s in aws_subnet.eks_private : s.id]
       tags = [
         {
-          "key"                 = "k8s.io/cluster-autoscaler/enabled"
-          "propagate_at_launch" = "false"
-          "value"               = "true"
+          key                 = "k8s.io/cluster-autoscaler/enabled"
+          value               = "true"
+          propagate_at_launch = false
         },
         {
-          "key"                 = "k8s.io/cluster-autoscaler/${var.cluster_name}"
-          "propagate_at_launch" = "false"
-          "value"               = "owned"
+          key                 = "k8s.io/cluster-autoscaler/${var.cluster_name}"
+          value               = "owned"
+          propagate_at_launch = false
         }
       ]
     }

--- a/terraform/deployments/cluster-infrastructure/remote.tf
+++ b/terraform/deployments/cluster-infrastructure/remote.tf
@@ -2,11 +2,11 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
-data "terraform_remote_state" "infra_networking" {
+data "terraform_remote_state" "infra_vpc" {
   backend = "s3"
   config = {
     bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-networking.tfstate"
+    key    = "govuk/infra-vpc.tfstate"
     region = data.aws_region.current.name
   }
 }

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -14,6 +14,21 @@ variable "cluster_name" {
   default     = "govuk"
 }
 
+variable "eks_control_plane_subnets" {
+  type        = map(object({ az = string, cidr = string }))
+  description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the public subnets for the EKS cluster's apiserver."
+}
+
+variable "eks_private_subnets" {
+  type        = map(object({ az = string, cidr = string }))
+  description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the private subnets for the EKS cluster's nodes and pods."
+}
+
+variable "eks_public_subnets" {
+  type        = map(object({ az = string, cidr = string }))
+  description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the public subnets where the EKS cluster will create Internet-facing load balancers."
+}
+
 variable "workers_instance_type" {
   type        = string
   description = "Instance type for the managed node group."

--- a/terraform/deployments/cluster-infrastructure/vpc.tf
+++ b/terraform/deployments/cluster-infrastructure/vpc.tf
@@ -1,0 +1,161 @@
+# vpc.tf manages the subnets for the EKS cluster and their associated
+# paraphernalia such as NAT gateways and route tables. The VPC itself is
+# defined in https://github.com/alphagov/govuk-aws/ while we transition to
+# Kubernetes.
+#
+# https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
+
+# TODO: Once the EC2 environment is gone, move the aws_vpc from
+# alphagov/govuk-aws to here.
+
+# TODO: Consider factoring out the (subnet, route_table,
+# route_table_association, route) resources into a local module (or maybe two,
+# for public/private), perhaps after we've imported the VPC resource from
+# govuk-aws. Also consider using terraform-aws-modules/terraform-aws-vpc to
+# replace the whole lot. (That module makes some dubious use of count() but
+# it's ok because we're very unlikely to add or remove availability zones.)
+
+locals {
+  route_create_timeout = "5m" # Same workaround as terraform-aws-vpc module.
+}
+
+
+# Control plane subnets and associated resources. The control plane subnets are
+# small, private subnets where EKS creates the ENIs for private access to
+# the master node, which runs in an Amazon-owned VPC.
+
+resource "aws_subnet" "eks_control_plane" {
+  for_each          = var.eks_control_plane_subnets
+  vpc_id            = data.terraform_remote_state.infra_vpc.outputs.vpc_id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+  tags = {
+    Name = "${var.cluster_name}-eks-control-plane-${each.key}"
+  }
+}
+
+resource "aws_route_table" "eks_control_plane" {
+  for_each = var.eks_control_plane_subnets
+  vpc_id   = data.terraform_remote_state.infra_vpc.outputs.vpc_id
+  tags = {
+    Name = "${var.cluster_name}-eks-control-plane-${each.key}"
+  }
+}
+
+
+resource "aws_route_table_association" "eks_control_plane" {
+  for_each       = var.eks_control_plane_subnets
+  subnet_id      = aws_subnet.eks_control_plane[each.key].id
+  route_table_id = aws_route_table.eks_control_plane[each.key].id
+}
+
+resource "aws_route" "eks_control_plane_nat" {
+  for_each               = var.eks_control_plane_subnets
+  route_table_id         = aws_route_table.eks_control_plane[each.key].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.eks[each.key].id
+  timeouts {
+    create = local.route_create_timeout
+  }
+}
+
+
+# Public subnets and associated resources. The public subnets are used by
+# controllers in the cluster (such as aws-load-balancer-controller) for
+# creating Internet-facing load balancers.
+
+resource "aws_subnet" "eks_public" {
+  for_each          = var.eks_public_subnets
+  vpc_id            = data.terraform_remote_state.infra_vpc.outputs.vpc_id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+  tags = {
+    Name = "${var.cluster_name}-eks-public-${each.key}"
+    # https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
+    "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+    "kubernetes.io/role/elb"                    = "1"
+  }
+  map_public_ip_on_launch = true
+}
+
+resource "aws_route_table" "eks_public" {
+  vpc_id = data.terraform_remote_state.infra_vpc.outputs.vpc_id
+  tags = {
+    Name = "${var.cluster_name}-eks-public"
+  }
+}
+
+resource "aws_route_table_association" "eks_public" {
+  for_each       = var.eks_public_subnets
+  subnet_id      = aws_subnet.eks_public[each.key].id
+  route_table_id = aws_route_table.eks_public.id
+}
+
+resource "aws_route" "public_internet_gateway" {
+  route_table_id         = aws_route_table.eks_public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = data.terraform_remote_state.infra_vpc.outputs.internet_gateway_id
+  timeouts {
+    create = local.route_create_timeout
+  }
+}
+
+resource "aws_eip" "eks_nat" {
+  for_each = var.eks_public_subnets
+  vpc      = true
+  tags = {
+    Name = "${var.cluster_name}-eks-nat-${each.key}"
+  }
+  # TODO: depends_on = [aws_internet_gateway.gw] once we've imported the IGW from govuk-aws.
+}
+
+resource "aws_nat_gateway" "eks" {
+  for_each      = var.eks_public_subnets
+  allocation_id = aws_eip.eks_nat[each.key].id
+  subnet_id     = aws_subnet.eks_public[each.key].id
+  tags = {
+    Name = "${var.cluster_name}-eks-${each.key}"
+  }
+  # TODO: depends_on = [aws_internet_gateway.gw] once we've imported the IGW from govuk-aws.
+}
+
+
+# Private subnets and associated resources. The private subnets contain the
+# worker nodes and the pods.
+
+resource "aws_subnet" "eks_private" {
+  for_each          = var.eks_private_subnets
+  vpc_id            = data.terraform_remote_state.infra_vpc.outputs.vpc_id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+  tags = {
+    Name = "${var.cluster_name}-eks-private-${each.key}"
+    # https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
+    "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+    "kubernetes.io/role/internal-elb"           = "1"
+  }
+}
+
+resource "aws_route_table" "eks_private" {
+  for_each = var.eks_private_subnets
+  vpc_id   = data.terraform_remote_state.infra_vpc.outputs.vpc_id
+  tags = {
+    Name = "${var.cluster_name}-eks-private-${each.key}"
+  }
+}
+
+resource "aws_route_table_association" "eks_private" {
+  for_each       = var.eks_private_subnets
+  subnet_id      = aws_subnet.eks_private[each.key].id
+  route_table_id = aws_route_table.eks_private[each.key].id
+}
+
+resource "aws_route" "eks_private_nat" {
+  for_each               = var.eks_private_subnets
+  route_table_id         = aws_route_table.eks_private[each.key].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.eks[each.key].id
+  timeouts {
+    create = local.route_create_timeout
+  }
+}

--- a/terraform/deployments/cluster-services/remote.tf
+++ b/terraform/deployments/cluster-services/remote.tf
@@ -3,7 +3,8 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 data "terraform_remote_state" "cluster_infrastructure" {
-  backend = "s3"
+  backend   = "s3"
+  workspace = terraform.workspace
   config = {
     bucket = var.cluster_infrastructure_state_bucket
     key    = "projects/cluster-infrastructure.tfstate"

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -1,8 +1,52 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-test"
 cluster_infrastructure_state_bucket = "govuk-terraform-test"
 
-cluster_name                  = "govuk"
 cluster_log_retention_in_days = 7
+
+eks_control_plane_subnets = {
+  a = {
+    az   = "eu-west-1a"
+    cidr = "10.200.19.0/28"
+  }
+  b = {
+    az   = "eu-west-1b"
+    cidr = "10.200.19.16/28"
+  }
+  c = {
+    az   = "eu-west-1c"
+    cidr = "10.200.19.32/28"
+  }
+}
+
+eks_public_subnets = {
+  a = {
+    az   = "eu-west-1a"
+    cidr = "10.200.20.0/24"
+  }
+  b = {
+    az   = "eu-west-1b"
+    cidr = "10.200.21.0/24"
+  }
+  c = {
+    az   = "eu-west-1c"
+    cidr = "10.200.22.0/24"
+  }
+}
+
+eks_private_subnets = {
+  a = {
+    az   = "eu-west-1a"
+    cidr = "10.200.24.0/22"
+  }
+  b = {
+    az   = "eu-west-1b"
+    cidr = "10.200.28.0/22"
+  }
+  c = {
+    az   = "eu-west-1c"
+    cidr = "10.200.32.0/22"
+  }
+}
 
 govuk_environment             = "test"
 ecs_default_capacity_provider = "FARGATE_SPOT"


### PR DESCRIPTION
The VPC itself and the Internet gateway are still defined in alphagov/govuk-aws for now, since the current plan is to use the existing VPC and move/import it here after the migration to Kubernetes.

This follows the guidance in [Cluster VPC considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) in the EKS user guide.

In each of three AZs, we have a public /28 for the control plane (i.e. the master ENIs) as recommended, a public /24 for Internet-facing load balancers and a private /22 for nodes and pods.

Separating the node and pod subnets is possible but involves some [hairy configuration of Amazon's CNI plugin][cni-custom-network], so it doesn't seem worth it without a specific need.

Also some small fixes while we're there (see commit messages).

[cni-custom-network]: https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html

[Trello card](https://trello.com/c/mtzlqNa5/622-use-separate-subnets-for-the-eks-cluster)

#### Testing
* Terraform plan/apply of cluster-infrastructure and cluster-services works in a separate workspace (with a different cluster name).
* Resulting cluster comes up and nodes are able to join.
* AWS LB Controller ingress still works.

#### Alternatives considered

Looked at using a library module to create all this lot, but the main one seems to be terraform-aws-modules/terraform-aws-vpc and it doesn't have an option to use an existing VPC.

Was tempted to factor the {subnet, route_table, route_table_association, default route} set of resources into a local module, but resisted that temptation for now as it's probably premature abstraction given that we know we're going to be importing the remaining bits of VPC gubbins from govuk-aws at some point and given how much friction TF causes in refactoring anything that involves moving resources into/out of/between modules.

(I added a TODO mentioning both of the above.)