### PR TITLE
Update kube-prometheus-stack to 19.0.3

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -4,7 +4,7 @@ resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"
-  version          = "18.0.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "19.2.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = "monitoring"
   create_namespace = true
   values = [yamlencode({


### PR DESCRIPTION
No config changes required; see [changelog](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-18x-to-19x).

This doesn't actually upgrade Prometheus to the latest version, just the Helm chart. The upgrade story is actually kinda interesting, but that's for another day.

Tested: deployed in the test cluster; Prometheus still works fine and there are no errors in the operator logs.