### PR TITLE
Permit ingress to EC2-hosted Content Store from EKS

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -118,3 +118,13 @@ resource "aws_security_group_rule" "search_elb_from_eks_workers" {
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_search_elb_id
   source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }
+
+resource "aws_security_group_rule" "content_store_ec2_from_eks_workers" {
+  description              = "Content Store ELB requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_content-store_internal_elb_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+}


### PR DESCRIPTION
This will enable EKS services such as the Frontend app
to send requests to the EC2 hosted Content Store application.