### PR TITLE
Enable lifecycle management of core cluster addons.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -47,7 +47,7 @@ module "eks" {
   version = "17.8.0"
 
   cluster_name     = var.cluster_name
-  cluster_version  = "1.21"
+  cluster_version  = var.cluster_version
   subnets          = [for s in aws_subnet.eks_control_plane : s.id]
   vpc_id           = data.terraform_remote_state.infra_vpc.outputs.vpc_id
   enable_irsa      = true

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -96,3 +96,14 @@ module "eks" {
     }
   ]
 }
+
+# TODO: move these into module.eks once it supports cluster addons, i.e. once
+# https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1443 is
+# merged.
+resource "aws_eks_addon" "cluster_addons" {
+  for_each          = toset(["coredns", "kube-proxy", "vpc-cni"])
+  addon_name        = each.key
+  addon_version     = lookup(var.cluster_addon_versions, each.key, null)
+  cluster_name      = module.eks.cluster_id
+  resolve_conflicts = "OVERWRITE"
+}

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -14,6 +14,17 @@ variable "cluster_name" {
   default     = "govuk"
 }
 
+variable "cluster_version" {
+  type        = string
+  description = "Kubernetes release version for the cluster, e.g. 1.21"
+}
+
+variable "cluster_addon_versions" {
+  type        = map(string)
+  description = "Map of {addon_name: version} denoting pinned versions of the core EKS-managed cluster addons (coredns, kube-proxy, vpc-cni). This is intended to be used only when a default version is broken, and only for a short time. Core addon versions should normally be managed by Amazon, so that cluster upgrades are stable and security patches are rolled out."
+  default     = {}
+}
+
 variable "eks_control_plane_subnets" {
   type        = map(object({ az = string, cidr = string }))
   description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the public subnets for the EKS cluster's apiserver."

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -1,6 +1,7 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-integration"
 cluster_infrastructure_state_bucket = "govuk-terraform-integration"
 
+cluster_version               = 1.21
 cluster_log_retention_in_days = 7
 
 eks_control_plane_subnets = {

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -1,6 +1,7 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-test"
 cluster_infrastructure_state_bucket = "govuk-terraform-test"
 
+cluster_version               = 1.21
 cluster_log_retention_in_days = 7
 
 eks_control_plane_subnets = {


### PR DESCRIPTION
Enable EKS management of the three core cluster addons which are installed by default: coredns, kube-proxy, vpc-cni.

Without this, EKS still installs the default versions of these addons but doesn't manage their lifecycle, leaving it to the user to manually make any necessary upgrades or changes during a cluster upgrade.

I added a module variable for overriding the default addon versions just in case we ever need to do so (i.e. in the unlikely event that Amazon were to make a bad version the default), but I don't expect we'll actually need it. We don't want to pin these versions because it would defeat the benefit of Amazon managing the core addons for us and make things less reliable and secure overall.

Also stop hardcoding the cluster version, as we'll need it to vary between environments when rolling out cluster upgrades.

Tested: applied in test account, addon versions remain as expected. Checked that overriding a version to the default version produces no diff. Checked that overriding a version to a non-default version produces the expected diff.

[Trello card](https://trello.com/c/r3DYG1Fy/664)