### PR TITLE
Add pipeline and registries to build govuk-ruby base images

### DIFF
--- a/concourse/pipelines/build-base-images.yml
+++ b/concourse/pipelines/build-base-images.yml
@@ -1,0 +1,443 @@
+---
+definitions:
+
+resources:
+  - name: daily
+    type: time
+    icon: clock-outline
+
+  - &git-repo
+    name: govuk-infrastructure
+    icon: github
+    type: git
+    source: &git-repo-source
+      uri: git@github.com:alphagov/govuk-infrastructure.git
+      branch: base_image
+      private_key: | # pragma: allowlist secret
+        ((govukci_private_key))
+
+  - &docker-image
+    name: govuk-ruby-2.7.2-image
+    type: registry-image
+    icon: docker
+    source: &docker-image-source
+      repository: govuk-ruby-2.7.2
+      tag: latest
+      aws_region: ((concourse-ecr-user_aws-region))
+      aws_access_key_id: ((concourse-ecr-user_aws-access-key))
+      aws_secret_access_key: ((concourse-ecr-user_aws-secret-access-key))
+      aws_role_arn:
+        "arn:aws:iam::((aws_production_account_id)):role\
+        /push_image_to_ecr_role"
+
+  - <<: *docker-image
+    name: govuk-ruby-2.7.3-image
+    source:
+      <<: *docker-image-source
+      repository: govuk-ruby-2.7.3
+
+  - <<: *docker-image
+    name: govuk-ruby-2.6.6-image
+    source:
+      <<: *docker-image-source
+      repository: govuk-ruby-2.6.6
+
+  - &semver-version
+    name: govuk-ruby-2.7.2-version
+    type: semver
+    source: &semver-version-source
+      driver: s3
+      access_key_id: ((readonly_access_key_id))
+      secret_access_key: ((readonly_secret_access_key))
+      session_token: ((readonly_session_token))
+      bucket: ((readonly_private_bucket_name))
+      key: govuk-ruby-2.7.2-version
+      region_name: eu-west-2
+      initial_version: '1.0.0'
+
+  - <<: *semver-version
+    name: govuk-ruby-2.7.3-version
+    source:
+      <<: *semver-version-source
+      key: govuk-ruby-2.7.3-version
+
+  - <<: *semver-version
+    name: govuk-ruby-2.6.6-version
+    source:
+      <<: *semver-version-source
+      key: govuk-ruby-2.6.6-version
+
+  - &s3-file
+    name: govuk-ruby-2.7.2-file
+    type: s3
+    icon: file
+    source: &s3-file-source
+      bucket: ((readonly_private_bucket_name))
+      access_key_id: ((readonly_access_key_id))
+      secret_access_key: ((readonly_secret_access_key))
+      session_token: ((readonly_session_token))
+      region_name: eu-west-2
+      versioned_file: govuk-ruby-2.7.2-file
+      initial_version: "0"
+      disable_multipart: true
+
+  - <<: *s3-file
+    name: govuk-ruby-2.7.3-file
+    source:
+      <<: *s3-file-source
+      versioned_file: govuk-ruby-2.7.3-file
+
+  - <<: *s3-file
+    name: govuk-ruby-2.6.6-file
+    source:
+      <<: *s3-file-source
+      versioned_file: govuk-ruby-2.6.6-file
+
+
+jobs:
+
+  - name: govuk-ruby-2.7.2
+    plan:
+      - in_parallel:
+          - get: daily
+            trigger: true
+          - get: govuk-infrastructure
+          - get: govuk-ruby-2.7.2-image
+      - task: build-image
+        privileged: true
+        file: govuk-infrastructure/concourse/tasks/build-image-definition.yml
+        input_mapping:
+          git-repo: govuk-infrastructure
+        params:
+          DOCKERFILE: git-repo/docker/images/govuk-ruby/2.7.2/buster/Dockerfile
+          UNPACK_ROOTFS: true
+        output_mapping:
+          image: built_image
+      - task: get-status-built
+        privileged: true
+        image: built_image
+        config:
+          platform: linux
+          run:
+            path: "sh"
+            args:
+              - -cx
+              - |
+                echo "Get a hash of the packages list"
+                dpkg -l | shasum | awk '{print $1}' > status-built/status-built
+          outputs:
+            - name: status-built
+      - task: get-status-latest
+        privileged: true
+        image: govuk-ruby-2.7.2-image
+        config:
+          platform: linux
+          run:
+            path: "sh"
+            args:
+              - -cx
+              - |
+                echo "Get a hash of the packages list"
+                dpkg -l | shasum | awk '{print $1}' > \
+                status-latest/status-latest
+          outputs:
+            - name: status-latest
+      - task: compare_status
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: busybox
+              tag: 'latest'
+          inputs:
+            - name: status-built
+            - name: status-latest
+          run:
+            path: "sh"
+            args:
+              - -cx
+              - |
+                echo "Compare package lists between built image and latest,\
+                 if identical we don't need to push a new image to ECR"
+                ! diff ./status-built/status-built ./status-latest/status-latest
+        on_success:
+          do:
+            - put: govuk-ruby-2.7.2-file
+              params:
+                file: built_image/image.tar
+
+  - name: push_govuk-ruby-2.7.2
+    plan:
+      - in_parallel:
+          - get: govuk-ruby-2.7.2-file
+            trigger: true
+            passed:
+              - govuk-ruby-2.7.2
+          - get: govuk-ruby-2.7.2-image
+      - task: push-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: busybox
+              tag: 'latest'
+          inputs:
+            - name: built_image
+          run:
+            path: "echo"
+            args: ["Pushing new image to ECR"]
+          outputs:
+            - name: built_image
+        on_success:
+          do:
+            - get: govuk-ruby-2.7.2-version
+              params:
+                bump: minor
+                pre_without_version: true
+                pre: release
+            - put: govuk-ruby-2.7.2-image
+              params:
+                image: built_image/govuk-ruby-2.7.2-file
+                additional_tags: govuk-ruby-2.7.2-version/version
+            - put: govuk-ruby-2.7.2-version
+              params:
+                bump: minor
+                pre_without_version: true
+                pre: release
+        input_mapping:
+          built_image: govuk-ruby-2.7.2-file
+
+  - name: govuk-ruby-2.7.3
+    plan:
+      - in_parallel:
+          - get: daily
+            trigger: true
+          - get: govuk-infrastructure
+          - get: govuk-ruby-2.7.3-image
+      - task: build-image
+        privileged: true
+        file: govuk-infrastructure/concourse/tasks/build-image-definition.yml
+        input_mapping:
+          git-repo: govuk-infrastructure
+        params:
+          DOCKERFILE: git-repo/docker/images/govuk-ruby/2.7.3/buster/Dockerfile
+          UNPACK_ROOTFS: true
+        output_mapping:
+          image: built_image
+      - task: get-status-built
+        privileged: true
+        image: built_image
+        config:
+          platform: linux
+          run:
+            path: "sh"
+            args:
+              - -cx
+              - |
+                echo "Get a hash of the packages list"
+                dpkg -l | shasum | awk '{print $1}' > status-built/status-built
+          outputs:
+            - name: status-built
+      - task: get-status-latest
+        privileged: true
+        image: govuk-ruby-2.7.3-image
+        config:
+          platform: linux
+          run:
+            path: "sh"
+            args:
+              - -cx
+              - |
+                echo "Get a hash of the packages list"
+                dpkg -l | shasum | awk '{print $1}' > \
+                status-latest/status-latest
+          outputs:
+            - name: status-latest
+      - task: compare_status
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: busybox
+              tag: 'latest'
+          inputs:
+            - name: status-built
+            - name: status-latest
+          run:
+            path: "sh"
+            args:
+              - -cx
+              - |
+                echo "Compare package lists between built image and latest,\
+                      if identical we don't need to push a new image to ECR"
+                ! diff ./status-built/status-built ./status-latest/status-latest
+        on_success:
+          do:
+            - put: govuk-ruby-2.7.3-file
+              params:
+                file: built_image/image.tar
+
+  - name: push_govuk-ruby-2.7.3
+    plan:
+      - in_parallel:
+          - get: govuk-ruby-2.7.3-file
+            trigger: true
+            passed:
+              - govuk-ruby-2.7.3
+          - get: govuk-ruby-2.7.3-image
+      - task: push-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: busybox
+              tag: 'latest'
+          inputs:
+            - name: built_image
+          run:
+            path: "echo"
+            args: ["Pushing new image to ECR"]
+          outputs:
+            - name: built_image
+        on_success:
+          do:
+            - get: govuk-ruby-2.7.3-version
+              params:
+                bump: minor
+                pre_without_version: true
+                pre: release
+            - put: govuk-ruby-2.7.3-image
+              params:
+                image: built_image/govuk-ruby-2.7.3-file
+                additional_tags: govuk-ruby-2.7.3-version/version
+            - put: govuk-ruby-2.7.3-version
+              params:
+                bump: minor
+                pre_without_version: true
+                pre: release
+        input_mapping:
+          built_image: govuk-ruby-2.7.3-file
+
+  - name: govuk-ruby-2.6.6
+    plan:
+      - in_parallel:
+          - get: daily
+            trigger: true
+          - get: govuk-infrastructure
+          - get: govuk-ruby-2.6.6-image
+      - task: build-image
+        privileged: true
+        file: govuk-infrastructure/concourse/tasks/build-image-definition.yml
+        input_mapping:
+          git-repo: govuk-infrastructure
+        params:
+          DOCKERFILE: git-repo/docker/images/govuk-ruby/2.6.6/buster/Dockerfile
+          UNPACK_ROOTFS: true
+        output_mapping:
+          image: built_image
+      - task: get-status-built
+        privileged: true
+        image: built_image
+        config:
+          platform: linux
+          run:
+            path: "sh"
+            args:
+              - -cx
+              - |
+                echo "Get a hash of the packages list"
+                dpkg -l | shasum | awk '{print $1}' > status-built/status-built
+          outputs:
+            - name: status-built
+      - task: get-status-latest
+        privileged: true
+        image: govuk-ruby-2.6.6-image
+        config:
+          platform: linux
+          run:
+            path: "sh"
+            args:
+              - -cx
+              - |
+                echo "Get a hash of the packages list"
+                dpkg -l | shasum | awk '{print $1}' > \
+                status-latest/status-latest
+          outputs:
+            - name: status-latest
+      - task: compare_status
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: busybox
+              tag: 'latest'
+          inputs:
+            - name: status-built
+            - name: status-latest
+          run:
+            path: "sh"
+            args:
+              - -cx
+              - |
+                echo "Compare package lists between built image and latest,\
+                 if identical we don't need to push a new image to ECR"
+                ! diff ./status-built/status-built ./status-latest/status-latest
+        on_success:
+          do:
+            - put: govuk-ruby-2.6.6-file
+              params:
+                file: built_image/image.tar
+
+
+  - name: push_govuk-ruby-2.6.6
+    plan:
+      - in_parallel:
+          - get: govuk-ruby-2.6.6-file
+            trigger: true
+            passed:
+              - govuk-ruby-2.6.6
+          - get: govuk-ruby-2.6.6-image
+      - task: push-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: busybox
+              tag: 'latest'
+          inputs:
+            - name: built_image
+          run:
+            path: "echo"
+            args: ["Pushing new image to ECR"]
+          outputs:
+            - name: built_image
+        on_success:
+          do:
+            - get: govuk-ruby-2.6.6-version
+              params:
+                bump: minor
+                pre_without_version: true
+                pre: release
+            - put: govuk-ruby-2.6.6-image
+              params:
+                image: built_image/govuk-ruby-2.6.6-file
+                additional_tags: govuk-ruby-2.6.6-version/version
+            - put: govuk-ruby-2.6.6-version
+              params:
+                bump: minor
+                pre_without_version: true
+                pre: release
+        input_mapping:
+          built_image: govuk-ruby-2.6.6-file

--- a/docker/images/govuk-ruby/2.6.6/buster/Dockerfile
+++ b/docker/images/govuk-ruby/2.6.6/buster/Dockerfile
@@ -1,0 +1,2 @@
+FROM ruby:2.6.6
+RUN apt-get update -qq && apt-get upgrade -y

--- a/docker/images/govuk-ruby/2.7.2/buster/Dockerfile
+++ b/docker/images/govuk-ruby/2.7.2/buster/Dockerfile
@@ -1,0 +1,2 @@
+FROM ruby:2.7.2
+RUN apt-get update -qq && apt-get upgrade -y

--- a/docker/images/govuk-ruby/2.7.3/buster/Dockerfile
+++ b/docker/images/govuk-ruby/2.7.3/buster/Dockerfile
@@ -1,0 +1,2 @@
+FROM ruby:2.7.3
+RUN apt-get update -qq && apt-get upgrade -y

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -36,6 +36,9 @@ locals {
     "statsd",
     "authenticating-proxy",
     "govuk-terraform",
+    "govuk-ruby-2.7.2",
+    "govuk-ruby-2.7.3",
+    "govuk-ruby-2.6.6"
   ]
 }
 


### PR DESCRIPTION
We are building most of our govuk apps docker images on the official ruby images, as we are using older versions of ruby however, those images are not updated for security fixes.
The way we solve this problem is by building our own ruby images (govuk-ruby) that are based on the official ruby images but with an upgraded debian distro.
For this purpose we use a pipeline that build each version of govuk-ruby that we need (for now 2.7.2 for most apps, 2.7.3 for frontend and 2.6.6 for whitehall)
![base_images_pipeline](https://user-images.githubusercontent.com/36071946/132823517-d720d6af-04dd-49a0-95c3-818bae04d4a8.png)
This pipeline is triggered daily, after the build the list of packages of the newly built image is compared to the list of the current latest fetched from ECR, the newly built image is pushed to ECR only if the packages list has changed to avoid spamming ECR with identical images every day.
The first job in the pipeline will built the new image and compare it to latest, the job will then fail if packages are identical or proceed to the next job if they are not. The next job then tag and pushes the new image to ECR.

Trello card : https://trello.com/c/gOqiwHcZ/604-build-our-own-base-image
List of conainers per app : https://docs.google.com/spreadsheets/d/1v469JXRtZGCsWqiJdryPzXM-ckrVHw7DuwLb3oTpeHg/edit#gid=0

### Possible improvements and gotchas:
This pipeline is triggered on a time basis which is not optimal as ideally we would like to trigger it only when there are new packages/security fixes, there is no quick and easy way to monitor that however, an improvement would be to trigger only when needed. This would have the added benefit of not requiring any check to make sure the image is worth pushing to ECR
The comparison between the built image and latest is necessary to avoid spamming ECR with identical images, there should be a better way of doing this than checking the list of installed packages, using a digest of the image should be the logical way, it's not easy however as the task we use to build images provides us with a digest that changes even when the content of the image doesn't.