### PR TITLE
Add Elasticsearch, fluent-bit, Kibana to EKS cluster

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -17,7 +17,7 @@ variable "workers_instance_type" {
 variable "workers_size_desired" {
   type        = number
   description = "Desired capacity of managed node autoscale group."
-  default     = 3
+  default     = 6
 }
 
 variable "workers_size_min" {
@@ -29,5 +29,5 @@ variable "workers_size_min" {
 variable "workers_size_max" {
   type        = number
   description = "Max capacity of managed node autoscale group."
-  default     = 3
+  default     = 9
 }

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -1,0 +1,57 @@
+# logging.tf manages EFK Stack (Elasticsearch, Fluent-Bit, Kibana).
+# NOTE: Kibana and Elasticsearch will in future be replaced by Logit.
+
+locals {
+  fluentbit_service_account_name = "fluentbit"
+  logging_namespace              = "logging"
+
+  fluentbit_output = <<-OUTPUT
+  [OUTPUT]
+      Name es
+      Match kube.*
+      Host elasticsearch-master
+      Logstash_Format On
+      Retry_Limit False
+
+  [OUTPUT]
+      Name es
+      Match host.*
+      Host elasticsearch-master
+      Logstash_Format On
+      Logstash_Prefix node
+      Retry_Limit False
+  OUTPUT
+}
+
+resource "helm_release" "fluentbit" {
+  name             = "fluentbit"
+  repository       = "https://fluent.github.io/helm-charts"
+  chart            = "fluent-bit"
+  create_namespace = true
+  version          = "0.16.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace        = local.logging_namespace
+  values = [yamlencode({
+    clusterName = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
+    config = {
+      outputs = local.fluentbit_output
+    }
+  })]
+}
+
+resource "helm_release" "elasticsearch" {
+  name       = "elasticsearch"
+  repository = "https://helm.elastic.co"
+  chart      = "elasticsearch"
+  version    = "7.14.0"
+  namespace  = local.logging_namespace
+  depends_on = [helm_release.fluentbit]
+}
+
+resource "helm_release" "kibana" {
+  name       = "kibana"
+  repository = "https://helm.elastic.co"
+  chart      = "kibana"
+  version    = "7.14.0"
+  namespace  = local.logging_namespace
+  depends_on = [helm_release.fluentbit]
+}


### PR DESCRIPTION
Following [ADR 7](https://github.com/alphagov/govuk-infrastructure/blob/main/docs/architecture/decisions/0007-use-fluentbit-elasticsearch-and-kibana-for-application-logs.md) this adds the 'EFK stack' (Elasticsearch, fluent-bit, and Kibana).

We plan to remove Elasticsearch and Kibana next week and replace them with Logit (managed service for ES and Kibana).

I've increased the number of workers to cope with running Elasticsearch (workers=nodes in EKS nomenclature).

To access Kibana, you'll need to use kubectl port-forward:

    kubectl port-forward svc/kibana-kibana 5601 -n logging

Then navigate to localhost:5601 to view logs.

Trello: https://trello.com/c/zkJky4LX/595-configure-application-log-aggregation