### PR TITLE
Add security rule for EKS workers to access mapit

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -168,3 +168,13 @@ resource "aws_security_group_rule" "efs_from_eks_workers" {
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_asset-master-efs_id
   source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }
+
+resource "aws_security_group_rule" "mapit_from_eks_workers" {
+  description              = "Mapit accepts requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_mapit_elb_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+}


### PR DESCRIPTION
This is needed since mapit is still being run in EC2.