### PR TITLE
adding helm linting and install checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: ruby/setup-ruby@v1
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 1.0.0
           terraform_wrapper: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1.1
+        with:
+          version: 3.*
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
 
       - name: get date
         id: get-date
@@ -83,3 +98,21 @@ jobs:
               echo -e '\n-------------------------\n'
             )
           done
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ct.yml

--- a/ct.yml
+++ b/ct.yml
@@ -1,0 +1,4 @@
+remote: origin
+target-branch: main
+chart-dirs:
+  - helm


### PR DESCRIPTION
This PR adds to the GitHub Actions CI checks:
1. Helm Linting
2. Helm Install checks

The checks are performed by the Helm tool
[ct](https://github.com/helm/chart-testing)

**Note**
ct works by comparing a commit/PR against the
`main` branch (configurable via ct.yml file).

Ref:
1. [trello card](https://trello.com/c/N8aXJvkK/624-configure-github-actions-for-helm)