### PR TITLE
Ship logs to Logit

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -35,3 +35,13 @@ resource "helm_release" "cluster_secret_store" {
     serviceAccountName = data.terraform_remote_state.cluster_infrastructure.outputs.external_secrets_service_account_name
   })]
 }
+
+resource "helm_release" "cluster_secrets" {
+  depends_on = [helm_release.cluster_secret_store]
+
+  chart      = "cluster-secrets"
+  name       = "cluster-secrets"
+  namespace  = local.services_ns
+  repository = "https://alphagov.github.io/govuk-helm-charts/"
+  version    = "0.1.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+}

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -1,56 +1,49 @@
-# logging.tf manages EFK Stack (Elasticsearch, Fluent-Bit, Kibana).
-# NOTE: Kibana and Elasticsearch will in future be replaced by Logit.
+# logging.tf manages Filebeat, which ships logs to Logit, a managed ELK stack.
 
-locals {
-  logging_namespace = "logging"
-
-  fluentbit_output = <<-OUTPUT
-  [OUTPUT]
-      Name es
-      Match kube.*
-      Host elasticsearch-master
-      Logstash_Format On
-      Retry_Limit False
-
-  [OUTPUT]
-      Name es
-      Match host.*
-      Host elasticsearch-master
-      Logstash_Format On
-      Logstash_Prefix node
-      Retry_Limit False
-  OUTPUT
-}
-
-resource "helm_release" "fluentbit" {
-  name             = "fluentbit"
-  repository       = "https://fluent.github.io/helm-charts"
-  chart            = "fluent-bit"
-  create_namespace = true
-  version          = "0.16.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
-  namespace        = local.logging_namespace
+resource "helm_release" "filebeat" {
+  depends_on = [helm_release.cluster_secrets]
+  chart      = "filebeat"
+  name       = "filebeat"
+  namespace  = local.services_ns
+  repository = "https://helm.elastic.co"
+  version    = "7.7.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
-    clusterName = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
-    config = {
-      outputs = local.fluentbit_output
+    filebeatConfig = {
+      "filebeat.yml" = yamlencode({
+        "filebeat.inputs" = [
+          {
+            type  = "container"
+            paths = ["/var/lib/docker/containers/*/*.log"]
+            processors = [{
+              add_kubernetes_metadata = {
+                host = "$${NODE_NAME}"
+                matchers = [{
+                  logs_path = {
+                    logs_path = "/var/lib/docker/containers/"
+                  }
+                }]
+              }
+            }]
+          }
+        ]
+
+        "output.logstash" : {
+          "hosts" : ["$${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:18998"]
+          "loadbalance" : true
+          "ssl.enabled" : true
+        }
+      })
     }
+    extraEnvs = [
+      {
+        name = "LOGSTASH_HOST"
+        valueFrom = {
+          secretKeyRef = {
+            name = "logit-host"
+            key  = "host"
+          }
+        }
+      }
+    ]
   })]
-}
-
-resource "helm_release" "elasticsearch" {
-  name       = "elasticsearch"
-  repository = "https://helm.elastic.co"
-  chart      = "elasticsearch"
-  version    = "7.14.0"
-  namespace  = local.logging_namespace
-  depends_on = [helm_release.fluentbit]
-}
-
-resource "helm_release" "kibana" {
-  name       = "kibana"
-  repository = "https://helm.elastic.co"
-  chart      = "kibana"
-  version    = "7.14.0"
-  namespace  = local.logging_namespace
-  depends_on = [helm_release.fluentbit]
 }


### PR DESCRIPTION
This sends logs to Logit from Filebeat.

Filebeat is the recommended log shipper to use with Kubernetes and Logit: https://logit.io/sources/configure/kubernetes.

I replaced Fluent-Bit as we would need a corresponding Logstash filter in each stack:

```
filter {
  if [message] =~ /^{.*}/ or [type] == "json" {

    mutate { gsub => ["message", "app.kubernetes.io", "app_kubernetes_io"] }
    json { source => "message" }
 }
}
```

I manually added the host credential to SecretsManager for the Logit host, under `govuk/logit-host`. This is stored in the form `{"host":"foo"}`.

https://trello.com/c/zjJxCwDk/627-ship-logs-to-logit