### PR TITLE
Improve kube-prometheus-stack config.

### DIFF
--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -74,7 +74,7 @@ resource "helm_release" "dex" {
           name         = "alert-manager"
           idEnv        = "ALERT_MANAGER_CLIENT_ID"
           secretEnv    = "ALERT_MANAGER_CLIENT_SECRET"
-          redirectURIs = ["https://${local.alert_manager_host}/oauth2/callback"]
+          redirectURIs = ["https://${local.alertmanager_host}/oauth2/callback"]
         }
       ]
     }

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -235,35 +235,32 @@ resource "helm_release" "kube_prometheus_stack" {
         "AWS_WEB_IDENTITY_TOKEN_FILE" = "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
         "AWS_REGION"                  = data.aws_region.current.name
       }
-      extraSecretMounts = [
-        { name      = "aws-iam-token"
-          mountPath = "/var/run/secrets/eks.amazonaws.com/serviceaccount"
-          readOnly  = true
-          projected = {
-            defaultMode = 420 #This is 644 in octal
-            sources = [
-              { serviceAccountToken = {
-                audience          = "sts.amazonaws.com"
-                expirationSeconds = 86400
-                path              = "token"
-                }
-              },
-            ]
-          }
+      extraSecretMounts = [{
+        name      = "aws-iam-token"
+        mountPath = "/var/run/secrets/eks.amazonaws.com/serviceaccount"
+        readOnly  = true
+        projected = {
+          defaultMode = 420 # 0644 octal
+          sources = [{
+            serviceAccountToken = {
+              audience          = "sts.amazonaws.com"
+              expirationSeconds = 86400
+              path              = "token"
+            }
+          }]
         }
-      ]
-      additionalDataSources = [
-        { name     = "CloudWatch"
-          type     = "cloudwatch"
-          access   = "proxy"
-          uid      = "cloudwatch"
-          editable = false
-          jsonData = {
-            authType     = "default"
-            defaultRegion = data.aws_region.current.name
-          }
+      }]
+      additionalDataSources = [{
+        name     = "CloudWatch"
+        type     = "cloudwatch"
+        access   = "proxy"
+        uid      = "cloudwatch"
+        editable = false
+        jsonData = {
+          authType      = "default"
+          defaultRegion = data.aws_region.current.name
         }
-      ]
+      }]
     }
     prometheus = {
       # Match all PrometheusRules cluster-wide. (If an app/team needs a separate
@@ -276,7 +273,7 @@ resource "helm_release" "kube_prometheus_stack" {
             values   = []
           }]
         }
-        # Allow empty ruleSelector (https://github.com/prometheus-community/helm-charts/blob/2cacc16807caedc6cabf1606db27e0d78c844564/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml#L202)
+        # Allow empty ruleSelector (https://github.com/prometheus-community/helm-charts/blob/2cacc16/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml#L202)
         ruleSelectorNilUsesHelmValues = false
         podMonitorNamespaceSelector = {
           matchExpressions = [{

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -1,12 +1,12 @@
 # Installs Prometheus Operator, Prometheus, Prometheus rules, Grafana, Grafana dashboards, and Prometheus CRDs
 
 locals {
-  alert_manager_host         = "alertmanager.${local.external_dns_zone_name}"
-  grafana_host               = "grafana.${local.external_dns_zone_name}"
-  prometheus_host            = "prometheus.${local.external_dns_zone_name}"
-  grafana_iam_role           = data.terraform_remote_state.cluster_infrastructure.outputs.grafana_iam_role_arn
-  prometheus_internal_url    = "http://kube-prometheus-stack-prometheus:9090"
-  alert_manager_internal_url = "http://kube-prometheus-stack-alertmanager:9093"
+  alertmanager_host         = "alertmanager.${local.external_dns_zone_name}"
+  grafana_host              = "grafana.${local.external_dns_zone_name}"
+  prometheus_host           = "prometheus.${local.external_dns_zone_name}"
+  grafana_iam_role          = data.terraform_remote_state.cluster_infrastructure.outputs.grafana_iam_role_arn
+  prometheus_internal_url   = "http://kube-prometheus-stack-prometheus:9090"
+  alertmanager_internal_url = "http://kube-prometheus-stack-alertmanager:9093"
   oauth2_proxy_extra_env = [for k, v in {
     # Only one role is supported, so only admins can access Prometheus/Alertmanager UI.
     "OAUTH2_PROXY_ALLOWED_GROUP"         = var.github_read_write_team
@@ -37,7 +37,7 @@ resource "helm_release" "prometheus_oauth2_proxy" {
     extraArgs = { "skip-provider-button" = "true" }
     extraEnv = concat(local.oauth2_proxy_extra_env, [
       {
-        name = "OAUTH2_PROXY_UPSTREAMS"
+        name  = "OAUTH2_PROXY_UPSTREAMS"
         value = local.prometheus_internal_url
       },
       {
@@ -84,7 +84,7 @@ resource "helm_release" "alertmanager_oauth2_proxy" {
     ingress = {
       enabled  = true
       pathType = "Prefix"
-      hosts    = [local.alert_manager_host]
+      hosts    = [local.alertmanager_host]
       annotations = merge(local.alb_ingress_annotations, {
         "alb.ingress.kubernetes.io/load-balancer-name" = "alertmanager"
       })
@@ -92,8 +92,8 @@ resource "helm_release" "alertmanager_oauth2_proxy" {
     extraArgs = { "skip-provider-button" = "true" }
     extraEnv = concat(local.oauth2_proxy_extra_env, [
       {
-        name = "OAUTH2_PROXY_UPSTREAMS"
-        value = local.alert_manager_internal_url
+        name  = "OAUTH2_PROXY_UPSTREAMS"
+        value = local.alertmanager_internal_url
       },
       {
         name = "OAUTH2_PROXY_CLIENT_ID"

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -260,7 +260,7 @@ resource "helm_release" "kube_prometheus_stack" {
           editable = false
           jsonData = {
             authType     = "default"
-            efaultRegion = data.aws_region.current.name
+            defaultRegion = data.aws_region.current.name
           }
         }
       ]


### PR DESCRIPTION
- Fix a typo (`efaultRegion`) in one of the Helm values.
- Use a more conventional indentation style, consistent with the rest of the repo.
- Factor out some repeated config for the OAuth2 proxies.
- Consistently refer to Alertmanager by its official name (without space or `_`).

Tested: applied in integration and can still log into Prometheus/Grafana/Alertmanager. Deployments are healthy. Also checked the diffs.