### PR TITLE
Removing the maintainer validation helm lint check

### DIFF
--- a/ct.yml
+++ b/ct.yml
@@ -1,4 +1,5 @@
 remote: origin
 target-branch: main
+validate-maintainers: false
 chart-dirs:
   - helm


### PR DESCRIPTION
Adding validate-maintainers: false to the ct.yml 

This change will stop Helm Lint from failing if `maintainer:` has not been added to Chart.yaml 