### PR TITLE
Create AWS ECR repositories for all GOV.UK git repositories

### DIFF
--- a/terraform/deployments/ecr/README.md
+++ b/terraform/deployments/ecr/README.md
@@ -12,13 +12,21 @@ testing changes to the configuration of ECR itself or changes to this Terraform
 module, for example IAM permissions changes or nontrivial changes to repository
 settings.
 
+You can manually add an ECR registry, but if you're using an alphagov-owned
+GitHub repository (e.g. alphagov/whitehall) a registry will be created for
+the repository automatically.
+
 ## Applying Terraform
 
 Please only deploy this module in the `test` and `production` accounts, not
 integration or staging.
 
+You must generate a GITHUB_TOKEN with the `repo` permission to use this module.
+
 ```shell
 # Test registry (for testing this module or changes to the registry config)
+
+GITHUB_TOKEN=<generate-personal-access-token>
 
 gds aws govuk-test-admin -- \
   terraform init -backend-config test.backend -reconfigure -upgrade


### PR DESCRIPTION
This uses the GitHub API to create an ECR repository for each GitHub repository with the corresponding tags.