### PR TITLE
Add Postgres and Mysql security rule for EKS nodes

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -45,3 +45,19 @@ data "terraform_remote_state" "infra_vpc" {
     region = data.aws_region.current.name
   }
 }
+
+data "terraform_remote_state" "app_govuk_rds" {
+  backend = "s3"
+
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "blue/app-govuk-rds.tfstate"
+    region = data.aws_region.current.name
+  }
+
+  # TODO: hack because govuk-aws/app-govuk-rds is not terraformed in `test`.
+  # `test` still uses a single postgres instance for many apps.
+  defaults = {
+    sg_rds = {}
+  }
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -82,3 +82,29 @@ resource "aws_security_group_rule" "router_mongodb_from_eks_workers" {
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_router-backend_id
   source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }
+
+# TODO: Only the Postgresql instances created by govuk-aws/app-govuk-rds are
+# open to traffic from EKS nodes. There are 2 other instances, content-data-api
+# and transition, which are not covered since they are in a different terraform
+# project and have not been migrated yet.
+resource "aws_security_group_rule" "postgres_from_eks_workers" {
+  for_each                 = data.terraform_remote_state.app_govuk_rds.outputs.sg_rds
+  description              = "Database accepts requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = each.value
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+}
+
+resource "aws_security_group_rule" "mysql_from_eks_workers" {
+  for_each                 = data.terraform_remote_state.app_govuk_rds.outputs.sg_rds
+  description              = "Database accepts requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  security_group_id        = each.value
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+}


### PR DESCRIPTION
This change applies to GOV.UK environment other than `test` since
`test` uses a single Postgres instance for multiple app still.

Note that the `content-data-api` and `transition` postgres are not
covered by this change here as they are in different terraform
projects.