### PR TITLE
Use seperate job for calling `deploy to integration` workflow

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -64,7 +64,7 @@ jobs:
           echo "Pushing image to ECR..."
           docker push $ECR_REGISTRY/$ECR_REPOSITORY -a
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
-      - name: Deploy to integration
-        id: deploy-integration
-        uses: alphagov/govuk-infrastructure/.github/workflows/deploy-to-eks.yaml@main
+  deploy:
+    name: Deploy to integration
+    uses: alphagov/govuk-infrastructure/.github/workflows/deploy-to-eks.yaml@main
+    needs: publish


### PR DESCRIPTION
Calls to reusable GitHub action workflows must be specified at the job level, rather than in a step. This modifies the deploy to integration step from the build image job to be a separate job, thats triggered by successful completion of the build image job.