### PR TITLE
Fix path to deploy to integration workflow

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Deploy to integration
         id: deploy-integration
-        uses: ./.github/workflows/deploy-to-eks.yaml
+        uses: alphagov/govuk-infrastructure/.github/workflows/deploy-to-eks.yaml


### PR DESCRIPTION
The `deploy-to-eks` workflow is contained in the govuk-infrastructure repo, not in the local repository.