### PR TITLE
Build image pipeline fixes

### DIFF
--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -428,6 +428,10 @@ jobs:
     - in_parallel:
       - get: infra-concourse-task-repo
         trigger: true
+      - get: govuk-ruby-2.7.3
+        params:
+          format: oci
+        trigger: true
       - get: infra-concourse-task-version
         params:
           bump: minor
@@ -439,6 +443,7 @@ jobs:
       file: govuk-infrastructure/concourse/tasks/build-image-definition.yml
       input_mapping:
         git-repo: infra-concourse-task-repo
+        base-image: govuk-ruby-2.7.3
       params:
         DOCKERFILE: git-repo/docker/images/infra-concourse-task/Dockerfile
     - put: infra-concourse-task-image

--- a/concourse/pipelines/build-images.yml
+++ b/concourse/pipelines/build-images.yml
@@ -403,7 +403,7 @@ jobs:
       file: govuk-infrastructure/concourse/tasks/build-image-definition.yml
       input_mapping:
         git-repo: frontend-repo
-        base-image: govuk-ruby-2.7.2
+        base-image: govuk-ruby-2.7.3
       params:
         IMAGE_ARG_base_image: base-image/image.tar
     - put: frontend-image

--- a/docker/images/infra-concourse-task/Dockerfile
+++ b/docker/images/infra-concourse-task/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:2.7.3
+ARG base_image=ruby:2.7.3
+FROM ${base_image}
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential && apt-get clean
 
 ENV INFRA_HOME /src


### PR DESCRIPTION
This PR address two fixes from the recent work to use `govuk-ruby` as the base image for building our apps - setting Frontend to reference the correct Ruby version, and building `infra-concourse-tasks` also using the `govuk-ruby` base image.

Trello: https://trello.com/c/dZQwFSKK