### PR TITLE
Add Cloudwatch as additional source of data to Grafana

### DIFF
--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -43,6 +43,11 @@ output "cluster_services_namespace" {
   value       = local.cluster_services_namespace
 }
 
+output "cluster_oidc_issuer" {
+  description = "The OIDC issuer of the cluster"
+  value       = local.cluster_oidc_issuer
+}
+
 output "external_dns_service_account_name" {
   description = "Name of the k8s service account for the external-dns addon."
   value       = local.external_dns_service_account_name

--- a/terraform/deployments/cluster-services/remote.tf
+++ b/terraform/deployments/cluster-services/remote.tf
@@ -20,3 +20,13 @@ data "terraform_remote_state" "infra_security" {
     region = data.aws_region.current.name
   }
 }
+
+data "terraform_remote_state" "monitoring" {
+  backend   = "s3"
+  workspace = terraform.workspace
+  config = {
+    bucket = var.cluster_infrastructure_state_bucket
+    key    = "projects/monitoring.tfstate"
+    region = data.aws_region.current.name
+  }
+}

--- a/terraform/deployments/monitoring/grafana_iam_role.tf
+++ b/terraform/deployments/monitoring/grafana_iam_role.tf
@@ -1,0 +1,65 @@
+locals {
+  grafana_service_account = "kube-prometheus-stack-grafana"
+}
+
+module "grafana_iam_role" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "4.3.0"
+  create_role                   = true
+  role_name                     = "${local.grafana_service_account}-${local.cluster_name}"
+  role_description              = "Role for Grafana to access AWS data source. Corresponds to ${local.grafana_service_account} k8s ServiceAccount."
+  provider_url                  = local.cluster_oidc_issuer
+  role_policy_arns              = [aws_iam_policy.grafana.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.monitoring_namespace}:${local.grafana_service_account}"]
+}
+
+resource "aws_iam_policy" "grafana" {
+  name        = "grafana-${local.cluster_name}"
+  description = "Allows Grafana to access AWS data source."
+
+  # The argument to jsonencode() was obtained from
+  # https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "AllowReadingMetricsFromCloudWatch",
+        "Effect" : "Allow",
+        "Action" : [
+          "cloudwatch:DescribeAlarmsForMetric",
+          "cloudwatch:DescribeAlarmHistory",
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:ListMetrics",
+          "cloudwatch:GetMetricData",
+          "cloudwatch:GetInsightRuleReport"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Sid" : "AllowReadingLogsFromCloudWatch",
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:DescribeLogGroups",
+          "logs:GetLogGroupFields",
+          "logs:StartQuery",
+          "logs:StopQuery",
+          "logs:GetQueryResults",
+          "logs:GetLogEvents"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Sid" : "AllowReadingTagsInstancesRegionsFromEC2",
+        "Effect" : "Allow",
+        "Action" : ["ec2:DescribeTags", "ec2:DescribeInstances", "ec2:DescribeRegions"],
+        "Resource" : "*"
+      },
+      {
+        "Sid" : "AllowReadingResourcesForTags",
+        "Effect" : "Allow",
+        "Action" : "tag:GetResources",
+        "Resource" : "*"
+      }
+    ]
+  })
+}

--- a/terraform/deployments/monitoring/main.tf
+++ b/terraform/deployments/monitoring/main.tf
@@ -15,6 +15,7 @@ locals {
   vpc_id               = data.terraform_remote_state.infra_networking.outputs.vpc_id
   internal_dns_zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
   database_subnets     = data.terraform_remote_state.infra_networking.outputs.private_subnet_rds_ids
+  cluster_oidc_issuer  = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_oidc_issuer
 
   default_tags = {
     project              = "replatforming"

--- a/terraform/deployments/monitoring/outputs.tf
+++ b/terraform/deployments/monitoring/outputs.tf
@@ -1,0 +1,4 @@
+output "grafana_iam_role" {
+  description = "IAM role of Grafana"
+  value       = module.grafana_iam_role.iam_role_arn
+}

--- a/terraform/deployments/monitoring/variables.tf
+++ b/terraform/deployments/monitoring/variables.tf
@@ -19,3 +19,9 @@ variable "grafana_database_max_capacity" {
   description = "Maximum capacity of the Grafana database"
   default     = 8
 }
+
+variable "monitoring_namespace" {
+  type        = string
+  description = "Namespace where the monitoring apps are deployed to"
+  default     = "monitoring"
+}


### PR DESCRIPTION
This was done by following the instructions in
[grafana values.yaml](https://github.com/grafana/helm-charts/blob/285c6f7dfb6ac751fa67a7c072f06eed9011b042/charts/grafana/values.yaml#L351)
![cloudwatch elb www-origin ingress k8s](https://user-images.githubusercontent.com/43747728/162013937-e72e9287-da50-4c82-b6f5-1e7c38b4d040.png)

