### PR TITLE
Add EFS security rule for EKS nodes

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -148,3 +148,13 @@ resource "aws_security_group_rule" "account_api_ec2_from_eks_workers" {
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_account_elb_internal_id
   source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }
+
+resource "aws_security_group_rule" "efs_from_eks_workers" {
+  description              = "Shared EFS (Elastic File System) accepts requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_asset-master-efs_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+}


### PR DESCRIPTION
## What

Add EFS security rule for EKS nodes, this is needed by asset-manager as a temporary store for uploaded files before they are virus scanned and moved to s3.

## Reference 

https://trello.com/c/pRBFWfGx/688-asset-manager-replatforming