### PR TITLE
Avoid duplicate lint checks on first-party PRs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: linting
-on: [push, pull_request]
+on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See alphagov/govuk-helm-charts#40.