### PR TITLE
TLS and HTTPS redirect for Ingress

### DIFF
--- a/terraform/deployments/cluster-infrastructure/external_dns.tf
+++ b/terraform/deployments/cluster-infrastructure/external_dns.tf
@@ -1,12 +1,14 @@
 # external_dns.tf defines a Route53 zone and an IAM role and policy to allow
-# the k8s external-dns addon to manage the zone.
+# the k8s external-dns addon to manage the zone, plus a wildcard TLS cert which
+# covers the external-dns domain and the user-facing
+# *.(env.)?publishing.service.gov.uk domain.
 #
 # The k8s side of the external-dns addon is in
 # ../cluster-services/external_dns.tf.
 
 locals {
   external_dns_service_account_name = "external-dns"
-  external_dns_domain_name          = "${var.external_dns_subdomain}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}"
+  external_dns_zone_name            = trimsuffix("${var.external_dns_subdomain}.${data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_domain_name}", ".")
 }
 
 module "external_dns_iam_role" {
@@ -44,14 +46,54 @@ data "aws_iam_policy_document" "external_dns" {
 }
 
 resource "aws_route53_zone" "cluster_public" {
-  name          = local.external_dns_domain_name
+  name          = local.external_dns_zone_name
   force_destroy = var.force_destroy
 }
 
-resource "aws_route53_record" "cluster_public_ns" {
+resource "aws_route53_record" "cluster_public_ns_parent" {
   zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.external_root_zone_id
   name    = var.external_dns_subdomain
   type    = "NS"
   ttl     = 21600
   records = aws_route53_zone.cluster_public.name_servers
+}
+
+resource "aws_acm_certificate" "cluster_public" {
+  domain_name               = "*.${local.external_dns_zone_name}"
+  subject_alternative_names = ["*.${var.publishing_service_domain}"]
+  validation_method         = "DNS"
+  lifecycle {
+    create_before_destroy = true
+  }
+  tags = {
+    Name = local.external_dns_zone_name
+  }
+}
+
+# See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation#example-usage
+resource "aws_route53_record" "cluster_public_cert_validation" {
+  for_each = {
+    # TODO: Delegate the non-prod domains to the non-prod AWS accounts so that
+    # the validation records for *.(env.)?publishing.service.gov.uk can easily
+    # be added here as part of turnup/DR automation. Those records currently
+    # exist for the test/integration/staging/prod environments in a single zone
+    # managed in alphagov/govuk-dns-config.
+    for dvo in aws_acm_certificate.cluster_public.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+    if length(regexall("${local.external_dns_zone_name}\\.$", dvo.resource_record_name)) > 0
+    # i.e. if dvo.resource_record_name.endswith(local.external_dns_zone_name + ".")
+  }
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 300
+  type            = each.value.type
+  zone_id         = aws_route53_zone.cluster_public.id
+}
+
+resource "aws_acm_certificate_validation" "cluster_public" {
+  certificate_arn = aws_acm_certificate.cluster_public.arn
 }

--- a/terraform/deployments/cluster-infrastructure/external_dns.tf
+++ b/terraform/deployments/cluster-infrastructure/external_dns.tf
@@ -58,6 +58,15 @@ resource "aws_route53_record" "cluster_public_ns_parent" {
   records = aws_route53_zone.cluster_public.name_servers
 }
 
+resource "aws_route53_record" "cluster_public_soa" {
+  zone_id         = aws_route53_zone.cluster_public.id
+  name            = aws_route53_zone.cluster_public.name
+  type            = "SOA"
+  ttl             = 21600
+  records         = ["${aws_route53_zone.cluster_public.name_servers[0]} awsdns-hostmaster.amazon.com. 1 7200 900 1209600 900"] # NCACHE=10m
+  allow_overwrite = true
+}
+
 resource "aws_acm_certificate" "cluster_public" {
   domain_name               = "*.${local.external_dns_zone_name}"
   subject_alternative_names = ["*.${var.publishing_service_domain}"]

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -50,7 +50,7 @@ output "external_dns_zone_id" {
 
 output "external_dns_zone_name" {
   description = "Domain name of the Route53 zone to be managed by the external-dns addon."
-  value       = local.external_dns_domain_name
+  value       = local.external_dns_zone_name
 }
 
 output "external_secrets_service_account_name" {

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -34,6 +34,11 @@ variable "external_dns_subdomain" {
   description = "Subdomain name for a Route53 zone which will be created underneath external_root_zone (e.g. 'eks' to be created underneath staging.govuk.digital), for use by the external-dns addon. external-dns will create records for ALBs/NLBs created by Ingresses and Service[type=LoadBalancer] in this zone."
 }
 
+variable "publishing_service_domain" {
+  type        = string
+  description = "FQDN of the user-facing domain for the publishing apps, e.g. staging.publishing.gov.uk. This domain is included as a wildcard SAN on the TLS cert for Ingresses etc."
+}
+
 variable "force_destroy" {
   type        = bool
   description = "Setting for force_destroy on resources such as Route53 zones. For use in non-production environments to allow for automated tear-down."

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -1,7 +1,7 @@
 # Installs Prometheus Operator, Prometheus, Prometheus rules, Grafana, Grafana dashboards, and Prometheus CRDs
 
 locals {
-  dns_zone_name = trimsuffix(data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name, ".")
+  dns_zone_name = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name
 }
 
 resource "helm_release" "kube_prometheus_stack" {


### PR DESCRIPTION
Create a wildcard TLS cert for the external-dns domain, discoverable by the [Amazon Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/).

Also tweak the NCACHE time on the DNS zone where external-dns creates names for Ingresses and Services\[type=LoadBalancer], so that we don't get hosed by negative caching when turning up a new name.

[Trello card](https://trello.com/c/kL8xAztY/637)

Beware that [some of the aws-lb-controller documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/tasks/ssl_redirect/) is out of date with regard to configuring the HTTPS redirect. The new way as of v2.2 is `alb.ingress.kubernetes.io/ssl-redirect` whereas the old, hacky way is `alb.ingress.kubernetes.io/actions.ssl-redirect`. There are also still a lot of examples floating around using the deprecated v1beta1 Ingress API; those are also best avoided.

#### Testing

Using Amazon's [2048 example](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/examples/2048/2048_full_latest.yaml), checked that:

* The LB is created and destroyed as expected.
* The expected TLS cert is presented to the client.
* The name of the LB can be set.
* HTTPS redirect works.
* TLS <1.2 can be disabled.

```
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress-2048
  annotations:
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/target-type: ip
    alb.ingress.kubernetes.io/load-balancer-name: 2048game-test
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
    alb.ingress.kubernetes.io/ssl-redirect: "443"
    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06  # No TLS 1.0 or 1.1.
spec:
  rules:
  - host: 2048game.eks.test.govuk.digital
    http:
      paths:
      - pathType: Prefix
        path: "/"
        backend:
          service:
            name: service-2048
            port:
              number: 80
```

```
$ curl -sv http://2048game.eks.test.govuk.digital/  >/dev/null
*   Trying 54.194.48.85...
* TCP_NODELAY set
* Connected to 2048game.eks.test.govuk.digital (54.194.48.85) port 80 (#0)
> GET / HTTP/1.1
> Host: 2048game.eks.test.govuk.digital
> User-Agent: curl/7.64.1
> Accept: */*
> 
< HTTP/1.1 301 Moved Permanently
< Server: awselb/2.0
< Date: Tue, 14 Sep 2021 11:30:12 GMT
< Content-Type: text/html
< Content-Length: 134
< Connection: keep-alive
< Location: https://2048game.eks.test.govuk.digital:443/
```

I was a bit wary of the redundant `:443` but it seems at least Firefox and Chrome elide it so it doesn't cause any user-visible ugliness.

#### Follow-up work / not in this PR

I plan to update the existing Helm charts to use these annotations imminently in a separate PR.

I'd like to find a way to set some of these annotations as defaults via IngressClass (especially `target-type: ip`, since we'd never want the default spray-to-nodes sideways-forwarding comedy show, and `ssl-policy`). It doesn't look like that's implemented yet but it seems like it ought to be doable.

The validation DNS record for the `*.(env.)?publishing.service.gov.uk` SAN is not currently handled automatically; added a TODO for this because we can't easily fix it right now.