### PR TITLE
Argo has updated its GitHub SSH known_hosts; remove our workaround.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -8,20 +8,8 @@ resource "helm_release" "argo_cd" {
   name       = "argo-cd"
   namespace  = local.services_ns
   repository = "https://argoproj.github.io/argo-helm"
-  version    = "3.22.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "3.26.9" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
-    "configs" = {
-      "knownHosts" = {
-        "data" = {
-          "ssh_known_hosts" : <<-KNOWN_HOSTS
-          github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
-          github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
-          github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
-          KNOWN_HOSTS
-        }
-      }
-    }
-
     server = {
       # TLS Termination happens at the ALB, the insecure flag prevents Argo
       # server from upgrading the request after TLS termination.


### PR DESCRIPTION
As of [argo-helm](https://github.com/argoproj/argo-helm) PR 1018 (intentionally not linking to avoid linkspamming that PR), the official Helm chart no longer contains the offending expired DSA key.

Reverts #485 and updates `argo-cd` to the latest chart version.

[Trello](https://trello.com/c/Rp2xjAYJ/674)