### PR TITLE
Add Single Sign On to Grafana

### DIFF
--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -51,6 +51,12 @@ resource "helm_release" "dex" {
           idEnv        = "ARGOCD_CLIENT_ID"
           secretEnv    = "ARGOCD_CLIENT_SECRET"
           redirectURIs = ["https://${local.argo_host}/auth/callback"]
+        },
+        {
+          name         = "grafana"
+          idEnv        = "GRAFANA_CLIENT_ID"
+          secretEnv    = "GRAFANA_CLIENT_SECRET"
+          redirectURIs = ["https://${local.grafana_host}/login/generic_oauth"]
         }
       ]
     }
@@ -107,6 +113,24 @@ resource "helm_release" "dex" {
           secretKeyRef = {
             name = "govuk-dex-argocd"
             key  = "ARGOCD_CLIENT_SECRET"
+          }
+        }
+      },
+      {
+        name = "GRAFANA_CLIENT_ID"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-grafana"
+            key  = "GRAFANA_CLIENT_ID"
+          }
+        }
+      },
+      {
+        name = "GRAFANA_CLIENT_SECRET"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-grafana"
+            key  = "GRAFANA_CLIENT_SECRET"
           }
         }
       }


### PR DESCRIPTION
Add Dex, a federated OpenID Connect provider, Single Sign On to Grafana.
Currently all Dex authenticated users are admin to Grafana but
Dex allows only GitHub alphagov/gov-uk and alphagov/gov-uk-production
into the platform depending on environment.

Tested in integration: https://grafana.eks.integration.govuk.digital/

Ref:
1. [trello card](https://trello.com/c/Snqwc4Ac/784-deploy-dex-idp-and-configure-github-backend)