### PR TITLE
Adding `ecr:GetAuthorizationToken` to Github actions IAM policy

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -199,6 +199,7 @@ resource "aws_iam_user_policy" "github_ecr_user_policy" {
           "ecr:PutImage",
           "ecr:InitiateLayerUpload",
           "ecr:UploadLayerPart",
+          "ecr:GetAuthorizationToken",
           "ecr:CompleteLayerUpload"
         ],
         "Resource" : ["*"],


### PR DESCRIPTION
This change is necessary to allow the CI Github Action to authorise then upload the built container to ECR.