### PR TITLE
Add Grafana and Prometheus (MVP version)

### DIFF
--- a/terraform/deployments/cluster-services/grafana.tf
+++ b/terraform/deployments/cluster-services/grafana.tf
@@ -1,0 +1,42 @@
+# Installs Grafana.
+# NOTE: Dashboards should *not* be configured in cluster-services.
+#       Dashboards are user-supplied data and are deployed independently.
+
+resource "helm_release" "grafana" {
+  name             = "grafana"
+  repository       = "https://grafana.github.io/helm-charts"
+  chart            = "grafana"
+  create_namespace = true
+  version          = "6.16.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace        = "monitoring"
+  timeout          = 60 # seconds
+  values = [yamlencode({
+    datasources = {
+      "datasources.yaml" = {
+        apiVersion = 1
+        datasources = [
+          {
+            name            = "Prometheus"
+            type            = "prometheus"
+            access          = "proxy"
+            url             = "prometheus-server"
+            withCredentials = false
+            isDefault       = true
+            version         = 1
+            editable        = true
+          },
+          {
+            name            = "Elasticsearch"
+            type            = "elasticsearch"
+            access          = "proxy"
+            url             = "elasticsearch-master.${local.logging_namespace}:9200"
+            withCredentials = false
+            isDefault       = false
+            version         = 1
+            editable        = true
+          }
+        ]
+      }
+    }
+  })]
+}

--- a/terraform/deployments/cluster-services/prometheus.tf
+++ b/terraform/deployments/cluster-services/prometheus.tf
@@ -1,0 +1,10 @@
+# Installs Prometheus server, alertmanager, kube-state-metrics, node-exporter
+# and pushgateway.
+resource "helm_release" "prometheus" {
+  name             = "prometheus"
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus"
+  create_namespace = true
+  version          = "14.6.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace        = "monitoring"
+}


### PR DESCRIPTION
This installs two Helm charts (Prometheus and Grafana) into a new 'monitoring' namespace. The Helm charts also include sub-charts such as prometheus alertmanager.

This also configures Grafana's Elasticsearch and prom data sources, and adds three dashboards.

This is an MVP so I've not set up Grafana OAuth or integrations with CloudWatch or DNS records for Grafana/Prometheus/AlertManager. There are quite a few other parts to add, but this should serve our purposes for now.

Trello: https://trello.com/c/3JHJX5Lh/600-set-up-metrics-mvp

Screenshots:

<img width="1464" alt="Screenshot 2021-08-27 at 15 27 38" src="https://user-images.githubusercontent.com/8124374/131143245-b190fd03-d576-458d-ad79-155df92fa1c2.png">
<img width="1536" alt="Screenshot 2021-08-27 at 15 28 00" src="https://user-images.githubusercontent.com/8124374/131143250-fed482dc-db15-419e-a307-4532ef52d5e2.png">
