### PR TITLE
Update the Argocd-Apps Helm Version

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -61,7 +61,7 @@ resource "helm_release" "argo_config" {
   name       = "argocd-config"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
-  version    = "0.1.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "0.2.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.


### PR DESCRIPTION
In [PR](https://github.com/alphagov/govuk-helm-charts/pull/15),
we added existing GOV.UK apps for which there are Helm charts.
This PR bumps the argocd-apps version so that this change is
deployed.

Ref:
1. [trello card](https://trello.com/c/GqZuxOeR/699-create-argo-applications-for-remaining-apps)