### PR TITLE
Fix signon-resources build, publish and deploy workflow

### DIFF
--- a/.github/workflows/signon-resources.yaml
+++ b/.github/workflows/signon-resources.yaml
@@ -1,9 +1,13 @@
-name: Build and publish signon-resources image to ECR
+name: Build, publish to ECR and deploy to Integration Signon-resources image
 
 on:
   workflow_dispatch:
-    branches:
-      - main
+    inputs:
+      gitRef:
+        description: 'Commit, tag or branch name to deploy'
+        required: true
+        type: string
+        default: 'main'
   push:
     branches:
       - main
@@ -14,11 +18,11 @@ on:
       - ".ruby-version"
 
 jobs:
-  build-publish-image-to-ecr:
+  build-publish-image-image:
+    name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
     with:
-      ecr_repository_name: signon-resources
-      additional_build_args: "-f docker/images/signon-resources/Dockerfile"
+      gitRef: ${{ github.event.inputs.gitRef }}
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
@@ -26,6 +30,9 @@ jobs:
     name: Trigger deploy to integration
     needs: build-and-publish-image
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
+    with:
+      imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
+      manualDeploy: ${{ 'main' != github.event.inputs.gitRef }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.ARGO_EVENTS_WEBHOOK_URL }}


### PR DESCRIPTION
Update the worflow to match other apps such as [frontend](https://github.com/alphagov/frontend/blob/main/.github/workflows/deploy.yaml).

Mistake in the workflow file for some reason where the 2nd job
names a non-existing dependent job.