### PR TITLE
Add security group rule for Licence Finder to query ElasticSearch.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -109,6 +109,16 @@ resource "aws_security_group_rule" "mysql_from_eks_workers" {
   source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
 }
 
+resource "aws_security_group_rule" "elasticsearch_from_eks_workers" {
+  description              = "ElasticSearch accepts requests from EKS nodes (for example Licence Finder queries ES directly)."
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_elasticsearch6_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+}
+
 resource "aws_security_group_rule" "search_elb_from_eks_workers" {
   description              = "Search elb requests from EKS nodes"
   type                     = "ingress"


### PR DESCRIPTION
https://trello.com/c/F7vSHnws/841

Tested: without this SG rule, `curl $ELASTICSEARCH_URI` from a licencefinder pod hangs and eventually times out while attempting to connect. With the rule applied (ran Terraform locally), `curl $ELASTICSEARCH_URI` returns a blob of JSON as expected.