### PR TITLE
Update AWS LB controller to latest version.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
@@ -25,7 +25,7 @@ resource "aws_iam_policy" "aws_lb_controller" {
   description = "Allow AWS Load Balancer Controller to manage ALBs/NLBs etc."
 
   # The argument to jsonencode() is the verbatim contents of
-  # https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
+  # https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.0/docs/install/iam_policy.json
   # (except for whitespace changes from terraform fmt).
   policy = jsonencode({
     "Version" : "2012-10-17",
@@ -33,12 +33,24 @@ resource "aws_iam_policy" "aws_lb_controller" {
       {
         "Effect" : "Allow",
         "Action" : [
-          "iam:CreateServiceLinkedRole",
+          "iam:CreateServiceLinkedRole"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "iam:AWSServiceName" : "elasticloadbalancing.amazonaws.com"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
           "ec2:DescribeAccountAttributes",
           "ec2:DescribeAddresses",
           "ec2:DescribeAvailabilityZones",
           "ec2:DescribeInternetGateways",
           "ec2:DescribeVpcs",
+          "ec2:DescribeVpcPeeringConnections",
           "ec2:DescribeSubnets",
           "ec2:DescribeSecurityGroups",
           "ec2:DescribeInstances",

--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -9,7 +9,7 @@ resource "helm_release" "aws_lb_controller" {
   name             = "aws-load-balancer-controller"
   repository       = "https://aws.github.io/eks-charts"
   chart            = "aws-load-balancer-controller"
-  version          = "1.2.7" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "1.4.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({
@@ -21,6 +21,11 @@ resource "helm_release" "aws_lb_controller" {
         "eks.amazonaws.com/role-arn" = data.terraform_remote_state.cluster_infrastructure.outputs.aws_lb_controller_role_arn
       }
     }
+    # TODO: remove this clusterSecretsPermissions back-compatibility kludge
+    # once we have a proper Role/RoleBinding in place to allow
+    # aws-lb-controller to read just the secrets that it really needs
+    # (alphagov/govuk-helm-charts#348).
+    clusterSecretsPermissions = { allowAllSecrets : true }
   })]
 }
 


### PR DESCRIPTION
Temporarily preserve the [aws-lb-controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/)'s permissions to read all secrets, so as not to break things while we upgrade. I'll remove this once alphagov/govuk-helm-charts#348 is merged and confirmed working. Once this is done, the upgrade will be a win for security because the LB controller will no longer have excessive permissions.

There's also a security improvement in the IAM policy: the controller is now only permitted to create its own service-linked role (`elasticloadbalancing.amazonaws.com`) rather than any service-linked role.

https://trello.com/c/gipscM7t/873