### PR TITLE
Fix broken example usage for GitHub Actions workflow trigger.

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -2,9 +2,7 @@
 # -----
 #
 # on:
-#   workflow_dispatch:
-#     branches:
-#       - main
+#   workflow_dispatch: {}
 #   push:
 #     branches:
 #       - main


### PR DESCRIPTION
It looks like GitHub recently started validating this more strictly, causing workflows with spurious extra fields to fail.

Tested: here's an example showing the fix working: alphagov/licence-finder#1132