### PR TITLE
Add reusable GitHub workflow for ECR build and push

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -1,0 +1,62 @@
+# USAGE
+# -----
+#
+# on:
+#   workflow_dispatch:
+#     branches:
+#       - main
+#   push:
+#     branches:
+#       - main
+#     paths-ignore:
+#       - "Jenkinsfile"
+#       - ".git**"
+#
+# jobs:
+#   build-publish-image-to-ecr:
+#     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml
+
+
+# REUSABLE WORKFLOW
+# -----------------
+name: Build and publish to ECR
+
+on:
+  workflow_call:
+    types: [requested]
+    branches:
+      - 'main'
+      - 'master'
+
+jobs:
+  publish:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          # TODO: Remove long-lived keys and switch to OIDC once https://github.com/github/roadmap/issues/249 lands.
+          aws-access-key-id: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ github.event.repository.name }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          # Build a docker container and push it to ECR
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          echo "Pushing image to ECR..."
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY -a
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"


### PR DESCRIPTION
We had duplicated this config to every repository, making it hard to update the workflow quickly.

This moves the config to a single reusable workflow as in
https://docs.github.com/en/actions/using-workflows/reusing-workflows.

This is not a starter workflow, as you might find in alphagov/.github/.github/workflows.