### PR TITLE
Forward cluster-level k8s logs to logit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.45.0
     hooks:
       - id: terraform_fmt

--- a/terraform/deployments/cluster-infrastructure/cluster_logging_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/cluster_logging_iam.tf
@@ -1,0 +1,42 @@
+# IAM role and policy to allow Filebeat to access Cloudwatch Logs for the cluster-level k8s logs
+#
+# k8s side is in ../cluster-services/cluster_logging.tf
+
+locals {
+  cluster_logging_service_account_namespace = "kube-system"
+  cluster_logging_service_account_name      = "cluster-logging"
+}
+
+module "cluster_logging_iam_role" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "4.3.0"
+  create_role                   = true
+  role_name                     = "${local.cluster_autoscaler_service_account_name}-${var.cluster_name}"
+  role_description              = "Role for cluster-level log reading. Corresponds to ${local.cluster_autoscaler_service_account_name} k8s ServiceAccount."
+  provider_url                  = local.cluster_oidc_issuer
+  role_policy_arns              = [aws_iam_policy.cluster_logging.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_logging_service_account_namespace}:${local.cluster_logging_service_account_name}"]
+}
+
+resource "aws_iam_policy" "cluster_logging" {
+  name        = "EKSClusterLogging-${var.cluster_name}"
+  description = "Policy for cluster-level log reading for cluster ${module.eks.cluster_id}"
+  policy      = data.aws_iam_policy_document.cluster_logging.json
+}
+
+data "aws_iam_policy_document" "cluster_logging" {
+  statement {
+    sid = "clusterLoggingAllowRead"
+
+    effect = "Allow"
+
+    actions = [
+      "logs:DescribeLogGroups",
+      "logs:FilterLogEvents"
+    ]
+
+    resources = [
+      "arn:aws:logs:eu-west-1:${data.aws_caller_identity.current.account_id}:log-group:/aws/eks/govuk/cluster"
+    ]
+  }
+}

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -82,3 +82,13 @@ output "aws_lb_controller_service_account_name" {
   description = "Name of the k8s service account for the AWS Load Balancer Controller."
   value       = local.aws_lb_controller_service_account_name
 }
+
+output "cluster_logging_role_arn" {
+  description = "IAM role ARN corresponding to the k8s service account for cluster logging"
+  value       = module.cluster_logging_iam_role.iam_role_arn
+}
+
+output "cluster_logging_service_account_name" {
+  description = "Name of the k8s service account for cluster logging"
+  value       = local.cluster_logging_service_account_name
+}

--- a/terraform/deployments/cluster-services/cluster_logging.tf
+++ b/terraform/deployments/cluster-services/cluster_logging.tf
@@ -1,0 +1,68 @@
+# cluster_logging.tf manages Filebeat, which ships cluster-level logs to Logit
+
+resource "helm_release" "cluster_filebeat" {
+  depends_on = [helm_release.cluster_secrets]
+
+  name             = "cluster_filebeat"
+  repository       = "https://helm.elastic.co"
+  chart            = "filebeat"
+  version          = "7.15.0" # TODO: Make sure this doesn't get neglected
+  namespace        = local.services_ns
+  create_namespace = true
+  values = [
+    yamlencode(
+      {
+        daemonset = {
+          enabled = false
+        }
+        deployment = {
+          enabled   = true
+          runAsUser = 1
+          filebeatConfig = {
+            "filebeat.yml" = yamlencode({
+              "filebeat.inputs" = [
+                {
+                  type           = "aws-cloudwatch"
+                  log_group_arn  = "arn:aws:logs:eu-west-1:${data.aws_caller_identity.current.account_id}:log-group:/aws/eks/govuk/cluster"
+                  scan_frequency = "30s"
+                  start_position = "end"
+                }
+              ]
+              "output.elasticsearch" = {
+                hosts         = ["$${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:$${LOGSTASH_PORT:? LOGSTASH_PORT variable is not set}"]
+                loadbalance   = true
+                "ssl.enabled" = true
+              }
+            })
+          }
+          extraEnvs = [
+            {
+              name = "LOGSTASH_HOST"
+              valueFrom = {
+                secretKeyRef = {
+                  name = "logit-host"
+                  key  = "host"
+                }
+              }
+            },
+            {
+              name = "LOGSTASH_PORT"
+              valueFrom = {
+                secretKeyRef = {
+                  name = "logit-host"
+                  key  = "port"
+                }
+              }
+            }
+          ]
+        }
+        managedServiceAccount = false
+        serviceAccount        = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_logging_service_account_name
+        serviceAccountAnnotations = {
+          "eks.amazonaws.com/role-arn" = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_logging_role_arn
+        }
+        replicas = 1
+      }
+    )
+  ]
+}


### PR DESCRIPTION
This adds a new filebeat instance that forwards k8s logs from cloudwatch logs to logit. It also includes the IAM role that allows the filebeat instance to access cloudwatch. As it currently exists, it will send all k8s logs to logit. We can add a whitelist for different components if we decide we don't want logs from specific services (https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-cloudwatch.html#_log_streams)

Trello: https://trello.com/c/cCZKpsmx/672-ship-cluster-level-logs-to-new-logit-stack