### PR TITLE
Install and configure ArgoCD for application deployment

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -1,0 +1,70 @@
+# Installs and configures ArgoCD for deploying GOV.UK apps
+locals {
+  argo_host = "argo.${local.external_dns_zone_name}"
+}
+
+resource "helm_release" "argo_cd" {
+  chart      = "argo-cd"
+  name       = "argo-cd"
+  namespace  = local.services_ns
+  repository = "https://argoproj.github.io/argo-helm"
+  version    = "3.22.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  values = [yamlencode({
+    server = {
+      # TLS Termination happens at the ALB, the insecure flag prevents Argo
+      # server from upgrading the request after TLS termination.
+      extraArgs = ["--insecure"]
+
+      ingress = {
+        enabled = true
+        annotations = {
+          "alb.ingress.kubernetes.io/group.name"         = "argo"
+          "alb.ingress.kubernetes.io/scheme"             = "internet-facing"
+          "alb.ingress.kubernetes.io/target-type"        = "ip"
+          "alb.ingress.kubernetes.io/load-balancer-name" = "argo"
+          "alb.ingress.kubernetes.io/listen-ports"       = jsonencode([{ "HTTP" : 80 }, { "HTTPS" : 443 }])
+          "alb.ingress.kubernetes.io/ssl-redirect"       = "443"
+        }
+        labels           = {}
+        ingressClassName = "aws-alb"
+        hosts            = [local.argo_host]
+        https            = true
+      }
+
+      config = {
+        url = "https://${local.argo_host}"
+      }
+
+      ingressGrpc = {
+        enabled  = true
+        isAWSALB = true
+        annotations = {
+          "alb.ingress.kubernetes.io/group.name"         = "argo"
+          "alb.ingress.kubernetes.io/scheme"             = "internet-facing"
+          "alb.ingress.kubernetes.io/target-type"        = "ip"
+          "alb.ingress.kubernetes.io/load-balancer-name" = "argo"
+          "alb.ingress.kubernetes.io/listen-ports"       = jsonencode([{ "HTTP" : 80 }, { "HTTPS" : 443 }])
+          "alb.ingress.kubernetes.io/ssl-redirect"       = "443"
+        }
+        labels           = {}
+        ingressClassName = "aws-alb"
+        hosts            = [local.argo_host]
+        https            = true
+      }
+    }
+  })]
+}
+
+resource "helm_release" "argo_config" {
+  depends_on = [helm_release.argo_cd]
+  chart      = "argocd-config"
+  name       = "argocd-config"
+  namespace  = local.services_ns
+  repository = "https://alphagov.github.io/govuk-helm-charts/"
+  version    = "0.1.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  values = [yamlencode({
+    # TODO: This TF module should not need to know the govuk_environment, since
+    # there is only one per AWS account.
+    govukEnvironment = var.govuk_environment
+  })]
+}

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -7,3 +7,8 @@ variable "cluster_infrastructure_state_bucket" {
   type        = string
   description = "Name of the S3 bucket for the cluster-infrastructure module's Terraform state. Must match the name of the bucket specified in the backend config file."
 }
+
+variable "govuk_environment" {
+  type        = string
+  description = "Acceptable values are test, integration, staging, production"
+}


### PR DESCRIPTION
This installs ArgoCD at https://argo.eks.test.govuk.digital/.

We also install argocd-config, a Helm chart managed in govuk-helm-charts, which configures the Projects, Repositories, Repo Creds, and Applications managed by ArgoCD.

Trello: https://trello.com/c/knISYDSS/675-implement-argocd-pipeline-for-publisher