### PR TITLE
Fixup reusable workflow

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -14,7 +14,10 @@
 #
 # jobs:
 #   build-publish-image-to-ecr:
-#     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml
+#     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
+#     secrets:
+#       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+#       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
 
 
 # REUSABLE WORKFLOW

--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -26,10 +26,11 @@ name: Build and publish to ECR
 
 on:
   workflow_call:
-    types: [requested]
-    branches:
-      - 'main'
-      - 'master'
+    secrets:
+      AWS_GOVUK_ECR_ACCESS_KEY_ID:
+        required: true
+      AWS_GOVUK_ECR_SECRET_ACCESS_KEY:
+        required: true
 
 jobs:
   publish:


### PR DESCRIPTION
Two fixes:

- updated usage example
- add secrets input (and remove invalid `types` and `branches` keys)