### PR TITLE
Chore: reformat oauth secrets

### DIFF
--- a/docs/prerequisite-secrets.md
+++ b/docs/prerequisite-secrets.md
@@ -27,8 +27,8 @@ The format of secret is given below to aid creation from scratch:
 
    ```
    {
-     GITHUB_CLIENT_ID: <secret_1>,
-     GITHUB_CLIENT_SECRET: <secret_2>
+     clientID: <secret_1>,
+     clientSecret: <secret_2>
    }
    ```
 
@@ -38,8 +38,8 @@ The format of secret is given below to aid creation from scratch:
 
    ```
    {
-     ARGOCD_CLIENT_ID: <secret_1>,
-     ARGOCD_CLIENT_SECRET: <secret_2>
+     clientID: <secret_1>,
+     clientSecret: <secret_2>
    }
    ```
 
@@ -47,8 +47,8 @@ The format of secret is given below to aid creation from scratch:
 
    ```
    {
-     ARGO_WORKFLOWS_CLIENT_ID: <secret_1>,
-     ARGO_WORKFLOWS_CLIENT_SECRET: <secret_2>
+     clientID: <secret_1>,
+     clientSecret: <secret_2>
    }
    ```
 
@@ -56,8 +56,8 @@ The format of secret is given below to aid creation from scratch:
 
     ```
     {
-      GRAFANA_CLIENT_ID: <secret_1>,
-      GRAFANA_CLIENT_SECRET: <secret_2>
+      clientID: <secret_1>,
+      clientSecret: <secret_2>
     }
     ```
 

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -45,13 +45,13 @@ resource "helm_release" "argo_cd" {
         "oidc.config" = yamlencode({
           name         = "GitHub"
           issuer       = "https://${local.dex_host}"
-          clientID     = "$govuk-dex-argocd:ARGOCD_CLIENT_ID"
-          clientSecret = "$govuk-dex-argocd:ARGOCD_CLIENT_SECRET"
+          clientID     = "$govuk-dex-argocd:clientID"
+          clientSecret = "$govuk-dex-argocd:clientSecret"
         })
       }
 
       rbacConfig = {
-        # All log in users are admin
+        # TODO: all logged in users are admin, maybe we want differentiation
         "policy.default" = "role:admin"
       }
 
@@ -166,13 +166,14 @@ resource "helm_release" "argo_workflows" {
         issuer = "https://${local.dex_host}"
         clientId = {
           name = "govuk-dex-argo-workflows"
-          key  = "ARGO_WORKFLOWS_CLIENT_ID"
+          key  = "clientID"
         }
         clientSecret = {
           name = "govuk-dex-argo-workflows"
-          key  = "ARGO_WORKFLOWS_CLIENT_SECRET"
+          key  = "clientSecret"
         }
         redirectUrl = "https://${local.argo_workflows_host}/oauth2/callback"
+        # TODO: all logged in users are admin, maybe we want differentiation
       }
 
     }

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -79,7 +79,7 @@ resource "helm_release" "dex" {
         valueFrom = {
           secretKeyRef = {
             name = "govuk-dex-github"
-            key  = "GITHUB_CLIENT_ID"
+            key  = "clientID"
           }
         }
       },
@@ -88,7 +88,7 @@ resource "helm_release" "dex" {
         valueFrom = {
           secretKeyRef = {
             name = "govuk-dex-github"
-            key  = "GITHUB_CLIENT_SECRET"
+            key  = "clientSecret"
           }
         }
       },
@@ -97,7 +97,7 @@ resource "helm_release" "dex" {
         valueFrom = {
           secretKeyRef = {
             name = "govuk-dex-argo-workflows"
-            key  = "ARGO_WORKFLOWS_CLIENT_ID"
+            key  = "clientID"
           }
         }
       },
@@ -106,7 +106,7 @@ resource "helm_release" "dex" {
         valueFrom = {
           secretKeyRef = {
             name = "govuk-dex-argo-workflows"
-            key  = "ARGO_WORKFLOWS_CLIENT_SECRET"
+            key  = "clientSecret"
           }
         }
       },
@@ -115,7 +115,7 @@ resource "helm_release" "dex" {
         valueFrom = {
           secretKeyRef = {
             name = "govuk-dex-argocd"
-            key  = "ARGOCD_CLIENT_ID"
+            key  = "clientID"
           }
         }
       },
@@ -124,7 +124,7 @@ resource "helm_release" "dex" {
         valueFrom = {
           secretKeyRef = {
             name = "govuk-dex-argocd"
-            key  = "ARGOCD_CLIENT_SECRET"
+            key  = "clientSecret"
           }
         }
       },
@@ -133,7 +133,7 @@ resource "helm_release" "dex" {
         valueFrom = {
           secretKeyRef = {
             name = "govuk-dex-grafana"
-            key  = "GRAFANA_CLIENT_ID"
+            key  = "clientID"
           }
         }
       },
@@ -142,7 +142,7 @@ resource "helm_release" "dex" {
         valueFrom = {
           secretKeyRef = {
             name = "govuk-dex-grafana"
-            key  = "GRAFANA_CLIENT_SECRET"
+            key  = "clientSecret"
           }
         }
       },

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -64,13 +64,13 @@ resource "helm_release" "kube_prometheus_stack" {
         "GF_AUTH_GENERIC_OAUTH_CLIENT_ID" = {
           secretKeyRef = {
             name = "govuk-dex-grafana"
-            key  = "GRAFANA_CLIENT_ID"
+            key  = "clientID"
           }
         },
         "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET" = {
           secretKeyRef = {
             name = "govuk-dex-grafana"
-            key  = "GRAFANA_CLIENT_SECRET"
+            key  = "clientSecret"
           }
         }
       }


### PR DESCRIPTION
We will store the oauth secrets in the format:
```
{
  clientID: <secret_1>,
  clientSecret: <secret_2>
}
```

This is easier to rotate later compared to when the name of the app is added in the
secret structure.

Already modified/tested in integration.