### PR TITLE
Use managed node group and fix some cluster turnup issues.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -44,7 +44,7 @@ provider "aws" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "17.8.0"
+  version = "17.20.0"
 
   cluster_name     = var.cluster_name
   cluster_version  = var.cluster_version

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -56,10 +56,16 @@ variable "force_destroy" {
   default     = false
 }
 
-variable "workers_instance_type" {
+variable "workers_instance_types" {
+  type        = list(string)
+  description = "List of instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
+  default     = ["m5.xlarge"]
+}
+
+variable "workers_default_capacity_type" {
   type        = string
-  description = "Instance type for the managed node group."
-  default     = "m5.xlarge"
+  description = "Default capacity type for managed node groups: SPOT or ON_DEMAND."
+  default     = "ON_DEMAND"
 }
 
 variable "workers_size_desired" {

--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -6,11 +6,12 @@
 # https://github.com/alphagov/govuk-infrastructure/blob/main/docs/architecture/decisions/0003-split-terraform-state-into-separate-aws-cluster-and-kubernetes-resource-phases.md#decision for rationale.
 
 resource "helm_release" "aws_lb_controller" {
-  name       = "aws-load-balancer-controller"
-  repository = "https://aws.github.io/eks-charts"
-  chart      = "aws-load-balancer-controller"
-  version    = "1.2.7" # TODO: Dependabot or equivalent so this doesn't get neglected.
-  namespace  = local.services_ns
+  name             = "aws-load-balancer-controller"
+  repository       = "https://aws.github.io/eks-charts"
+  chart            = "aws-load-balancer-controller"
+  version          = "1.2.7" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace        = local.services_ns
+  create_namespace = true
   values = [yamlencode({
     clusterName      = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
     defaultSSLPolicy = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06" # No TLS 1.0 or 1.1.

--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -4,11 +4,12 @@
 # ../cluster-infrastructure/external_dns.tf.
 
 resource "helm_release" "external_dns" {
-  name       = "external-dns"
-  repository = "https://charts.bitnami.com/bitnami"
-  chart      = "external-dns"
-  version    = "5.4.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
-  namespace  = local.services_ns
+  name             = "external-dns"
+  repository       = "https://charts.bitnami.com/bitnami"
+  chart            = "external-dns"
+  version          = "5.4.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace        = local.services_ns
+  create_namespace = true
   values = [yamlencode({
     aws = {
       region   = data.aws_region.current.name

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -4,9 +4,9 @@ resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"
-  create_namespace = true
   version          = "18.0.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = "monitoring"
+  create_namespace = true
   values = [yamlencode({
     alertmanager = {
       ingress = {

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -2,11 +2,13 @@
 
 resource "helm_release" "filebeat" {
   depends_on = [helm_release.cluster_secrets]
-  chart      = "filebeat"
-  name       = "filebeat"
-  namespace  = local.services_ns
-  repository = "https://helm.elastic.co"
-  version    = "7.7.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+
+  name             = "filebeat"
+  repository       = "https://helm.elastic.co"
+  chart            = "filebeat"
+  version          = "7.7.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace        = local.services_ns
+  create_namespace = true
   values = [yamlencode({
     filebeatConfig = {
       "filebeat.yml" = yamlencode({


### PR DESCRIPTION
Turns out we were accidentally using self-managed nodes before (my mistake, in 1f30519). In fairness to myself, the terraform-aws-eks module is quite confusing in this area and the docs are in need of some love.

Also some fixes which I had to make in order to test this change:

* Update to [latest terraform-aws-eks module](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/CHANGELOG.md#v17200---2021-09-17).
* Fix a Terraform dependency issue that prevented creation of the TLS cert for the external_dns domain when turning up a cluster from scratch. (I think I broke this in efbe2cf.)
* Set a missing create_namespace to fix a race between helm_release resources where external_dns would fail to install if Terraform happened to run its `helm install` before one of the other helm_release resources had created the namespace. (`--create_namespace` itself is safe to run in parallel.)

Tested: brought up a test cluster using `terraform workspace`: https://eu-west-1.console.aws.amazon.com/eks/home?region=eu-west-1#/clusters/chris