### PR TITLE
Fix github-cli image

### DIFF
--- a/docker/images/github-cli/Dockerfile
+++ b/docker/images/github-cli/Dockerfile
@@ -9,7 +9,7 @@ RUN chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
 RUN apt-get update -qq && apt-get install -y gh
 
-RUN groupadd -r user && useradd -m -r -g user user
+RUN groupadd -g 1001 -r user && useradd -u 1001 -m -r -g user user
 
 ENV HOME=/home/user
 


### PR DESCRIPTION
The user and group use must have id 1001 because the argo-workflows
are defaulting to these when running.