### PR TITLE
Add Argo Workflows and Events

### DIFF
--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -1,3 +1,7 @@
+variable "argo_workflow_namespaces" {
+  type        = list(string)
+  description = "Namespaces in which Argo will run workflows."
+}
 variable "govuk_aws_state_bucket" {
   type        = string
   description = "Name of the S3 bucket used for govuk-aws's Terraform state."

--- a/terraform/deployments/variables/common.tfvars
+++ b/terraform/deployments/variables/common.tfvars
@@ -8,3 +8,5 @@ registry = "172025368201.dkr.ecr.eu-west-1.amazonaws.com"
 # TODO: replace with remote state
 office_cidrs_list    = ["213.86.153.212/32", "213.86.153.213/32", "213.86.153.214/32", "213.86.153.235/32", "213.86.153.236/32", "213.86.153.237/32", "85.133.67.244/32", "213.86.153.211/32", "213.86.153.231/32"]
 concourse_cidrs_list = ["35.178.226.106/32", "18.130.168.3/32"]
+
+argo_workflow_namespaces = ["apps"]


### PR DESCRIPTION
This commit installs Argo Workflows and Events also replaces `argocd-config` with a helm chart `argo-services`, since this now configures the config for all Argo services (cd, cd-notifications, events). It also removes the ArgoCD Notifications configuration from Terraform, as this will be configured in `argo-services`.

Co-Authored-By: @fredericfran-gds 

Trello: https://trello.com/c/h8F7nBbu/676-smoke-tests-after-each-deploy-by-app