### PR TITLE
Add reusable GitHub Action workflow for deploying to EKS

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -64,3 +64,7 @@ jobs:
           echo "Pushing image to ECR..."
           docker push $ECR_REGISTRY/$ECR_REPOSITORY -a
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Deploy to integration
+        id: deploy-integration
+        uses: ./.github/workflows/deploy-to-eks

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -1,0 +1,59 @@
+# USAGE
+# -----
+# # NOTE: Can be used as part of other workflows, such as ci-ecr.yaml
+# on:
+#   workflow_dispatch:
+#     branches:
+#       - main
+#   push:
+#     branches:
+#       - main
+#     paths-ignore:
+#       - "Jenkinsfile"
+#       - ".git**"
+#
+# jobs:
+#   deploy-to-eks:
+#     uses: alphagov/govuk-infrastructure/.github/workflows/deploy-to-eks.yaml@main
+#     secrets:
+#       CI_GITHUB_API_TOKEN: ${{ secrets.CI_GITHUB_API_TOKEN }}
+
+# REUSABLE WORKFLOW
+# -----------------
+
+name: Deploy to EKS
+
+on:
+  workflow_call:
+    secrets:
+      CI_GITHUB_API_TOKEN: ${{ secrets.CI_GITHUB_API_TOKEN }}
+
+jobs:
+  deploy:
+    name: Update image tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        env:
+          GIT_USER_EMAIL: govuk-ci@digital.cabinet-office.gov.uk
+          GIT_USER_NAME: govuk-ci
+          GITHUB_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+          GOVUK_ENV: integration
+          IMAGE_TAG: ${{ github.sha }}
+          REPOSITORY: ${{ github.event.repository.name }}
+        run: |
+          set -eu
+          git config --global user.email "${GIT_USER_EMAIL}"
+          git config --global user.name "${GIT_USER_NAME}"
+          echo "Modifying Helm Charts repo..."
+          repo="https://${GIT_USER_NAME}:${GITHUB_TOKEN}@github.com/alphagov/govuk-helm-charts.git"
+          branch="main"
+          file="charts/argocd-apps/image-tags/${GOVUK_ENV}/${REPOSITORY}"
+          git clone --depth 1 --branch main "${repo}"
+          cd "govuk-helm-charts"
+          echo "${IMAGE_TAG}" > "${file}"
+          git add $file
+          git commit -m "Deploy ${REPOSITORY}:${IMAGE_TAG} to ${GOVUK_ENV}"
+          REALLY_PUSH_TO_MAIN=1 git push "${repo}" "${branch}"
+          echo "Done!"
+          echo "::set-output deployed=image::${REPOSITORY}:${IMAGE_TAG}"

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -39,3 +39,8 @@ resource "github_actions_organization_secret_repositories" "aws_govuk_ecr_secret
   secret_name             = "AWS_GOVUK_ECR_SECRET_ACCESS_KEY"
   selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
 }
+
+resource "github_actions_organization_secret_repositories" "ci_user_github_api_token" {
+  secret_name             = "GOVUK_CI_GITHUB_API_TOKEN"
+  selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
+}


### PR DESCRIPTION
This workflow will be run by actions on app repos after images
are built and pushed to ECR.

The workflow pulls alphagov/govuk-helm-charts, modifies a file
in charts/argocd-apps/app-images/integration, commits, and creates
a PR, and auto-merges the PR once the status checks pass.

It uses the ci-user credentials to achieve this, and we must give
the ci-user permission to bypass the code reviewer restriction.

This is a first pass at the implementation. Sean is looking at
using an Argo Workflow to achieve this, which might be nice since
we'll need that for release promotion beyond integration in future.