### PR TITLE
Manage GitHub resources with Terraform

### DIFF
--- a/terraform/deployments/github/README.md
+++ b/terraform/deployments/github/README.md
@@ -1,0 +1,44 @@
+# GOV.UK GitHub Infrastructure configuration
+
+> **Note**: Currently this module can only be applied by an alphagov GitHub
+Organisation Admin.
+
+This module configures GitHub resources (currently just GitHub Action Organisation
+Secret Repositories) so that the platform can automatically give permissions to
+repositories with specific tags.
+
+We anticipate that teams will add GitHub tags to their repositories (similar to
+annotations on Kubernetes resources) to enable platform functionality.
+For instance creating an ECR registry and giving permissions to push to the
+registry might be enabled with the repo tag `dockerised`.
+
+This module provides similar functionality to the [govuk-saas-config]
+repository, which configures repositories with sensible defaults such as
+protecting the `main` branch and ensuring the repository is compatible with
+our old EC2-based platform (such as checking Jenkins config).
+This is noted as [tech debt] and we should migrate govuk-saas-config to this
+repository.
+
+Our intent is to replace govuk-saas-config with Terraform configuration.
+
+[govuk-saas-config]: https://github.com/alphagov/govuk-saas-config/tree/master/github/lib
+[tech debt]: https://trello.com/c/mojlsebq/226-we-have-two-tools-for-managing-github-resources
+
+## Applying Terraform
+
+1. Generate access token
+  1. Go to https://github.com/settings/tokens/new
+  2. Create a new token with permissions `admin:org` and `public_repo`
+2. Configure Terraform
+  ```shell
+  gds aws govuk-production-poweruser -- \
+    terraform init -backend-config production.backend -upgrade
+  ```
+3. Plan Terraform
+  ```shell
+  GITHUB_TOKEN=<token> gds aws govuk-production-poweruser -- terraform plan
+  ```
+4. Apply Terraform
+  ```shell
+  GITHUB_TOKEN=<token> gds aws govuk-production-poweruser -- terraform apply
+  ```

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  backend "s3" {}
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# NOTE: Uses GITHUB_TOKEN env var, an OAuth / Personal Access Token, for auth
+provider "github" {
+  owner = "alphagov"
+}
+
+#
+# Gives repositories access to push OCI images to GOV.UK Production AWS ECR
+# NOTE: AWS_GOVUK_ECR_ACCESS_KEY_ID and AWS_GOVUK_ECR_SECRET_ACCESS_KEY are
+# manually created.
+#
+
+data "github_repositories" "govuk" {
+  query = "topic:govuk org:alphagov fork:false archived:false"
+}
+
+data "github_repository" "govuk" {
+  for_each  = toset(data.github_repositories.govuk.full_names)
+  full_name = each.key
+}
+
+resource "github_actions_organization_secret_repositories" "aws_govuk_ecr_access_key_id" {
+  secret_name             = "AWS_GOVUK_ECR_ACCESS_KEY_ID"
+  selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
+}
+
+resource "github_actions_organization_secret_repositories" "aws_govuk_ecr_secret_access_key" {
+  secret_name             = "AWS_GOVUK_ECR_SECRET_ACCESS_KEY"
+  selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
+}

--- a/terraform/deployments/github/production.backend
+++ b/terraform/deployments/github/production.backend
@@ -1,0 +1,5 @@
+bucket  = "govuk-terraform-production"
+key     = "projects/github.tfstate"
+encrypt = true
+region  = "eu-west-1"
+dynamodb_table = "terraform-lock"


### PR DESCRIPTION
This adds a new GitHub deployment which enables us to manage GitHub resources with Terraform.

Currently it simply permits alphagov repositories with the tag 'govuk' to push images to ECR, by providing access to credentials.

There are various additional features we can add to simplify and automate the configuration of new repositories and deploying new applications to the Kubernetes cluster. This should tie in nicely with the ECR module, though that module could also use the github provider to fetch the repositories to create ECR registries, which would mean we don't need to manually add to a list of applications in the module when we add a new app.

One downside is that folks that use this module need to have org-level permissions. Ideally this deployment would be run by an automated process that sits in-cluster and watches GitHub for tag changes.