### PR TITLE
Removal of two steps from our Github actions workflow:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,3 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yml
-
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
-        if: steps.list-changed.outputs.changed == 'true'
-
-      - name: Run chart-testing (install)
-        run: ct install --config ct.yml


### PR DESCRIPTION
Create EKS cluster and run Helm chart testing have been removed.

Currently we do not need the above steps.

There is a need to come up with a testing solution which will be added to Trello as a new card and linked to the below Trello card.

Trello card: https://trello.com/c/RL7522ud/638-removal-of-create-eks-cluster-and-run-helm-chart-testing-steps-from-github-actions
