### PR TITLE
Add OAUTH for Prometheus and Alert Manager

### DIFF
--- a/docs/prerequisite-secrets.md
+++ b/docs/prerequisite-secrets.md
@@ -52,7 +52,7 @@ The format of secret is given below to aid creation from scratch:
    }
    ```
 
- 3. `govuk/dex/grafana`: shared OAUTH secret between Dex and Grafana.
+3. `govuk/dex/grafana`: shared OAUTH secret between Dex and Grafana.
 
     ```
     {
@@ -60,3 +60,12 @@ The format of secret is given below to aid creation from scratch:
       GRAFANA_CLIENT_SECRET: <secret_2>
     }
     ```
+
+4. `govuk/dex/alert-manager`: shared OAUTH secret between Dex and Alert Manager.
+
+   ```
+   {
+     clientID: <secret_1>,
+     clientSecret: <secret_2>
+   }
+   ```

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -57,6 +57,18 @@ resource "helm_release" "dex" {
           idEnv        = "GRAFANA_CLIENT_ID"
           secretEnv    = "GRAFANA_CLIENT_SECRET"
           redirectURIs = ["https://${local.grafana_host}/login/generic_oauth"]
+        },
+        {
+          name         = "prometheus"
+          idEnv        = "PROMETHEUS_CLIENT_ID"
+          secretEnv    = "PROMETHEUS_CLIENT_SECRET"
+          redirectURIs = ["https://${local.prometheus_host}/oauth2/idpresponse"]
+        },
+        {
+          name         = "alert-manager"
+          idEnv        = "ALERT_MANAGER_CLIENT_ID"
+          secretEnv    = "ALERT_MANAGER_CLIENT_SECRET"
+          redirectURIs = ["https://${local.alert_manager_host}/oauth2/idpresponse"]
         }
       ]
     }
@@ -131,6 +143,42 @@ resource "helm_release" "dex" {
           secretKeyRef = {
             name = "govuk-dex-grafana"
             key  = "GRAFANA_CLIENT_SECRET"
+          }
+        }
+      },
+      {
+        name = "PROMETHEUS_CLIENT_ID"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-prometheus"
+            key  = "clientID"
+          }
+        }
+      },
+      {
+        name = "PROMETHEUS_CLIENT_SECRET"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-prometheus"
+            key  = "clientSecret"
+          }
+        }
+      },
+      {
+        name = "ALERT_MANAGER_CLIENT_ID"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-alert-manager"
+            key  = "clientID"
+          }
+        }
+      },
+      {
+        name = "ALERT_MANAGER_CLIENT_SECRET"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-alert-manager"
+            key  = "clientSecret"
           }
         }
       }

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -22,6 +22,16 @@ resource "helm_release" "kube_prometheus_stack" {
         pathType = "Prefix"
         annotations = merge(local.alb_ingress_annotations, {
           "alb.ingress.kubernetes.io/load-balancer-name" = "alertmanager"
+          "alb.ingress.kubernetes.io/auth-type"          = "oidc"
+          "alb.ingress.kubernetes.io/auth-idp-oidc" = jsonencode(
+            { issuer                = "https://${local.dex_host}"
+              authorizationEndpoint = "https://${local.dex_host}/auth"
+              tokenEndpoint         = "https://${local.dex_host}/token"
+              userInfoEndpoint      = "https://${local.dex_host}/userinfo"
+              secretName            = "govuk-dex-alert-manager"
+          })
+          "alb.ingress.kubernetes.io/auth-on-unauthenticated-request" = "authenticate"
+          "alb.ingress.kubernetes.io/auth-scope"                      = "email openid"
         })
       }
     }
@@ -72,6 +82,16 @@ resource "helm_release" "kube_prometheus_stack" {
         pathType = "Prefix"
         annotations = merge(local.alb_ingress_annotations, {
           "alb.ingress.kubernetes.io/load-balancer-name" = "prometheus"
+          "alb.ingress.kubernetes.io/auth-type"          = "oidc"
+          "alb.ingress.kubernetes.io/auth-idp-oidc" = jsonencode(
+            { issuer                = "https://${local.dex_host}"
+              authorizationEndpoint = "https://${local.dex_host}/auth"
+              tokenEndpoint         = "https://${local.dex_host}/token"
+              userInfoEndpoint      = "https://${local.dex_host}/userinfo"
+              secretName            = "govuk-dex-prometheus"
+          })
+          "alb.ingress.kubernetes.io/auth-on-unauthenticated-request" = "authenticate"
+          "alb.ingress.kubernetes.io/auth-scope"                      = "email openid"
         })
       }
       # Match all PrometheusRules cluster-wide. (If an app/team needs a separate


### PR DESCRIPTION
Add OAUTH secret that the ingress of Prometheus and Alert-Manager
will use to control access to these 2 apps which do not support
in-built authentication.

Test:
1. https://prometheus.eks.integration.govuk.digital/
2. https://alertmanager.eks.integration.govuk.digital/

Ref:
1. [trello card](https://trello.com/c/XiOPhFt5/813-add-oidc-auth-to-prometheus-alertmanager-loadbalancers)

Co-authored-by: Bill Franklin <william.franklin@digital.cabinet-office.gov.uk>