### PR TITLE
Use podpatch to add default resources to main argo workflow container

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -134,6 +134,23 @@ resource "helm_release" "argo_workflows" {
             runAsNonRoot = true
             runAsUser    = 1001
           }
+          podSpecPatch = yamlencode({
+            containers = [
+              {
+                name = "main"
+                resources = {
+                  requests = {
+                    cpu    = "100m"
+                    memory = "64Mi"
+                  }
+                  limits = {
+                    cpu    = "500m"
+                    memory = "128Mi"
+                  }
+                }
+              }
+            ]
+          })
         }
       }
       containerRuntimeExecutor = "emissary"


### PR DESCRIPTION
Continuing from #608, we use a [podpatchspec](https://github.com/argoproj/argo-workflows/blob/136ebbc45b7cba346d7ba72f278624647a6b5a1c/test/e2e/manifests/mixins/workflow-controller-configmap.yaml#L12)
to give the workflow task/step containers default resources.