### PR TITLE
Various fixes to external-dns configuration.

### DIFF
--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -21,7 +21,7 @@ resource "helm_release" "external_dns" {
         "eks.amazonaws.com/role-arn" = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_role_arn
       }
     }
-    txtOwnerId    = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_id
+    txtOwnerId    = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
     domainFilters = [data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name]
     # TODO: hook up Prometheus metrics (metrics.enabled, metrics.podAnnotations etc.)
   })]

--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -7,7 +7,7 @@ resource "helm_release" "external_dns" {
   name             = "external-dns"
   repository       = "https://charts.bitnami.com/bitnami"
   chart            = "external-dns"
-  version          = "5.4.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.5.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({

--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -21,8 +21,10 @@ resource "helm_release" "external_dns" {
         "eks.amazonaws.com/role-arn" = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_role_arn
       }
     }
-    txtOwnerId    = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
-    domainFilters = [data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name]
+    txtOwnerId         = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
+    domainFilters      = [data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name]
+    interval           = "5m"
+    triggerLoopOnEvent = true
     # TODO: hook up Prometheus metrics (metrics.enabled, metrics.podAnnotations etc.)
   })]
 }


### PR DESCRIPTION
See commit messages for more details.

* Update the external-dns chart to the latest version.
* Use cluster ID for external-dns ownership record, not zone ID.
* Reduce external-dns's polling interval to 5m and enable watches, so that we don't blow through the 5 qps hard limit on Route53.

Rollout: requires deleting the A/TXT records in the external-dns-managed zone after deploying (so that external-dns recreates them with the new ownership details in the TXT records).

Tested: works in the test cluster; controller logs look good; records were recreated after deletion. Editing an Ingress triggered the reconciliation loop without waiting 5 minutes.