### PR TITLE
Update Github production team name

### DIFF
--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -13,7 +13,7 @@ variable "argo_workflows_namespaces" {
 variable "github_read_write_team" {
   type        = string
   description = "Name of the GitHub team that should have read-write access to Dex SSO-enabled applications"
-  default     = "alphagov:gov-uk-production"
+  default     = "alphagov:gov-uk-production-deploy"
 }
 
 variable "github_read_only_team" {
@@ -40,5 +40,5 @@ variable "govuk_environment" {
 variable "dex_github_orgs_teams" {
   type        = list(object({ name = string, teams = list(string) }))
   description = "List of GitHub orgs and associated teams that Dex authorises. Format [{name='github_org', teams=['github_team_name']}] "
-  default     = [{ name = "alphagov", teams = ["gov-uk-production"] }]
+  default     = [{ name = "alphagov", teams = ["gov-uk-production-deploy"] }]
 }

--- a/terraform/deployments/variables/common.tfvars
+++ b/terraform/deployments/variables/common.tfvars
@@ -1,1 +1,1 @@
-dex_github_orgs_teams = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production"] }]
+dex_github_orgs_teams = [{ name = "alphagov", teams = ["gov-uk", "gov-uk-production-deploy"] }]


### PR DESCRIPTION
As covered in RFC 146 - Implement "Production Deploy Access" ,
we are renaming the production team name from "GOV.UK Production"
to "GOV.UK Production Admin". This should ensure there is no
ambiguity between this level of access and "Production Deploy" access.
Users with production access will be members of both groups.

Trello card: https://trello.com/c/docwZ4Gm/2892-implement-production-deploy-access-5