### PR TITLE
build govuk-terraform image using concourse pipeline

### DIFF
--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -92,6 +92,14 @@ resources:
       uri: git@github.com:alphagov/govuk-infrastructure.git
       branch: main
 
+  - <<: *git-repo
+    name: govuk-infrastructure-govuk-terraform
+    source:
+      <<: *git-repo-source
+      uri: git@github.com:alphagov/govuk-infrastructure.git
+      branch: main
+      paths: [ docker/images/govuk-terraform ]
+
   - &docker-image
     name: smokey-image
     type: registry-image
@@ -173,6 +181,13 @@ resources:
       repository: authenticating-proxy
       tag: latest
 
+  - <<: *docker-image
+    name: govuk-terraform-image
+    source:
+      <<: *docker-image-source
+      repository: govuk-terraform
+      tag: latest
+
   - &semver-version
     name: smokey-version
     type: semver
@@ -245,6 +260,12 @@ resources:
     source:
       <<: *semver-version-source
       key: authenticating-proxy-version
+
+  - <<: *semver-version
+    name: govuk-terraform-version
+    source:
+      <<: *semver-version-source
+      key: govuk-terraform-proxy-version
 
   - name: ci-slack-channel
     type: slack-notification
@@ -630,5 +651,33 @@ jobs:
       - put: authenticating-proxy-version
         params:
           file: authenticating-proxy-version/version
+    on_failure:
+      <<: *notify-slack-failure
+
+  - name: govuk-terraform
+    serial: true
+    plan:
+    - in_parallel:
+      - get: govuk-infrastructure-govuk-terraform
+        trigger: true
+      - get: govuk-terraform-version
+        params:
+          bump: minor
+          pre_without_version: true
+          pre: release
+    - task: build-image
+      privileged: true
+      file: govuk-infrastructure-govuk-terraform/concourse/tasks/build-image-definition.yml
+      input_mapping:
+        git-repo: govuk-infrastructure-govuk-terraform
+      params:
+        DOCKERFILE: git-repo/docker/images/govuk-terraform/Dockerfile
+    - put: govuk-terraform-image
+      params:
+        image: image/image.tar
+        additional_tags: govuk-terraform-version/version
+    - put: govuk-terraform-version
+      params:
+        file: govuk-terraform-version/version
     on_failure:
       <<: *notify-slack-failure

--- a/docker/images/govuk-terraform/Dockerfile
+++ b/docker/images/govuk-terraform/Dockerfile
@@ -1,0 +1,30 @@
+ARG DEBIAN_VERSION=11.0-slim
+FROM debian:${DEBIAN_VERSION}
+
+ARG AWSCLI_VERSION=2.0.30
+ARG TERRAFORM_VERSION=1.0.0
+ARG TERRAFORM_SUM=8be33cc3be8089019d95eb8f546f35d41926e7c1e5deff15792e969dde573eb5
+ARG AWSCLI_SUM=7ee475f22c1b35cc9e53affbf96a9ffce91706e154a9441d0d39cbf8366b718e
+
+ENV PATH $PATH:/usr/local/bin
+ARG PACKAGES="jq curl unzip git"
+
+RUN apt-get update \
+    && apt-get install -y ${PACKAGES}
+
+ARG TERRAFORM_ZIP=terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+RUN set -ex \
+    && curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ZIP} -o /tmp/${TERRAFORM_ZIP} \
+    && echo "${TERRAFORM_SUM}  /tmp/${TERRAFORM_ZIP}" | sha256sum -c - \
+    && unzip /tmp/${TERRAFORM_ZIP} -d /usr/local/bin \
+    && rm /tmp/${TERRAFORM_ZIP}
+
+ARG AWSCLI_ZIP=awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip
+
+RUN set -ex \
+    && curl "https://awscli.amazonaws.com/${AWSCLI_ZIP}" -o "/tmp/${AWSCLI_ZIP}" \
+    && echo "${AWSCLI_SUM}  /tmp/${AWSCLI_ZIP}" | sha256sum -c - \
+    && unzip /tmp/${AWSCLI_ZIP} -d /tmp/aws_${AWSCLI_VERSION} \
+    && ./tmp/aws_${AWSCLI_VERSION}/aws/install \
+    && rm -rf /tmp/${AWSCLI_ZIP} /tmp/aws_${AWSCLI_VERSION}


### PR DESCRIPTION
We create our own image of terraform with aws-cli and jq since these 3
binaries are now needed to run terraform with assume role, see #378.

This image is based on what the PaaS team is doing
[here](https://github.com/alphagov/paas-docker-cloudfoundry-tools)

While in the trello card, it mentions to user ARG, it is not clear
whether we want to pass in these args from Concourse or not.  PaaS
directly modifies the Dockerfile.

We use a Debian image since awscli v2 is not easily compiled for
alpine base image, see
[issue](aws/aws-cli#4685 (comment))

**Testing**
I modified the `build-images` pipeline and checked that it
is running
[successfully](https://cd.gds-reliability.engineering/teams/govuk-ci/pipelines/build-images/jobs/govuk-terraform/builds/4)

I also tested the images with a test `eks-test` pipeline
[here](https://cd.gds-reliability.engineering/teams/govuk-test/pipelines/eks-test)

Ref: 1.
[trello-card](https://trello.com/c/r2cYPT8p/621-create-a-tools-image-with-terraformawsclijq-for-concourse-to-replace-the-3rd-party-one-were-using-temporarily)