### PR TITLE
Fix ability to apply `ecr` module in the test account.

### DIFF
--- a/terraform/deployments/ecr/README.md
+++ b/terraform/deployments/ecr/README.md
@@ -1,11 +1,24 @@
-# GOV.UK AWS ECR
+# Elastic Container Registry for GOV.UK in Kubernetes
 
-In the new platform, container images are stored in AWS ECR. The AWS account
-that has been chosen to host the ECR is the GOV.UK production one
+Container images for GOV.UK on Kubernetes are stored in AWS ECR. The registry is hosted in the GOV.UK production AWS account. There is also a test registry (for example for testing IAM changes to the registry itself) in the test AWS account.
 
-## Applying
+## Applying Terraform
 
 ```shell
-gds aws govuk-production-admin -- terraform apply \
- -var-file ../variables/common.tfvars
+# Test registry (for testing changes to the registry config)
+
+gds aws govuk-test-admin -- \
+  terraform init -backend-config test.backend -upgrade
+
+gds aws govuk-test-admin -- \
+  terraform apply -var-file ../variables/test/ecr.tfvars
+
+
+# Production registry (for use by all environments)
+
+gds aws govuk-production-admin -- \
+  terraform init -backend-config production.backend -upgrade
+
+gds aws govuk-production-admin -- \
+  terraform apply -var-file ../variables/production/ecr.tfvars
 ```

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -64,8 +64,8 @@ resource "aws_iam_user" "github_ecr_user" {
   tags = { "Description" = "GitHub Actions publishes images to ECR." }
 }
 
-resource "aws_iam_role" "push_image_to_ecr_role" {
-  name = "push_image_to_ecr_role"
+resource "aws_iam_role" "push_to_ecr" {
+  name = "push_to_ecr"
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -80,7 +80,7 @@ resource "aws_iam_role" "push_image_to_ecr_role" {
   })
 }
 
-data "aws_iam_policy_document" "push_image_to_ecr_policy_document" {
+data "aws_iam_policy_document" "push_to_ecr" {
   statement {
     actions = [
       "ecr:GetAuthorizationToken",
@@ -102,17 +102,17 @@ data "aws_iam_policy_document" "push_image_to_ecr_policy_document" {
   }
 }
 
-resource "aws_iam_policy" "push_image_to_ecr_policy" {
-  name   = "push_image_to_ecr_policy"
-  policy = data.aws_iam_policy_document.push_image_to_ecr_policy_document.json
+resource "aws_iam_policy" "push_to_ecr" {
+  name   = "push_to_ecr"
+  policy = data.aws_iam_policy_document.push_to_ecr.json
 }
 
-resource "aws_iam_role_policy_attachment" "push_to_ecr_role_attachment" {
-  role       = aws_iam_role.push_image_to_ecr_role.name
-  policy_arn = aws_iam_policy.push_image_to_ecr_policy.arn
+resource "aws_iam_role_policy_attachment" "push_to_ecr" {
+  role       = aws_iam_role.push_to_ecr.name
+  policy_arn = aws_iam_policy.push_to_ecr.arn
 }
 
-resource "aws_ecr_repository_policy" "pull_images_from_ecr_policy_policy" {
+resource "aws_ecr_repository_policy" "pull_from_ecr" {
   for_each   = toset([for repo in local.repositories : aws_ecr_repository.repositories[repo].name])
   repository = each.key
   policy = jsonencode({
@@ -132,8 +132,8 @@ resource "aws_ecr_repository_policy" "pull_images_from_ecr_policy_policy" {
   })
 }
 
-resource "aws_iam_role" "pull_images_from_ecr_role" {
-  name = "pull_images_from_ecr_role"
+resource "aws_iam_role" "pull_from_ecr" {
+  name = "pull_from_ecr"
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -148,8 +148,8 @@ resource "aws_iam_role" "pull_images_from_ecr_role" {
   })
 }
 
-resource "aws_iam_policy" "pull_images_from_ecr_policy" {
-  name = "pull_images_from_ecr_policy"
+resource "aws_iam_policy" "pull_from_ecr" {
+  name = "pull_from_ecr"
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -200,7 +200,7 @@ resource "aws_iam_user_policy" "github_ecr_user_policy" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "pull_images_from_ecr_role_attachment" {
-  role       = aws_iam_role.pull_images_from_ecr_role.name
-  policy_arn = aws_iam_policy.pull_images_from_ecr_policy.arn
+resource "aws_iam_role_policy_attachment" "pull_from_ecr" {
+  role       = aws_iam_role.pull_from_ecr.name
+  policy_arn = aws_iam_policy.pull_from_ecr.arn
 }

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -12,6 +12,13 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
+  default_tags {
+    tags = {
+      project              = "replatforming"
+      repository           = "govuk-infrastructure"
+      terraform_deployment = basename(abspath(path.root))
+    }
+  }
 }
 
 # TODO: Get rid of this list and just give CI permission to create repos, e.g.

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -1,12 +1,5 @@
-# This module should be applied in the production account only.
-
 terraform {
-  backend "s3" {
-    bucket  = "govuk-terraform-steppingstone-production"
-    key     = "govuk/ecr.tfstate"
-    region  = "eu-west-1"
-    encrypt = true
-  }
+  backend "s3" {}
 
   required_version = "~> 1.0"
   required_providers {

--- a/terraform/deployments/ecr/production.backend
+++ b/terraform/deployments/ecr/production.backend
@@ -1,0 +1,5 @@
+bucket  = "govuk-terraform-production"
+key     = "projects/ecr.tfstate"
+encrypt = true
+region  = "eu-west-1"
+dynamodb_table = "terraform-lock"

--- a/terraform/deployments/ecr/test.backend
+++ b/terraform/deployments/ecr/test.backend
@@ -1,0 +1,5 @@
+bucket  = "govuk-terraform-test"
+key     = "projects/ecr.tfstate"
+encrypt = true
+region  = "eu-west-1"
+dynamodb_table = "terraform-lock"

--- a/terraform/deployments/ecr/variables.tf
+++ b/terraform/deployments/ecr/variables.tf
@@ -1,9 +1,4 @@
-variable "test_aws_account_id" {
-  type        = string
-  description = "account id for the test environment"
-}
-
-variable "integration_aws_account_id" {
-  type        = string
-  description = "account id for the integration environment"
+variable "puller_arns" {
+  type        = list(string)
+  description = "List of IAM principals who should be authorised to pull from this registry."
 }

--- a/terraform/deployments/variables/common.tfvars
+++ b/terraform/deployments/variables/common.tfvars
@@ -1,12 +1,1 @@
-production_aws_account_id  = "172025368201"
-integration_aws_account_id = "210287912431"
-test_aws_account_id        = "430354129336"
-concourse_aws_account_id   = "047969882937"
-
-registry = "172025368201.dkr.ecr.eu-west-1.amazonaws.com"
-
-# TODO: replace with remote state
-office_cidrs_list    = ["213.86.153.212/32", "213.86.153.213/32", "213.86.153.214/32", "213.86.153.235/32", "213.86.153.236/32", "213.86.153.237/32", "85.133.67.244/32", "213.86.153.211/32", "213.86.153.231/32"]
-concourse_cidrs_list = ["35.178.226.106/32", "18.130.168.3/32"]
-
 argo_workflow_namespaces = ["apps"]

--- a/terraform/deployments/variables/production/ecr.tfvars
+++ b/terraform/deployments/variables/production/ecr.tfvars
@@ -1,0 +1,6 @@
+puller_arns = [
+  "arn:aws:iam::172025368201:root", # Production
+  "arn:aws:iam::696911096973:root", # Staging
+  "arn:aws:iam::210287912431:root", # Integration
+  "arn:aws:iam::430354129336:root", # Test
+]

--- a/terraform/deployments/variables/test/ecr.tfvars
+++ b/terraform/deployments/variables/test/ecr.tfvars
@@ -1,0 +1,4 @@
+puller_arns = [
+  "arn:aws:iam::210287912431:root", # Integration
+  "arn:aws:iam::430354129336:root", # Test
+]


### PR DESCRIPTION
Fix the ability to apply the `ecr` Terraform module in the test account by adding missing backend files. We had added a test ECR config but no backend file for it. This allows us to deploy both of the environments again.

Also a bunch of other cleanup while we're there:

* Use the new S3 bucket for the prod tfstate rather than the legacy one (i.e. govuk-terraform-production, not govuk-terraform-steppingstone-production).
* Instead of declaring and passing a variable for every AWS account that's authorised to pull from the registry, just pass a list of principals. It's simpler, more flexible and easier to understand and maintain.
* Move the vars (actually now just one var) for the ECR module into separate files to make it clear that they're specific to that module. Helps to avoid warnings about unused vars when applying other modules.
* Add the staging account to the puller ACLs for the prod registry, since it was missing.
* Remove the prod account from the puller ACLs for the test registry, since we don't ever want prod or staging to pull from the test registry.
* Add missing backend files for the module. We had added a test ECR config but no backend file for it. This allows us to deploy both of the environments again.
* Add provider default AWS tags for resources created by the module.
* Some style cleanup in ecr/main.tf and add a couple of TODOs.

I wanted to add CNAMEs for the registries to make them more developer-friendly, but unfortunately this can't work because Amazon still doesn't support custom domains on ECR. So we're stuck with ugly, long, opaque URLs in all the image names for the time being.

Tested: applied in the test account, checked that the integration cluster can still pull cross-account from the test ECR.

Rollout: for prod, will need to copy the tfstate to the new location (probably something like: check versioning enabled, apply with old backend config, then apply with new backend config and let TF do the copying, then delete the old file from the old S3 bucket)