### PR TITLE
Attach search-api s3 bucket policies to EKS nodes

### DIFF
--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -8,6 +8,11 @@ output "worker_iam_role_arn" {
   value       = module.eks.worker_iam_role_arn
 }
 
+output "worker_iam_role_name" {
+  description = "IAM role name for EKS worker node groups"
+  value       = module.eks.worker_iam_role_name
+}
+
 output "cluster_security_group_id" {
   description = "ID of the security group which contains the kube-apiservers and managed worker nodes."
   value       = module.eks.cluster_primary_security_group_id

--- a/terraform/deployments/govuk-publishing-infrastructure/app_search_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/app_search_s3.tf
@@ -1,0 +1,11 @@
+# TODO: instead of granting write access to nodes, use IRSA (IAM Roles for
+# Service Accounts aka pod identity) so that only search-api containers can write.
+resource "aws_iam_role_policy_attachment" "search_relevancy_s3_eks_policy_attachment" {
+  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  policy_arn = data.terraform_remote_state.app_search.outputs.search_relevancy_s3_policy_arn
+}
+
+resource "aws_iam_role_policy_attachment" "sitemaps_s3_eks_policy_attachment" {
+  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  policy_arn = data.terraform_remote_state.app_search.outputs.sitemaps_s3_policy_arn
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -61,3 +61,13 @@ data "terraform_remote_state" "app_govuk_rds" {
     sg_rds = {}
   }
 }
+
+data "terraform_remote_state" "app_search" {
+  backend = "s3"
+
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "blue/app-search.tfstate"
+    region = data.aws_region.current.name
+  }
+}


### PR DESCRIPTION
For search-api to run in EKS, it needs to access 2 S3 buckets.
We export the arn of the iam_policies of these 2 buckets in
[govuk-aws](https://github.com/alphagov/govuk-aws/pull/1558) to
the terraform remote state.

We then attach these iam_policies arns to attach the EKS nodes for
node. Later, we need to attach them to a custom  service account
used to run the search-api pod/container.