### PR TITLE
Add git ref to deploy to integration workflow reference

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Deploy to integration
         id: deploy-integration
-        uses: alphagov/govuk-infrastructure/.github/workflows/deploy-to-eks.yaml
+        uses: alphagov/govuk-infrastructure/.github/workflows/deploy-to-eks.yaml@main


### PR DESCRIPTION
For workflow references to remote repositories you need to have a git ref.