### PR TITLE
Use BuildKit for docker image builds.

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -58,9 +58,10 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
           IMAGE_TAG: ${{ github.sha }}
+          DOCKER_BUILDKIT: "1"
         run: |
           # Build a docker container and push it to ECR
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker build -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest" .
           echo "Pushing image to ECR..."
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY -a
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}" -a
+          echo "::set-output name=image::${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"


### PR DESCRIPTION
[BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) is a bit more efficient and better at exploiting parallelism than the old Docker builder. It's also already the default on Docker Desktop, so this makes CI use the same (more modern) build process that's used when building locally.

Also fix the shell quoting while we're in there.

Testing: builds work fine with BuildKit locally (everyone who builds locally with Docker Desktop has been using it for a couple of years now). Can't easily test the change to the CI job without merging. I'll trigger a couple of builds manually after merge.