### PR TITLE
Use OnWorkflowSuccess PodGC strategy

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -128,7 +128,7 @@ resource "helm_release" "argo_workflows" {
             secondsAfterSuccess = 432000
           }
           podGC = {
-            strategy = "OnPodCompletion"
+            strategy = "OnWorkflowSuccess"
           }
         }
       }


### PR DESCRIPTION
We want pods to stick around until the ttlStrategy.secondsAfterSuccess.
OnPodCompletion deletes the pod immediately which isn't desirable as
it makes it harder to debug failing workflows.