### PR TITLE
Fix Role-Based Access Control for Single Signon-On apps

### DIFF
--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -64,13 +64,13 @@ resource "helm_release" "dex" {
           name         = "prometheus"
           idEnv        = "PROMETHEUS_CLIENT_ID"
           secretEnv    = "PROMETHEUS_CLIENT_SECRET"
-          redirectURIs = ["https://${local.prometheus_host}/oauth2/idpresponse"]
+          redirectURIs = ["https://${local.prometheus_host}/oauth2/callback"]
         },
         {
           name         = "alert-manager"
           idEnv        = "ALERT_MANAGER_CLIENT_ID"
           secretEnv    = "ALERT_MANAGER_CLIENT_SECRET"
-          redirectURIs = ["https://${local.alert_manager_host}/oauth2/idpresponse"]
+          redirectURIs = ["https://${local.alert_manager_host}/oauth2/callback"]
         }
       ]
     }

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -1,12 +1,157 @@
 # Installs Prometheus Operator, Prometheus, Prometheus rules, Grafana, Grafana dashboards, and Prometheus CRDs
 
 locals {
-  alert_manager_host = "alertmanager.${local.external_dns_zone_name}"
-  grafana_host       = "grafana.${local.external_dns_zone_name}"
-  prometheus_host    = "prometheus.${local.external_dns_zone_name}"
-  grafana_iam_role   = data.terraform_remote_state.cluster_infrastructure.outputs.grafana_iam_role_arn
+  alert_manager_host         = "alertmanager.${local.external_dns_zone_name}"
+  grafana_host               = "grafana.${local.external_dns_zone_name}"
+  prometheus_host            = "prometheus.${local.external_dns_zone_name}"
+  grafana_iam_role           = data.terraform_remote_state.cluster_infrastructure.outputs.grafana_iam_role_arn
+  prometheus_internal_url    = "http://kube-prometheus-stack-prometheus:9090"
+  alert_manager_internal_url = "http://kube-prometheus-stack-alertmanager:9093"
 }
 
+resource "helm_release" "prometheus_oauth2_proxy" {
+  name             = "prometheus-oauth2-proxy"
+  repository       = "https://oauth2-proxy.github.io/manifests"
+  chart            = "oauth2-proxy"
+  version          = "6.2.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace        = local.monitoring_ns
+  create_namespace = true
+
+  values = [yamlencode({
+    ingress = {
+      enabled  = true
+      pathType = "Prefix"
+      hosts    = [local.prometheus_host]
+      annotations = merge(local.alb_ingress_annotations, {
+        "alb.ingress.kubernetes.io/load-balancer-name" = "prometheus"
+      })
+    }
+
+    proxyVarsAsSecrets = false
+
+    extraEnv = [
+      {
+        name  = "OAUTH2_PROXY_UPSTREAMS"
+        value = local.prometheus_internal_url
+      },
+      {
+        name  = "OAUTH2_PROXY_PROVIDER"
+        value = "oidc"
+      },
+      {
+        name  = "OAUTH2_PROXY_PROVIDER_DISPLAY_NAME"
+        value = "GitHub"
+      },
+      {
+        name  = "OAUTH2_PROXY_OIDC_ISSUER_URL"
+        value = "https://${local.dex_host}"
+      },
+      { # Only one role is supported so only admins will be able access Prometheus UI
+        name  = "OAUTH2_PROXY_ALLOWED_GROUP"
+        value = var.github_read_write_team
+      },
+      {
+        name = "OAUTH2_PROXY_CLIENT_ID"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-prometheus"
+            key  = "clientID"
+          }
+        }
+      },
+      {
+        name = "OAUTH2_PROXY_CLIENT_SECRET"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-prometheus"
+            key  = "clientSecret"
+          }
+        }
+      },
+      {
+        name = "OAUTH2_PROXY_COOKIE_SECRET"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-prometheus"
+            key  = "cookieSecret"
+          }
+        }
+      }
+    ]
+  })]
+}
+
+resource "helm_release" "alertmanager_oauth2_proxy" {
+  name             = "alertmanager-oauth2-proxy"
+  repository       = "https://oauth2-proxy.github.io/manifests"
+  chart            = "oauth2-proxy"
+  version          = "6.2.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace        = local.monitoring_ns
+  create_namespace = true
+
+  values = [yamlencode({
+    ingress = {
+      enabled  = true
+      pathType = "Prefix"
+      hosts    = [local.alert_manager_host]
+      annotations = merge(local.alb_ingress_annotations, {
+        "alb.ingress.kubernetes.io/load-balancer-name" = "alertmanager"
+      })
+    }
+
+    proxyVarsAsSecrets = false
+
+    extraEnv = [
+      {
+        name  = "OAUTH2_PROXY_UPSTREAMS"
+        value = local.alert_manager_internal_url
+      },
+      {
+        name  = "OAUTH2_PROXY_PROVIDER"
+        value = "oidc"
+      },
+      {
+        name  = "OAUTH2_PROXY_PROVIDER_DISPLAY_NAME"
+        value = "GitHub"
+      },
+      {
+        name  = "OAUTH2_PROXY_OIDC_ISSUER_URL"
+        value = "https://${local.dex_host}"
+      },
+      { # Only one role is supported so only admins will be able access Alert Manager UI
+        name  = "OAUTH2_PROXY_ALLOWED_GROUP"
+        value = var.github_read_write_team
+      },
+      {
+        name = "OAUTH2_PROXY_CLIENT_ID"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-alert-manager"
+            key  = "clientID"
+          }
+        }
+      },
+      {
+        name = "OAUTH2_PROXY_CLIENT_SECRET"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-alert-manager"
+            key  = "clientSecret"
+          }
+        }
+      },
+      {
+        name = "OAUTH2_PROXY_COOKIE_SECRET"
+        valueFrom = {
+          secretKeyRef = {
+            name = "govuk-dex-alert-manager"
+            key  = "cookieSecret"
+          }
+        }
+      }
+    ]
+  })]
+}
 
 resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
@@ -16,28 +161,6 @@ resource "helm_release" "kube_prometheus_stack" {
   namespace        = local.monitoring_ns
   create_namespace = true
   values = [yamlencode({
-    alertmanager = {
-      ingress = {
-        enabled  = true
-        hosts    = [local.alert_manager_host]
-        pathType = "Prefix"
-        annotations = merge(local.alb_ingress_annotations, {
-          "alb.ingress.kubernetes.io/load-balancer-name" = "alertmanager"
-          "alb.ingress.kubernetes.io/auth-type"          = "oidc"
-          "alb.ingress.kubernetes.io/auth-idp-oidc" = jsonencode(
-            {
-              issuer                = "https://${local.dex_host}"
-              authorizationEndpoint = "https://${local.dex_host}/auth"
-              tokenEndpoint         = "https://${local.dex_host}/token"
-              userInfoEndpoint      = "https://${local.dex_host}/userinfo"
-              secretName            = "govuk-dex-alert-manager"
-            }
-          )
-          "alb.ingress.kubernetes.io/auth-on-unauthenticated-request" = "authenticate"
-          "alb.ingress.kubernetes.io/auth-scope"                      = "email openid"
-        })
-      }
-    }
     grafana = {
       ingress = {
         enabled  = true
@@ -141,24 +264,6 @@ resource "helm_release" "kube_prometheus_stack" {
       ]
     }
     prometheus = {
-      ingress = {
-        enabled  = true
-        hosts    = [local.prometheus_host]
-        pathType = "Prefix"
-        annotations = merge(local.alb_ingress_annotations, {
-          "alb.ingress.kubernetes.io/load-balancer-name" = "prometheus"
-          "alb.ingress.kubernetes.io/auth-type"          = "oidc"
-          "alb.ingress.kubernetes.io/auth-idp-oidc" = jsonencode(
-            { issuer                = "https://${local.dex_host}"
-              authorizationEndpoint = "https://${local.dex_host}/auth"
-              tokenEndpoint         = "https://${local.dex_host}/token"
-              userInfoEndpoint      = "https://${local.dex_host}/userinfo"
-              secretName            = "govuk-dex-prometheus"
-          })
-          "alb.ingress.kubernetes.io/auth-on-unauthenticated-request" = "authenticate"
-          "alb.ingress.kubernetes.io/auth-scope"                      = "email openid"
-        })
-      }
       # Match all PrometheusRules cluster-wide. (If an app/team needs a separate
       # Prom instance, it almost certainly needs a separate EKS cluster too.)
       prometheusSpec = {

--- a/terraform/deployments/cluster-services/kubescape.tf
+++ b/terraform/deployments/cluster-services/kubescape.tf
@@ -21,5 +21,6 @@ resource "helm_release" "kubescape" {
     name  = "accountGuid"
     value = jsondecode(data.aws_secretsmanager_secret_version.kubescape-account-guid.secret_string)["accountGuid"]
   }
+  wait          = false
   wait_for_jobs = false
 }

--- a/terraform/deployments/variables/common.tfvars
+++ b/terraform/deployments/variables/common.tfvars
@@ -1,1 +1,1 @@
-dex_github_orgs_teams  = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]
+dex_github_orgs_teams = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]

--- a/terraform/deployments/variables/common.tfvars
+++ b/terraform/deployments/variables/common.tfvars
@@ -1,0 +1,1 @@
+dex_github_orgs_teams  = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -31,7 +31,6 @@ frontend_memcached_node_type   = "cache.t4g.micro"
 shared_redis_cluster_node_type = "cache.t4g.small"
 
 # Non-production-only access is sufficient to access tools in this cluster.
-dex_github_orgs_teams  = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]
 github_read_write_team = "alphagov:gov-uk"
 
 grafana_db_auto_pause   = true

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -34,7 +34,6 @@ frontend_memcached_node_type   = "cache.t4g.micro"
 shared_redis_cluster_node_type = "cache.t4g.small"
 
 # Non-production-only access is sufficient to access tools in this cluster.
-dex_github_orgs_teams  = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]
 github_read_write_team = "alphagov:gov-uk"
 
 grafana_db_auto_pause   = true


### PR DESCRIPTION
1. Relax Dex allowed github teams (3c346e9c92c0b897da06b42f03af58355d92d1d1) 

Relax Dex allowed github teams to the 2 govuk teams across all environments.
The privileges of a team will be decided at the app level.

2. Swap ALB OIDC auth to OAuth2-Proxy OIDC Auth (8501d3a863bdc12e0861bc0e86daab5c7d7bd7e5)

Previously:
1. Prometheus and Alert-Manager used the OIDC functionality of AWS ALBs
since these applications do not natively support OIDC and have very limited access control,
e.g. basic auth password
2. only the GitHub admin team/group(s) in each environment had access to Dex,
the federated OpenID Connect provider of the platform

Now (see previous commit) that Dex access control has been relaxed because some its downstream
apps such as Grafana and Argo apps support Role Based Access Control, non-admin
GitHub teams would have had access to Prometheus and Alert-Manager because the AWS ALB
cannot do access control based on group membership.

In order to avoid this, OIDC authentication happens in the OAuth2-proxy which supports authorisation
based on group membership. Hence this allows Prometheus and Alert-Manager to still be only restricted
to admin groups.

Ref:
1. [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/)
2. [aws alb jwt](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html)