### PR TITLE
Argo fix

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -11,6 +11,13 @@ resource "helm_release" "argo_cd" {
   repository = "https://argoproj.github.io/argo-helm"
   version    = "3.32.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
+    global = {
+      image = { # TODO: remove this section when v2.3.0 is released and includes fix: https://github.com/argoproj/argo-cd/pull/8350
+        repository = "quay.io/argoproj/argocd"
+        tag        = "v2.3.0-rc5"
+      }
+    }
+
     server = {
       # TLS Termination happens at the ALB, the insecure flag prevents Argo
       # server from upgrading the request after TLS termination.


### PR DESCRIPTION
ArgoCD has a bug when ArgoCD does not reload the OIDC config if its
underlying secrets are changed. This was fixed upstream in this
[PR](https://github.com/argoproj/argo-cd/pull/8350) and is now
included in the release candidate v2.3.0-rc5.

The reason why we want this fix is that when a new cluster is
created, the OIDC secrets are only pulled from AWS secret manager
after ArgoCD installs the `cluster-secrets` Helm chart. So ArgoCD
needs to reload its config to take in the new interpolated OIDC
config.

We need to wait for the fix to reach a mainstream release, i.e.
v2.3.0 and the helm chart of Argo to default use this image or
higher in order to remove this chart here.