### PR TITLE
Fix race between creating apps namespace and aws-auth configmap.

### DIFF
--- a/terraform/deployments/cluster-services/aws_auth_configmap.tf
+++ b/terraform/deployments/cluster-services/aws_auth_configmap.tf
@@ -49,6 +49,7 @@ locals {
       groups   = ["powerusers", "readonly"]
     }
   ]
+  poweruser_namespaces = [kubernetes_namespace.apps]
 }
 
 resource "kubernetes_config_map" "aws_auth" {
@@ -142,7 +143,7 @@ resource "kubernetes_cluster_role" "poweruser" {
 }
 
 resource "kubernetes_role_binding" "poweruser" {
-  for_each = toset(var.powerusers_namespaces)
+  for_each = toset([for ns in local.poweruser_namespaces : ns.metadata[0].name])
 
   metadata {
     name      = "poweruser-${each.key}"

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -42,9 +42,3 @@ variable "dex_github_orgs_teams" {
   description = "List of GitHub orgs and associated teams that Dex authorises. Format [{name='github_org', teams=['github_team_name']}] "
   default     = [{ name = "alphagov", teams = ["gov-uk-production"] }]
 }
-
-variable "powerusers_namespaces" {
-  type        = list(string)
-  description = "List of namespaces where powerusers have admin access"
-  default     = ["apps"]
-}


### PR DESCRIPTION
This was causing the cluster-services module to fail on first apply.

Tested: works in staging.