### PR TITLE
Update kube-prometheus-stack from 0.55.0 to 0.56.2.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -20,7 +20,7 @@ resource "helm_release" "prometheus_oauth2_proxy" {
   name             = "prometheus-oauth2-proxy"
   repository       = "https://oauth2-proxy.github.io/manifests"
   chart            = "oauth2-proxy"
-  version          = "6.2.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "6.2.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
 
@@ -75,7 +75,7 @@ resource "helm_release" "alertmanager_oauth2_proxy" {
   name             = "alertmanager-oauth2-proxy"
   repository       = "https://oauth2-proxy.github.io/manifests"
   chart            = "oauth2-proxy"
-  version          = "6.2.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "6.2.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
 
@@ -130,7 +130,7 @@ resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"
-  version          = "34.9.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "35.3.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
   values = [yamlencode({


### PR DESCRIPTION
Also update the OAuth2 proxy from 7.2.0 to 7.2.1.

https://trello.com/c/smNta30K

Rollout: CRDs need updating (because Helm doesn't do it) - see https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-34x-to-35x