### PR TITLE
Specify the subnet CIDR blocks for the integration account.

### DIFF
--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -3,6 +3,24 @@ cluster_infrastructure_state_bucket = "govuk-terraform-integration"
 
 cluster_log_retention_in_days = 7
 
+eks_control_plane_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.1.19.0/28" }
+  b = { az = "eu-west-1b", cidr = "10.1.19.16/28" }
+  c = { az = "eu-west-1c", cidr = "10.1.19.32/28" }
+}
+
+eks_public_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.1.20.0/24" }
+  b = { az = "eu-west-1b", cidr = "10.1.21.0/24" }
+  c = { az = "eu-west-1c", cidr = "10.1.22.0/24" }
+}
+
+eks_private_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.1.24.0/22" }
+  b = { az = "eu-west-1b", cidr = "10.1.28.0/22" }
+  c = { az = "eu-west-1c", cidr = "10.1.32.0/22" }
+}
+
 govuk_environment             = "integration"
 ecs_default_capacity_provider = "FARGATE_SPOT"
 

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -4,48 +4,21 @@ cluster_infrastructure_state_bucket = "govuk-terraform-test"
 cluster_log_retention_in_days = 7
 
 eks_control_plane_subnets = {
-  a = {
-    az   = "eu-west-1a"
-    cidr = "10.200.19.0/28"
-  }
-  b = {
-    az   = "eu-west-1b"
-    cidr = "10.200.19.16/28"
-  }
-  c = {
-    az   = "eu-west-1c"
-    cidr = "10.200.19.32/28"
-  }
+  a = { az = "eu-west-1a", cidr = "10.200.19.0/28" }
+  b = { az = "eu-west-1b", cidr = "10.200.19.16/28" }
+  c = { az = "eu-west-1c", cidr = "10.200.19.32/28" }
 }
 
 eks_public_subnets = {
-  a = {
-    az   = "eu-west-1a"
-    cidr = "10.200.20.0/24"
-  }
-  b = {
-    az   = "eu-west-1b"
-    cidr = "10.200.21.0/24"
-  }
-  c = {
-    az   = "eu-west-1c"
-    cidr = "10.200.22.0/24"
-  }
+  a = { az = "eu-west-1a", cidr = "10.200.20.0/24" }
+  b = { az = "eu-west-1b", cidr = "10.200.21.0/24" }
+  c = { az = "eu-west-1c", cidr = "10.200.22.0/24" }
 }
 
 eks_private_subnets = {
-  a = {
-    az   = "eu-west-1a"
-    cidr = "10.200.24.0/22"
-  }
-  b = {
-    az   = "eu-west-1b"
-    cidr = "10.200.28.0/22"
-  }
-  c = {
-    az   = "eu-west-1c"
-    cidr = "10.200.32.0/22"
-  }
+  a = { az = "eu-west-1a", cidr = "10.200.24.0/22" }
+  b = { az = "eu-west-1b", cidr = "10.200.28.0/22" }
+  c = { az = "eu-west-1c", cidr = "10.200.32.0/22" }
 }
 
 govuk_environment             = "test"


### PR DESCRIPTION
Also improve the formatting of the equivalent config for the test account.

No diff. (`tf plan -var-file ../variables/test/common.tfvars -lock=false`)