### PR TITLE
Update EKS module to v18 and fix cluster turnup blockers.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
@@ -25,7 +25,7 @@ resource "aws_iam_policy" "aws_lb_controller" {
   description = "Allow AWS Load Balancer Controller to manage ALBs/NLBs etc."
 
   # The argument to jsonencode() is the verbatim contents of
-  # https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
+  # https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.0/docs/install/iam_policy.json
   # (except for whitespace changes from terraform fmt).
   policy = jsonencode({
     "Version" : "2012-10-17",
@@ -33,12 +33,24 @@ resource "aws_iam_policy" "aws_lb_controller" {
       {
         "Effect" : "Allow",
         "Action" : [
-          "iam:CreateServiceLinkedRole",
+          "iam:CreateServiceLinkedRole"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "iam:AWSServiceName" : "elasticloadbalancing.amazonaws.com"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
           "ec2:DescribeAccountAttributes",
           "ec2:DescribeAddresses",
           "ec2:DescribeAvailabilityZones",
           "ec2:DescribeInternetGateways",
           "ec2:DescribeVpcs",
+          "ec2:DescribeVpcPeeringConnections",
           "ec2:DescribeSubnets",
           "ec2:DescribeSecurityGroups",
           "ec2:DescribeInstances",

--- a/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
@@ -15,7 +15,7 @@ module "aws_lb_controller_iam_role" {
   create_role                   = true
   role_name                     = "${local.aws_lb_controller_service_account_name}-${var.cluster_name}"
   role_description              = "Role for the AWS Load Balancer Controller. Corresponds to ${local.aws_lb_controller_service_account_name} k8s ServiceAccount."
-  provider_url                  = local.cluster_oidc_issuer
+  provider_url                  = module.eks.oidc_provider
   role_policy_arns              = [aws_iam_policy.aws_lb_controller.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_services_namespace}:${local.aws_lb_controller_service_account_name}"]
 }

--- a/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
@@ -26,7 +26,7 @@ module "cluster_autoscaler_iam_role" {
   create_role                   = true
   role_name                     = "${local.cluster_autoscaler_service_account_name}-${var.cluster_name}"
   role_description              = "Role for Cluster Autoscaler. Corresponds to ${local.cluster_autoscaler_service_account_name} k8s ServiceAccount."
-  provider_url                  = local.cluster_oidc_issuer
+  provider_url                  = module.eks.oidc_provider
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_autoscaler_service_account_namespace}:${local.cluster_autoscaler_service_account_name}"]
 }

--- a/terraform/deployments/cluster-infrastructure/external_dns.tf
+++ b/terraform/deployments/cluster-infrastructure/external_dns.tf
@@ -17,7 +17,7 @@ module "external_dns_iam_role" {
   create_role                   = true
   role_name                     = "${local.external_dns_service_account_name}-${var.cluster_name}"
   role_description              = "Role for External DNS addon. Corresponds to ${local.external_dns_service_account_name} k8s ServiceAccount."
-  provider_url                  = local.cluster_oidc_issuer
+  provider_url                  = module.eks.oidc_provider
   role_policy_arns              = [aws_iam_policy.external_dns.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_services_namespace}:${local.external_dns_service_account_name}"]
 }

--- a/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
@@ -14,7 +14,7 @@ module "external_secrets_iam_role" {
   create_role                   = true
   role_name                     = "${local.external_secrets_service_account_name}-${var.cluster_name}"
   role_description              = "Role for External Secrets addon. Corresponds to ${local.external_secrets_service_account_name} k8s ServiceAccount."
-  provider_url                  = local.cluster_oidc_issuer
+  provider_url                  = module.eks.oidc_provider
   role_policy_arns              = [aws_iam_policy.external_secrets.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_services_namespace}:${local.external_secrets_service_account_name}"]
 }

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -5,17 +5,22 @@ output "cluster_certificate_authority_data" {
 
 output "worker_iam_role_arn" {
   description = "IAM role ARN for EKS worker node groups"
-  value       = module.eks.worker_iam_role_arn
+  value       = module.eks.eks_managed_node_groups["main"].iam_role_arn
 }
 
 output "worker_iam_role_name" {
   description = "IAM role name for EKS worker node groups"
-  value       = module.eks.worker_iam_role_name
+  value       = module.eks.eks_managed_node_groups["main"].iam_role_name
 }
 
-output "cluster_security_group_id" {
-  description = "ID of the security group which contains the kube-apiservers and managed worker nodes."
+output "control_plane_security_group_id" {
+  description = "ID of the security group which contains the (AWS-owned) control plane nodes."
   value       = module.eks.cluster_primary_security_group_id
+}
+
+output "node_security_group_id" {
+  description = "ID of the security group which contains the worker nodes."
+  value       = module.eks.node_security_group_id
 }
 
 output "cluster_autoscaler_service_account_name" {

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -4,12 +4,21 @@ locals {
   argo_workflows_host = "argo-workflows.${local.external_dns_zone_name}"
 }
 
+resource "kubernetes_namespace" "apps" {
+  metadata {
+    name   = var.apps_namespace
+    labels = { "app.kubernetes.io/managed-by" = "Terraform" }
+  }
+}
+
 resource "helm_release" "argo_cd" {
-  chart      = "argo-cd"
-  name       = "argo-cd"
-  namespace  = local.services_ns
-  repository = "https://argoproj.github.io/argo-helm"
-  version    = "3.32.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  depends_on       = [helm_release.aws_lb_controller]
+  chart            = "argo-cd"
+  name             = "argo-cd"
+  namespace        = local.services_ns
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  version          = "3.32.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     global = {
       image = { # TODO: remove this section when v2.3.0 is released and includes fix: https://github.com/argoproj/argo-cd/pull/8350
@@ -81,11 +90,12 @@ resource "helm_release" "argo_cd" {
 
 resource "helm_release" "argo_services" {
   # Relies on CRDs
-  depends_on = [helm_release.argo_cd, helm_release.argo_events]
-  chart      = "argo-services"
-  name       = "argo-services"
-  namespace  = local.services_ns
-  repository = "https://alphagov.github.io/govuk-helm-charts/"
+  depends_on       = [helm_release.argo_cd, helm_release.argo_events]
+  chart            = "argo-services"
+  name             = "argo-services"
+  namespace        = local.services_ns
+  create_namespace = true
+  repository       = "https://alphagov.github.io/govuk-helm-charts/"
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.
@@ -95,11 +105,12 @@ resource "helm_release" "argo_services" {
 }
 
 resource "helm_release" "argo_notifications" {
-  chart      = "argocd-notifications"
-  name       = "argocd-notifications"
-  namespace  = local.services_ns
-  repository = "https://argoproj.github.io/argo-helm"
-  version    = "1.5.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  chart            = "argocd-notifications"
+  name             = "argocd-notifications"
+  namespace        = local.services_ns
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  version          = "1.5.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     # Configured in argo-services Helm chart
     cm = {
@@ -118,12 +129,13 @@ resource "helm_release" "argo_notifications" {
 resource "helm_release" "argo_workflows" {
   # Dex is used to provide SSO facility to Argo-Workflows and there is a bug
   # where Argo Workflows fail to start if Dex is not present
-  depends_on = [helm_release.dex]
-  chart      = "argo-workflows"
-  name       = "argo-workflows"
-  namespace  = local.services_ns
-  repository = "https://argoproj.github.io/argo-helm"
-  version    = "0.9.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  depends_on       = [helm_release.dex]
+  chart            = "argo-workflows"
+  name             = "argo-workflows"
+  namespace        = local.services_ns
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  version          = "0.9.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     controller = {
       workflowNamespaces = concat([local.services_ns], var.argo_workflows_namespaces)
@@ -180,11 +192,12 @@ resource "helm_release" "argo_workflows" {
 }
 
 resource "helm_release" "argo_events" {
-  chart      = "argo-events"
-  name       = "argo-events"
-  namespace  = local.services_ns
-  repository = "https://argoproj.github.io/argo-helm"
-  version    = "1.7.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  chart            = "argo-events"
+  name             = "argo-events"
+  namespace        = local.services_ns
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  version          = "1.7.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     namespace = local.services_ns
   })]

--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -9,7 +9,7 @@ resource "helm_release" "aws_lb_controller" {
   name             = "aws-load-balancer-controller"
   repository       = "https://aws.github.io/eks-charts"
   chart            = "aws-load-balancer-controller"
-  version          = "1.2.7" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "1.4.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -5,11 +5,13 @@ locals {
 }
 
 resource "helm_release" "dex" {
-  chart      = "dex"
-  name       = "dex"
-  namespace  = local.services_ns
-  repository = "https://charts.dexidp.io"
-  version    = "0.6.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  depends_on       = [helm_release.aws_lb_controller]
+  chart            = "dex"
+  name             = "dex"
+  namespace        = local.services_ns
+  create_namespace = true
+  repository       = "https://charts.dexidp.io"
+  version          = "0.6.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     config = {
       issuer = "https://${local.dex_host}"

--- a/terraform/deployments/cluster-services/kubescape.tf
+++ b/terraform/deployments/cluster-services/kubescape.tf
@@ -7,11 +7,12 @@ data "aws_secretsmanager_secret_version" "kubescape-account-guid" {
 }
 
 resource "helm_release" "kubescape" {
-  chart      = "armo-cluster-components"
-  name       = "armo"
-  namespace  = "armo-system"
-  repository = "https://armosec.github.io/armo-helm/"
-  version    = "1.7.0"
+  chart            = "armo-cluster-components"
+  name             = "armo"
+  namespace        = "armo-system"
+  create_namespace = true
+  repository       = "https://armosec.github.io/armo-helm/"
+  version          = "1.7.0"
   set {
     name  = "clusterName"
     value = "govuk-${var.govuk_environment}"

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -23,7 +23,7 @@ terraform {
     # do not add AWS resources to this module.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -1,6 +1,13 @@
+variable "apps_namespace" {
+  type        = string
+  description = "Name of the namespace to create for ArgoCD to deploy apps into by default."
+  default     = "apps"
+}
+
 variable "argo_workflows_namespaces" {
   type        = list(string)
   description = "Namespaces in which Argo will run workflows."
+  default     = ["apps"]
 }
 
 variable "govuk_aws_state_bucket" {
@@ -21,9 +28,11 @@ variable "govuk_environment" {
 variable "dex_github_orgs_teams" {
   type        = list(object({ name = string, teams = list(string) }))
   description = "List of GitHub orgs and associated teams that Dex authorises. Format [{name='github_org', teams=['github_team_name']}] "
+  default     = [{ name = "alphagov", teams = ["gov-uk-production"] }]
 }
 
 variable "powerusers_namespaces" {
   type        = list(string)
   description = "List of namespaces where powerusers have admin access"
+  default     = ["apps"]
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -25,14 +25,13 @@ resource "aws_security_group_rule" "shared_redis_cluster_to_any_any" {
 }
 
 resource "aws_security_group_rule" "shared_redis_cluster_from_any" {
-  description       = "Shared Redis cluster for EKS accepts requests from EKS nodes"
-  type              = "ingress"
-  from_port         = 6379
-  to_port           = 6379
-  protocol          = "tcp"
-  security_group_id = aws_security_group.shared_redis_cluster.id
-  # EKS creates *managed* nodes in the *cluster* SG, not the worker node SG. Go figure.
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  description              = "Shared Redis cluster for EKS accepts requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.shared_redis_cluster.id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 #
@@ -56,7 +55,7 @@ resource "aws_security_group_rule" "frontend_memcached_from_eks_workers" {
   to_port                  = 11211
   protocol                 = "tcp"
   security_group_id        = aws_security_group.frontend_memcached.id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 #
@@ -70,7 +69,7 @@ resource "aws_security_group_rule" "mongodb_from_eks_workers" {
   to_port                  = 27017
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_mongo_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "router_mongodb_from_eks_workers" {
@@ -80,7 +79,7 @@ resource "aws_security_group_rule" "router_mongodb_from_eks_workers" {
   to_port                  = 27017
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_router-backend_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 # TODO: Only the Postgresql instances created by govuk-aws/app-govuk-rds are
@@ -95,7 +94,7 @@ resource "aws_security_group_rule" "postgres_from_eks_workers" {
   to_port                  = 5432
   protocol                 = "tcp"
   security_group_id        = each.value
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "mysql_from_eks_workers" {
@@ -106,7 +105,7 @@ resource "aws_security_group_rule" "mysql_from_eks_workers" {
   to_port                  = 3306
   protocol                 = "tcp"
   security_group_id        = each.value
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "elasticsearch_from_eks_workers" {
@@ -116,7 +115,7 @@ resource "aws_security_group_rule" "elasticsearch_from_eks_workers" {
   to_port                  = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_elasticsearch6_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "search_elb_from_eks_workers" {
@@ -126,7 +125,7 @@ resource "aws_security_group_rule" "search_elb_from_eks_workers" {
   to_port                  = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_search_elb_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "content_store_ec2_from_eks_workers" {
@@ -136,7 +135,7 @@ resource "aws_security_group_rule" "content_store_ec2_from_eks_workers" {
   to_port                  = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_content-store_internal_elb_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "email_alert_api_ec2_from_eks_workers" {
@@ -146,7 +145,7 @@ resource "aws_security_group_rule" "email_alert_api_ec2_from_eks_workers" {
   to_port                  = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_email-alert-api_elb_internal_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "account_api_ec2_from_eks_workers" {
@@ -156,7 +155,7 @@ resource "aws_security_group_rule" "account_api_ec2_from_eks_workers" {
   to_port                  = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_account_elb_internal_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "backend_ec2_from_eks_workers" {
@@ -166,7 +165,7 @@ resource "aws_security_group_rule" "backend_ec2_from_eks_workers" {
   to_port                  = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_backend_elb_internal_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "efs_from_eks_workers" {
@@ -176,7 +175,7 @@ resource "aws_security_group_rule" "efs_from_eks_workers" {
   to_port                  = 2049
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_asset-master-efs_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "mapit_from_eks_workers" {
@@ -186,7 +185,7 @@ resource "aws_security_group_rule" "mapit_from_eks_workers" {
   to_port                  = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_mapit_elb_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
 resource "aws_security_group_rule" "licensify_frontend_from_eks_workers" {
@@ -196,5 +195,5 @@ resource "aws_security_group_rule" "licensify_frontend_from_eks_workers" {
   to_port                  = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_licensify-frontend_internal_lb_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }

--- a/terraform/deployments/monitoring/aurora_serverless.tf
+++ b/terraform/deployments/monitoring/aurora_serverless.tf
@@ -18,7 +18,7 @@ module "grafana_database" {
   subnets               = local.database_subnets
   create_security_group = true
 
-  allowed_security_groups = [data.terraform_remote_state.cluster_infrastructure.outputs.cluster_security_group_id]
+  allowed_security_groups = [data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id]
 
   db_parameter_group_name         = aws_db_parameter_group.grafana_database.id
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.grafana_database.id

--- a/terraform/deployments/variables/common.tfvars
+++ b/terraform/deployments/variables/common.tfvars
@@ -1,3 +1,0 @@
-argo_workflows_namespaces = ["apps"]
-dex_github_orgs_teams     = [{ name = "alphagov", teams = ["gov-uk-production"] }]
-powerusers_namespaces     = ["apps"]

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -36,4 +36,5 @@ external_dns_subdomain    = "eks"
 frontend_memcached_node_type   = "cache.t4g.micro"
 shared_redis_cluster_node_type = "cache.t4g.small"
 
+# Non-production-only access is sufficient to access tools in this cluster.
 dex_github_orgs_teams = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -37,4 +37,5 @@ external_dns_subdomain    = "eks"
 frontend_memcached_node_type   = "cache.t4g.micro"
 shared_redis_cluster_node_type = "cache.t4g.small"
 
+# Non-production-only access is sufficient to access tools in this cluster.
 dex_github_orgs_teams = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -3,6 +3,8 @@ cluster_infrastructure_state_bucket = "govuk-terraform-test"
 
 cluster_version               = 1.21
 cluster_log_retention_in_days = 7
+workers_default_capacity_type = "SPOT"
+workers_size_desired          = 3
 
 eks_control_plane_subnets = {
   a = { az = "eu-west-1a", cidr = "10.200.19.0/28" }


### PR DESCRIPTION
* Update EKS module to v18 and fix up security group rules. The nodes now belong to a different security group than the cluster control plane, per [Amazon's guidance](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) and various things needed fixing up to reflect that.
* Fix some dependency issues that were breaking cluster turnup. — mostly around namespace creation.
* Update AWS LB controller from v2.2 to v2.4. This provides some security improvement as the controller now only has access to the secrets that it needs, rather than all secrets the cluster like in the previous version.
* Update Terraform AWS provider to v4.
* When turning up test clusters, use spot instances and only run 3 nodes initially.

See individual commits for more details.

Tested: cluster turnup works in the test account and I was able to create a Deploy, Service and Ingress and serve traffic from it.

https://trello.com/c/gipscM7t/873