### PR TITLE
Add k8s resources to Argo Workflows components

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -131,6 +131,29 @@ resource "helm_release" "argo_workflows" {
         }
       }
       containerRuntimeExecutor = "emissary"
+      resources = {
+        requests = {
+          cpu    = "100m"
+          memory = "64Mi"
+        }
+        limits = {
+          cpu    = "500m"
+          memory = "128Mi"
+        }
+      }
+    }
+
+    executor = {
+      resources = {
+        requests = {
+          cpu    = "100m"
+          memory = "64Mi"
+        }
+        limits = {
+          cpu    = "500m"
+          memory = "512Mi"
+        }
+      }
     }
 
     workflow = {
@@ -166,6 +189,16 @@ resource "helm_release" "argo_workflows" {
         }
         redirectUrl = "https://${local.argo_workflows_host}/oauth2/callback"
         # TODO: all logged in users are admin, maybe we want differentiation
+      }
+      resources = {
+        requests = {
+          cpu    = "100m"
+          memory = "64Mi"
+        }
+        limits = {
+          cpu    = "500m"
+          memory = "128Mi"
+        }
       }
     }
   })]


### PR DESCRIPTION
There are 3 types of Argo Workflows components: controller, server
and executor where k8s resources can be set. They seem to have
their default values removed from the [Helm chart](https://github.com/argoproj/argo-helm/blob/master/charts/argo-workflows/values.yaml)

The values are added back and were obtained from [here](https://argoproj.github.io/argo-workflows/cost-optimisation/)

Ref:
1. [trello card](https://trello.com/c/54xe0QEk/892-add-resource-limits-to-workflow-and-job-pods)