### PR TITLE
Bump `argo-services` Helm chart to `0.1.2`

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -62,7 +62,7 @@ resource "helm_release" "argo_services" {
   name       = "argo-services"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
-  version    = "0.1.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "0.1.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.


### PR DESCRIPTION
This PR bumps the `argo-services` Helm chart to version `0.1.2`, fixing various errors with the `argocd-notifications-cm` when running a Terraform apply of the form:

```
Error: error validating "": error validating data: [ValidationError(ConfigMap.data.context): invalid type for io.k8s.api.core.v1.ConfigMap.data: got "map", expected "string"
```
(see the commit https://github.com/alphagov/govuk-helm-charts/commit/72911bce9a96f3d9b52c86566ee00249297d6cd2#diff-5ed1a66d94c1c1e2851d74e0df3ebe7195f2732641d67e36a73ef197b9afd2bb for details)

As described in this ConfigMap, at some stage in the future we should have Dependabot or something which operates in a similar fashion keep our charts up-to-date, at least with patch versions and probably too minor versions.