### PR TITLE
Support building and deploying images using a git ref

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -75,12 +75,15 @@ jobs:
           DOCKER_BUILDKIT: "1"
         run: |
           IMAGE_TAG=$(git rev-parse HEAD)
+          LATEST_GIT_SHA=$(git ls-remote origin HEAD | cut -f 1)
+          IMAGE_TAG_ARGS="-t ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+
+          if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]; then
+            IMAGE_TAG_ARGS+=" -t ${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+          fi
 
           # Build a docker container and push it to ECR
-          docker build \
-            -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" \
-            -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest" \
-            ${{ inputs.additional_build_args }} .
+          docker build ${IMAGE_TAG_ARGS} ${{ inputs.additional_build_args }} .
           echo "Pushing image to ECR..."
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}" -a
           echo "::set-output name=image::${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"

--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -34,6 +34,10 @@ on:
       additional_build_args:
         required: false
         type: string
+      gitRef:
+        required: false
+        type: string
+        default: ${{ github.sha }}
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID:
         required: true
@@ -46,7 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        id: checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.gitRef }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -65,9 +72,10 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr_repository_name }}
-          IMAGE_TAG: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: |
+          IMAGE_TAG=$(git rev-parse HEAD)
+
           # Build a docker container and push it to ECR
           docker build \
             -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,11 @@ name: Deploy
 
 on:
   workflow_call:
+    inputs:
+      imageTag:
+        description: 'A image tag to deploy'
+        required: true
+        type: string
     secrets:
       WEBHOOK_TOKEN:
         required: true
@@ -40,7 +45,7 @@ jobs:
       - name: Send webhook
         env:
           ENVIRONMENT: integration
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: ${{ inputs.imageTag }}
           REPO_NAME: ${{ github.event.repository.name }}
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}


### PR DESCRIPTION
This updates the ci-ecr and deploy GitHub Actions to support using a specific git ref (i.e. commit, tag or branch name) of the codebase. This allows us to deploy one-off commits (that aren't the latest on main) to our integration environment. 

The ci-ecr workflow (responsible for building images) now accepts a gitRef input to specify which commit of the code to build the image from. The deploy workflow now accepts a imageTag input to specify which image to deploy.

This also fixes behaviour whereby the most recently built image was tagged as "latest". The "latest" tag is a for human use as a quick reference to the most up to date version of the application. However, as we support building images that could older version of the code (e.g. branch commits) this assumption breaks. This adds a check to only tag images with "latest" when the commit sha of the code matches the HEAD of default branch. (e.g. latest commit on main)