### PR TITLE
Add the external-dns cluster addon.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/external_dns.tf
+++ b/terraform/deployments/cluster-infrastructure/external_dns.tf
@@ -1,0 +1,56 @@
+# external_dns.tf defines a Route53 zone and an IAM role and policy to allow
+# the k8s external-dns addon to manage the zone.
+#
+# The k8s side of the external-dns addon is in
+# ../cluster-services/external_dns.tf.
+
+locals {
+  external_dns_service_account_name = "external-dns"
+  external_dns_domain_name          = "${var.external_dns_subdomain}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
+}
+
+module "external_dns_iam_role" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "4.3.0"
+  create_role                   = true
+  role_name                     = "${local.external_dns_service_account_name}-${var.cluster_name}"
+  role_description              = "Role for External DNS addon. Corresponds to ${local.external_dns_service_account_name} k8s ServiceAccount."
+  provider_url                  = local.cluster_oidc_issuer
+  role_policy_arns              = [aws_iam_policy.external_dns.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_services_namespace}:${local.external_dns_service_account_name}"]
+}
+
+resource "aws_iam_policy" "external_dns" {
+  name        = "EKSExternalDNS-${var.cluster_name}"
+  description = "EKS ${local.external_dns_service_account_name} policy for cluster ${module.eks.cluster_id}"
+  policy      = data.aws_iam_policy_document.external_dns.json
+}
+
+# https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#iam-policy
+data "aws_iam_policy_document" "external_dns" {
+  statement {
+    effect    = "Allow"
+    actions   = ["route53:ChangeResourceRecordSets"]
+    resources = [aws_route53_zone.cluster_public.arn]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "route53:ListHostedZones",
+      "route53:ListResourceRecordSets",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_route53_zone" "cluster_public" {
+  name = local.external_dns_domain_name
+}
+
+resource "aws_route53_record" "cluster_public_ns" {
+  zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id
+  name    = var.external_dns_subdomain
+  type    = "NS"
+  ttl     = 21600
+  records = aws_route53_zone.cluster_public.name_servers
+}

--- a/terraform/deployments/cluster-infrastructure/external_dns.tf
+++ b/terraform/deployments/cluster-infrastructure/external_dns.tf
@@ -44,7 +44,8 @@ data "aws_iam_policy_document" "external_dns" {
 }
 
 resource "aws_route53_zone" "cluster_public" {
-  name = local.external_dns_domain_name
+  name          = local.external_dns_domain_name
+  force_destroy = var.force_destroy
 }
 
 resource "aws_route53_record" "cluster_public_ns" {

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -33,6 +33,26 @@ output "cluster_services_namespace" {
   value       = local.cluster_services_namespace
 }
 
+output "external_dns_service_account_name" {
+  description = "Name of the k8s service account for the external-dns addon."
+  value       = local.external_dns_service_account_name
+}
+
+output "external_dns_role_arn" {
+  description = "IAM role ARN corresponding to the k8s service account for the external-dns addon."
+  value       = module.external_dns_iam_role.iam_role_arn
+}
+
+output "external_dns_zone_id" {
+  description = "Hosted Zone ID of the Route53 zone to be managed by the external-dns addon."
+  value       = aws_route53_zone.cluster_public.zone_id
+}
+
+output "external_dns_zone_name" {
+  description = "Domain name of the Route53 zone to be managed by the external-dns addon."
+  value       = local.external_dns_domain_name
+}
+
 output "external_secrets_service_account_name" {
   description = "Name of the k8s service account for external-secrets."
   value       = local.external_secrets_service_account_name

--- a/terraform/deployments/cluster-infrastructure/remote.tf
+++ b/terraform/deployments/cluster-infrastructure/remote.tf
@@ -10,3 +10,12 @@ data "terraform_remote_state" "infra_vpc" {
     region = data.aws_region.current.name
   }
 }
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-root-dns-zones.tfstate"
+    region = data.aws_region.current.name
+  }
+}

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -29,6 +29,11 @@ variable "eks_public_subnets" {
   description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the public subnets where the EKS cluster will create Internet-facing load balancers."
 }
 
+variable "external_dns_subdomain" {
+  type        = string
+  description = "Subdomain name for a Route53 zone which will be created underneath external_root_zone (e.g. 'eks' to be created underneath staging.govuk.digital), for use by the external-dns addon. external-dns will create records for ALBs/NLBs created by Ingresses and Service[type=LoadBalancer] in this zone."
+}
+
 variable "workers_instance_type" {
   type        = string
   description = "Instance type for the managed node group."

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -34,6 +34,12 @@ variable "external_dns_subdomain" {
   description = "Subdomain name for a Route53 zone which will be created underneath external_root_zone (e.g. 'eks' to be created underneath staging.govuk.digital), for use by the external-dns addon. external-dns will create records for ALBs/NLBs created by Ingresses and Service[type=LoadBalancer] in this zone."
 }
 
+variable "force_destroy" {
+  type        = bool
+  description = "Setting for force_destroy on resources such as Route53 zones. For use in non-production environments to allow for automated tear-down."
+  default     = false
+}
+
 variable "workers_instance_type" {
   type        = string
   description = "Instance type for the managed node group."

--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -1,0 +1,27 @@
+# external_dns.tf manages the in-cluster components of the external-dns addon.
+#
+# The AWS resources (IAM policy, Route53 zone) for external-dns are in
+# ../cluster-infrastructure/external_dns.tf.
+
+resource "helm_release" "external_dns" {
+  name       = "external-dns"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "external-dns"
+  version    = "5.4.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace  = local.services_ns
+  values = [yamlencode({
+    aws = {
+      region   = data.aws_region.current.name
+      zoneType = "public"
+    }
+    serviceAccount = {
+      name = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_service_account_name
+      annotations = {
+        "eks.amazonaws.com/role-arn" = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_role_arn
+      }
+    }
+    txtOwnerId    = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_id
+    domainFilters = [data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name]
+    # TODO: hook up Prometheus metrics (metrics.enabled, metrics.podAnnotations etc.)
+  })]
+}

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -22,3 +22,6 @@ eks_private_subnets = {
 }
 
 govuk_environment = "test"
+
+publishing_service_domain = "test.publishing.service.gov.uk"
+external_dns_subdomain    = "eks"

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -22,6 +22,7 @@ eks_private_subnets = {
 }
 
 govuk_environment = "test"
+force_destroy     = true
 
 publishing_service_domain = "test.publishing.service.gov.uk"
 external_dns_subdomain    = "eks"


### PR DESCRIPTION
- Install the addon using Bitnami's Helm chart.
- Create a Route53 hosted zone to be managed by the addon, taking the name of the parent domain from the canonical source in alphagov/govuk-aws.
- Create an IAM role and service account to allow it to manage the zone.
- Add a var for passing force_destroy to resource in non-prod, so that we can still run `terraform destroy`
in the test account without manual faff.

Records will not be automatically deleted when Ingresses/Services are deleted. It's possible to change this by setting `policy=sync` instead of the default `upsert-only`, but there's a good reason for the default behaviour: e.g. if we were to set `policy=sync` and someone were to remove and then immediately reinstall a Helm chart, it could cause significant downtime beyond the actual window where the record didn't exist (because of negative caching).

TTL defaults to 5 minutes, which seems fine for now so I've left it alone.

Considered using https://registry.terraform.io/modules/lablabs/eks-external-dns/aws/ but that would only fit if we decided to merge the cluster-infrastructure and cluster-services modules.

[Trello card](https://trello.com/c/hqCr1ozs/625)

Tested:
- Tried the [Service example from the docs](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#verify-externaldns-works-service-example) with `nginx-test.eks.test.govuk.digital`. Works.
- Checked for any significant warnings on [Zonemaster](https://zonemaster.net/result/73385cfed48e262f) - nothing major.