### PR TITLE
Change Argo Workflow default config

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -101,6 +101,17 @@ resource "helm_release" "argo_workflows" {
   values = [yamlencode({
     controller = {
       workflowNamespaces = concat([local.services_ns], var.argo_workflow_namespaces)
+      workflowDefaults = {
+        spec = {
+          activeDeadlineSeconds = 7200
+          ttlStrategy = {
+            secondsAfterSuccess = 432000
+          }
+          podGC = {
+            strategy = "OnPodCompletion"
+          }
+        }
+      }
     }
 
     workflow = {


### PR DESCRIPTION
We need to change the default Argo Workflow TTL so
that resources are not wasted storing Argo workflow
artifacts "indefinitely".

Ref:
1. [trello card](https://trello.com/c/N9ER3ukt/755-cleanup-completed-jobs)
2. [argo workflow docs](https://argoproj.github.io/argo-workflows/default-workflow-specs/#setting-default-workflow-values)