### PR TITLE
Fix terraform.sh to use common.tfvars

### DIFF
--- a/concourse/tasks/terraform.sh
+++ b/concourse/tasks/terraform.sh
@@ -43,5 +43,6 @@ cd "${DEPLOYMENT_PATH}"
 terraform init -input=false -backend-config "${ENVIRONMENT}.backend"
 
 terraform "$tf_action" -input=false \
+  -var-file "../variables/common.tfvars" \
   -var-file "../variables/${ENVIRONMENT}/common.tfvars" \
   $auto_approve "$@"

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -2,6 +2,7 @@ variable "argo_workflow_namespaces" {
   type        = list(string)
   description = "Namespaces in which Argo will run workflows."
 }
+
 variable "govuk_aws_state_bucket" {
   type        = string
   description = "Name of the S3 bucket used for govuk-aws's Terraform state."


### PR DESCRIPTION
The terraform.sh that is used by the concourse pipelines does not use the common.tfvars that is common across all gov.uk environment, it only uses the common one inside an environment. This commit fixes that.