### PR TITLE
Update External Secrets Operator to latest version.

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -7,7 +7,7 @@ resource "helm_release" "external_secrets" {
   name             = "external-secrets"
   repository       = "https://charts.external-secrets.io"
   chart            = "external-secrets"
-  version          = "0.3.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.4.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({


### PR DESCRIPTION
There are important bug fixes, specifically https://github.com/external-secrets/external-secrets/ 510 and 545 (intentionally not linking directly to avoid GitHub reference spam).