### PR TITLE
Ensure unique names for IRSA IAM roles within the account.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
@@ -6,7 +6,7 @@
 
 locals {
   cluster_autoscaler_service_account_namespace = "kube-system"
-  cluster_autoscaler_service_account_name      = "cluster-autoscaler-${var.cluster_name}"
+  cluster_autoscaler_service_account_name      = "cluster-autoscaler"
 }
 
 # The rest of this file is taken from
@@ -24,7 +24,7 @@ module "cluster_autoscaler_iam_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "4.3.0"
   create_role                   = true
-  role_name                     = local.cluster_autoscaler_service_account_name
+  role_name                     = "${local.cluster_autoscaler_service_account_name}-${var.cluster_name}"
   provider_url                  = local.cluster_oidc_issuer
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_autoscaler_service_account_namespace}:${local.cluster_autoscaler_service_account_name}"]

--- a/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
@@ -25,6 +25,7 @@ module "cluster_autoscaler_iam_role" {
   version                       = "4.3.0"
   create_role                   = true
   role_name                     = "${local.cluster_autoscaler_service_account_name}-${var.cluster_name}"
+  role_description              = "Role for Cluster Autoscaler. Corresponds to ${local.cluster_autoscaler_service_account_name} k8s ServiceAccount."
   provider_url                  = local.cluster_oidc_issuer
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_autoscaler_service_account_namespace}:${local.cluster_autoscaler_service_account_name}"]

--- a/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
@@ -13,6 +13,7 @@ module "external_secrets_iam_role" {
   version                       = "4.3.0"
   create_role                   = true
   role_name                     = "${local.external_secrets_service_account_name}-${var.cluster_name}"
+  role_description              = "Role for External Secrets addon. Corresponds to ${local.external_secrets_service_account_name} k8s ServiceAccount."
   provider_url                  = local.cluster_oidc_issuer
   role_policy_arns              = [aws_iam_policy.external_secrets.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_services_namespace}:${local.external_secrets_service_account_name}"]

--- a/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
@@ -12,7 +12,7 @@ module "external_secrets_iam_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "4.3.0"
   create_role                   = true
-  role_name                     = local.external_secrets_service_account_name
+  role_name                     = "${local.external_secrets_service_account_name}-${var.cluster_name}"
   provider_url                  = local.cluster_oidc_issuer
   role_policy_arns              = [aws_iam_policy.external_secrets.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_services_namespace}:${local.external_secrets_service_account_name}"]

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -21,6 +21,14 @@ terraform {
 locals {
   cluster_services_namespace = "cluster-services"
   secrets_prefix             = "govuk"
+
+  # module.eks.cluster_oidc_issuer_url is a full URL, e.g.
+  # "https://oidc.eks.eu-west-1.amazonaws.com/id/B4378A8EBD334FEEFDF3BCB6D0E612C6"
+  # but the string to which IAM compares this lacks the protocol part, so we
+  # have to strip the "https://" when we construct the trust policy
+  # (assume-role policy).
+  cluster_oidc_issuer = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+
   default_tags = {
     cluster              = var.cluster_name
     project              = "replatforming"

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -45,7 +45,7 @@ output "external_secrets_role_arn" {
 
 output "aws_lb_controller_role_arn" {
   description = "IAM role ARN corresponding to the k8s service account for the AWS Load Balancer Controller."
-  value       = aws_iam_role.aws_lb_controller.arn
+  value       = module.aws_lb_controller_iam_role.iam_role_arn
 }
 
 output "aws_lb_controller_service_account_name" {


### PR DESCRIPTION
- Ensure that the IAM role for external-secrets contains the cluster name, so that we don't break the ability to turn up extra clusters in the test account.
- Construct the role names consistently for all of the cluster addons. I've chosen to include the cluster name in the IAM role names to satisfy the uniqueness constraint but omit it from the k8s ClusterRole names so that the ClusterRole names stay the same (and so that they don't contain a spurious "govuk-" prefix).
- Add descriptions to the IAM roles and include the name of the k8s ClusterRole.

[Trello card](https://trello.com/c/hqCr1ozs/625)