### PR TITLE
Add security group rules to allow connections to legacy databases.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -8,6 +8,11 @@ output "worker_iam_role_arn" {
   value       = module.eks.worker_iam_role_arn
 }
 
+output "worker_security_group_id" {
+  description = "ID of the security group which contains the worker nodes."
+  value       = module.eks.worker_security_group_id
+}
+
 output "cluster_autoscaler_service_account_name" {
   description = "Name of the k8s service account for the cluster autoscaler."
   value       = local.cluster_autoscaler_service_account_name

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -2,6 +2,7 @@ variable "argo_workflow_namespaces" {
   type        = list(string)
   description = "Namespaces in which Argo will run workflows."
 }
+
 variable "govuk_aws_state_bucket" {
   type        = string
   description = "Name of the S3 bucket used for govuk-aws's Terraform state."

--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -1,5 +1,15 @@
 data "aws_region" "current" {}
 
+data "terraform_remote_state" "cluster_infrastructure" {
+  backend   = "s3"
+  workspace = terraform.workspace
+  config = {
+    bucket = var.cluster_infrastructure_state_bucket
+    key    = "projects/cluster-infrastructure.tfstate"
+    region = data.aws_region.current.name
+  }
+}
+
 data "terraform_remote_state" "infra_networking" {
   backend = "s3"
   config = {
@@ -14,6 +24,15 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   config = {
     bucket = var.govuk_aws_state_bucket
     key    = "govuk/infra-root-dns-zones.tfstate"
+    region = data.aws_region.current.name
+  }
+}
+
+data "terraform_remote_state" "infra_security_groups" {
+  backend = "s3"
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-security-groups.tfstate"
     region = data.aws_region.current.name
   }
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -3,6 +3,11 @@ variable "govuk_aws_state_bucket" {
   description = "The name of the S3 bucket used for govuk-aws's Terraform state files."
 }
 
+variable "cluster_infrastructure_state_bucket" {
+  type        = string
+  description = "Name of the S3 bucket for the cluster-infrastructure module's Terraform state. Must match the name of the bucket specified in the backend config file."
+}
+
 variable "shared_redis_cluster_name" {
   type        = string
   description = "Name of the shared Redis cluster"


### PR DESCRIPTION
Allow connections from nodes (including all pods) to:

- Router MongoDB (running on EC2 router-backend VMs)
- Shared DocumentDB (which content-store uses)
- Frontend memcache

Intentionally not adding any others preemptively, because I think it's better to add them at the same time as adding the clients, so we can test that the rules work.

Tested: removed the manually-added allow-all-from-10/8 rules (on govuk_router-backend_access, govuk_frontend_cache_access, govuk_mongo_access) in the test environment, checked that frontend, router and content-store break and complain about database connectivity; ran tf apply and checked that all three apps work again and logs look good.