### PR TITLE
Create GP3 StorageClass

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_ebs_csi_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_ebs_csi_iam.tf
@@ -1,0 +1,169 @@
+locals {
+  csi_driver_controller_service_account_name = "ebs-csi-controller-sa"
+}
+
+module "aws_ebs_csi_driver_iam_role" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "~> 4.0"
+  create_role                   = true
+  role_name                     = "${local.csi_driver_controller_service_account_name}-${var.cluster_name}"
+  role_description              = "Role for the AWS EBS CSI driver controller. Corresponds to ${local.csi_driver_controller_service_account_name} k8s ServiceAccount."
+  provider_url                  = module.eks.oidc_provider
+  role_policy_arns              = [aws_iam_policy.aws_ebs_csi_driver.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:${local.csi_driver_controller_service_account_name}"]
+}
+
+resource "aws_iam_policy" "aws_ebs_csi_driver" {
+  name        = "AWSEbsCsiController-${var.cluster_name}"
+  description = "Allow the driver to manage AWS EBS"
+
+  # The argument to jsonencode() is the verbatim contents of
+  # https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master/docs/example-iam-policy.json
+  # (except for whitespace changes from terraform fmt).
+  policy = jsonencode({
+
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateSnapshot",
+          "ec2:AttachVolume",
+          "ec2:DetachVolume",
+          "ec2:ModifyVolume",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInstances",
+          "ec2:DescribeSnapshots",
+          "ec2:DescribeTags",
+          "ec2:DescribeVolumes",
+          "ec2:DescribeVolumesModifications"
+        ],
+        "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateTags"
+        ],
+        "Resource" : [
+          "arn:aws:ec2:*:*:volume/*",
+          "arn:aws:ec2:*:*:snapshot/*"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:CreateAction" : [
+              "CreateVolume",
+              "CreateSnapshot"
+            ]
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:DeleteTags"
+        ],
+        "Resource" : [
+          "arn:aws:ec2:*:*:volume/*",
+          "arn:aws:ec2:*:*:snapshot/*"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateVolume"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringLike" : {
+            "aws:RequestTag/ebs.csi.aws.com/cluster" : "true"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateVolume"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringLike" : {
+            "aws:RequestTag/CSIVolumeName" : "*"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateVolume"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringLike" : {
+            "aws:RequestTag/kubernetes.io/cluster/*" : "owned"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:DeleteVolume"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringLike" : {
+            "ec2:ResourceTag/ebs.csi.aws.com/cluster" : "true"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:DeleteVolume"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringLike" : {
+            "ec2:ResourceTag/CSIVolumeName" : "*"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:DeleteVolume"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringLike" : {
+            "ec2:ResourceTag/kubernetes.io/cluster/*" : "owned"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:DeleteSnapshot"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringLike" : {
+            "ec2:ResourceTag/CSIVolumeSnapshotName" : "*"
+          }
+        }
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:DeleteSnapshot"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringLike" : {
+            "ec2:ResourceTag/ebs.csi.aws.com/cluster" : "true"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -13,6 +13,11 @@ output "worker_iam_role_name" {
   value       = module.eks.eks_managed_node_groups["main"].iam_role_name
 }
 
+output "aws_ebs_csi_driver_iam_role_arn" {
+  description = "IAM role ARN for AWS EBS CSI controller role"
+  value       = module.aws_ebs_csi_driver_iam_role.iam_role_arn
+}
+
 output "control_plane_security_group_id" {
   description = "ID of the security group which contains the (AWS-owned) control plane nodes."
   value       = module.eks.cluster_primary_security_group_id

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -88,6 +88,11 @@ output "aws_lb_controller_service_account_name" {
   value       = local.aws_lb_controller_service_account_name
 }
 
+output "aws_ebs_csi_driver_controller_service_account_name" {
+  description = "Name of the k8s service account for the AWS Ebs Csi Controller"
+  value       = local.csi_driver_controller_service_account_name
+}
+
 output "grafana_iam_role_arn" {
   description = "IAM role ARN corresponding to the k8s service account for Grafana."
   value       = module.grafana_iam_role.iam_role_arn

--- a/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
@@ -13,6 +13,11 @@ resource "helm_release" "csi_driver" {
     name  = "controller.serviceAccount.name"
     value = data.terraform_remote_state.cluster_infrastructure.outputs.aws_ebs_csi_driver_controller_service_account_name
   }
+
+  set {
+    name  = "controller.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = data.terraform_remote_state.cluster_infrastructure.outputs.aws_ebs_csi_driver_iam_role_arn
+  }
   set {
     name  = "enableVolumeResizing"
     value = true

--- a/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
@@ -1,0 +1,31 @@
+resource "helm_release" "csi_driver" {
+  chart      = "aws-ebs-csi-driver"
+  name       = "aws-ebs-csi-driver"
+  namespace  = "kube-system"
+  repository = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver"
+  version    = "2.6.8" # TODO: Dependabot or equivalent so this doesn't get neglected.
+
+  set {
+    name  = "controller.serviceAccount.create"
+    value = true
+  }
+  set {
+    name  = "controller.serviceAccount.name"
+    value = data.terraform_remote_state.cluster_infrastructure.outputs.aws_ebs_csi_driver_controller_service_account_name
+  }
+  set {
+    name  = "enableVolumeResizing"
+    value = true
+  }
+  values = [yamlencode({
+    storageClasses = [{
+      apiVersion        = "storage.k8s.io/v1"
+      kind              = "StorageClass"
+      metadata          = { name = "ebs-sc" }
+      provisioner       = "ebs.csi.aws.com"
+      parameters        = { type = "gp3" }
+      reclaimPolicy     = "Retain"
+      volumeBindingMode = "WaitForFirstConsumer"
+    }]
+  })]
+}

--- a/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
@@ -5,24 +5,17 @@ resource "helm_release" "csi_driver" {
   repository = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver"
   version    = "2.6.8" # TODO: Dependabot or equivalent so this doesn't get neglected.
 
-  set {
-    name  = "controller.serviceAccount.create"
-    value = true
-  }
-  set {
-    name  = "controller.serviceAccount.name"
-    value = data.terraform_remote_state.cluster_infrastructure.outputs.aws_ebs_csi_driver_controller_service_account_name
-  }
-
-  set {
-    name  = "controller.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-    value = data.terraform_remote_state.cluster_infrastructure.outputs.aws_ebs_csi_driver_iam_role_arn
-  }
-  set {
-    name  = "enableVolumeResizing"
-    value = true
-  }
   values = [yamlencode({
+    enableVolumeResizing = true
+    controller = {
+      serviceAccount = {
+        create = true
+        name   = data.terraform_remote_state.cluster_infrastructure.outputs.aws_ebs_csi_driver_controller_service_account_name
+        annotations = {
+          "eks.amazonaws.com/role-arn" = data.terraform_remote_state.cluster_infrastructure.outputs.aws_ebs_csi_driver_iam_role_arn
+        }
+      }
+    }
     storageClasses = [{
       apiVersion        = "storage.k8s.io/v1"
       kind              = "StorageClass"


### PR DESCRIPTION
For https://trello.com/c/Wz9dRNWA/931-create-gp3-storageclass.
Added the [EBS CSI driver Helm chart](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html), this is to create a GP3 StorageClass for the cluster, using the EBS CSI driver as the provisioner.

update, this has been tested and is working correctly.
A pod, persistent volume claim and storage class has been deployed into the default namespace, using gp3 volume type.
