### PR TITLE
Skip dex approval screen to share data with application

### DIFF
--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -16,6 +16,10 @@ resource "helm_release" "dex" {
     config = {
       issuer = "https://${local.dex_host}"
 
+      oauth2 = {
+        skipApprovalScreen = true
+      }
+
       storage = {
         type = "kubernetes"
         config = {


### PR DESCRIPTION
This is to save some clicking when logging into an application. At the moment every new session shows a screen that ask for your approval for Dex to share data with the application (argo, grafana etc.). Approval for sharing data from connected IdP to Dex is separate process on IdP.

![image](https://user-images.githubusercontent.com/11051676/165789590-e288551d-8782-4cc9-bac3-4bc8cb4d5cc1.png)
