### PR TITLE
Enable tflint and fix errors in cluster-services module.

### DIFF
--- a/terraform/deployments/cluster-services/.tflint.hcl
+++ b/terraform/deployments/cluster-services/.tflint.hcl
@@ -1,0 +1,18 @@
+plugin "aws" {
+  enabled = true
+}
+
+config {
+  varfile = [
+    "../variables/common.tfvars",
+    "../variables/test/common.tfvars",
+  ]
+}
+
+rule "terraform_comment_syntax" { enabled = true }
+rule "terraform_deprecated_index" { enabled = true }
+rule "terraform_required_providers" { enabled = true }
+rule "terraform_standard_module_structure" { enabled = true }
+rule "terraform_typed_variables" { enabled = true }
+rule "terraform_unused_declarations" { enabled = true }
+rule "terraform_unused_required_providers" { enabled = true }

--- a/terraform/deployments/cluster-services/aws_auth_configmap.tf
+++ b/terraform/deployments/cluster-services/aws_auth_configmap.tf
@@ -111,7 +111,7 @@ resource "kubernetes_cluster_role_binding" "read_crs_and_crbs" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"
-    name      = kubernetes_cluster_role.read_crs_and_crbs.metadata.0.name
+    name      = kubernetes_cluster_role.read_crs_and_crbs.metadata[0].name
   }
   subject {
     kind      = "Group"

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -2,8 +2,7 @@
 # NOTE: Kibana and Elasticsearch will in future be replaced by Logit.
 
 locals {
-  fluentbit_service_account_name = "fluentbit"
-  logging_namespace              = "logging"
+  logging_namespace = "logging"
 
   fluentbit_output = <<-OUTPUT
   [OUTPUT]

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -8,6 +8,22 @@
 
 terraform {
   backend "s3" {}
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.4"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.3"
+    }
+    # The AWS provider is only used here for remote state in remote.tf. Please
+    # do not add AWS resources to this module.
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.57"
+    }
+  }
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
Follows from #418, where it transpired that we're only linting Terraform modules which contain a `.tflint.hcl`.

Enable tflint for the `cluster-services` module (with same config as the other modules) and fix lint errors:

* Unused variable (`fluentbit_service_account_name`)
* Missing provider version constraints.
* Missing `outputs.tf`. Considered disabling this one, but it's not possible to disable just this specific rule; unfortunately it's conflated with other rules about enforcing the standard module structure which we do kinda want - so let's just put up with it insisting on an empty file for now.

It'd be good to sort out the lint job so that we can have one base config file (ideally still with the ability to override per module) instead of having to remember to put this hidden `.tflint.hcl` file in every root module, but I'll leave that to figure out later.

[Trello card](https://trello.com/c/b3GJgOAW/631)

Tested: `tf init -backend-config test.backend -upgrade` and `tf apply -var-file=../variables/test/common.tfvars` succeeded. The `-upgrade` is in theory only necessary because I'm running with existing state in `.terraform`; CD should continue to work without it. (Famous last words.)