### PR TITLE
Fix Prometheus and Alertmanager ingress

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -10,7 +10,8 @@ resource "helm_release" "kube_prometheus_stack" {
   values = [yamlencode({
     alertmanager = {
       ingress = {
-        enabled = true
+        enabled  = true
+        pathType = "Prefix"
         annotations = {
           "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
           "alb.ingress.kubernetes.io/target-type" = "ip"
@@ -30,7 +31,8 @@ resource "helm_release" "kube_prometheus_stack" {
     }
     prometheus = {
       ingress = {
-        enabled = true
+        enabled  = true
+        pathType = "Prefix"
         annotations = {
           "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
           "alb.ingress.kubernetes.io/target-type" = "ip"


### PR DESCRIPTION
Quick fix for incorrect ALB path matching for Prometheus and Alertmanager ingress while investigating why specifying `Ingress.pathType = "Prefix"` is necessary. See [Ingress path types docs](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types)