### PR TITLE
Adding Nginx reverse proxy to Rails apps as sidecar.

### DIFF
--- a/helm/content-store/Chart.yaml
+++ b/helm/content-store/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: content-store
 description: A Helm chart for GOV.UK Content-Store
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.16.0"

--- a/helm/content-store/templates/configmap.yaml
+++ b/helm/content-store/templates/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-nginx-conf
+data:
+  nginx.conf: |-
+    user  nginx;
+    
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
+
+    events {
+      worker_connections  1024;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+
+      server_tokens off;
+
+      sendfile        on;
+      keepalive_timeout  65;
+
+      upstream {{ .Release.Name }} {
+        server 127.0.0.1:{{ .Values.appPort }};
+      }
+
+      server {
+        listen {{ .Values.nginxPort }};
+
+        location / {
+          proxy_pass         http://{{ .Release.Name }};
+          proxy_redirect     off;
+        }
+      }
+    }

--- a/helm/content-store/templates/deployment.yaml
+++ b/helm/content-store/templates/deployment.yaml
@@ -16,9 +16,9 @@ spec:
     spec:
       containers:
         - name: {{ .Release.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           ports:
-            - containerPort: {{ .Values.containerPort }}
+            - containerPort: {{ .Values.appPort }}
           env:
             - name: DEFAULT_TTL
               value: "{{ .Values.appDefaultTtl }}"
@@ -45,7 +45,7 @@ spec:
             - name: PLEK_SERVICE_SIGNON_URI
               value: "{{ .Values.appPlekServiceSignonUri | default (printf "http://signon.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
             - name: PORT
-              value: "{{ .Values.containerPort }}"
+              value: "{{ .Values.appPort }}"
             - name: RAILS_ENV
               value: "{{ .Values.appRailsEnv }}"
             - name: SECRET_KEY_BASE
@@ -58,12 +58,24 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthcheck/live
-              port: {{ .Values.containerPort }}
+              port: {{ .Values.appPort }}
             initialDelaySeconds: 30
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /healthcheck/ready
-              port: {{ .Values.containerPort }}
+              port: {{ .Values.appPort }}
             initialDelaySeconds: 30
             periodSeconds: 5
+        - name: {{ .Release.Name }}-nginx
+          image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
+          ports:
+            - containerPort: {{ .Values.nginxPort }}
+          volumeMounts:
+          - name: {{ .Release.Name }}-nginx-conf
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+      volumes:
+      - name: {{ .Release.Name }}-nginx-conf
+        configMap:
+          name: {{ .Release.Name }}-nginx-conf

--- a/helm/content-store/templates/deployment.yaml
+++ b/helm/content-store/templates/deployment.yaml
@@ -18,7 +18,8 @@ spec:
         - name: {{ .Release.Name }}
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           ports:
-            - containerPort: {{ .Values.appPort }}
+            - name: http
+              containerPort: {{ .Values.appPort }}
           env:
             - name: DEFAULT_TTL
               value: "{{ .Values.appDefaultTtl }}"
@@ -58,19 +59,36 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthcheck/live
-              port: {{ .Values.appPort }}
+              port: http
             initialDelaySeconds: 30
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /healthcheck/ready
-              port: {{ .Values.appPort }}
+              port: http
             initialDelaySeconds: 30
             periodSeconds: 5
         - name: {{ .Release.Name }}-nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:
-            - containerPort: {{ .Values.nginxPort }}
+            - name: http
+              containerPort: {{ .Values.nginxPort }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 6
+            successThreshold: 1
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
           volumeMounts:
           - name: {{ .Release.Name }}-nginx-conf
             mountPath: /etc/nginx/nginx.conf

--- a/helm/content-store/templates/service.yaml
+++ b/helm/content-store/templates/service.yaml
@@ -16,6 +16,6 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
       protocol: TCP
-      name: https
+      name: http
   selector:
     app: {{ .Release.Name }}

--- a/helm/content-store/templates/service.yaml
+++ b/helm/content-store/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.containerPort }}
+      targetPort: {{ .Values.nginxPort }}
       protocol: TCP
       name: https
   selector:

--- a/helm/content-store/values.yaml
+++ b/helm/content-store/values.yaml
@@ -15,12 +15,12 @@ replicaCount: 1
 
 appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: latest
 
 nginxImage:
   repository: nginx
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: stable
 
 appPort: 3000

--- a/helm/content-store/values.yaml
+++ b/helm/content-store/values.yaml
@@ -10,39 +10,48 @@ service:
   annotations: {}
   type: NodePort
   port: 80
-  targetPort: 80
-
 
 replicaCount: 1
 
-image:
+appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/content-store
   pullPolicy: IfNotPresent
   tag: latest
 
-containerPort: 80
+nginxImage:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  tag: stable
 
-resources:
-  limits:
-  # cpu:
-  # memory: 1024M
-  requests:
-  # cpu:
-  # memory: 1024M
+appPort: 3000
+nginxPort: 80
 
+resources: {}
+  # If you do want to specify resources, uncomment the following lines,
+  # adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
 
+## See template file for how application conatiner env default value is computed
 appDefaultTtl: "1800"
-appGovukAppDomain: # see template for how default value is computed
-appGovukDomainExternal: # see template for how default value is computed
-appGovukAppName: # see template for how default value is computed
+appGovukAppDomain:
+appGovukDomainExternal:
+appGovukAppName:
 appGovukAppType: "rack"
 appGovukContentSchemasPath: "/govuk-content-schemas"
-appGovukWebsiteRoot: # see template for how default value is computed
-appMongodbUri: # see template for how default value is computed
-appPlekServicePublishingApiUri: # see template for how default value is computed
-appPlekServiceRouterApiUri: # see template for how default value is computed
-appPlekServiceSignonUri: # see template for how default value is computed
+appGovukWebsiteRoot:
+appMongodbUri:
+appPlekServicePublishingApiUri:
+appPlekServiceRouterApiUri:
+appPlekServiceSignonUri:
 appRailsEnv: "production"
-appExtraEnv: # extra envs that you to pass to the app
- #- name: hello
- #  value: world
+
+## Extra environment variables to attach to application container
+##
+# appExtraEnv:
+#   - name: hello
+#     value: world

--- a/helm/frontend/Chart.yaml
+++ b/helm/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for GOV.UK Frontend
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.16.0"

--- a/helm/frontend/templates/configmap.yaml
+++ b/helm/frontend/templates/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-nginx-conf
+data:
+  nginx.conf: |-
+    user  nginx;
+    
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
+
+    events {
+      worker_connections  1024;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+
+      server_tokens off;
+
+      sendfile        on;
+      keepalive_timeout  65;
+
+      upstream {{ .Release.Name }} {
+        server 127.0.0.1:{{ .Values.appPort }};
+      }
+
+      server {
+        listen {{ .Values.nginxPort }};
+
+        location / {
+          proxy_pass         http://{{ .Release.Name }};
+          proxy_redirect     off;
+        }
+      }
+    }

--- a/helm/frontend/templates/deployment.yaml
+++ b/helm/frontend/templates/deployment.yaml
@@ -18,7 +18,8 @@ spec:
         - name: {{ .Release.Name }}
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           ports:
-            - containerPort: {{ .Values.appPort }}
+            - name: http
+              containerPort: {{ .Values.appPort }}
           env:
             - name: ASSET_HOST
               value: "{{ .Values.appAssetHost | default (printf "https://www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
@@ -62,19 +63,36 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthcheck/live
-              port: {{ .Values.appPort }}
+              port: http
             initialDelaySeconds: 30
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /healthcheck/ready
-              port: {{ .Values.appPort }}
+              port: http
             initialDelaySeconds: 30
             periodSeconds: 5
         - name: {{ .Release.Name }}-nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:
-            - containerPort: {{ .Values.nginxPort }}
+            - name: http
+              containerPort: {{ .Values.nginxPort }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 6
+            successThreshold: 1
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
           volumeMounts:
           - name: {{ .Release.Name }}-nginx-conf
             mountPath: /etc/nginx/nginx.conf

--- a/helm/frontend/templates/deployment.yaml
+++ b/helm/frontend/templates/deployment.yaml
@@ -16,9 +16,9 @@ spec:
     spec:
       containers:
         - name: {{ .Release.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           ports:
-            - containerPort: {{ .Values.containerPort }}
+            - containerPort: {{ .Values.appPort }}
           env:
             - name: ASSET_HOST
               value: "{{ .Values.appAssetHost | default (printf "https://www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
@@ -49,7 +49,7 @@ spec:
             - name: PLEK_SERVICE_STATIC_URI
               value: "{{ .Values.appPlekServiceStaticUri | default (printf "http://static.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
             - name: PORT
-              value: "{{ .Values.containerPort }}"
+              value: "{{ .Values.appPort }}"
             - name: RAILS_ENV
               value: "{{ .Values.appRailsEnv }}"
             - name: SECRET_KEY_BASE
@@ -62,12 +62,24 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthcheck/live
-              port: {{ .Values.containerPort }}
+              port: {{ .Values.appPort }}
             initialDelaySeconds: 30
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /healthcheck/ready
-              port: {{ .Values.containerPort }}
+              port: {{ .Values.appPort }}
             initialDelaySeconds: 30
             periodSeconds: 5
+        - name: {{ .Release.Name }}-nginx
+          image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
+          ports:
+            - containerPort: {{ .Values.nginxPort }}
+          volumeMounts:
+          - name: {{ .Release.Name }}-nginx-conf
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+      volumes:
+      - name: {{ .Release.Name }}-nginx-conf 
+        configMap:
+          name: {{ .Release.Name }}-nginx-conf

--- a/helm/frontend/templates/service.yaml
+++ b/helm/frontend/templates/service.yaml
@@ -16,6 +16,6 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
       protocol: TCP
-      name: https
+      name: http
   selector:
     app: {{ .Release.Name }}

--- a/helm/frontend/templates/service.yaml
+++ b/helm/frontend/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.containerPort }}
+      targetPort: {{ .Values.nginxPort }}
       protocol: TCP
       name: https
   selector:

--- a/helm/frontend/values.yaml
+++ b/helm/frontend/values.yaml
@@ -10,38 +10,49 @@ service:
   annotations: {}
   port: 80
 
-
 replicaCount: 1
 
-image:
+appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend
   pullPolicy: IfNotPresent
   tag: latest
 
-containerPort: 80
+nginxImage:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  tag: stable
 
-resources:
-  limits:
-  # cpu:
-  # memory: 1024M
-  requests:
-  # cpu:
-  # memory: 1024M
+nginxPort: 80
+appPort: 3000
 
+resources: {}
+  # If you do want to specify resources, uncomment the following lines,
+  # adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+## See template file for how application conatiner env default value is computed
 appDefaultTtl: "1800"
-appGovukAppDomain: # see template for how default value is computed
-appGovukDomainExternal: # see template for how default value is computed
-appGovukAppName: # see template for how default value is computed
+appGovukAppDomain:
+appGovukDomainExternal:
+appGovukAppName:
 appGovukAppType: "rack"
 appGovukContentSchemasPath: "/govuk-content-schemas"
-appGovukWebsiteRoot: # see template for how default value is computed
-appPlekServicePublishingApiUri: # see template for how default value is computed
-appPlekServiceSignonUri: # see template for how default value is computed
-appPlekServiceContentStoreUri: # see template for how default value is computed
-appPlekServiceStaticUri: # see template for how default value is computed
+appGovukWebsiteRoot:
+appPlekServicePublishingApiUri:
+appPlekServiceSignonUri:
+appPlekServiceContentStoreUri:
+appPlekServiceStaticUri:
 appRailsEnv: "production"
-appAssetHost: # see template for how default value is computed
-appGovukAssetRoot: # see template for how default value is computed
-appExtraEnv: # extra envs that you to pass to the app
- #- name: hello
- #  value: world
+appAssetHost:
+appGovukAssetRoot:
+
+## Extra environment variables to attach to application container
+##
+# appExtraEnv:
+#   - name: hello
+#     value: world

--- a/helm/frontend/values.yaml
+++ b/helm/frontend/values.yaml
@@ -14,12 +14,12 @@ replicaCount: 1
 
 appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/frontend
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: latest
 
 nginxImage:
   repository: nginx
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: stable
 
 nginxPort: 80

--- a/helm/static/Chart.yaml
+++ b/helm/static/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: static
 description: A Helm chart for GOV.UK Static
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.16.0"

--- a/helm/static/templates/configmap.yaml
+++ b/helm/static/templates/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-nginx-conf
+data:
+  nginx.conf: |-
+    user  nginx;
+    
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
+
+    events {
+      worker_connections  1024;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+
+      server_tokens off;
+
+      sendfile        on;
+      keepalive_timeout  65;
+
+      upstream {{ .Release.Name }} {
+        server 127.0.0.1:{{ .Values.appPort }};
+      }
+
+      server {
+        listen {{ .Values.nginxPort }};
+
+        location / {
+          proxy_pass         http://{{ .Release.Name }};
+          proxy_redirect     off;
+        }
+      }
+    }

--- a/helm/static/templates/deployment.yaml
+++ b/helm/static/templates/deployment.yaml
@@ -16,9 +16,9 @@ spec:
     spec:
       containers:
         - name: {{ .Release.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           ports:
-            - containerPort: {{ .Values.containerPort }}
+            - containerPort: {{ .Values.appPort }}
           env:
             - name: GOVUK_APP_DOMAIN
               value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
@@ -35,7 +35,7 @@ spec:
             - name: GOVUK_ENVIRONMENT
               value: "{{ .Values.govukEnvironment }}"
             - name: PORT
-              value: "{{ .Values.containerPort }}"
+              value: "{{ .Values.appPort }}"
             - name: RAILS_ENV
               value: "{{ .Values.govukEnvironment }}"
             - name: REDIS_URL
@@ -54,12 +54,24 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthcheck/live
-              port: {{ .Values.containerPort }}
+              port: {{ .Values.appPort }}
             initialDelaySeconds: 30
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /healthcheck/ready
-              port: {{ .Values.containerPort }}
+              port: {{ .Values.appPort }}
             initialDelaySeconds: 30
             periodSeconds: 5
+        - name: {{ .Release.Name }}-nginx
+          image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
+          ports:
+            - containerPort: {{ .Values.nginxPort }}
+          volumeMounts:
+          - name: {{ .Release.Name }}-nginx-conf
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+      volumes:
+      - name: {{ .Release.Name }}-nginx-conf
+        configMap:
+          name: {{ .Release.Name }}-nginx-conf

--- a/helm/static/templates/deployment.yaml
+++ b/helm/static/templates/deployment.yaml
@@ -18,7 +18,8 @@ spec:
         - name: {{ .Release.Name }}
           image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
           ports:
-            - containerPort: {{ .Values.appPort }}
+            - name: http
+              containerPort: {{ .Values.appPort }}
           env:
             - name: GOVUK_APP_DOMAIN
               value: "{{ .Values.appGovukAppDomain | default (printf "%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
@@ -54,19 +55,36 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthcheck/live
-              port: {{ .Values.appPort }}
+              port: http
             initialDelaySeconds: 30
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /healthcheck/ready
-              port: {{ .Values.appPort }}
+              port: http
             initialDelaySeconds: 30
             periodSeconds: 5
         - name: {{ .Release.Name }}-nginx
           image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
           ports:
-            - containerPort: {{ .Values.nginxPort }}
+            - name: http
+              containerPort: {{ .Values.nginxPort }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 6
+            successThreshold: 1
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
           volumeMounts:
           - name: {{ .Release.Name }}-nginx-conf
             mountPath: /etc/nginx/nginx.conf

--- a/helm/static/templates/service.yaml
+++ b/helm/static/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.containerPort}}
+      targetPort: {{ .Values.nginxPort}}
       protocol: TCP
       name: https
   selector:

--- a/helm/static/templates/service.yaml
+++ b/helm/static/templates/service.yaml
@@ -16,6 +16,6 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort}}
       protocol: TCP
-      name: https
+      name: http
   selector:
     app: {{ .Release.Name }}

--- a/helm/static/values.yaml
+++ b/helm/static/values.yaml
@@ -10,34 +10,45 @@ service:
   type: NodePort
   annotations: {}
   port: 80
-  targetPort: 80
 
 replicaCount: 1
 
-image:
+appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
   pullPolicy: IfNotPresent
   tag: latest
 
-containerPort: 80
+nginxImage:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  tag: stable
 
-resources:
-  limits:
-  # cpu:
-  # memory: 1024M
-  requests:
-  # cpu:
-  # memory: 1024M
+appPort: 3000
+nginxPort: 80
 
-appGovukAppDomain: # see template for how default value is computed
-appGovukDomainExternal: # see template for how default value is computed
-appGovukAppName: # see template for how default value is computed
-appGovukWebsiteRoot: # see template for how default value is computed
+resources: {}
+  # If you do want to specify resources, uncomment the following lines,
+  # adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+## See template file for how application conatiner env default value is computed
+appGovukAppDomain:
+appGovukDomainExternal:
+appGovukAppName:
+appGovukWebsiteRoot:
 appDefaultTtl: "1800"
-appGovukAssetRoot: # see template for how default value is computed
-appRedisUrl: # see template for how default value is computed
+appGovukAssetRoot:
+appRedisUrl:
 appGovukAppRoot: "/var/apps/static"
 appGovukAppType: "rack"
-appExtraEnv: # extra envs that you to pass to the app
- #- name: hello
- #  value: world
+
+## Extra environment variables to attach to application container
+##
+# appExtraEnv:
+#   - name: hello
+#     value: world

--- a/helm/static/values.yaml
+++ b/helm/static/values.yaml
@@ -15,12 +15,12 @@ replicaCount: 1
 
 appImage:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/static
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: latest
 
 nginxImage:
   repository: nginx
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: stable
 
 appPort: 3000


### PR DESCRIPTION
We're not 100% sure what behaviour these will need in the future. Possibly they'll be involved in serving static assets  such ad CSS, JS etc.

It will certainly be needed in some applications such asset manager, which uses ‘x-accel-redirect’.

We are not mandating the use of Nginx sidecar for every Rails app, though we believe it will be the case.

If it turns out that the Nginx sidecar have no behaviour, we may consider removing them at a later date.

**Some of the reasons to why we are adding Nginx sidecar:**

We want apps to be able to work as independently as possible.

  Helm chart should be a self-contained encapsulated artefact.
  
Nginx sidecar will just be doing reverse proxy, static serving and possibly some x-accel-redirect stuff to s3 for the few apps that need this.
  
Unicorn can't deal with slow clients efficiently.

**Nginx sidecar Config:**

The Nginx config itself will need to be updated to support functionality we require in the future,

Some reference for NGINX requirements can be found here

https://docs.google.com/document/d/1hOgkeimIn20O5zrD0wTflap1_DTVatb7NOnb223NhSE/
https://trello.com/c/Lkb8N313/381-epic-nginx-and-varnish-changes-needed

**Values naming changes:**

  Rails application image to: appImage
  Rails application container port to: appPort

  Nginx sidecar image to - nginxImage
  Nginx sidecar container port to: nginxPort