### PR TITLE
create govuk-terraform repo

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -34,6 +34,7 @@ locals {
     "static",
     "statsd",
     "authenticating-proxy",
+    "govuk-terraform",
   ]
 }
 


### PR DESCRIPTION
We are going to create our own image of terraform with aws-cli and jq
since these 3 binaries are now needed to run terraform with assume
role, see #378.

Hence, we create the `govuk-terraform` AWS ECR repository to host these images.

Ref:
1. [trello-card](https://trello.com/c/r2cYPT8p/621-create-a-tools-image-with-terraformawsclijq-for-concourse-to-replace-the-3rd-party-one-were-using-temporarily)