### PR TITLE
Add Terraform for `app-assets-$env` S3 buckets.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/app_assets_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/app_assets_s3.tf
@@ -1,0 +1,52 @@
+resource "aws_s3_bucket" "app_assets" {
+  bucket = "govuk-app-assets-${var.govuk_environment}"
+  tags = {
+    Name        = "App static assets for ${var.govuk_environment}"
+    Environment = var.govuk_environment
+  }
+}
+
+resource "aws_s3_bucket_versioning" "app_assets" {
+  bucket = aws_s3_bucket.app_assets.id
+  versioning_configuration { status = "Suspended" }
+}
+
+resource "aws_s3_bucket_policy" "app_assets" {
+  bucket = aws_s3_bucket.app_assets.id
+  policy = data.aws_iam_policy_document.app_assets.json
+}
+
+# TODO: instead of granting write access to nodes, use IRSA (IAM Roles for
+# Service Accounts aka pod identity) so that only ArgoCD can write.
+data "aws_iam_policy_document" "app_assets" {
+  statement {
+    sid = "PublicCanReadButNotList"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.app_assets.arn}/*"]
+  }
+  statement {
+    sid = "EKSNodesCanList"
+    principals {
+      type        = "AWS"
+      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+    }
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.app_assets.arn]
+  }
+  statement {
+    sid = "EKSNodesCanWrite"
+    principals {
+      type        = "AWS"
+      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["${aws_s3_bucket.app_assets.arn}/*"]
+  }
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/deployments/govuk-publishing-infrastructure/rabbitmq.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/rabbitmq.tf
@@ -6,7 +6,7 @@ resource "aws_mq_broker" "rabbitmq_broker" {
   broker_name = local.rabbitmq_name
 
   engine_type                = "RabbitMQ"
-  engine_version             = "3.8.26"
+  engine_version             = "3.8.27"
   storage_type               = "ebs"
   host_instance_type         = "mq.m5.large"
   security_groups            = [aws_security_group.rabbitmq.id]

--- a/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
@@ -17,16 +17,16 @@ resource "aws_security_group" "shared_redis_cluster" {
 }
 
 resource "aws_elasticache_replication_group" "shared_redis_cluster" {
-  apply_immediately             = var.govuk_environment != "production"
-  replication_group_id          = local.shared_redis_name
-  replication_group_description = "${local.shared_redis_name} Redis cluster with Redis master and replica"
-  node_type                     = var.shared_redis_cluster_node_type
-  number_cache_clusters         = 2
-  automatic_failover_enabled    = true
-  parameter_group_name          = "default.redis6.x"
-  engine_version                = "6.x"
-  subnet_group_name             = aws_elasticache_subnet_group.shared_redis_cluster.name
-  security_group_ids            = [aws_security_group.shared_redis_cluster.id]
+  apply_immediately          = var.govuk_environment != "production"
+  replication_group_id       = local.shared_redis_name
+  description                = "${local.shared_redis_name} Redis cluster with Redis master and replica"
+  node_type                  = var.shared_redis_cluster_node_type
+  num_cache_clusters         = 2
+  automatic_failover_enabled = true
+  parameter_group_name       = "default.redis6.x"
+  engine_version             = "6.x"
+  subnet_group_name          = aws_elasticache_subnet_group.shared_redis_cluster.name
+  security_group_ids         = [aws_security_group.shared_redis_cluster.id]
   tags = {
     Name = local.shared_redis_name
   }

--- a/terraform/docs/applying-terraform.md
+++ b/terraform/docs/applying-terraform.md
@@ -16,8 +16,8 @@ When turning up from scratch, deploy the root modules in this order:
 1. `terraform-lock`
 1. `ecr` (test and production accounts only)
 1. `cluster-infrastructure`
-1. `cluster-services`
 1. `govuk-publishing-infrastructure`
+1. `cluster-services`
 
 ### `cluster-infrastructure`, `cluster-services` or `govuk-publishing-infrastructure` modules
 


### PR DESCRIPTION
Define the S3 buckets for app assets (CSS, JS etc.) in Terraform.

These buckets (one per AWS account / environment) are for storing and serving app assets such as CSS, JavaScript, logo images and so on. Asset files are uploaded when an app is deployed.

See https://github.com/alphagov/govuk-helm-charts/pull/178 for more background.

Also [update `govuk-publishing-infrastructure` to v4 of the AWS provider](https://github.com/alphagov/govuk-infrastructure/commit/932ae88cb5a97712a47c7eb9a2282bcc91e1f80f) because v4 includes significant changes to the S3 resources so it makes sense to upgrade now rather than define a bunch of S3 stuff using the old provider and have to port it to v4 later. Since we don't yet have any S3 stuff defined, the upgrade requires only [trivial fixes](https://github.com/alphagov/govuk-infrastructure/commit/da2a2a100b907071948b3baa1abd323cb506f2e2).

And a trivial (but annoying and unrelated) [fix](https://github.com/alphagov/govuk-infrastructure/commit/dbe66684a05469b8195101f26f41ab61a70f1661) to the MQ config to work around a TF provider bug in order to apply the `govuk-publishing-infrastructure` module. This will be a game of whack-a-mole until the bug gets fixed upstream or we remove the Amazon MQ instance (which I think we should - see commit message).

Trello: https://trello.com/c/ZR6s2YhF/839

#### Rollout

- [x] The buckets already exist in the integration account (created manually and imported into TF state before applying) and the test account (created by applying this TF).
- [ ] Need to remove the manually-added IAM policy attached to the role associated with the managed nodes' EC2 instance profile.

#### Testing

Applied TF in the test account, verified that upload-app-assets jobs run successfully and that assets can be downloaded via app nginx proxy sidecars.