### PR TITLE
Annotate Ingresses for HTTPS redirect and TLS options.

### DIFF
--- a/helm/publisher/Chart.yaml
+++ b/helm/publisher/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: publisher
 description: A Helm chart for GOV.UK Publisher
 type: application
-version: 0.1.0
-appVersion: "1.16.0"
+version: 0.2.0

--- a/helm/publisher/templates/web/ingress.yaml
+++ b/helm/publisher/templates/web/ingress.yaml
@@ -26,11 +26,11 @@ spec:
     - host: {{ .Values.ingress.host | default (printf "publisher-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}
       http:
         paths:
-          - backend:
+          - path: {{ .Values.ingress.path }}
+            pathType: Prefix
+            backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-            path: {{ .Values.ingress.path }}
-            pathType: {{ .Values.ingress.pathType }}
 {{- end }}

--- a/helm/publisher/templates/web/ingress.yaml
+++ b/helm/publisher/templates/web/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := .Release.Name -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Values.ingress.name }}
@@ -34,21 +23,14 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: "{{ .Values.ingress.host | default (printf "publisher.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}"
+    - host: {{ .Values.ingress.host | default (printf "publisher-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}
       http:
         paths:
           - backend:
-            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-            {{- else }}
-            serviceName: {{ $fullName }}
-            servicePort: {{ $svcPort }}
-            {{- end }}
             path: {{ .Values.ingress.path }}
-            {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
 {{- end }}

--- a/helm/publisher/values.yaml
+++ b/helm/publisher/values.yaml
@@ -91,10 +91,13 @@ ingress:
   name: publisher
   host:
   path: "/"
-  pathType: "Prefix"
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/load-balancer-name: publisher
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06  # No TLS 1.0 or 1.1.
 
 secretsPrefix: "govuk/"
 

--- a/helm/router/Chart.yaml
+++ b/helm/router/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: router
 description: A Helm chart for GOV.UK router
 type: application
-version: 0.2.0
-appVersion: "1.16.0"
+version: 0.3.0

--- a/helm/router/templates/ingress.yaml
+++ b/helm/router/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
       http:
        paths:
          - path: {{ .Values.ingress.path }}
-           pathType: {{ .Values.ingress.pathType }}
+           pathType: Prefix
            backend:
              service:
                name: {{ $fullName }}

--- a/helm/router/templates/ingress.yaml
+++ b/helm/router/templates/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := .Release.Name -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Values.ingress.name }}
@@ -34,21 +23,14 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: "{{ .Values.ingress.host | default (printf "www-origin.%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}"
+    - host: {{ .Values.ingress.host | default (printf "www-origin-%s.eks.%s.%s" .Release.Namespace .Values.govukEnvironment .Values.govukDomainExternal ) }}
       http:
-        paths:
-          - path: {{ .Values.ingress.path }}
-            {{- if and .Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .Values.ingress.pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
+       paths:
+         - path: {{ .Values.ingress.path }}
+           pathType: {{ .Values.ingress.pathType }}
+           backend:
+             service:
+               name: {{ $fullName }}
+               port:
+                 number: {{ $svcPort }}
 {{- end }}

--- a/helm/router/values.yaml
+++ b/helm/router/values.yaml
@@ -15,7 +15,7 @@ replicaCount: 1
 
 image:
   repository: 172025368201.dkr.ecr.eu-west-1.amazonaws.com/router
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: latest
 
 containerPort: 80

--- a/helm/router/values.yaml
+++ b/helm/router/values.yaml
@@ -50,7 +50,10 @@ ingress:
   name: www-origin
   host:
   path: "/"
-  pathType: "Prefix"
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/load-balancer-name: www-origin
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06  # No TLS 1.0 or 1.1.


### PR DESCRIPTION
- Configure the http->https redirect (301 Moved Permanently).
- Disable TLS 1.0 and 1.1. This won't affect compatibility for the general public as all connections to the ALBs will be either from the CDN or from publisher (CMS) users.
- Set default human-readable names for the ALBs.
- Get rid of PathType as a Helm var. It has to be Prefix; ExactMatch wouldn't make any sense here.
- Remove nasty template logic for obsolete Ingress versions.
- Tweak the default value for `host` so that it's covered by the wildcard cert. We can't use an extra level for the namespace until we have a controller/CRD for issuing TLS certs.
- Remove `appVersion`; it's optional and it's not feasible for us to have it reflect the actual app version at the moment.
- Fix wrong `PullPolicy` for Router (kinda unrelated but 🤷).

[Trello card](https://trello.com/c/kL8xAztY/637)

Tested: Deployed all the apps to a new namespace, checked that TLS works as expected: https://www-origin-chris.eks.test.govuk.digital/

I'll fix up the Ingresses in `cluster-services/` in the next PR.