### PR TITLE
Add Publisher Helm Chart

### DIFF
--- a/helm/publisher/.helmignore
+++ b/helm/publisher/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/publisher/Chart.yaml
+++ b/helm/publisher/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: publisher
+description: A Helm chart for GOV.UK Publisher
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/helm/publisher/templates/NOTES.txt
+++ b/helm/publisher/templates/NOTES.txt
@@ -1,0 +1,20 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+  export INGRESS_NAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "publisher.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export FQDN=$(kubectl get ingress --namespace {{ .Release.Namespace }} $INGRESS_NAME -o jsonpath="{.spec.rules[0].host}")
+  echo "Visit $FQDN to use GOV.UK Publisher"
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "publisher.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "publisher.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "publisher.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "publisher.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/publisher/templates/_helpers.tpl
+++ b/helm/publisher/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "publisher.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "publisher.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "publisher.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "publisher.labels" -}}
+helm.sh/chart: {{ include "publisher.chart" . }}
+{{ include "publisher.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "publisher.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "publisher.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "publisher.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "publisher.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/publisher/templates/common/configmap.yaml
+++ b/helm/publisher/templates/common/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-env
+data:
+  ASSETS_PREFIX: "{{ .Values.appAssetsPrefix }}"
+  BASIC_AUTH_USERNAME: "{{ .Values.appBasicAuthUsername }}"
+  DEFAULT_TTL: "{{ .Values.appDefaultTtl }}"
+  EMAIL_GROUP_BUSINESS: "{{ .Values.appEmailGroupBusiness }}"
+  EMAIL_GROUP_CITIZEN: "{{ .Values.appEmailGroupCitizen }}"
+  EMAIL_GROUP_FORCE_PUBLISH_ALERTS: "{{ .Values.appEmailGroupForcePublishAlerts }}"
+  FACT_CHECK_SUBJECT_PREFIX: "{{ .Values.appFactCheckSubjectPrefix }}"
+  FACT_CHECK_USERNAME: "{{ .Values.appFactCheckUsername }}"
+  GOVUK_APP_DOMAIN: "{{ .Values.appGovukAppDomain | default (printf "%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.clusterDomain) }}"
+  GOVUK_APP_DOMAIN_EXTERNAL: "{{ .Values.appGovukDomainExternal | default (printf "%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+  GOVUK_APP_NAME: "{{ .Values.appGovukAppName | default .Release.Name }}"
+  GOVUK_APP_ROOT: "{{ .Values.appGovukAppRoot }}"
+  GOVUK_APP_TYPE: "{{ .Values.appGovukAppType }}"
+  GOVUK_ASSET_ROOT: "{{ .Values.appGovukAssetRoot | default (printf "https://assets.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+  ASSET_HOST: "{{ .Values.appAssetHost | default (printf "https://www-origin.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+  GOVUK_ENVIRONMENT: "{{ .Values.govukEnvironment }}"
+  GOVUK_WEBSITE_ROOT: "{{ .Values.appGovukWebsiteRoot | default (printf "https://www-origin.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+  PLEK_SERVICE_CONTENT_STORE_URI: "{{ .Values.appPlekServiceContentStoreUri | default (printf "http://content-store.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+  PLEK_SERVICE_DRAFT_ORIGIN_URI: "{{ .Values.appPlekServiceContentStoreUri | default (printf "https://draft-origin.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+  PLEK_SERVICE_PUBLISHING_API_URI: "{{ .Values.appPlekServicePublishingApiUri | default (printf "http://publishing-api-web.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+  PLEK_SERVICE_SIGNON_URI: "{{ .Values.appPlekServiceSignonUri | default (printf "https://signon.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal) }}"
+  PLEK_SERVICE_STATIC_URI: "{{ .Values.appPlekServiceStaticUri | default (printf "http://static.%s.%s" .Release.Namespace .Values.clusterDomain) }}"
+  PORT: "{{ .Values.appPort }}"
+  RAILS_ENV: "{{ .Values.appRailsEnv }}"
+  REDIS_URL: "{{ .Values.appRedisUrl }}"    # TODO: decide on Redis for EKS

--- a/helm/publisher/templates/common/secrets.yaml
+++ b/helm/publisher/templates/common/secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  refreshInterval: 2m
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Release.Name }}
+  dataFrom:
+    - key: "{{ .Values.secretsPrefix }}{{ .Release.Name }}"

--- a/helm/publisher/templates/dbmigrationjob.yaml
+++ b/helm/publisher/templates/dbmigrationjob.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.dbMigrationEnabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-dbmigrate-{{ now | unixEpoch }}
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: {{ .Release.Name }}-dbmigrate
+        image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+        command: ["bundle"]
+        args: ["exec", "rails", "db:migrate"]
+        envFrom:
+          - configMapRef:
+              name: {{ .Release.Name }}-env
+        env:
+        {{- range .Values.secrets }}
+          - name: {{ . | title }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $.Release.Name }}
+                key: {{ . | title }}
+        {{- end }}
+        {{- with .Values.webExtraEnv }}
+          {{- . | toYaml | trim | nindent 12 }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.webResources | indent 12 }}
+{{- end}}

--- a/helm/publisher/templates/web/configmap.yaml
+++ b/helm/publisher/templates/web/configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-web-nginx-conf
+data:
+  nginx.conf: |-
+    user  nginx;
+
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
+
+    events {
+      worker_connections  1024;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+
+      server_tokens off;
+
+      sendfile        on;
+      keepalive_timeout  65;
+
+      upstream {{ .Release.Name }} {
+        server 127.0.0.1:{{ .Values.appPort }};
+      }
+
+      server {
+        listen {{ .Values.nginxPort }};
+
+        location / {
+          proxy_set_header   Host $host;
+          proxy_set_header   X-Real-IP $remote_addr;
+          proxy_pass         http://{{ .Release.Name }};
+          proxy_redirect     off;
+        }
+      }
+    }

--- a/helm/publisher/templates/web/deployment.yaml
+++ b/helm/publisher/templates/web/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-web
+  labels:
+    app: {{ .Release.Name }}-web
+spec:
+  replicas: {{ .Values.webReplicaCount}}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-web
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-web
+      annotations:
+        # TODO: if Helm library is used, `$.Template.BasePath` needs to be replaced
+        # by chart name, see https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        checksum/configmap: {{ include (print $.Template.BasePath "/common/configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: app
+          image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          command: ["foreman"]
+          args: ["run", "web"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.appPort }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-env
+          env:
+          {{- range .Values.secrets }}
+            - name: {{ . | title }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}
+                  key: {{ . | title }}
+          {{- end }}
+          {{- with .Values.webExtraEnv }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.webResources | indent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthcheck/live
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthcheck/ready
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 5
+        - name: nginx
+          image: "{{ .Values.nginxImage.repository }}:{{ .Values.nginxImage.tag }}"
+          ports:
+            - name: http
+              containerPort: {{ .Values.nginxPort }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 6
+            successThreshold: 1
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          volumeMounts:
+          - name: {{ .Release.Name }}-web-nginx-conf
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+      volumes:
+      - name: {{ .Release.Name }}-web-nginx-conf
+        configMap:
+          name: {{ .Release.Name }}-web-nginx-conf

--- a/helm/publisher/templates/web/ingress.yaml
+++ b/helm/publisher/templates/web/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := .Release.Name -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}
+  labels:
+    {{- include "publisher.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: "{{ .Values.ingress.host | default (printf "publisher.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}"
+      http:
+        paths:
+          - backend:
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            {{- else }}
+            serviceName: {{ $fullName }}
+            servicePort: {{ $svcPort }}
+            {{- end }}
+            path: {{ .Values.ingress.path }}
+            {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+{{- end }}

--- a/helm/publisher/templates/web/service.yaml
+++ b/helm/publisher/templates/web/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+{{ if .Values.service.annotations}}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.nginxPort }}
+  selector:
+    app: {{ .Release.Name }}-web

--- a/helm/publisher/templates/worker/deployment.yaml
+++ b/helm/publisher/templates/worker/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-worker
+  labels:
+    app: {{ .Release.Name }}-worker
+spec:
+  replicas: {{ .Values.workerReplicaCount}}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-worker
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-worker
+      annotations:
+        # TODO: if Helm library is used, `$.Template.BasePath` needs to be replaced
+        # by chart name, see https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        checksum/configmap: {{ include (print $.Template.BasePath "/common/configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: app
+          image: "{{ .Values.appImage.repository }}:{{ .Values.appImage.tag }}"
+          command: ["foreman"]
+          args: ["run", "worker"]
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-env
+          env:
+          {{- range .Values.secrets }}
+            - name: {{ . | title }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}
+                  key: {{ . | title }}
+          {{- end }}
+          {{- with .Values.webExtraEnv }}
+            {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.webResources | indent 12 }}
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - exit 0
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - exit 0
+            initialDelaySeconds: 30
+            periodSeconds: 5

--- a/helm/publisher/values.yaml
+++ b/helm/publisher/values.yaml
@@ -1,0 +1,118 @@
+# Default values for Publisher.
+
+govukEnvironment: test
+govukDomainExternal: govuk.digital
+govukDomainInternal: govuk-internal.digital
+clusterDomain: svc.cluster.local
+
+service:
+  type: NodePort
+  annotations: {}
+  port: 80
+
+webReplicaCount: 1
+workerReplicaCount: 1
+
+# Publisher uses the same image version in both Web and Worker mode.
+appImage:
+  repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/publisher
+  pullPolicy: Always
+  tag: latest
+
+nginxImage:
+  repository: nginx
+  pullPolicy: Always
+  tag: stable
+
+nginxPort: 80
+appPort: 3000
+
+webResources: {}
+  # If you do want to specify resources, uncomment the following lines,
+  # adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+workerResources: {}
+  # If you do want to specify resources, uncomment the following lines,
+  # adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+## See template file for how application conatiner env default value is computed
+appAssetsPrefix: "/assets/publisher"
+appBasicAuthUsername: "gds"
+appDefaultTtl: "1800"
+appEmailGroupBusiness: "test-address@digital.cabinet-office.gov.uk"
+appEmailGroupCitizen: "test-address@digital.cabinet-office.gov.uk"
+appEmailGroupForcePublishAlerts: "test-address@digital.cabinet-office.gov.uk"
+appFactCheckSubjectPrefix: "dev"
+appFactCheckUsername: "govuk-fact-check-test@digital.cabinet-office.gov.uk"
+appGovukAppDomain:
+appGovukDomainExternal:
+appGovukAppName:
+appGovukAppRoot: "/app"
+appGovukAppType: "rack"
+appGovukWebsiteRoot:
+appGovukAssetRoot:
+appAssetHost:
+appPlekServicePublishingApiUri:
+appPlekServiceSignonUri:
+appPlekServiceContentStoreUri:
+appPlekServicePublisherUri:
+appPlekServiceStaticUri:
+appRailsEnv: "production"
+appRedisUrl: "redis://redis.ecs.test.govuk-internal.digital:6379"    # TODO: decide on Redis for EKS
+
+
+## Extra environment variables to attach to Publisher Web container
+##
+# webExtraEnv:
+#   - name: hello
+#     value: world
+
+## Extra environment variables to attach to Publisher Worker container
+##
+# workerExtraEnv:
+#   - name: hello
+#     value: world
+
+
+ingress:
+  enabled: true
+  name: publisher
+  host:
+  path: "/"
+  pathType: "Prefix"
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+
+secretsPrefix: "govuk/"
+
+secrets:
+  - ASSET_MANAGER_BEARER_TOKEN
+  - FACT_CHECK_PASSWORD
+  - FACT_CHECK_REPLY_TO_ADDRESS
+  - FACT_CHECK_REPLY_TO_ID
+  - GA_UNIVERSAL_ID
+  - GDS_SSO_OAUTH_ID
+  - GDS_SSO_OAUTH_SECRET
+  - GOVUK_NOTIFY_API_KEY
+  - GOVUK_NOTIFY_TEMPLATE_ID
+  - JWT_AUTH_SECRET
+  - LINK_CHECKER_API_BEARER_TOKEN
+  - LINK_CHECKER_API_SECRET_TOKEN
+  - MONGODB_URI
+  - PUBLISHING_API_BEARER_TOKEN
+  - SECRET_KEY_BASE
+
+dbMigrationEnabled: true


### PR DESCRIPTION
This PR adds the Publisher Helm Chart.

Compared to the previous apps, publisher works in 2 modes:
web and worker. This is accounted for in the chart.

We also include a Kubernetes job that does the db migration if enabled
in the values.yaml file on each loading of the chart in Kubernetes.

Ref:
1. [trello card](https://trello.com/c/bnJygqQl/640-add-database-migration-job-to-helm-charts)