### PR TITLE
Increase argo workflow pod memory limits

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -153,7 +153,7 @@ resource "helm_release" "argo_workflows" {
                   }
                   limits = {
                     cpu    = "500m"
-                    memory = "128Mi"
+                    memory = "256Mi"
                   }
                 }
               }
@@ -169,7 +169,7 @@ resource "helm_release" "argo_workflows" {
         }
         limits = {
           cpu    = "500m"
-          memory = "256Mi"
+          memory = "512Mi"
         }
       }
     }
@@ -231,7 +231,7 @@ resource "helm_release" "argo_workflows" {
         }
         limits = {
           cpu    = "500m"
-          memory = "128Mi"
+          memory = "256Mi"
         }
       }
     }


### PR DESCRIPTION
Previous limits may have been too low as containers were being terminated. This doubles the limits of the workflows controller and server pods.