### PR TITLE
Use iam-assumable-role module in aws_lb_controller_iam.tf

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -21,6 +21,14 @@ terraform {
 locals {
   cluster_services_namespace = "cluster-services"
   secrets_prefix             = "govuk"
+
+  # module.eks.cluster_oidc_issuer_url is a full URL, e.g.
+  # "https://oidc.eks.eu-west-1.amazonaws.com/id/B4378A8EBD334FEEFDF3BCB6D0E612C6"
+  # but the string to which IAM compares this lacks the protocol part, so we
+  # have to strip the "https://" when we construct the trust policy
+  # (assume-role policy).
+  cluster_oidc_issuer = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+
   default_tags = {
     cluster              = var.cluster_name
     project              = "replatforming"

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -65,7 +65,7 @@ output "external_secrets_role_arn" {
 
 output "aws_lb_controller_role_arn" {
   description = "IAM role ARN corresponding to the k8s service account for the AWS Load Balancer Controller."
-  value       = aws_iam_role.aws_lb_controller.arn
+  value       = module.aws_lb_controller_iam_role.iam_role_arn
 }
 
 output "aws_lb_controller_service_account_name" {

--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -10,7 +10,7 @@ resource "helm_release" "aws_lb_controller" {
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
   version    = "1.2.6" # TODO: Dependabot or equivalent so this doesn't get neglected.
-  namespace  = "kube-system"
+  namespace  = local.services_ns
   values = [yamlencode({
     clusterName = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
     serviceAccount = {


### PR DESCRIPTION
Trying again. (See #435, rolled back in #440).

It broke last time owing to a copy-pasto in the assume-role policy (aka trust relationship) where the namespace didn't match the namespace where the serviceaccount was actually deployed.

This time, move the LB controller from kube-system to the cluster-services namespace. This also has the small advantage that the LB controller won't be treated specially by cluster-autoscaler (which we don't really want it to be, as it's arguably less critical than pods which are serving user traffic, for example).