### PR TITLE
Give the EKS environment its own frontend memcache.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/frontend_memcache.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/frontend_memcache.tf
@@ -1,0 +1,43 @@
+locals {
+  frontend_memcached_name = "frontend-memcached-${local.cluster_name}"
+}
+
+resource "aws_elasticache_subnet_group" "frontend_memcached" {
+  name       = "frontend-memcached"
+  subnet_ids = local.elasticache_subnets
+}
+
+resource "aws_security_group" "frontend_memcached" {
+  name        = local.frontend_memcached_name
+  vpc_id      = local.vpc_id
+  description = "${local.frontend_memcached_name} memcached instance"
+  tags = {
+    Name = local.frontend_memcached_name
+  }
+}
+
+resource "aws_elasticache_cluster" "frontend_memcached" {
+  cluster_id = "frontend-memcached-${local.cluster_name}"
+
+  engine          = "memcached"
+  engine_version  = "1.6.6"
+  node_type       = var.frontend_memcached_node_type
+  num_cache_nodes = 1 # TODO: consider whether failover is needed
+
+  apply_immediately    = var.govuk_environment != "production"
+  parameter_group_name = "default.memcached1.6"
+  subnet_group_name    = aws_elasticache_subnet_group.frontend_memcached.name
+  security_group_ids   = [aws_security_group.frontend_memcached.id]
+  tags = {
+    Name = local.frontend_memcached_name
+  }
+}
+
+resource "aws_route53_record" "frontend_memcached" {
+  zone_id = local.internal_dns_zone_id
+  # TODO: consider removing EKS suffix once the old EC2 environments are gone.
+  name    = "frontend-memcached-${local.cluster_name}.eks"
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_elasticache_cluster.frontend_memcached.cluster_address]
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -11,9 +11,10 @@ terraform {
 }
 
 locals {
+  cluster_name         = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
   vpc_id               = data.terraform_remote_state.infra_networking.outputs.vpc_id
   internal_dns_zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
-  redis_subnets        = data.terraform_remote_state.infra_networking.outputs.private_subnet_elasticache_ids
+  elasticache_subnets  = data.terraform_remote_state.infra_networking.outputs.private_subnet_elasticache_ids
 
   default_tags = {
     project              = "replatforming"

--- a/terraform/deployments/govuk-publishing-infrastructure/outputs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/outputs.tf
@@ -1,7 +1,3 @@
 output "shared_redis_cluster_host" {
-  value = aws_route53_record.shared_redis_cluster_internal_service_record.fqdn
-}
-
-output "shared_redis_cluster_port" {
-  value = var.shared_redis_cluster_port
+  value = aws_route53_record.shared_redis_cluster.fqdn
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
@@ -1,48 +1,41 @@
-resource "aws_elasticache_subnet_group" "shared_redis_cluster_subnet_group" {
-  name       = var.shared_redis_cluster_name
-  subnet_ids = local.redis_subnets
+locals {
+  shared_redis_name = "shared-redis-${local.cluster_name}"
+}
+
+resource "aws_elasticache_subnet_group" "shared_redis_cluster" {
+  name       = local.shared_redis_name
+  subnet_ids = local.elasticache_subnets
 }
 
 resource "aws_security_group" "shared_redis_cluster" {
-  name        = var.shared_redis_cluster_name
+  name        = local.shared_redis_name
   vpc_id      = local.vpc_id
-  description = "Access to the ${var.shared_redis_cluster_name} Redis cluster"
-
-  tags = merge(
-    local.default_tags,
-    {
-      Name = "${var.shared_redis_cluster_name}"
-    },
-  )
-
+  description = "${local.shared_redis_name} Redis cluster"
+  tags = {
+    Name = local.shared_redis_name
+  }
 }
 
 resource "aws_elasticache_replication_group" "shared_redis_cluster" {
-  apply_immediately             = var.govuk_environment != "production" ? true : false
-  replication_group_id          = var.shared_redis_cluster_name
-  replication_group_description = "${var.shared_redis_cluster_name} Redis cluster with Redis master and replica"
+  apply_immediately             = var.govuk_environment != "production"
+  replication_group_id          = local.shared_redis_name
+  replication_group_description = "${local.shared_redis_name} Redis cluster with Redis master and replica"
   node_type                     = var.shared_redis_cluster_node_type
-  port                          = var.shared_redis_cluster_port
   number_cache_clusters         = 2
-  parameter_group_name          = "default.redis6.x"
   automatic_failover_enabled    = true
+  parameter_group_name          = "default.redis6.x"
   engine_version                = "6.x"
-  subnet_group_name             = aws_elasticache_subnet_group.shared_redis_cluster_subnet_group.name
+  subnet_group_name             = aws_elasticache_subnet_group.shared_redis_cluster.name
   security_group_ids            = [aws_security_group.shared_redis_cluster.id]
-
-  tags = merge(
-    local.default_tags,
-    {
-      Name = "${var.shared_redis_cluster_name}"
-    },
-  )
-
+  tags = {
+    Name = local.shared_redis_name
+  }
 }
 
-resource "aws_route53_record" "shared_redis_cluster_internal_service_record" {
+resource "aws_route53_record" "shared_redis_cluster" {
   zone_id = local.internal_dns_zone_id
   # TODO: consider removing EKS suffix once the old EC2 environments are gone.
-  name    = "${var.shared_redis_cluster_name}.eks"
+  name    = "${local.shared_redis_name}.eks"
   type    = "CNAME"
   ttl     = 300
   records = [aws_elasticache_replication_group.shared_redis_cluster.primary_endpoint_address]

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -8,25 +8,17 @@ variable "cluster_infrastructure_state_bucket" {
   description = "Name of the S3 bucket for the cluster-infrastructure module's Terraform state. Must match the name of the bucket specified in the backend config file."
 }
 
-variable "shared_redis_cluster_name" {
+variable "govuk_environment" {
   type        = string
-  description = "Name of the shared Redis cluster"
-  default     = "shared-redis"
+  description = "GOV.UK environment where resources are being deployed"
 }
 
-variable "shared_redis_cluster_port" {
-  type        = number
-  description = "Port of the shared Redis cluster"
-  default     = 6379
+variable "frontend_memcached_node_type" {
+  type        = string
+  description = "Instance type for the Frontend memcached."
 }
 
 variable "shared_redis_cluster_node_type" {
   type        = string
-  description = "Node type to used for the shared Redis cluster. Must not be t.* in order to use failover."
-  default     = "cache.m3.medium"
-}
-
-variable "govuk_environment" {
-  type        = string
-  description = "GOV.UK environment where resources are being deployed"
+  description = "Instance type for the shared Redis cluster. t1 and t2 instances are not supported."
 }

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -26,3 +26,6 @@ govuk_environment = "integration"
 
 publishing_service_domain = "integration.publishing.service.gov.uk"
 external_dns_subdomain    = "eks"
+
+frontend_memcached_node_type   = "cache.t4g.micro"
+shared_redis_cluster_node_type = "cache.t4g.small"

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -27,3 +27,6 @@ force_destroy     = true
 
 publishing_service_domain = "test.publishing.service.gov.uk"
 external_dns_subdomain    = "eks"
+
+frontend_memcached_node_type   = "cache.t4g.micro"
+shared_redis_cluster_node_type = "cache.t4g.small"


### PR DESCRIPTION
We can't share the Frontend memcache with the EC2 environments, because Frontend uses it to cache rendered HTML which contains links to Rails assets. My mistake 🤦

Also:

- Tweak the config for the shared Redis while we're there; it's very similar to the memcache one so let's make the two consistent.
- Remove the defaults for instance types and added those vars to the per-environment `.tfvars`, to make it less likely that we'll forget to set them appropriately when adding staging and prod.
- Hardcode the standard ports for Redis and memcached; we'd never want to run them on nonstandard ports so on balance it's cleaner to get rid of the module variable and save on interface clutter.
- Use a slightly smaller and cheaper instance type for Redis.
- Use provider default tags to simplify tagging the Redis cluster and associated resources. Saves the repeated boilerplate merge on every tagged resource.

Tested: applied successfully in the test account. Clusters/instances show up healthy in the AWS web console.