### PR TITLE
Create RabbitMQ broker for Kubernetes platform

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -7,6 +7,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
   }
 }
 
@@ -27,3 +31,5 @@ provider "aws" {
   region = "eu-west-1"
   default_tags { tags = local.default_tags }
 }
+
+provider "random" {}

--- a/terraform/deployments/govuk-publishing-infrastructure/rabbitmq.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/rabbitmq.tf
@@ -1,0 +1,75 @@
+locals {
+  rabbitmq_name = "rabbitmq-${local.cluster_name}"
+}
+
+resource "aws_mq_broker" "rabbitmq_broker" {
+  broker_name = local.rabbitmq_name
+
+  engine_type                = "RabbitMQ"
+  engine_version             = "3.8.26"
+  storage_type               = "ebs"
+  host_instance_type         = "mq.m5.large"
+  security_groups            = [aws_security_group.rabbitmq.id]
+  subnet_ids                 = [for sn in aws_subnet.rabbitmq : sn.id]
+  authentication_strategy    = "simple"
+  auto_minor_version_upgrade = true
+  deployment_mode            = "CLUSTER_MULTI_AZ"
+
+  logs {
+    general = true
+  }
+
+  user {
+    # NOTE: For engine_type of RabbitMQ, Amazon MQ does not return broker users
+    # preventing this resource from making user updates and drift detection.
+    # NOTE: AWS currently does not support updating RabbitMQ users.
+    # Updates to users can only be in the RabbitMQ UI.
+    username = "publishing_api"
+    password = random_password.rabbitmq_password.result
+  }
+
+  tags = {
+    Name = local.rabbitmq_name
+  }
+}
+
+resource "aws_subnet" "rabbitmq" {
+  for_each          = var.rabbitmq_subnets
+  vpc_id            = data.terraform_remote_state.infra_vpc.outputs.vpc_id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+  tags = {
+    Name = "${local.rabbitmq_name}-${each.key}"
+  }
+}
+
+resource "aws_security_group" "rabbitmq" {
+  name        = local.rabbitmq_name
+  vpc_id      = local.vpc_id
+  description = "${local.rabbitmq_name} RabbitMQ broker"
+  tags = {
+    Name = local.rabbitmq_name
+  }
+}
+
+resource "random_password" "rabbitmq_password" {
+  length  = 16
+  special = false
+}
+
+resource "aws_secretsmanager_secret" "rabbitmq" {
+  name = "govuk/common/${local.rabbitmq_name}"
+}
+
+resource "aws_secretsmanager_secret_version" "rabbitmq" {
+  secret_id = aws_secretsmanager_secret.rabbitmq.id
+  secret_string = jsonencode({
+    password = random_password.rabbitmq_password.result
+    hosts    = [for instance in aws_mq_broker.rabbitmq_broker.instances : instance.ip_address]
+  })
+
+  lifecycle {
+    # NOTE: Ignored changes since password can be rotated in SecretsManager.
+    ignore_changes = [secret_string]
+  }
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -36,3 +36,12 @@ data "terraform_remote_state" "infra_security_groups" {
     region = data.aws_region.current.name
   }
 }
+
+data "terraform_remote_state" "infra_vpc" {
+  backend = "s3"
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-vpc.tfstate"
+    region = data.aws_region.current.name
+  }
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -18,6 +18,11 @@ variable "frontend_memcached_node_type" {
   description = "Instance type for the Frontend memcached."
 }
 
+variable "rabbitmq_subnets" {
+  type        = map(object({ az = string, cidr = string }))
+  description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the private subnets for the RabbitMQ broker."
+}
+
 variable "shared_redis_cluster_node_type" {
   type        = string
   description = "Instance type for the shared Redis cluster. t1 and t2 instances are not supported."

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -22,6 +22,12 @@ eks_private_subnets = {
   c = { az = "eu-west-1c", cidr = "10.1.32.0/22" }
 }
 
+rabbitmq_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.1.36.0/28" }
+  b = { az = "eu-west-1b", cidr = "10.1.36.16/28" }
+  c = { az = "eu-west-1c", cidr = "10.1.36.32/28" }
+}
+
 govuk_environment = "integration"
 
 publishing_service_domain = "integration.publishing.service.gov.uk"

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -22,6 +22,12 @@ eks_private_subnets = {
   c = { az = "eu-west-1c", cidr = "10.200.32.0/22" }
 }
 
+rabbitmq_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.200.36.0/28" }
+  b = { az = "eu-west-1b", cidr = "10.200.36.16/28" }
+  c = { az = "eu-west-1c", cidr = "10.200.36.32/28" }
+}
+
 govuk_environment = "test"
 force_destroy     = true
 


### PR DESCRIPTION
This is a work-in-progress. We're not yet sure if we want to use an AWS MQ broker before we switchover to Kubernetes. We can use this in place of the unmaintained RabbitMQ cluster running on EC2 in the AWS test env.

Merging this is **not** a decision to migrate RabbitMQ as part of the first cutover.

https://trello.com/c/ZEn9p3Hk/810-migrate-publishing-api-to-eks