### PR TITLE
Add Grafana persistence

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -59,6 +59,10 @@ resource "helm_release" "kube_prometheus_stack" {
           domain   = local.grafana_host
           root_url = "https://%(domain)s"
         }
+        database = {
+          type     = "mysql"
+          ssl_mode = "false"
+        }
       }
       envValueFrom = {
         "GF_AUTH_GENERIC_OAUTH_CLIENT_ID" = {
@@ -71,6 +75,24 @@ resource "helm_release" "kube_prometheus_stack" {
           secretKeyRef = {
             name = "govuk-dex-grafana"
             key  = "clientSecret"
+          }
+        },
+        "GF_DATABASE_HOST" = {
+          secretKeyRef = {
+            name = "govuk-grafana-database"
+            key  = "host"
+          }
+        },
+        "GF_DATABASE_USER" = {
+          secretKeyRef = {
+            name = "govuk-grafana-database"
+            key  = "username"
+          }
+        },
+        "GF_DATABASE_PASSWORD" = {
+          secretKeyRef = {
+            name = "govuk-grafana-database"
+            key  = "password"
           }
         }
       }

--- a/terraform/deployments/monitoring/aurora_serverless.tf
+++ b/terraform/deployments/monitoring/aurora_serverless.tf
@@ -1,0 +1,79 @@
+locals {
+  grafana_database_name = "grafana-${local.cluster_name}"
+}
+
+
+module "grafana_database" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "3.5.0"
+
+  name              = local.grafana_database_name
+  engine            = "aurora-mysql"
+  engine_mode       = "serverless"
+  engine_version    = "5.7.mysql_aurora.2.07.1"
+  storage_encrypted = true
+  database_name     = "grafana"
+
+  vpc_id                = local.vpc_id
+  subnets               = local.database_subnets
+  create_security_group = true
+
+  allowed_security_groups = [data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id]
+
+  db_parameter_group_name         = aws_db_parameter_group.grafana_database.id
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.grafana_database.id
+
+  scaling_configuration = {
+    auto_pause               = true
+    min_capacity             = var.grafana_database_min_capacity
+    max_capacity             = var.grafana_database_max_capacity
+    seconds_until_auto_pause = 300
+    timeout_action           = "ForceApplyCapacityChange"
+  }
+
+  replica_count = 0
+
+  apply_immediately = true
+}
+
+resource "aws_db_parameter_group" "grafana_database" {
+  name        = "${local.grafana_database_name}-aurora-db-mysql-parameter-group"
+  family      = "aurora-mysql5.7"
+  description = "${local.grafana_database_name}-aurora-db-mysql-parameter-group"
+}
+
+resource "aws_rds_cluster_parameter_group" "grafana_database" {
+  name        = "${local.grafana_database_name}-aurora-mysql-cluster-parameter-group"
+  family      = "aurora-mysql5.7"
+  description = "${local.grafana_database_name}-aurora-mysql-cluster-parameter-group"
+}
+
+resource "aws_route53_record" "grafana_database" {
+  zone_id = local.internal_dns_zone_id
+  # TODO: consider removing EKS suffix once the old EC2 environments are gone.
+  name    = "${local.grafana_database_name}-db.eks"
+  type    = "CNAME"
+  ttl     = 300
+  records = [module.grafana_database.this_rds_cluster_endpoint]
+}
+
+resource "aws_secretsmanager_secret" "grafana_database" {
+  name = "${local.cluster_name}/grafana/database"
+}
+
+resource "aws_secretsmanager_secret_version" "grafana_database" {
+  secret_id = aws_secretsmanager_secret.grafana_database.id
+  secret_string = jsonencode({
+    "engine"   = "aurora"
+    "host"     = aws_route53_record.grafana_database.fqdn
+    "username" = module.grafana_database.this_rds_cluster_master_username
+    "password" = module.grafana_database.this_rds_cluster_master_password
+    "dbname"   = local.grafana_database_name
+    "port"     = module.grafana_database.this_rds_cluster_port
+  })
+
+  lifecycle {
+    # NOTE: Ignored changes since password can be rotated in SecretsManager.
+    ignore_changes = [secret_string]
+  }
+}

--- a/terraform/deployments/monitoring/integration.backend
+++ b/terraform/deployments/monitoring/integration.backend
@@ -1,0 +1,5 @@
+bucket  = "govuk-terraform-integration"
+key     = "projects/monitoring.tfstate"
+encrypt = true
+region  = "eu-west-1"
+dynamodb_table = "terraform-lock"

--- a/terraform/deployments/monitoring/main.tf
+++ b/terraform/deployments/monitoring/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  backend "s3" {}
+
+  required_version = "~> 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+locals {
+  cluster_name         = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
+  vpc_id               = data.terraform_remote_state.infra_networking.outputs.vpc_id
+  internal_dns_zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
+  database_subnets     = data.terraform_remote_state.infra_networking.outputs.private_subnet_rds_ids
+
+  default_tags = {
+    project              = "replatforming"
+    repository           = "govuk-infrastructure"
+    terraform_deployment = basename(abspath(path.root))
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+  default_tags { tags = local.default_tags }
+}

--- a/terraform/deployments/monitoring/remote.tf
+++ b/terraform/deployments/monitoring/remote.tf
@@ -1,0 +1,47 @@
+data "aws_region" "current" {}
+
+data "terraform_remote_state" "cluster_infrastructure" {
+  backend   = "s3"
+  workspace = terraform.workspace
+  config = {
+    bucket = var.cluster_infrastructure_state_bucket
+    key    = "projects/cluster-infrastructure.tfstate"
+    region = data.aws_region.current.name
+  }
+}
+
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-networking.tfstate"
+    region = data.aws_region.current.name
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-root-dns-zones.tfstate"
+    region = data.aws_region.current.name
+  }
+}
+
+data "terraform_remote_state" "infra_security_groups" {
+  backend = "s3"
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-security-groups.tfstate"
+    region = data.aws_region.current.name
+  }
+}
+
+data "terraform_remote_state" "infra_vpc" {
+  backend = "s3"
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-vpc.tfstate"
+    region = data.aws_region.current.name
+  }
+}

--- a/terraform/deployments/monitoring/test.backend
+++ b/terraform/deployments/monitoring/test.backend
@@ -1,0 +1,5 @@
+bucket  = "govuk-terraform-test"
+key     = "projects/monitoring.tfstate"
+encrypt = true
+region  = "eu-west-1"
+dynamodb_table = "terraform-lock"

--- a/terraform/deployments/monitoring/variables.tf
+++ b/terraform/deployments/monitoring/variables.tf
@@ -1,0 +1,21 @@
+variable "govuk_aws_state_bucket" {
+  type        = string
+  description = "The name of the S3 bucket used for govuk-aws's Terraform state files."
+}
+
+variable "cluster_infrastructure_state_bucket" {
+  type        = string
+  description = "Name of the S3 bucket for the cluster-infrastructure module's Terraform state. Must match the name of the bucket specified in the backend config file."
+}
+
+variable "grafana_database_min_capacity" {
+  type        = number
+  description = "Minimum capacity of the Grafana database"
+  default     = 2
+}
+
+variable "grafana_database_max_capacity" {
+  type        = number
+  description = "Maximum capacity of the Grafana database"
+  default     = 8
+}

--- a/terraform/docs/applying-terraform.md
+++ b/terraform/docs/applying-terraform.md
@@ -17,6 +17,7 @@ When turning up from scratch, deploy the root modules in this order:
 1. `ecr` (test and production accounts only)
 1. `cluster-infrastructure`
 1. `govuk-publishing-infrastructure`
+1. `monitoring`
 1. `cluster-services`
 
 ### `cluster-infrastructure`, `cluster-services` or `govuk-publishing-infrastructure` modules


### PR DESCRIPTION
Add AWS Serverless Mysql Aurora to the infra to act as a backing database for Grafana to persist in its state.