### PR TITLE
Raise helpful error when bearer_tokens are misconfigured

### DIFF
--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -39,11 +39,20 @@ def bootstrap_signon
 
   bearer_tokens = api_users.map { |username, data|
     data.fetch("bearer_tokens", []).map do |token|
+      app_slug = token["application_slug"]
+      app_id = signon_apps[app_slug]
+
+      unless app_id
+        raise ArgumentError, "
+          Unknown application: #{app_slug} for api_user #{username}.\n
+          Did you create the #{app_slug} application?"
+      end
+
       {
         name: "signon-token-#{username}-#{token['application_slug']}",
         permissions: token.fetch("permissions", []),
         api_user_id: signon_users[username],
-        application_id: signon_apps[token["application_slug"]],
+        application_id: app_id,
       }
     end
   }.flatten


### PR DESCRIPTION
We will immediately raise an error when invalid bearer token config is discovered and tell the user which bearer token is invalid.

Currently it takes a while for the error to occur, since invalid requests are made to the Signon API (and these back off exponentially).