### PR TITLE
Specify Terraform required_version and normalise provider constraints.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -9,10 +9,11 @@
 terraform {
   backend "s3" {}
 
+  required_version = "~> 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.33"
+      version = "~> 3.0"
     }
   }
 }

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -8,20 +8,22 @@
 
 terraform {
   backend "s3" {}
+
+  required_version = "~> 1.0"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.4"
+      version = "~> 2.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.3"
+      version = "~> 2.0"
     }
     # The AWS provider is only used here for remote state in remote.tf. Please
     # do not add AWS resources to this module.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.57"
+      version = "~> 3.0"
     }
   }
 }

--- a/terraform/deployments/concourse-iam/main.tf
+++ b/terraform/deployments/concourse-iam/main.tf
@@ -9,10 +9,11 @@
 terraform {
   backend "s3" {}
 
+  required_version = "~> 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.13"
+      version = "~> 3.0"
     }
   }
 }

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -1,4 +1,4 @@
-# This is supposed to be applied in the production environment
+# This module should be applied in the production account only.
 
 terraform {
   backend "s3" {
@@ -8,10 +8,11 @@ terraform {
     encrypt = true
   }
 
+  required_version = "~> 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.13"
+      version = "~> 3.0"
     }
   }
 }

--- a/terraform/deployments/terraform-lock/main.tf
+++ b/terraform/deployments/terraform-lock/main.tf
@@ -1,12 +1,11 @@
 terraform {
-  # Backend config in ./<env>.backend file
-  backend "s3" {
-  }
+  backend "s3" {}
 
+  required_version = "~> 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.33"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
Specify [`terraform.required_version`](https://www.terraform.io/docs/language/settings/index.html#specifying-a-required-terraform-version) in all root modules. This allows Terraform to raise an error when running on an unintended version. Hopefully in time this will replace tfenv's `.terraform_version` (but not quite yet it seems - see tfenv issue 124).

Also normalise the provider version constraints so we're no longer specifying arbitrary minor versions. There are no changes to the actual versions selected when running TF. This should clarify the intent behind these constraints, which is to hold off unexpected major (i.e. potentially breaking) version changes.

We shouldn't expect any breaking changes on [TF 1.x minor version updates](https://www.terraform.io/docs/language/v1-compatibility-promises.html). Let's see how that goes.

[Trello card](https://trello.com/c/My3xZicq/632)

Tested: `tf init -backend-config test.backend -reconfigure && tf apply -var-file=../variables/test/common.tfvars -var-file=../variables/common.tfvars` in each root module. No diffs and the selected provider versions remain the same.

