### PR TITLE
Fix the output for the node security group ID again.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/grafana.tf
+++ b/terraform/deployments/cluster-infrastructure/grafana.tf
@@ -79,7 +79,7 @@ module "grafana_db" {
   vpc_id                  = data.terraform_remote_state.infra_networking.outputs.vpc_id
   subnets                 = data.terraform_remote_state.infra_networking.outputs.private_subnet_rds_ids
   create_security_group   = true
-  allowed_security_groups = [module.eks.node_security_group_id]
+  allowed_security_groups = [local.node_security_group_id]
 
   db_parameter_group_name         = aws_db_parameter_group.grafana.id
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.grafana.id

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -19,8 +19,8 @@ output "control_plane_security_group_id" {
 }
 
 output "node_security_group_id" {
-  description = "ID of the security group which contains the worker nodes."
-  value       = module.eks.node_security_group_id
+  description = "ID of the security group which contains the worker nodes. May or may not be the same as control_plane_security_group_id."
+  value       = local.node_security_group_id
 }
 
 output "cluster_autoscaler_service_account_name" {


### PR DESCRIPTION
Setting `create_launch_template = false` (#624) changes the meanings of the [outputs of the EKS module](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest?tab=outputs). In particular, `module.eks.node_security_group_id` is no longer the SG that contains the worker nodes. The nodes now belong to the cluster primary SG, like they used to before we upgraded the EKS module.

So this should fix all the security group / firewall issues that we've started seeing lately.

Tested: already ran `terraform refresh` to update the outputs in integration and then applied govuk-publishing-infrastructure to update all the SG rules; traffic passes again.