### PR TITLE
Use Workflows rather than workflow for Argo Workflows

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -1,7 +1,7 @@
 # Installs and configures ArgoCD for deploying GOV.UK apps
 locals {
   argo_host          = "argo.${local.external_dns_zone_name}"
-  argo_workflow_host = "argo-workflow.${local.external_dns_zone_name}"
+  argo_workflow_host = "argo-workflows.${local.external_dns_zone_name}"
 }
 
 resource "helm_release" "argo_cd" {


### PR DESCRIPTION
The official name is Argo Workflows (plural) and to keep
consistency, we put the plural name in the url of Argo
Workflows

1. [original pr](govuk-infrastructue pr)