### PR TITLE
Update GitHub.com SSH known hosts for ArgoCD

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -10,6 +10,18 @@ resource "helm_release" "argo_cd" {
   repository = "https://argoproj.github.io/argo-helm"
   version    = "3.22.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
+    "configs" = {
+      "knownHosts" = {
+        "data" = {
+          "ssh_known_hosts" : <<-KNOWN_HOSTS
+          github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+          github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+          github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+          KNOWN_HOSTS
+        }
+      }
+    }
+
     server = {
       # TLS Termination happens at the ALB, the insecure flag prevents Argo
       # server from upgrading the request after TLS termination.


### PR DESCRIPTION
On November 16 2021 (yesterday) GitHub [expired an SSH key](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints) `SHA256:br9IjFspm1vxR3iA35FWE+4VTyz1hYVLIE2t1/CeyWQ` (DSA).

ArgoCD maintains a ConfigMap containing SSH known_hosts, and by default their Helm chart ships with various fingerprints for github, gitlab, etc.

Unfortunately, when GitHub removed their DSA key this caused an SSH error when Argo attempted to sync with our GitHub repos: "key mismatch error".

The fix is to remove the expired key from the ConfigMap, as done here. Now the ConfigMap matches the result of `ssh-keyscan github.com`, and there's no longer a mismatch.