### PR TITLE
Dex

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -5,6 +5,8 @@ locals {
 }
 
 resource "helm_release" "argo_cd" {
+  # Dex is used to provide SSO facility to ArgoCD
+  depends_on = [helm_release.dex]
   chart      = "argo-cd"
   name       = "argo-cd"
   namespace  = local.services_ns
@@ -98,6 +100,8 @@ resource "helm_release" "argo_notifications" {
 }
 
 resource "helm_release" "argo_workflows" {
+  # Dex is used to provide SSO facility to ArgoCD
+  depends_on = [helm_release.dex]
   chart      = "argo-workflows"
   name       = "argo-workflows"
   namespace  = local.services_ns
@@ -126,7 +130,7 @@ resource "helm_release" "argo_workflows" {
     }
 
     server = {
-      vextraArgs = ["--auth-mode=client"]
+      extraArgs = ["--auth-mode=client", "--auth-mode=sso"]
       ingress = {
         enabled = true
         annotations = {
@@ -140,6 +144,19 @@ resource "helm_release" "argo_workflows" {
         ingressClassName = "aws-alb"
         hosts            = [local.argo_workflows_host]
       }
+      sso = {
+        issuer = "https://${local.dex_host}"
+        clientId = {
+          name = "govuk-dex-argo-workflows"
+          key  = "ARGO_WORKFLOWS_CLIENT_ID"
+        }
+        clientSecret = {
+          name = "govuk-dex-argo-workflows"
+          key  = "ARGO_WORKFLOWS_CLIENT_SECRET"
+        }
+        redirectUrl = "https://${local.argo_workflows_host}/oauth2/callback"
+      }
+
     }
   })]
 }

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -53,6 +53,10 @@ resource "helm_release" "argo_cd" {
         https            = true
       }
     }
+
+    dex = {
+      enabled = false
+    }
   })]
 }
 

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -1,0 +1,126 @@
+# Installs and configures Dex, a federated OpenID Connect provider
+
+locals {
+  dex_host = "dex.${local.external_dns_zone_name}"
+}
+
+resource "helm_release" "dex" {
+  chart      = "dex"
+  name       = "dex"
+  namespace  = local.services_ns
+  repository = "https://charts.dexidp.io"
+  version    = "0.6.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  values = [yamlencode({
+    config = {
+      issuer = "https://${local.dex_host}"
+
+      storage = {
+        type = "kubernetes"
+        config = {
+          inCluster = true
+        }
+      }
+
+      connectors = [
+        {
+          type = "github"
+          id   = "github"
+          name = "GitHub"
+          config = {
+            clientID      = "$GITHUB_CLIENT_ID"
+            clientSecret  = "$GITHUB_CLIENT_SECRET"
+            redirectURI   = "https://${local.dex_host}/callback"
+            orgs          = var.dex_github_orgs_teams
+            teamNameField = "both"
+            useLoginAsID  = true
+          }
+        }
+      ]
+
+      # staticClients uses a different method for expansion of environment
+      # variables, see [bug](https://github.com/gabibbo97/charts/issues/36#issuecomment-736911424)
+      staticClients = [
+        {
+          name         = "argo-workflows"
+          idEnv        = "ARGO_WORKFLOWS_CLIENT_ID"
+          secretEnv    = "ARGO_WORKFLOWS_CLIENT_SECRET"
+          redirectURIs = ["https://${local.argo_workflows_host}/oauth2/callback"]
+        }
+      ]
+    }
+
+    envVars = [
+      {
+        name = "GITHUB_CLIENT_ID"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-github"
+            key  = "GITHUB_CLIENT_ID"
+          }
+        }
+      },
+      {
+        name = "GITHUB_CLIENT_SECRET"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-github"
+            key  = "GITHUB_CLIENT_SECRET"
+          }
+        }
+      },
+      {
+        name = "ARGO_WORKFLOWS_CLIENT_ID"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-argo-workflows"
+            key  = "ARGO_WORKFLOWS_CLIENT_ID"
+          }
+        }
+      },
+      {
+        name = "ARGO_WORKFLOWS_CLIENT_SECRET"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-argo-workflows"
+            key  = "ARGO_WORKFLOWS_CLIENT_SECRET"
+          }
+        }
+      }
+    ]
+
+    service = {
+      ports = {
+        http = {
+          port = 80
+        }
+        https = {
+          port = 443
+        }
+      }
+    }
+
+    ingress = {
+      enabled = true
+      annotations = {
+        "alb.ingress.kubernetes.io/group.name"         = "dex"
+        "alb.ingress.kubernetes.io/scheme"             = "internet-facing"
+        "alb.ingress.kubernetes.io/target-type"        = "ip"
+        "alb.ingress.kubernetes.io/load-balancer-name" = "dex"
+        "alb.ingress.kubernetes.io/listen-ports"       = jsonencode([{ "HTTP" : 80 }, { "HTTPS" : 443 }])
+        "alb.ingress.kubernetes.io/ssl-redirect"       = "443"
+      }
+      className = "aws-alb"
+      hosts = [
+        {
+          host = local.dex_host
+          paths = [
+            {
+              path     = "/*"
+              pathType = "ImplementationSpecific"
+            }
+          ]
+        }
+      ]
+    }
+  })]
+}

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -17,3 +17,8 @@ variable "govuk_environment" {
   type        = string
   description = "Acceptable values are test, integration, staging, production"
 }
+
+variable "dex_github_orgs_teams" {
+  type        = list(object({ name = string, teams = list(string) }))
+  description = "List of GitHub orgs and associated teams that Dex authorises. Format [{name='github_org', teams=['github_team_name']}] "
+}

--- a/terraform/deployments/variables/common.tfvars
+++ b/terraform/deployments/variables/common.tfvars
@@ -1,1 +1,2 @@
 argo_workflows_namespaces = ["apps"]
+dex_github_orgs_teams     = [{ name = "alphagov", teams = ["gov-uk-production"] }]

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -29,3 +29,5 @@ external_dns_subdomain    = "eks"
 
 frontend_memcached_node_type   = "cache.t4g.micro"
 shared_redis_cluster_node_type = "cache.t4g.small"
+
+dex_github_orgs_teams = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -30,3 +30,5 @@ external_dns_subdomain    = "eks"
 
 frontend_memcached_node_type   = "cache.t4g.micro"
 shared_redis_cluster_node_type = "cache.t4g.small"
+
+dex_github_orgs_teams = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]


### PR DESCRIPTION
# commit 62da66befe9727207881d2079930a96c6df17e86 :

Remove Dex from ArgoCD installation
Dex is installed from ArgoCD installation but we want Dex to be
installed and managed in a stand-alone fashion since Dex will be
used as an Identity Provider abstractor for multiple apps in the
GOV.UK cluster.

Ref:
1. [trello card](https://trello.com/c/Snqwc4Ac/784-deploy-dex-idp-and-configure-github-backend)
2. [argocd helm values file](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml)

# commit 5f27521380cfdbf0904b12ddd7755d313c0de7a6 :

Add Dex and test with Argo Workflows

Add Dex via its [own helm chart](https://github.com/dexidp/helm-charts).

Dex is configured to work only with GitHub for now as backing/
connector identity provider but others can be added later.

Argo-workflows was configured to use Dex for Single Sign-on (SSO)

It was tested in [integration](https://argo-workflows.eks.integration.govuk.digital/):
1. a user in `alphagov` and either `gov-uk` or `gov-uk-production` team
   can access Argo-workflows
2. a user not in `alphagov` cannot access Argo-workflows
3. a user in `alphagov` and not in gov-uk or `gov-uk-production`
   can access Argo-workflows

Current access
1. `test` and `integration` envs: `alphagov` and either `gov-uk` or `gov-uk-production` team membership
2. all other envs: `alphagov` and either `gov-uk-production` team membership

Future work:
1. add SSO to a number of other apps

Note that the mapping of a user to a service account with a set of
privileges is beyond the scope of this card. E.g. [SSO RBAC for Argo-Workflows](https://argoproj.github.io/argo-workflows/argo-server-sso/#sso-rbac).

Ref:
1. [trello card](https://trello.com/c/Snqwc4Ac/784-deploy-dex-idp-and-configure-github-backend)