### PR TITLE
Add cluster autoscaler to EKS cluster

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
@@ -228,9 +228,8 @@ locals {
   # "https://oidc.eks.eu-west-1.amazonaws.com/id/B4378A8EBD334FEEFDF3BCB6D0E612C6"
   # but the string to which IAM compares this lacks the protocol part, so we
   # have to strip the "https://" when we construct the trust policy
-  # (assume-role policy). The subscript [0] is not an off-by-one; it really
-  # does means the first capturing group and not the entire matched pattern.
-  cluster_oidc_issuer = regex("https://(.*)", module.eks.cluster_oidc_issuer_url)[0]
+  # (assume-role policy).
+  cluster_oidc_issuer = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
 }
 
 resource "aws_iam_role" "aws_lb_controller" {

--- a/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
@@ -1,0 +1,76 @@
+# IAM role and policy to enable the k8s cluster autoscaler to talk to AWS
+# APIs to manage autoscaling groups and instances.
+#
+# The k8s side of the autoscaler is in
+# ../cluster-services/cluster_autoscaler.tf.
+
+locals {
+  cluster_autoscaler_service_account_namespace = "kube-system"
+  cluster_autoscaler_service_account_name      = "cluster-autoscaler"
+}
+
+# The rest of this file is taken from
+# https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/examples/irsa/irsa.tf,
+# which is Apache-2.0 licenced:
+# https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/LICENSE
+#
+# TODO: If we make any significant changes to this code (i.e. if it diverges
+# significantly from upstream), we need to summarise those changes here
+# in order to comply with the licence.
+module "cluster_autoscaler_iam_role" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "4.3.0"
+  create_role                   = true
+  role_name                     = local.cluster_autoscaler_service_account_name
+  provider_url                  = local.cluster_oidc_issuer
+  role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_autoscaler_service_account_namespace}:${local.cluster_autoscaler_service_account_name}"]
+}
+
+resource "aws_iam_policy" "cluster_autoscaler" {
+  name_prefix = "cluster-autoscaler"
+  description = "EKS cluster-autoscaler policy for cluster ${module.eks.cluster_id}"
+  policy      = data.aws_iam_policy_document.cluster_autoscaler.json
+}
+
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  statement {
+    sid    = "clusterAutoscalerAll"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeLaunchTemplateVersions",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "clusterAutoscalerOwn"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${module.eks.cluster_id}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
+      values   = ["true"]
+    }
+  }
+}

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -8,6 +8,16 @@ output "worker_iam_role_arn" {
   value       = module.eks.worker_iam_role_arn
 }
 
+output "cluster_autoscaler_service_account_name" {
+  description = "Name of the k8s service account for the cluster autoscaler."
+  value       = local.cluster_autoscaler_service_account_name
+}
+
+output "cluster_autoscaler_role_arn" {
+  description = "IAM role ARN corresponding to the k8s service account for the AWS Load Balancer Controller."
+  value       = module.cluster_autoscaler_iam_role.iam_role_arn
+}
+
 output "cluster_id" {
   description = "The name (also known as the ID) of the EKS cluster."
   value       = module.eks.cluster_id

--- a/terraform/deployments/cluster-services/cluster_autoscaler.tf
+++ b/terraform/deployments/cluster-services/cluster_autoscaler.tf
@@ -1,0 +1,31 @@
+# cluster_autoscaler.tf manages the in-cluster components of the cluster
+# autoscaler.
+# The implementation follows the AWS docs:
+# https://github.com/terraform-aws-modules/terraform-aws-eks/blob/e3216e3cf80cb59089ba0e0365c6650520000aaf/docs/autoscaling.md
+#
+# The AWS IAM resources for the autoscaler are in
+# ../cluster-infrastructure/cluster_autoscaler_iam.tf.
+
+resource "helm_release" "cluster_autoscaler" {
+  name       = "cluster-autoscaler"
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  version    = "9.10.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace  = "kube-system"
+  values = [yamlencode({
+    awsRegion = data.aws_region.current.name
+    rbac = {
+      create = true
+      serviceAccount = {
+        name = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_autoscaler_service_account_name
+        annotations = {
+          "eks.amazonaws.com/role-arn" = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_autoscaler_role_arn
+        }
+      }
+    }
+    autoDiscovery = {
+      clusterName = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
+      enabled     = true
+    }
+  })]
+}


### PR DESCRIPTION
The autoscaler manages the autoscaling group for the worker nodes.

It automatically adjusts the size of the Kubernetes cluster when
there are pods that can't run due to insufficient resources or
there are nodes that are underutilised for a long time and we can
move their pods onto other nodes.

The implementation follows the AWS documentation:
* https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html
* https://github.com/terraform-aws-modules/terraform-aws-eks/blob/e3216e3cf80cb59089ba0e0365c6650520000aaf/docs/autoscaling.md

Trello: https://trello.com/c/pSUJPwuB/601-enable-cluster-autoscaler