### PR TITLE
Set Prometheus to auto-discover all `PrometheusRule`s

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -37,6 +37,10 @@ resource "helm_release" "kube_prometheus_stack" {
           "alb.ingress.kubernetes.io/load-balancer-name" = "prometheus"
         })
       }
+      prometheusSpec = {
+        # Allow empty ruleSelector (https://github.com/prometheus-community/helm-charts/blob/2cacc16807caedc6cabf1606db27e0d78c844564/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml#L202)
+        ruleSelectorNilUsesHelmValues = false
+      }
     }
   })]
 }


### PR DESCRIPTION
This PR ensures that Prometheus auto-discovers all `PrometheusRule`s (such as those included as part of application-specific Helm charts) by setting `ruleSelectorNilUsesHelmValues: false` in Prometheus' config.

Currently the Prometheus as created by Prometheus Operator is only checking for `PrometheusRule`s that have the labels of `app: kube-prometheus-stack` and `release: kube-prometheus-stack`, meaning that those labels would have to be applied to any new rules in order for them to be picked up, and it doesn't make sense to apply these labels for anything other than rules for Prometheus itself; [this config is defined in the template file of the Prometheus Operator](https://github.com/prometheus-community/helm-charts/blob/2cacc16807caedc6cabf1606db27e0d78c844564/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml#L202).

To ensure that we instead auto-dicsover all rules, we set `ruleSelectorNilUsesHelmValues: false` which forces the conditional logic to end up outputting `ruleSelector: {}` in Prometheus' config. Whilst we theoretically _could_ just specify `ruleSelector: {}` in this commit (rather than `ruleSelectorNilUsesHelmValues: false`), the problem is that when Helm applies this config, `ruleSelector` would be ignored because it is empty and therefore won't have any actual affect on Prometheus, hence the reason that we need to explicitly set the boolean `ruleSelectorNilUsesHelmValues`.