### PR TITLE
Increase the maximum number of worker nodes

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -83,5 +83,5 @@ variable "workers_size_min" {
 variable "workers_size_max" {
   type        = number
   description = "Max capacity of managed node autoscale group."
-  default     = 9
+  default     = 15
 }


### PR DESCRIPTION
After setting the default no. of replicas to 2, we need more worker
nodes.

Note during load testing, we can adjust the number of worker nodes
and type.