### PR TITLE
Add podMonitorNamespaceSelector to prometheus stack

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -106,6 +106,14 @@ resource "helm_release" "kube_prometheus_stack" {
         }
         # Allow empty ruleSelector (https://github.com/prometheus-community/helm-charts/blob/2cacc16807caedc6cabf1606db27e0d78c844564/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml#L202)
         ruleSelectorNilUsesHelmValues = false
+        podMonitorNamespaceSelector = {
+          matchExpressions = [{
+            key      = "no_monitor"
+            operator = "DoesNotExist"
+            values   = []
+          }]
+        }
+        podMonitorSelectorNilUsesHelmValues = false
       }
     }
   })]


### PR DESCRIPTION
Add podMonitorNamespaceSelector to allow prometheus to see the podMonitor operators in the apps namespace.