### PR TITLE
Add Reusable ECR Github Workflow

### DIFF
--- a/.github/workflows/reusable-ecr.yaml
+++ b/.github/workflows/reusable-ecr.yaml
@@ -1,0 +1,42 @@
+name: Reusable workflow to build and publish to ECR
+
+on:
+  workflow_call:
+    secrets:
+      AWS_GOVUK_ECR_ACCESS_KEY_ID:
+        required: true
+      AWS_GOVUK_ECR_SECRET_ACCESS_KEY:
+        required: true
+
+jobs:
+  publish:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          # TODO: Remove long-lived keys and switch to OIDC once https://github.com/github/roadmap/issues/249 lands.
+          aws-access-key-id: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ github.event.repository.name }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          # Build a docker container and push it to ECR
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          echo "Pushing image to ECR..."
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"


### PR DESCRIPTION
A reusable Github Workflow is added to handle the build of docker images
for GOV.UK apps.

Ref:
1. [trello card](https://trello.com/c/1jjfu91I/770-improve-dockerfile-authenticating-proxy)
2. [github docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows)