### PR TITLE
Add back the version numbers to helm_release resources.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -98,7 +98,7 @@ resource "helm_release" "argo_services" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
-  version          = "0.1.11"
+  version          = "0.1.11" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.

--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -28,4 +28,5 @@ resource "helm_release" "aws_lb_ingress_class" {
   name       = "aws-lb-ingress-class"
   repository = "https://alphagov.github.io/govuk-helm-charts/"
   chart      = "ingress-class"
+  version    = "0.1.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
 }

--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -28,6 +28,7 @@ resource "helm_release" "cluster_secret_store" {
   name       = "cluster-secret-store"
   repository = "https://alphagov.github.io/govuk-helm-charts/"
   chart      = "cluster-secret-store"
+  version    = "0.1.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace  = local.services_ns
   values = [yamlencode({
     awsRegion          = data.aws_region.current.name
@@ -42,4 +43,5 @@ resource "helm_release" "cluster_secrets" {
   name       = "cluster-secrets"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
+  version    = "0.9.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
 }

--- a/terraform/deployments/cluster-services/fastly_exporter.tf
+++ b/terraform/deployments/cluster-services/fastly_exporter.tf
@@ -1,7 +1,8 @@
 resource "helm_release" "fastly-exporter" {
-  chart            = "fastly-exporter"
   name             = "fastly-exporter"
+  repository       = "https://alphagov.github.io/govuk-helm-charts/"
+  chart            = "fastly-exporter"
+  version          = "0.1.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
-  repository       = "https://alphagov.github.io/govuk-helm-charts/"
 }


### PR DESCRIPTION
Turns out that the Helm TF provider docs are misleading (though technically correct); omitting the version attribute installs the latest available version, but only once. On subsequent runs of `terraform apply`, newer versions of the chart are ignored. This is worse than having to update the version explicitly, so let's put the version numbers back.

There appears to be no way (currently) to make TF do what we want, which is to automatically keep up to date with the latest version of the chart (for charts that we release ourselves) without needing to manually `taint` the resource before running `terraform apply`.

Basically reverts e98d308.

Thanks to @samsimpson1 for finding this issue.

https://trello.com/c/gipscM7t/873