### PR TITLE
Update Argo Workflows helm chart to 0.15.0

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -140,7 +140,7 @@ resource "helm_release" "argo_workflows" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "0.13.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.15.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     controller = {
       podSecurityContext = {


### PR DESCRIPTION
This contains fixes to missing verbs in the clusterrole.