### PR TITLE
cluster-services shouldn't depend on GOV.UK-specific stuff.

### DIFF
--- a/concourse/pipelines/eks.yml
+++ b/concourse/pipelines/eks.yml
@@ -102,7 +102,6 @@ jobs:
       trigger: true
       passed:
       - terraform-cluster-infrastructure
-      - terraform-govuk-publishing-infrastructure
     - task: terraform-apply
       config:
         <<: *terraform-apply-config


### PR DESCRIPTION
The cluster-services Terraform module isn't supposed to depend on any application-specific stuff, so it shouldn't need to wait for the govuk-publishing-infrastructure module.

This is more of a documentation fix than anything functional; it fixes the graph on the Concourse dashboard so that it's no longer misleading.