### PR TITLE
Specify default TLS policy in the Ingress controller config.

### DIFF
--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -9,7 +9,7 @@ resource "helm_release" "aws_lb_controller" {
   name       = "aws-load-balancer-controller"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
-  version    = "1.2.6" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "1.2.7" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace  = local.services_ns
   values = [yamlencode({
     clusterName = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id

--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -12,7 +12,8 @@ resource "helm_release" "aws_lb_controller" {
   version    = "1.2.7" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace  = local.services_ns
   values = [yamlencode({
-    clusterName = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
+    clusterName      = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
+    defaultSSLPolicy = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06" # No TLS 1.0 or 1.1.
     serviceAccount = {
       name = data.terraform_remote_state.cluster_infrastructure.outputs.aws_lb_controller_service_account_name
       annotations = {


### PR DESCRIPTION
- Disable legacy TLS (1.0 and 1.1) by specifying the default TLS policy on the controller command line. This removes the need for the `alb.ingress.kubernetes.io/ssl-policy` annotation on every Ingress and reduces the chance of misconfiguration.
- Update to the latest stable aws-load-balancer-controller Helm chart.

Tested: applied in the test account (`tf apply -var-file ../variables/test/common.tfvars`); controller seems happy (apart from some duplicate LB names which it was already complaining about before) (`k logs -n cluster-services -l app.kubernetes.io/name=aws-load-balancer-controller -f`)

[Trello card](https://trello.com/c/kL8xAztY/637)