### PR TITLE
Skip the unnecessary prompt screen when logging into Prometheus etc.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -29,6 +29,7 @@ resource "helm_release" "prometheus_oauth2_proxy" {
 
     proxyVarsAsSecrets = false
 
+    extraArgs = { "skip-provider-button" = "true" }
     extraEnv = [
       {
         name  = "OAUTH2_PROXY_UPSTREAMS"
@@ -101,6 +102,7 @@ resource "helm_release" "alertmanager_oauth2_proxy" {
 
     proxyVarsAsSecrets = false
 
+    extraArgs = { "skip-provider-button" = "true" }
     extraEnv = [
       {
         name  = "OAUTH2_PROXY_UPSTREAMS"


### PR DESCRIPTION
See `--skip-provider-prompt` in https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview/