### PR TITLE
Fix security group rules for nodes talking to databases.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -8,9 +8,9 @@ output "worker_iam_role_arn" {
   value       = module.eks.worker_iam_role_arn
 }
 
-output "worker_security_group_id" {
-  description = "ID of the security group which contains the worker nodes."
-  value       = module.eks.worker_security_group_id
+output "cluster_security_group_id" {
+  description = "ID of the security group which contains the kube-apiservers and managed worker nodes."
+  value       = module.eks.cluster_security_group_id
 }
 
 output "cluster_autoscaler_service_account_name" {

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -25,13 +25,14 @@ resource "aws_security_group_rule" "shared_redis_cluster_to_any_any" {
 }
 
 resource "aws_security_group_rule" "shared_redis_cluster_from_any" {
-  description              = "Shared Redis cluster for EKS accepts requests from EKS nodes"
-  type                     = "ingress"
-  from_port                = 6379
-  to_port                  = 6379
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.shared_redis_cluster.id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.worker_security_group_id
+  description       = "Shared Redis cluster for EKS accepts requests from EKS nodes"
+  type              = "ingress"
+  from_port         = 6379
+  to_port           = 6379
+  protocol          = "tcp"
+  security_group_id = aws_security_group.shared_redis_cluster.id
+  # EKS creates *managed* nodes in the *cluster* SG, not the worker node SG. Go figure.
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }
 
 #
@@ -55,7 +56,7 @@ resource "aws_security_group_rule" "frontend_memcached_from_eks_workers" {
   to_port                  = 11211
   protocol                 = "tcp"
   security_group_id        = aws_security_group.frontend_memcached.id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.worker_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }
 
 #
@@ -69,7 +70,7 @@ resource "aws_security_group_rule" "mongodb_from_eks_workers" {
   to_port                  = 27017
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_mongo_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.worker_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }
 
 resource "aws_security_group_rule" "router_mongodb_from_eks_workers" {
@@ -79,5 +80,5 @@ resource "aws_security_group_rule" "router_mongodb_from_eks_workers" {
   to_port                  = 27017
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_router-backend_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.worker_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }


### PR DESCRIPTION
EKS creates *managed* nodes in the *cluster* SG, not the worker node SG 🙃

Amazon's docs leave much to be desired on this topic, but there are some explanations buried in the UI:

> The Cluster Security Group is a unified security group that is used to
> control communications between the Kubernetes control plane and compute
> resources on the cluster. The cluster security group is applied by
> default to the Kubernetes control plane managed by Amazon EKS **as well as
> any managed compute resources created through the Amazon EKS API**.
>
> Additional cluster security groups control communications from the
> Kubernetes control plane to compute resources in your account. Worker
> node security groups are security groups applied to unmanaged worker
> nodes that control communications from worker nodes to the Kubernetes
> control plane.

Kudos to @bilbof for spotting my mistake and finding the elusive documentation!