### PR TITLE
Include "redis" in the DNS name of the Redis cluster.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
@@ -41,7 +41,8 @@ resource "aws_elasticache_replication_group" "shared_redis_cluster" {
 
 resource "aws_route53_record" "shared_redis_cluster_internal_service_record" {
   zone_id = local.internal_dns_zone_id
-  name    = var.shared_redis_cluster_name
+  # TODO: consider removing EKS suffix once the old EC2 environments are gone.
+  name    = "${var.shared_redis_cluster_name}.eks"
   type    = "CNAME"
   ttl     = 300
   records = [aws_elasticache_replication_group.shared_redis_cluster.primary_endpoint_address]

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -6,7 +6,7 @@ variable "govuk_aws_state_bucket" {
 variable "shared_redis_cluster_name" {
   type        = string
   description = "Name of the shared Redis cluster"
-  default     = "shared-eks"
+  default     = "shared-redis"
 }
 
 variable "shared_redis_cluster_port" {


### PR DESCRIPTION
Looks like nothing much is using this yet so it's a good time to rename.

This changes the names from e.g. `shared-eks.integration.govuk-internal.digital` (which conveys no clue that it's a Redis cluster 😅) to `shared-redis.eks.integration.govuk-internal.digital`.

We can't just set `shared_redis_cluster_name` to "shared-redis.eks" because Redis doesn't allow dots in replica names, hence we're appending it at the point where we specify the Route53 CNAME record.

[Trello](https://trello.com/c/Rp2xjAYJ/674)