### PR TITLE
Update external-dns from 0.10.1 to 0.11.1.

### DIFF
--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -7,7 +7,7 @@ resource "helm_release" "external_dns" {
   name             = "external-dns"
   repository       = "https://charts.bitnami.com/bitnami"
   chart            = "external-dns"
-  version          = "5.5.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "6.4.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({


### PR DESCRIPTION
We're not using either of the two Helm values which have been renamed between v5 and v6 of the Bitnami external-dns chart.

external-dns changelog: https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.11.0
Helm chart changelog: https://github.com/bitnami/charts/tree/master/bitnami/external-dns#to-600

https://trello.com/c/smNta30K