### PR TITLE
Update GHA workflow to allow for update inputs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,6 +42,11 @@ on:
         required: false
         default: ${{ github.event.repository.name }}
         type: string
+      environment:
+        description: 'Environment to deploy to'
+        required: false
+        default: 'integration'
+        type: string
     secrets:
       WEBHOOK_TOKEN:
         required: true
@@ -55,7 +60,7 @@ jobs:
     steps:
       - name: Send webhook
         env:
-          ENVIRONMENT: integration
+          ENVIRONMENT: ${{ inputs.environment }}
           IMAGE_TAG: ${{ inputs.imageTag }}
           REPO_NAME: ${{ inputs.appName }}
           MANUAL_DEPLOY: ${{ inputs.manualDeploy }}


### PR DESCRIPTION
https://trello.com/c/tUyJa4cb/923-extend-gha-to-deploy-to-specific-environment

Adding in additional inputs to allow for the passing of an environment name when running the workflow manually in the source app repo. This will allow us to more easily roll back deployments to environments other than integration.

See Trello card for more detail.