### PR TITLE
Limit number of repos with ECR push authorisation

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -21,7 +21,7 @@ provider "github" {
 #
 
 data "github_repositories" "govuk" {
-  query = "topic:govuk org:alphagov fork:false archived:false"
+  query = "topic:govuk topic:container org:alphagov fork:false archived:false"
 }
 
 data "github_repository" "govuk" {


### PR DESCRIPTION
We tagged the app GitHub repos which we'll deploy to k8s with
'container'.