### PR TITLE
Allow EKS nodes to access licensify frontend internal elb

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -178,3 +178,13 @@ resource "aws_security_group_rule" "mapit_from_eks_workers" {
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_mapit_elb_id
   source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }
+
+resource "aws_security_group_rule" "licensify_frontend_from_eks_workers" {
+  description              = "Licensify Frontend accepts requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_licensify-frontend_internal_lb_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+}


### PR DESCRIPTION
Since licensify frontend is staying in EC2 for now, we add a
security rule to allow EKS nodes to access its internal ELB.
This is required so that apps such as frontend in EKS can
access licensify frontend.