### PR TITLE
Avoid creating an unused secondary SG for the cluster.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -52,7 +52,10 @@ module "eks" {
     "api", "audit", "authenticator", "controllerManager", "scheduler"
   ]
 
-  create_node_security_group = false # We're just using the cluster primary SG.
+  # We're just using the cluster primary SG as created by EKS.
+  create_cluster_security_group = false
+  create_node_security_group    = false
+
   eks_managed_node_group_defaults = {
     ami_type              = "AL2_x86_64"
     capacity_type         = var.workers_default_capacity_type


### PR DESCRIPTION
By default, the terraform-aws-modules/eks module creates an additional security group for the cluster and adds some rules to it that refer to the default node group SG that it creates, which we're also not using.

In order to avoid creating these unused (and therefore confusing) SGs, we need to disable both, otherwise the module fails to plan.

 Tested: plan now succeeds in staging.