### PR TITLE
Install ArgoCD-Notifications

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -68,3 +68,84 @@ resource "helm_release" "argo_config" {
     govukEnvironment = var.govuk_environment
   })]
 }
+
+resource "helm_release" "argo_notifications" {
+  chart      = "argocd-notifications"
+  name       = "argocd-notifications"
+  namespace  = local.services_ns
+  repository = "https://argoproj.github.io/argo-helm"
+  version    = "1.5.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  values = [yamlencode({
+    argocdUrl = "https://${local.argo_host}"
+
+    # argocd-notifications-secret will be created by ExternalSecrets
+    # since the secrets are stored in AWS SecretsManager
+    secret = {
+      create = false
+    }
+
+    notifiers = {
+      # this slack webhook (managed by IT Services) allows messages on the `govuk-deploy-alerts` channel 
+      "service.webhook.slack_webhook" = yamlencode({
+        url = "$slack_url"
+        headers = [{
+          name  = "Content-Type"
+          value = "application/json"
+        }]
+      })
+      "service.slack" = null # remove default unconfigured slack service to remove misconfiguration error
+    }
+
+    triggers = {
+      "trigger.sync-operation-change" = yamlencode([
+        {
+          when    = "app.status.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy'"
+          oncePer = "app.status.sync.revision"
+          send    = ["send-slack"]
+        },
+        {
+          when    = "app.status.operationState.phase in ['Running']"
+          oncePer = "app.status.sync.revision"
+          send    = ["send-slack"]
+        },
+        {
+          when    = "app.status.operationState.phase in ['Error', 'Failed']"
+          oncePer = "app.status.sync.revision"
+          send    = ["send-slack"]
+        },
+      ])
+    }
+
+    templates = {
+      "template.send-slack" = yamlencode({
+        webhook = {
+          slack_webhook = {
+            method = "POST"
+            body   = <<-EOB
+            {
+              "attachments": [{
+                "title": "{{.app.metadata.name}}",
+                "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+                {{- if eq .app.status.operationState.phase "Succeeded" -}}
+                "color": "#18be52",
+                {{- else if eq .app.status.operationState.phase "Running" -}}
+                "color": "#beb618",
+                {{- else if or (eq .app.status.operationState.phase "Error") (eq .app.status.operationState.phase "Failed") -}}
+                "color": "#be1b18",
+                {{- else -}}
+                "color": "#183cbe",
+                {{- end -}}
+                "fields": [{
+                  "title": "state",
+                  "value": "{{.app.status.operationState.phase}}",
+                  "short": true
+                }]
+              }]
+            }
+            EOB
+          }
+        }
+      })
+    }
+  })]
+}


### PR DESCRIPTION
[argocd-notifications](https://argocd-notifications.readthedocs.io/en/stable/) is installed so that slack notifications can be sent during sync status changes of apps deployed by ArgoCD.

Ref:
1. [trello card](https://trello.com/c/UrW8YuI9/700-add-a-slack-notify-task-after-argocd-apps-are-deployed)