### PR TITLE
Allow traffic from cluster nodes to EC2 backend instances.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -149,6 +149,16 @@ resource "aws_security_group_rule" "account_api_ec2_from_eks_workers" {
   source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }
 
+resource "aws_security_group_rule" "backend_ec2_from_eks_workers" {
+  description              = "Backend apps in EC2 receive requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_backend_elb_internal_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+}
+
 resource "aws_security_group_rule" "efs_from_eks_workers" {
   description              = "Shared EFS (Elastic File System) accepts requests from EKS nodes"
   type                     = "ingress"


### PR DESCRIPTION
This should fix the timeouts on Feedback talking to support-api etc.

Pair: @NH10

https://trello.com/c/kBkPNDie/842

Tested: already applied in integration; checked with curl from a Feedback pod that we couldn't reach support-api (`https://support-api.integration.govuk-internal.digital/`) before and we could after applying.