### PR TITLE
Fix External Secrets pod Crashing

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -12,7 +12,8 @@ resource "helm_release" "external_secrets" {
   create_namespace = true
   values = [yamlencode({
     serviceAccount = {
-      name = data.terraform_remote_state.cluster_infrastructure.outputs.external_secrets_service_account_name
+      name      = data.terraform_remote_state.cluster_infrastructure.outputs.external_secrets_service_account_name
+      namespace = local.services_ns
       annotations = {
         "eks.amazonaws.com/role-arn" = data.terraform_remote_state.cluster_infrastructure.outputs.external_secrets_role_arn
       }


### PR DESCRIPTION
[External Secrets](https://github.com/external-secrets/external-secrets) was installed via Helm in #415. Unfortunately, its pod kept crashing due to some auth issue.

Further investigation shows that the service account information pass to the helm chart misses the namespace of the service account, this can be seen in the tests run in [here](https://github.com/external-secrets/external-secrets/blob/8827e3ab92cdd87800f44d8f8bd995f0ea749476/pkg/provider/aws/auth/auth_test.go#L342)