### PR TITLE
fix EKS output security group

### DIFF
--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -10,7 +10,7 @@ output "worker_iam_role_arn" {
 
 output "cluster_security_group_id" {
   description = "ID of the security group which contains the kube-apiservers and managed worker nodes."
-  value       = module.eks.cluster_security_group_id
+  value       = module.eks.cluster_primary_security_group_id
 }
 
 output "cluster_autoscaler_service_account_name" {


### PR DESCRIPTION
The wrong security group was outputted for the EKS cluster.

See [doc](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest?tab=outputs)