### PR TITLE
Add DNS records for www Fastly service to Terraform.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/cdn.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/cdn.tf
@@ -1,0 +1,15 @@
+resource "aws_route53_record" "www" {
+  zone_id = local.external_dns_zone_id
+  name    = var.www_dns_name
+  type    = "CNAME"
+  ttl     = 300
+  records = ["www-gov-uk.map.fastly.net."]
+}
+
+resource "aws_route53_record" "www_validation" {
+  zone_id = local.external_dns_zone_id
+  name    = var.www_dns_validation_name
+  type    = "CNAME"
+  ttl     = 300
+  records = [var.www_dns_validation_rdata]
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -18,6 +18,7 @@ locals {
   cluster_name         = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
   vpc_id               = data.terraform_remote_state.infra_networking.outputs.vpc_id
   internal_dns_zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
+  external_dns_zone_id = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_id
   elasticache_subnets  = data.terraform_remote_state.infra_networking.outputs.private_subnet_elasticache_ids
 
   default_tags = {

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -22,3 +22,20 @@ variable "shared_redis_cluster_node_type" {
   type        = string
   description = "Instance type for the shared Redis cluster. t1 and t2 instances are not supported."
 }
+
+variable "www_dns_name" {
+  type        = string
+  description = "Name of the CNAME record to create in the eks.environment.govuk.digital zone, pointing to the CDN. Intended for use when testing Terraform alongside an existing cluster."
+  default     = "www"
+}
+
+variable "www_dns_validation_name" {
+  type        = string
+  description = "The name (hostname part) of the CNAME record to be created for the CDN to validate ownership of the www domain name."
+  default     = "_acme-challenge.www"
+}
+
+variable "www_dns_validation_rdata" {
+  type        = string
+  description = "The record data (contents) of the CNAME record to be created for the CDN to validate ownership of the www domain name."
+}

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -26,6 +26,7 @@ govuk_environment = "integration"
 
 publishing_service_domain = "integration.publishing.service.gov.uk"
 external_dns_subdomain    = "eks"
+www_dns_validation_rdata  = "8xpwlbcbmg9qjx9d2v.fastly-validations.com"
 
 frontend_memcached_node_type   = "cache.t4g.micro"
 shared_redis_cluster_node_type = "cache.t4g.small"

--- a/terraform/deployments/variables/staging/common.tfvars
+++ b/terraform/deployments/variables/staging/common.tfvars
@@ -26,6 +26,7 @@ govuk_environment = "staging"
 
 publishing_service_domain = "staging.publishing.service.gov.uk"
 external_dns_subdomain    = "eks"
+www_dns_validation_rdata  = "fnvjfn8tfff6n003cf.fastly-validations.com"
 
 frontend_memcached_node_type   = "cache.t4g.medium"
 shared_redis_cluster_node_type = "cache.t4g.medium"


### PR DESCRIPTION
I'd created these manually when setting up www.eks on Fastly.

The process of adding a Fastly service is still somewhat manual anyway, but at least this way we won't have to recreate the records manually if we tear down integration/staging and turn it back up again.

https://trello.com/c/gipscM7t

Tested: already applied successfully in the integration and staging accounts (imported the existing records).