### PR TITLE
Add backing services MySQL and Redis to CI workflow

### DIFF
--- a/.github/workflows/test-rails.yaml
+++ b/.github/workflows/test-rails.yaml
@@ -14,6 +14,7 @@
 #     with:
 #       requiresJavaScript: true
 #       requiresMongoDB: true
+#       requiresRedis: true
 #       requiresMySQL: true
 #       mysqlUsername: "test"
 #       mysqlPassword: "password"
@@ -33,6 +34,11 @@ on:
         type: boolean
       requiresMongoDB:
         description: 'Run MongoDB'
+        required: false
+        default: false
+        type: boolean
+      requiresRedis:
+        description: 'Run Redis'
         required: false
         default: false
         type: boolean
@@ -91,6 +97,12 @@ jobs:
          uses: supercharge/mongodb-github-action@1.7.0
          with:
            mongodb-version: 2.6
+
+       - name: Setup Redis
+         if: ${{ inputs.requiresRedis }}
+         uses: supercharge/redis-github-action@1.4.0
+         with:
+           redis-version: 6.0
 
        - name: Setup MySQL
          id: setup-mysql


### PR DESCRIPTION
This adds the ability to enable a MySQL or/and Redis backing service when running CI test using GitHub Actions. This is required by some apps such as Whitehall and Signon.