### PR TITLE
Run `terraform-govuk-publishing-infrastructure` After Pipeline Update

### DIFF
--- a/concourse/pipelines/eks.yml
+++ b/concourse/pipelines/eks.yml
@@ -85,6 +85,8 @@ jobs:
     plan:
     - get: govuk-infrastructure
       trigger: true
+      passed:
+      - update-pipeline
     - task: terraform-apply
       config:
         <<: *terraform-apply-config


### PR DESCRIPTION
Fix #463 by running `terraform-govuk-publishing-infrastructure` job after `pipeline-update` in the `eks` concourse pipeline.


![fixed `EKS` ci pipeline](https://user-images.githubusercontent.com/43747728/138258852-16eaa297-1f7d-464f-bae8-3a7c879676cf.png)

