### PR TITLE
Minor updates to helm charts

### DIFF
--- a/helm/content-store/Chart.yaml
+++ b/helm/content-store/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: content-store
 description: A Helm chart for GOV.UK Content-Store
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.16.0"

--- a/helm/content-store/templates/configmap.yaml
+++ b/helm/content-store/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   nginx.conf: |-
     user  nginx;
-    
+
     error_log  /var/log/nginx/error.log warn;
     pid        /var/run/nginx.pid;
 
@@ -30,6 +30,8 @@ data:
         listen {{ .Values.nginxPort }};
 
         location / {
+          proxy_set_header   Host $host;
+          proxy_set_header   X-Real-IP $remote_addr;
           proxy_pass         http://{{ .Release.Name }};
           proxy_redirect     off;
         }

--- a/helm/content-store/templates/service.yaml
+++ b/helm/content-store/templates/service.yaml
@@ -15,7 +15,5 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
-      protocol: TCP
-      name: http
   selector:
     app: {{ .Release.Name }}

--- a/helm/frontend/Chart.yaml
+++ b/helm/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for GOV.UK Frontend
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.16.0"

--- a/helm/frontend/templates/configmap.yaml
+++ b/helm/frontend/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   nginx.conf: |-
     user  nginx;
-    
+
     error_log  /var/log/nginx/error.log warn;
     pid        /var/run/nginx.pid;
 
@@ -30,6 +30,8 @@ data:
         listen {{ .Values.nginxPort }};
 
         location / {
+          proxy_set_header   Host $host;
+          proxy_set_header   X-Real-IP $remote_addr;
           proxy_pass         http://{{ .Release.Name }};
           proxy_redirect     off;
         }

--- a/helm/frontend/templates/service.yaml
+++ b/helm/frontend/templates/service.yaml
@@ -15,7 +15,5 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort }}
-      protocol: TCP
-      name: http
   selector:
     app: {{ .Release.Name }}

--- a/helm/router/Chart.yaml
+++ b/helm/router/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: router
 description: A Helm chart for GOV.UK router
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.16.0"

--- a/helm/router/templates/NOTES.txt
+++ b/helm/router/templates/NOTES.txt
@@ -1,6 +1,6 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host | default (printf "www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}{{ .path }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host | default (printf "www-origin.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}{{ .path }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "router.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/helm/router/templates/ingress.yaml
+++ b/helm/router/templates/ingress.yaml
@@ -34,8 +34,8 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    #- host: "{{ .Values.ingress.host | default (printf "www-origin.%s.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}" #TODO: fix when k8s DNS set up
-    -  http:
+    - host: "{{ .Values.ingress.host | default (printf "www-origin.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}"
+      http:
         paths:
           - path: {{ .Values.ingress.path }}
             {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}

--- a/helm/router/templates/service.yaml
+++ b/helm/router/templates/service.yaml
@@ -15,7 +15,5 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.containerPort }}
-      protocol: TCP
-      name: https
   selector:
     app: {{ .Release.Name }}

--- a/helm/router/values.yaml
+++ b/helm/router/values.yaml
@@ -29,30 +29,28 @@ resources:
   # memory: 1024M
   # values used to generate the environment variables for the pod
 
-appGovukAppDomain: # see template for how default value is computed
-appGovukAppName: # see template for how default value is computed
+appGovukAppDomain:
+appGovukAppName:
 appGovukAppType: "rack"
-appMongodbUri: # see template for how default value is computed
+appMongodbUri:
 appRouterMongoDb: "router"
 appRailsEnv: "production"
-appBackendUrlContentStore: # see template for how default value is computed
-appBackendUrlFrontend: # see template for how default value is computed
-appBackendUrlStatic: # see template for how default value is computed
+appBackendUrlContentStore:
+appBackendUrlFrontend:
+appBackendUrlStatic:
 appDefaultTtl: "1800"
-appGovukDomainExternal: # see template for how default value is computed
+appGovukDomainExternal:
 appGovukAppRoot: "/var/apps/router"
-appGovukWebsiteRoot: # see template for how default value is computed
+appGovukWebsiteRoot:
 appRouterApiAddr: "3055"
 appRouterBackendHeaderTimeout: "20"
 
 ingress:
   enabled: true
   name: www-origin
-  host: # default (printf "www-origin.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal)
+  host:
   path: "/"
   pathType: "Prefix"
-  className: alb
   annotations:
-    kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/scheme : internet-facing
+    alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip

--- a/helm/static/Chart.yaml
+++ b/helm/static/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: static
 description: A Helm chart for GOV.UK Static
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.16.0"

--- a/helm/static/templates/configmap.yaml
+++ b/helm/static/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   nginx.conf: |-
     user  nginx;
-    
+
     error_log  /var/log/nginx/error.log warn;
     pid        /var/run/nginx.pid;
 
@@ -30,6 +30,8 @@ data:
         listen {{ .Values.nginxPort }};
 
         location / {
+          proxy_set_header   Host $host;
+          proxy_set_header   X-Real-IP $remote_addr;
           proxy_pass         http://{{ .Release.Name }};
           proxy_redirect     off;
         }

--- a/helm/static/templates/service.yaml
+++ b/helm/static/templates/service.yaml
@@ -15,7 +15,5 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.nginxPort}}
-      protocol: TCP
-      name: http
   selector:
     app: {{ .Release.Name }}


### PR DESCRIPTION
Minor updates to the other Helm chart to reflect what was done in #442, i.e:
1. removed default service protocol TCP and name
2. changed the Nginx config of the sidecar to forward IP and host to the app

In addition for Router, we:
1. removed some extra comments in the values.yaml to bring it in line with the other values.yaml files.
2. added the host for the ingress now that the DNS controller is active in the cluster.

Tested end-to-end connectivity: http://www-origin.fred.eks.test.govuk.digital/