### PR TITLE
Publish Rubygem GitHub action workflow

### DIFF
--- a/.github/workflows/publish-rubygem.yaml
+++ b/.github/workflows/publish-rubygem.yaml
@@ -1,0 +1,65 @@
+# USAGE
+# -----
+#
+# on: [push, pull_request]
+#
+# jobs:
+#   test:
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/checkout@v2
+#     - uses: ruby/setup-ruby@v1
+#       with:
+#         bundler-cache: true
+#     - run: bundle exec rake
+#
+#   publish:
+#     needs: test
+#     if: ${{ github.ref == 'refs/heads/main' }}
+#     permissions:
+#       contents: write
+#     uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yaml@main
+#     secrets:
+#       GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}
+
+# REUSABLE WORKFLOW
+# -----------------
+name: Publish a Rubygem
+
+on:
+  workflow_call:
+    inputs:
+      gem_name:
+        required: false
+        type: string
+        default: ${{ github.event.repository.name }}
+    secrets:
+      GEM_HOST_API_KEY:
+        required: true
+
+jobs:
+  publish:
+    name: Publish gem
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        rubygems: latest
+        bundler-cache: true
+    - env:
+        GEM_NAME: ${{ inputs.gem_name }}
+        GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
+      run: |
+        VERSION=$(ruby -e "puts eval(File.read('$GEM_NAME.gemspec')).version")
+        GEM_VERSION=$(gem list --exact --remote $GEM_NAME)
+        if [ "$GEM_VERSION" != "$GEM_NAME (${VERSION})" ]; then
+          gem build ${GEM_NAME}.gemspec
+          gem push "${GEM_NAME}-${VERSION}.gem"
+        fi
+        if ! git ls-remote --tags --exit-code origin v${VERSION}; then
+          git tag v${VERSION}
+          git push --tags
+        fi


### PR DESCRIPTION
This adds a GitHub action workflow that can be used to push a gem to
Rubygems. The motivation for adding this is that we want to reduce the
duplication of bash code used in mutltiple repositories before expanding
our usage of GitHub Actions to more gems.

An example of this action being used with a repo is available at: https://github.com/alphagov/rubocop-govuk/commit/1ac785c96aec754afe039c9b746bf6cee3b00f50

I felt that it made sense for this action to be included in the
govuk-infrastructure repo as we already have precedence for similar
actions, such as publishing to ECR, available.