### PR TITLE
fix signon-resources ecr job

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -29,6 +29,10 @@ on:
         required: false
         type: string
         default: ${{ github.event.repository.name }}
+      dockerfile_path:
+        required: false
+        type: string
+        default: Dockerfile
       additional_build_args:
         required: false
         type: string
@@ -87,7 +91,7 @@ jobs:
           fi
 
           # Build a docker container and push it to ECR
-          docker build ${IMAGE_TAG_ARGS} ${{ inputs.additional_build_args }} .
+          docker build ${IMAGE_TAG_ARGS} ${{ inputs.additional_build_args }} -f ${{ inputs.dockerfile_path }} .
           echo "Pushing image to ECR..."
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}" -a
           echo "::set-output name=imageTag::${IMAGE_TAG}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,6 +37,11 @@ on:
         required: false
         default: "false"
         type: string
+      appName:
+        description: 'Name of the app being deployed'
+        required: false
+        default: ${{ github.event.repository.name }}
+        type: string
     secrets:
       WEBHOOK_TOKEN:
         required: true
@@ -52,7 +57,7 @@ jobs:
         env:
           ENVIRONMENT: integration
           IMAGE_TAG: ${{ inputs.imageTag }}
-          REPO_NAME: ${{ github.event.repository.name }}
+          REPO_NAME: ${{ inputs.appName }}
           MANUAL_DEPLOY: ${{ inputs.manualDeploy }}
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}

--- a/.github/workflows/signon-resources.yaml
+++ b/.github/workflows/signon-resources.yaml
@@ -23,6 +23,7 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
     with:
       ecr_repository_name: signon-resources
+      dockerfile_path: docker/images/signon-resources/Dockerfile
       gitRef: ${{ github.event.inputs.gitRef }}
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}

--- a/.github/workflows/signon-resources.yaml
+++ b/.github/workflows/signon-resources.yaml
@@ -35,6 +35,7 @@ jobs:
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
       manualDeploy: ${{ 'main' != github.event.inputs.gitRef }}
+      appName: signon-resources
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.ARGO_EVENTS_WEBHOOK_URL }}

--- a/.github/workflows/signon-resources.yaml
+++ b/.github/workflows/signon-resources.yaml
@@ -22,6 +22,7 @@ jobs:
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
     with:
+      ecr_repository_name: signon-resources
       gitRef: ${{ github.event.inputs.gitRef }}
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}


### PR DESCRIPTION
1. Modify ci-ecr GitHub Workflow to optionally take the path of a Dockerfile
2. Modify deploy GitHub Workflow to optionally take an app name
3. Modify the signon-resources GitHub Workflow to take advantage of the 2 changes above