### PR TITLE
Add build-base-image-definition task

### DIFF
--- a/concourse/pipelines/build-base-images.yml
+++ b/concourse/pipelines/build-base-images.yml
@@ -104,7 +104,7 @@ jobs:
           - get: govuk-ruby-2.7.2-image
       - task: build-image
         privileged: true
-        file: govuk-infrastructure/concourse/tasks/build-image-definition.yml
+        file: govuk-infrastructure/concourse/tasks/build-base-image-definition.yml
         input_mapping:
           git-repo: govuk-infrastructure
         params:
@@ -219,7 +219,7 @@ jobs:
           - get: govuk-ruby-2.7.3-image
       - task: build-image
         privileged: true
-        file: govuk-infrastructure/concourse/tasks/build-image-definition.yml
+        file: govuk-infrastructure/concourse/tasks/build-base-image-definition.yml
         input_mapping:
           git-repo: govuk-infrastructure
         params:
@@ -334,7 +334,7 @@ jobs:
           - get: govuk-ruby-2.6.6-image
       - task: build-image
         privileged: true
-        file: govuk-infrastructure/concourse/tasks/build-image-definition.yml
+        file: govuk-infrastructure/concourse/tasks/build-base-image-definition.yml
         input_mapping:
           git-repo: govuk-infrastructure
         params:

--- a/concourse/tasks/build-base-image-definition.yml
+++ b/concourse/tasks/build-base-image-definition.yml
@@ -1,0 +1,14 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: vito/oci-build-task
+inputs:
+- name: git-repo
+outputs:
+- name: image
+params:
+  CONTEXT: git-repo
+  DOCKERFILE: git-repo/Dockerfile
+run:
+  path: build


### PR DESCRIPTION
Following 3fbbc90b045402eb7444252160cf3f2af0b031d7 we can't use the build-image-defition task anymore to build base images. build-base-image-definition replace it