### PR TITLE
Make imageTag an optional input for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,8 +28,9 @@ on:
   workflow_call:
     inputs:
       imageTag:
-        description: 'A image tag to deploy'
-        required: true
+        description: 'An image tag to deploy'
+        required: false
+        default: ${{ github.sha }}
         type: string
     secrets:
       WEBHOOK_TOKEN:


### PR DESCRIPTION
This should preserve current functionality (having it required means workflows that haven't been updated will break)

Trello: https://trello.com/c/gd6iQBmT/899-add-ability-to-deploy-one-off-commits