### PR TITLE
GDS-669-PSP: Using terraform to provision the helm release for the pod security policy.

### DIFF
--- a/terraform/deployments/cluster-services/pod_security_policy.tf
+++ b/terraform/deployments/cluster-services/pod_security_policy.tf
@@ -1,6 +1,6 @@
 resource "helm_release" "pod_security_policy" {
   name       = "psp-baseline"
-  chart      = "./cluster-security"
-  count = length(var.psp_baseline_namespaces)
-  namespace  = var.psp_baseline_namespaces[count.index] 
+  chart      = "cluster-security"
+  repository = "https://alphagov.github.io/govuk-helm-charts/"
+  namespace  = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_services_namespace
 }

--- a/terraform/deployments/cluster-services/pod_security_policy.tf
+++ b/terraform/deployments/cluster-services/pod_security_policy.tf
@@ -1,0 +1,6 @@
+resource "helm_release" "pod_security_policy" {
+  name       = "psp-baseline"
+  chart      = "./cluster-security"
+  count = length(var.psp_baseline_namespaces)
+  namespace  = var.psp_baseline_namespaces[count.index] 
+}

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -48,9 +48,3 @@ variable "powerusers_namespaces" {
   description = "List of namespaces where powerusers have admin access"
   default     = ["apps"]
 }
-
-variable "psp_baseline_namespaces" {
-  type        = list(string)
-  description = "List of namespaces where psp-baseline should apply"
-  default = ["apps", "default"]
-}

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -48,3 +48,9 @@ variable "powerusers_namespaces" {
   description = "List of namespaces where powerusers have admin access"
   default     = ["apps"]
 }
+
+variable "psp_baseline_namespaces" {
+  type        = list(string)
+  description = "List of namespaces where psp-baseline should apply"
+  default = ["apps", "default"]
+}


### PR DESCRIPTION
This has been tested, the rolebinding's, clusterroles and psp come up in their appropriate namespaces.
eks.privileged psp was deleted and a simply nginx deployment which used root was restricted from spinning up.
