### PR TITLE
Refactor ArgoCD prometheus config

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -108,13 +108,6 @@ resource "helm_release" "argo_cd" {
 
     dex = {
       enabled = false
-      metrics = {
-        enabled = true
-        serviceMonitor = {
-          enabled   = true
-          namespace = local.monitoring_ns
-        }
-      }
     }
 
     notifications = {

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -3,6 +3,13 @@ locals {
   argo_host           = "argo.${local.external_dns_zone_name}"
   argo_workflows_host = "argo-workflows.${local.external_dns_zone_name}"
   argo_events_host    = "argo-events.${local.external_dns_zone_name}"
+  argo_metrics_config = {
+    enabled = true
+    serviceMonitor = {
+      enabled   = true
+      namespace = local.monitoring_ns
+    }
+  }
 }
 
 resource "kubernetes_namespace" "apps" {
@@ -77,33 +84,15 @@ resource "helm_release" "argo_cd" {
         https            = true
       }
 
-      metrics = {
-        enabled = true
-        serviceMonitor = {
-          enabled   = true
-          namespace = local.monitoring_ns
-        }
-      }
+      metrics = local.argo_metrics_config
     }
 
     controller = {
-      metrics = {
-        enabled = true
-        serviceMonitor = {
-          enabled   = true
-          namespace = local.monitoring_ns
-        }
-      }
+      metrics = local.argo_metrics_config
     }
 
     repoServer = {
-      metrics = {
-        enabled = true
-        serviceMonitor = {
-          enabled   = true
-          namespace = local.monitoring_ns
-        }
-      }
+      metrics = local.argo_metrics_config
     }
 
     dex = {
@@ -114,13 +103,7 @@ resource "helm_release" "argo_cd" {
       argocdUrl = "https://${local.argo_host}"
       cm        = { create = false }
       secret    = { create = false }
-      metrics = {
-        enabled = true
-        serviceMonitor = {
-          enabled   = true
-          namespace = local.monitoring_ns
-        }
-      }
+      metrics   = local.argo_metrics_config
     }
   })]
 }


### PR DESCRIPTION
This removes the Dex prometheus config, as its not enabled in the first place. This also refactors the shared config into a local variable.