### PR TITLE
Fix external-secrets controller

### DIFF
--- a/helm/services/cluster-secret-store/templates/cluster_secret_store.yaml
+++ b/helm/services/cluster-secret-store/templates/cluster_secret_store.yaml
@@ -11,3 +11,4 @@ spec:
         jwt:
           serviceAccountRef:
             name: {{ .Values.serviceAccountName }}
+            namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The external-secrets controller service account's namespace must be explicitly specifed when using ClusterSecretStore. This does not appear to be documented anywhere, but the assumption that the namespace is specified can be seen in the source: https://github.com/external-secrets/external-secrets/blob/867006996753dbd4b96d2e8bf3e22c3d583fbcbc/pkg/provider/aws/auth/auth.go#L163