### PR TITLE
Create namespace when deploying Armo Kubescape.

### DIFF
--- a/terraform/deployments/cluster-services/kubescape.tf
+++ b/terraform/deployments/cluster-services/kubescape.tf
@@ -7,11 +7,12 @@ data "aws_secretsmanager_secret_version" "kubescape-account-guid" {
 }
 
 resource "helm_release" "kubescape" {
-  chart      = "armo-cluster-components"
-  name       = "armo"
-  namespace  = "armo-system"
-  repository = "https://armosec.github.io/armo-helm/"
-  version    = "1.7.0"
+  chart            = "armo-cluster-components"
+  name             = "armo"
+  namespace        = "armo-system"
+  create_namespace = true
+  repository       = "https://armosec.github.io/armo-helm/"
+  version          = "1.7.0"
   set {
     name  = "clusterName"
     value = "govuk-${var.govuk_environment}"


### PR DESCRIPTION
This fixes cluster turnup.

Tested: `tf apply` on a new cluster works again with this change.