### PR TITLE
Add github-cli image

### DIFF
--- a/.github/workflows/build-github-cli-image.yaml
+++ b/.github/workflows/build-github-cli-image.yaml
@@ -11,34 +11,11 @@ on:
       - "docker/images/github-cli/Dockerfile"
 
 jobs:
-  publish:
-    name: Build image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          # TODO: Remove long-lived keys and switch to OIDC once https://github.com/github/roadmap/issues/249 lands.
-          aws-access-key-id: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Build, tag, and push image to Amazon ECR
-        id: build-image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: github-cli
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          # Build a docker container and push it to ECR
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f docker/images/github-cli/Dockerfile .
-          echo "Pushing image to ECR..."
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+  build-publish-image-to-ecr:
+    uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
+    with:
+      ecr_repository_name: github-cli
+      additional_build_args: "-f docker/images/github-cli/Dockerfile"
+    secrets:
+      AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+      AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-github-cli-image.yaml
+++ b/.github/workflows/build-github-cli-image.yaml
@@ -1,0 +1,44 @@
+name: Build and publish github-cli image to ECR
+
+on:
+  workflow_dispatch:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    paths:
+      - "docker/images/github-cli/Dockerfile"
+
+jobs:
+  publish:
+    name: Build image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          # TODO: Remove long-lived keys and switch to OIDC once https://github.com/github/roadmap/issues/249 lands.
+          aws-access-key-id: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: github-cli
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          # Build a docker container and push it to ECR
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f docker/images/github-cli/Dockerfile .
+          echo "Pushing image to ECR..."
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -26,6 +26,14 @@ name: Build and publish to ECR
 
 on:
   workflow_call:
+    inputs:
+      ecr_repository_name:
+        required: false
+        type: string
+        default: ${{ github.event.repository.name }}
+      additional_build_args:
+        required: false
+        type: string
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID:
         required: true
@@ -56,12 +64,15 @@ jobs:
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ github.event.repository.name }}
+          ECR_REPOSITORY: ${{ inputs.ecr_repository_name }}
           IMAGE_TAG: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: |
           # Build a docker container and push it to ECR
-          docker build -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest" .
+          docker build \
+            -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" \
+            -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest" \
+            ${{ inputs.additional_build_args }} .
           echo "Pushing image to ECR..."
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}" -a
           echo "::set-output name=image::${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"

--- a/docker/images/github-cli/Dockerfile
+++ b/docker/images/github-cli/Dockerfile
@@ -1,0 +1,21 @@
+ARG base_image=bitnami/minideb:latest
+
+FROM ${base_image}
+
+RUN apt-get update -qq && apt-get install -y ca-certificates git
+
+ADD https://cli.github.com/packages/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg
+RUN chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
+RUN apt-get update -qq && apt-get install -y gh
+
+RUN groupadd -r user && useradd -m -r -g user user
+
+ENV HOME=/home/user
+
+RUN chown -R user:user $HOME
+WORKDIR $HOME
+
+USER user
+
+CMD /bin/bash

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -41,6 +41,7 @@ locals {
   )
 
   extra_repositories = [
+    "github-cli",
     "signon-resources",
     "statsd",
     "govuk-terraform",


### PR DESCRIPTION
This adds the Dockerfile and a GitHub Action to build the an image for using the github-cli. This need by the update-image-tag Argo workflow. This will improve the security of the workflow by not running a container as root and improve the speed by pre-installing required dependencies.