### PR TITLE
Add SSO to ArgoCD

### DIFF
--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -45,6 +45,12 @@ resource "helm_release" "dex" {
           idEnv        = "ARGO_WORKFLOWS_CLIENT_ID"
           secretEnv    = "ARGO_WORKFLOWS_CLIENT_SECRET"
           redirectURIs = ["https://${local.argo_workflows_host}/oauth2/callback"]
+        },
+        {
+          name         = "argocd"
+          idEnv        = "ARGOCD_CLIENT_ID"
+          secretEnv    = "ARGOCD_CLIENT_SECRET"
+          redirectURIs = ["https://${local.argo_host}/auth/callback"]
         }
       ]
     }
@@ -83,6 +89,24 @@ resource "helm_release" "dex" {
           secretKeyRef = {
             name = "govuk-dex-argo-workflows"
             key  = "ARGO_WORKFLOWS_CLIENT_SECRET"
+          }
+        }
+      },
+      {
+        name = "ARGOCD_CLIENT_ID"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-argocd"
+            key  = "ARGOCD_CLIENT_ID"
+          }
+        }
+      },
+      {
+        name = "ARGOCD_CLIENT_SECRET"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-argocd"
+            key  = "ARGOCD_CLIENT_SECRET"
           }
         }
       }


### PR DESCRIPTION
Following the deployment of Dex (#524), ArgoCD is configured to use
Dex as SSO provider.

Ref:
1. [trello card](https://trello.com/c/Snqwc4Ac/784-deploy-dex-idp-and-configure-github-backend)
2. [secrets pr](https://github.com/alphagov/govuk-helm-charts/pull/71)