### PR TITLE
Fastly exporter

### DIFF
--- a/terraform/deployments/cluster-infrastructure/grafana.tf
+++ b/terraform/deployments/cluster-infrastructure/grafana.tf
@@ -11,7 +11,7 @@ module "grafana_iam_role" {
   role_description              = "Role for Grafana to access AWS data sources. Corresponds to ${local.grafana_service_account} k8s ServiceAccount."
   provider_url                  = module.eks.oidc_provider
   role_policy_arns              = [aws_iam_policy.grafana.arn]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:${local.grafana_service_account}"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.monitoring_namespace}:${local.grafana_service_account}"]
 }
 
 resource "aws_iam_policy" "grafana" {

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -21,6 +21,7 @@ terraform {
 locals {
   cluster_services_namespace = "cluster-services"
   secrets_prefix             = "govuk"
+  monitoring_namespace       = "monitoring"
 }
 
 provider "aws" {

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -92,3 +92,8 @@ output "grafana_iam_role_arn" {
   description = "IAM role ARN corresponding to the k8s service account for Grafana."
   value       = module.grafana_iam_role.iam_role_arn
 }
+
+output "monitoring_namespace" {
+  description = "The namespace for monitoring."
+  value       = local.monitoring_namespace
+}

--- a/terraform/deployments/cluster-services/fastly_exporter.tf
+++ b/terraform/deployments/cluster-services/fastly_exporter.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "fastly-exporter" {
   chart            = "fastly-exporter"
   name             = "fastly-exporter"
-  namespace        = "monitoring"
+  namespace        = local.monitoring_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
 }

--- a/terraform/deployments/cluster-services/fastly_exporter.tf
+++ b/terraform/deployments/cluster-services/fastly_exporter.tf
@@ -1,0 +1,7 @@
+resource "helm_release" "fastly-exporter" {
+  chart            = "fastly-exporter"
+  name             = "fastly-exporter"
+  namespace        = "monitoring"
+  create_namespace = true
+  repository       = "https://alphagov.github.io/govuk-helm-charts/"
+}

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -13,7 +13,7 @@ resource "helm_release" "kube_prometheus_stack" {
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"
   version          = "34.9.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
-  namespace        = "monitoring"
+  namespace        = local.monitoring_ns
   create_namespace = true
   values = [yamlencode({
     alertmanager = {
@@ -177,7 +177,7 @@ resource "helm_release" "kube_prometheus_stack" {
             values   = []
           }]
         }
-        podMonitorSelectorNilUsesHelmValues = false
+        podMonitorSelectorNilUsesHelmValues     = false
         serviceMonitorSelectorNilUsesHelmValues = false
       }
     }

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -178,6 +178,7 @@ resource "helm_release" "kube_prometheus_stack" {
           }]
         }
         podMonitorSelectorNilUsesHelmValues = false
+        serviceMonitorSelectorNilUsesHelmValues = false
       }
     }
   })]

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -56,6 +56,7 @@ provider "helm" {
 }
 
 locals {
+  monitoring_ns          = data.terraform_remote_state.cluster_infrastructure.outputs.monitoring_namespace
   services_ns            = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_services_namespace
   external_dns_zone_name = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name
   alb_ingress_annotations = {


### PR DESCRIPTION
fastly-exporter allows Fastly metrics to be exposed in Prometheus
format. It also configures Prometheus to scrape it.