### PR TITLE
Bump argo-services helm chart

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -86,7 +86,7 @@ resource "helm_release" "argo_services" {
   name       = "argo-services"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
-  version    = "0.1.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "0.1.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.


### PR DESCRIPTION
Needed since new version has been released
(https://github.com/alphagov/govuk-helm-charts/pull/256)
which will allow better post-sync workflow naming.