### PR TITLE
Add kube-prometheus-stack Helm release

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -11,16 +11,31 @@ resource "helm_release" "kube_prometheus_stack" {
     alertmanager = {
       ingress = {
         enabled = true
+        annotations = {
+          "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
+          "alb.ingress.kubernetes.io/target-type" = "ip"
+          "kubernetes.io/ingress.class"           = "alb"
+        }
       }
     }
     grafana = {
       ingress = {
         enabled = true
+        annotations = {
+          "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
+          "alb.ingress.kubernetes.io/target-type" = "ip"
+          "kubernetes.io/ingress.class"           = "alb"
+        }
       }
     }
     prometheus = {
       ingress = {
         enabled = true
+        annotations = {
+          "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
+          "alb.ingress.kubernetes.io/target-type" = "ip"
+          "kubernetes.io/ingress.class"           = "alb"
+        }
       }
     }
   })]

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -1,0 +1,27 @@
+# Installs Prometheus Operator, Prometheus, Prometheus rules, Grafana, Grafana dashboards, and Prometheus CRDs
+
+resource "helm_release" "kube_prometheus_stack" {
+  name             = "kube-prometheus-stack"
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "kube-prometheus-stack"
+  create_namespace = true
+  version          = "18.0.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace        = "monitoring"
+  values = [yamlencode({
+    alertmanager = {
+      ingress = {
+        enabled = true
+      }
+    }
+    grafana = {
+      ingress = {
+        enabled = true
+      }
+    }
+    prometheus = {
+      ingress = {
+        enabled = true
+      }
+    }
+  })]
+}


### PR DESCRIPTION
Default [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) configuration, with Ingress enabled - this is just a starting point, for further modification/configuration for our purposes.