### PR TITLE
Set default IngressClass and add DNS for Prometheus stack

### DIFF
--- a/helm/services/ingress-class/Chart.yaml
+++ b/helm/services/ingress-class/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v3
+name: ingress-class
+description: A Helm chart for a IngressClass resource, for use with AWS Load Balancer Controller
+version: 0.1.0

--- a/helm/services/ingress-class/templates/ingress-class.yaml
+++ b/helm/services/ingress-class/templates/ingress-class.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: {{ .Values.className }}
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: {{ .Values.controller }}

--- a/helm/services/ingress-class/values.yaml
+++ b/helm/services/ingress-class/values.yaml
@@ -1,0 +1,2 @@
+className: aws-alb
+controller: ingress.k8s.aws/alb

--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -21,3 +21,9 @@ resource "helm_release" "aws_lb_controller" {
     }
   })]
 }
+
+resource "helm_release" "aws_lb_ingress_class" {
+  name    = "aws-lb-ingress-class"
+  chart   = "../../../helm/services/ingress-class"
+  version = "0.1.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+}

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -1,5 +1,9 @@
 # Installs Prometheus Operator, Prometheus, Prometheus rules, Grafana, Grafana dashboards, and Prometheus CRDs
 
+locals {
+  dns_zone_name = trimsuffix(data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name, ".")
+}
+
 resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
@@ -11,6 +15,7 @@ resource "helm_release" "kube_prometheus_stack" {
     alertmanager = {
       ingress = {
         enabled  = true
+        hosts    = ["alertmanager.${local.dns_zone_name}"]
         pathType = "Prefix"
         annotations = {
           "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
@@ -20,7 +25,8 @@ resource "helm_release" "kube_prometheus_stack" {
     }
     grafana = {
       ingress = {
-        enabled = true
+        enabled  = true
+        hosts    = ["grafana.${local.dns_zone_name}"]
         pathType = "Prefix"
         annotations = {
           "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
@@ -31,6 +37,7 @@ resource "helm_release" "kube_prometheus_stack" {
     prometheus = {
       ingress = {
         enabled  = true
+        hosts    = ["prometheus.${local.dns_zone_name}"]
         pathType = "Prefix"
         annotations = {
           "alb.ingress.kubernetes.io/scheme"      = "internet-facing"

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -15,7 +15,6 @@ resource "helm_release" "kube_prometheus_stack" {
         annotations = {
           "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
           "alb.ingress.kubernetes.io/target-type" = "ip"
-          "kubernetes.io/ingress.class"           = "alb"
         }
       }
     }
@@ -25,7 +24,6 @@ resource "helm_release" "kube_prometheus_stack" {
         annotations = {
           "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
           "alb.ingress.kubernetes.io/target-type" = "ip"
-          "kubernetes.io/ingress.class"           = "alb"
         }
       }
     }
@@ -36,7 +34,6 @@ resource "helm_release" "kube_prometheus_stack" {
         annotations = {
           "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
           "alb.ingress.kubernetes.io/target-type" = "ip"
-          "kubernetes.io/ingress.class"           = "alb"
         }
       }
     }

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -21,6 +21,7 @@ resource "helm_release" "kube_prometheus_stack" {
     grafana = {
       ingress = {
         enabled = true
+        pathType = "Prefix"
         annotations = {
           "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
           "alb.ingress.kubernetes.io/target-type" = "ip"


### PR DESCRIPTION
- Adds an `ingress-class` Helm chart to create a default `IngressClass` resource for AWS LB Controller
- Removes ingress class annotation on Prometheus ingress resources
- Adds Ingress pathType to Grafana ingress for consistency
- Specifies hostnames to Ingress resources for external-dns