### PR TITLE
Have Prometheus Operator read PrometheusRules from all namespaces.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -37,7 +37,16 @@ resource "helm_release" "kube_prometheus_stack" {
           "alb.ingress.kubernetes.io/load-balancer-name" = "prometheus"
         })
       }
+      # Match all PrometheusRules cluster-wide. (If an app/team needs a separate
+      # Prom instance, it almost certainly needs a separate EKS cluster too.)
       prometheusSpec = {
+        ruleNamespaceSelector = {
+          matchExpressions = [{
+            key      = "no_monitor"
+            operator = "DoesNotExist"
+            values   = []
+          }]
+        }
         # Allow empty ruleSelector (https://github.com/prometheus-community/helm-charts/blob/2cacc16807caedc6cabf1606db27e0d78c844564/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml#L202)
         ruleSelectorNilUsesHelmValues = false
       }


### PR DESCRIPTION
This allows apps to define their own PrometheusRules etc. while still allowing copies of apps to be deployed in extra namespaces for testing, including their monitoring rules.

This might change if we were to decide we wanted more than one Prometheus stack in the cluster, but I think that's highly unlikely: if an application warrants having its metrics segregated on its own Prometheus stack then it also shouldn't be sharing fate or security boundaries with anything else in the cluster, so therefore should have its own cluster. (Repeat after me: k8s is not designed for (hard) multitenancy ;-)

There seem to be some issues with configuring the Prometheus Operator to just look at all namespaces - there are conflicting docs and it doesn't appear to be possible currently when using its Helm chart - so instead we're configuring it to look at all namespaces except those labelled "no_monitor". That's arguably better anyway as it allows for someone to run their own Prometheus with prom operator if they really wanted to.