### PR TITLE
Check for deploy permissions in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,8 @@
 #     secrets:
 #       WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
 #       WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-
+#       GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+#
 # REUSABLE WORKFLOW
 # -----------------
 
@@ -47,6 +48,8 @@ on:
         required: true
       WEBHOOK_URL:
         required: true
+      GOVUK_CI_GITHUB_API_TOKEN:
+        required: true
 
 jobs:
   update-image-tag:
@@ -61,9 +64,18 @@ jobs:
           MANUAL_DEPLOY: ${{ inputs.manualDeploy }}
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
         run: |
-          curl \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
-            -d "{\"environment\": \"${ENVIRONMENT}\", \"repoName\": \"${REPO_NAME}\", \"imageTag\": \"${IMAGE_TAG}\", \"manualDeploy\": \"${MANUAL_DEPLOY}\"}" \
-            "${WEBHOOK_URL}"
+          # Check actor has permission to deploy
+          DEPLOY_TEAM_MEMBERSHIP=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/orgs/alphagov/teams/gov-uk-production-deploy/memberships/${{ github.actor }} | jq -r '.state')
+
+          if [[ "${DEPLOY_TEAM_MEMBERSHIP}" = "active" ]]; then
+            curl -s \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
+              -d "{\"environment\": \"${ENVIRONMENT}\", \"repoName\": \"${REPO_NAME}\", \"imageTag\": \"${IMAGE_TAG}\", \"manualDeploy\": \"${MANUAL_DEPLOY}\"}" \
+              "${WEBHOOK_URL}"
+          else
+            echo '::error title="Insufficient permissions to deploy"::The user needs to be a member of the GOV.UK Production Deploy GitHub team to deploy.'
+            exit 1
+          fi


### PR DESCRIPTION
This adds a check in the GitHub Actions workflow for triggering a deploy in Argo Workflows. The script now checks to see if the actor (who called triggered the GitHub Action) is a member of the relevant GitHub team that allows permission to deploy (GOV.UK Production Deploy). This check will prevent those without permission for manually triggering a deploy using a workflow dispatch event.