### PR TITLE
Add Powerusers as new category of k8s users

### DIFF
--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -22,3 +22,8 @@ variable "dex_github_orgs_teams" {
   type        = list(object({ name = string, teams = list(string) }))
   description = "List of GitHub orgs and associated teams that Dex authorises. Format [{name='github_org', teams=['github_team_name']}] "
 }
+
+variable "powerusers_namespaces" {
+  type        = list(string)
+  description = "List of namespaces where powerusers have admin access"
+}

--- a/terraform/deployments/variables/common.tfvars
+++ b/terraform/deployments/variables/common.tfvars
@@ -1,2 +1,3 @@
 argo_workflows_namespaces = ["apps"]
 dex_github_orgs_teams     = [{ name = "alphagov", teams = ["gov-uk-production"] }]
+powerusers_namespaces     = ["apps"]


### PR DESCRIPTION
A new category of K8s users `powerusers` are added to the GOV.UK
cluster. These users will have admin access to a restricted
number of namespaces, `apps` namespace initially where GOV.UK
apps are deployed. In addition, the users will have read-access
at a cluster level.

A cluster role is used as it is possible to bind it to a set of roles
in different namespaces rather than a single namespace.

Tested by running:
1. `gds aws govuk-integration-poweruser -- kubectl -n apps delete deployment signon` (works - pass)
2. `gds aws govuk-integration-poweruser -- kubectl get all -n apps` (works - pass)
3. `gds aws govuk-integration-poweruser -- kubectl -n cluster-services get all` (works - pass)
4. `gds aws govuk-integration-poweruser -- kubectl -n cluster-services delete deployment.apps/sync-notification-sensor-lvmm5` (unathorised - pass)

Ref:
1. [trello card](https://trello.com/c/IM6wt4Vj/718-create-basic-rbac-structure)
2. [k8s docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-example)