### PR TITLE
Update external-secrets from 0.4.1 to 0.5.3.

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -7,7 +7,7 @@ resource "helm_release" "external_secrets" {
   name             = "external-secrets"
   repository       = "https://charts.external-secrets.io"
   chart            = "external-secrets"
-  version          = "0.4.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.5.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({


### PR DESCRIPTION
external-secrets changelog: https://github.com/external-secrets/external-secrets/releases

#### Rollout

CRDs will need updating (since Helm doesn't update them) and ExternalSecrets specs will need updating from v1alpha1 to v1beta1. Specifically this means changing `dataFrom.key` to `dataFrom.extract.key`. See

* https://external-secrets.io/v0.5.0/guides-v1beta1/
* https://external-secrets.io/v0.5.3/api-externalsecret/
* https://external-secrets.io/v0.5.3/provider-aws-secrets-manager/