### PR TITLE
Use full team name for argo RBAC; specify a version for argo-services helm release

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -55,8 +55,8 @@ resource "helm_release" "argo_cd" {
 
       rbacConfig = {
         "policy.csv" = <<-EOT
-          g, alphagov:${var.argo_read_only_team}, role:readonly
-          g, alphagov:${var.argo_read_write_team}, role:admin
+          g, ${var.argo_read_only_team}, role:readonly
+          g, ${var.argo_read_write_team}, role:admin
           EOT
       }
 
@@ -98,6 +98,7 @@ resource "helm_release" "argo_services" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
+  version          = "0.1.11"
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -13,13 +13,13 @@ variable "argo_workflows_namespaces" {
 variable "argo_read_write_team" {
   type        = string
   description = "Name of the GitHub team that should have read-write access to Argo"
-  default     = "gov-uk-production"
+  default     = "alphagov:gov-uk-production"
 }
 
 variable "argo_read_only_team" {
   type        = string
   description = "Name of the GitHub team that should have read-only access to Argo"
-  default     = "gov-uk"
+  default     = "alphagov:gov-uk"
 }
 
 variable "govuk_aws_state_bucket" {

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -32,7 +32,7 @@ shared_redis_cluster_node_type = "cache.t4g.small"
 
 # Non-production-only access is sufficient to access tools in this cluster.
 dex_github_orgs_teams = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]
-argo_read_write_team  = "gov-uk"
+argo_read_write_team  = "alphagov:gov-uk"
 
 grafana_db_auto_pause   = true
 rds_apply_immediately   = true

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -35,7 +35,7 @@ shared_redis_cluster_node_type = "cache.t4g.small"
 
 # Non-production-only access is sufficient to access tools in this cluster.
 dex_github_orgs_teams = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]
-argo_read_write_team  = "gov-uk"
+argo_read_write_team  = "alphagov:gov-uk"
 
 grafana_db_auto_pause   = true
 rds_apply_immediately   = true


### PR DESCRIPTION
Trello: https://trello.com/c/TRdEXluH/876-align-roles-within-argo-workflows-with-the-k8s-roles