### PR TITLE
Annotate prom-stack Ingresses for HTTPS redirect and TLS options.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -1,9 +1,5 @@
 # Installs Prometheus Operator, Prometheus, Prometheus rules, Grafana, Grafana dashboards, and Prometheus CRDs
 
-locals {
-  dns_zone_name = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name
-}
-
 resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
@@ -15,34 +11,31 @@ resource "helm_release" "kube_prometheus_stack" {
     alertmanager = {
       ingress = {
         enabled  = true
-        hosts    = ["alertmanager.${local.dns_zone_name}"]
+        hosts    = ["alertmanager.${local.external_dns_zone_name}"]
         pathType = "Prefix"
-        annotations = {
-          "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
-          "alb.ingress.kubernetes.io/target-type" = "ip"
-        }
+        annotations = merge(local.alb_ingress_annotations, {
+          "alb.ingress.kubernetes.io/load-balancer-name" = "alertmanager"
+        })
       }
     }
     grafana = {
       ingress = {
         enabled  = true
-        hosts    = ["grafana.${local.dns_zone_name}"]
+        hosts    = ["grafana.${local.external_dns_zone_name}"]
         pathType = "Prefix"
-        annotations = {
-          "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
-          "alb.ingress.kubernetes.io/target-type" = "ip"
-        }
+        annotations = merge(local.alb_ingress_annotations, {
+          "alb.ingress.kubernetes.io/load-balancer-name" = "grafana"
+        })
       }
     }
     prometheus = {
       ingress = {
         enabled  = true
-        hosts    = ["prometheus.${local.dns_zone_name}"]
+        hosts    = ["prometheus.${local.external_dns_zone_name}"]
         pathType = "Prefix"
-        annotations = {
-          "alb.ingress.kubernetes.io/scheme"      = "internet-facing"
-          "alb.ingress.kubernetes.io/target-type" = "ip"
-        }
+        annotations = merge(local.alb_ingress_annotations, {
+          "alb.ingress.kubernetes.io/load-balancer-name" = "prometheus"
+        })
       }
     }
   })]

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -56,5 +56,13 @@ provider "helm" {
 }
 
 locals {
-  services_ns = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_services_namespace
+  services_ns            = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_services_namespace
+  external_dns_zone_name = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name
+  alb_ingress_annotations = {
+    "alb.ingress.kubernetes.io/scheme"       = "internet-facing"
+    "alb.ingress.kubernetes.io/target-type"  = "ip"
+    "alb.ingress.kubernetes.io/listen-ports" = jsonencode([{ HTTP = 80 }, { HTTPS = 443 }])
+    "alb.ingress.kubernetes.io/ssl-redirect" = "443"
+    "alb.ingress.kubernetes.io/ssl-policy"   = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06" # No TLS 1.0 or 1.1.
+  }
 }


### PR DESCRIPTION
- Configure the http->https redirect (301 Moved Permanently).
- Disable TLS 1.0 and 1.1.
- Set default human-readable names for the ALBs.
- Factor out the common stuff.

See also #448.

[Trello card](https://trello.com/c/kL8xAztY/637)

Tested: applied in the test account

- http://prometheus.eks.test.govuk.digital/
- http://grafana.eks.test.govuk.digital/
- http://alertmanager.eks.test.govuk.digital/