### PR TITLE
Trivial: fix misleading example in var description.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -36,7 +36,7 @@ variable "external_dns_subdomain" {
 
 variable "publishing_service_domain" {
   type        = string
-  description = "FQDN of the user-facing domain for the publishing apps, e.g. staging.publishing.gov.uk. This domain is included as a wildcard SAN on the TLS cert for Ingresses etc."
+  description = "FQDN of the user-facing domain for the publishing apps, e.g. staging.publishing.service.gov.uk. This domain is included as a wildcard SAN on the TLS cert for Ingresses etc."
 }
 
 variable "force_destroy" {


### PR DESCRIPTION
Got this wrong in #443.

[Trello card](https://trello.com/c/kL8xAztY/637)