### PR TITLE
Unpin chart versions for charts that we own.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -86,7 +86,6 @@ resource "helm_release" "argo_services" {
   name       = "argo-services"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
-  version    = "0.1.7" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.

--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -28,5 +28,4 @@ resource "helm_release" "aws_lb_ingress_class" {
   name       = "aws-lb-ingress-class"
   repository = "https://alphagov.github.io/govuk-helm-charts/"
   chart      = "ingress-class"
-  version    = "0.1.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
 }

--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -28,7 +28,6 @@ resource "helm_release" "cluster_secret_store" {
   name       = "cluster-secret-store"
   repository = "https://alphagov.github.io/govuk-helm-charts/"
   chart      = "cluster-secret-store"
-  version    = "0.1.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace  = local.services_ns
   values = [yamlencode({
     awsRegion          = data.aws_region.current.name
@@ -43,5 +42,4 @@ resource "helm_release" "cluster_secrets" {
   name       = "cluster-secrets"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
-  version    = "0.1.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
 }


### PR DESCRIPTION
During cluster turnup, we always want to use the latest chart versions for charts that we release ourselves. Unlike for third-party charts, long-term pinning of our own chart versions introduces extra toil and risk for no benefit.

Unfortunately we still need to bump the version numbers of these charts when making changes to the charts themselves, otherwise chart-releaser wouldn't build a new chart tarball and the turnup automation (Terraform) would break because it'd be stuck with the last-released version rather than the latest chart from the source repo.

https://trello.com/c/gipscM7t/873