### PR TITLE
Add production terraform config

### DIFF
--- a/terraform/deployments/cluster-infrastructure/production.backend
+++ b/terraform/deployments/cluster-infrastructure/production.backend
@@ -1,0 +1,6 @@
+bucket  = "govuk-terraform-production"
+key     = "projects/cluster-infrastructure.tfstate"
+encrypt = true
+region  = "eu-west-1"
+
+dynamodb_table = "terraform-lock"

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -20,7 +20,7 @@ resource "kubernetes_namespace" "apps" {
 }
 
 resource "helm_release" "argo_cd" {
-  depends_on       = [helm_release.aws_lb_controller]
+  depends_on       = [helm_release.dex]
   chart            = "argo-cd"
   name             = "argo-cd"
   namespace        = local.services_ns

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 resource "helm_release" "dex" {
-  depends_on       = [helm_release.aws_lb_controller]
+  depends_on       = [helm_release.aws_lb_controller, helm_release.cluster_secrets]
   chart            = "dex"
   name             = "dex"
   namespace        = local.services_ns

--- a/terraform/deployments/cluster-services/fastly_exporter.tf
+++ b/terraform/deployments/cluster-services/fastly_exporter.tf
@@ -1,4 +1,5 @@
 resource "helm_release" "fastly-exporter" {
+  depends_on       = [helm_release.cluster_secrets]
   name             = "fastly-exporter"
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
   chart            = "fastly-exporter"

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -17,6 +17,7 @@ locals {
 }
 
 resource "helm_release" "prometheus_oauth2_proxy" {
+  depends_on       = [helm_release.dex]
   name             = "prometheus-oauth2-proxy"
   repository       = "https://oauth2-proxy.github.io/manifests"
   chart            = "oauth2-proxy"
@@ -72,6 +73,7 @@ resource "helm_release" "prometheus_oauth2_proxy" {
 }
 
 resource "helm_release" "alertmanager_oauth2_proxy" {
+  depends_on       = [helm_release.dex]
   name             = "alertmanager-oauth2-proxy"
   repository       = "https://oauth2-proxy.github.io/manifests"
   chart            = "oauth2-proxy"
@@ -127,6 +129,7 @@ resource "helm_release" "alertmanager_oauth2_proxy" {
 }
 
 resource "helm_release" "kube_prometheus_stack" {
+  depends_on       = [helm_release.dex]
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"

--- a/terraform/deployments/cluster-services/production.backend
+++ b/terraform/deployments/cluster-services/production.backend
@@ -1,0 +1,6 @@
+bucket  = "govuk-terraform-production"
+key     = "projects/cluster-services.tfstate"
+encrypt = true
+region  = "eu-west-1"
+
+dynamodb_table = "terraform-lock"

--- a/terraform/deployments/govuk-publishing-infrastructure/production.backend
+++ b/terraform/deployments/govuk-publishing-infrastructure/production.backend
@@ -1,0 +1,6 @@
+bucket  = "govuk-terraform-production"
+key     = "projects/govuk-publishing-infrastructure.tfstate"
+encrypt = true
+region  = "eu-west-1"
+
+dynamodb_table = "terraform-lock"

--- a/terraform/deployments/variables/production/common.tfvars
+++ b/terraform/deployments/variables/production/common.tfvars
@@ -1,0 +1,34 @@
+govuk_aws_state_bucket              = "govuk-terraform-steppingstone-production"
+cluster_infrastructure_state_bucket = "govuk-terraform-production"
+
+cluster_version               = 1.21
+cluster_log_retention_in_days = 7
+
+eks_control_plane_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.13.19.0/28" }
+  b = { az = "eu-west-1b", cidr = "10.13.19.16/28" }
+  c = { az = "eu-west-1c", cidr = "10.13.19.32/28" }
+}
+
+eks_public_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.13.20.0/24" }
+  b = { az = "eu-west-1b", cidr = "10.13.21.0/24" }
+  c = { az = "eu-west-1c", cidr = "10.13.22.0/24" }
+}
+
+eks_private_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.13.24.0/22" }
+  b = { az = "eu-west-1b", cidr = "10.13.28.0/22" }
+  c = { az = "eu-west-1c", cidr = "10.13.32.0/22" }
+}
+
+govuk_environment = "production"
+
+publishing_service_domain = "publishing.service.gov.uk"
+external_dns_subdomain    = "eks"
+
+# TODO: Needs to be updated
+www_dns_validation_rdata = "fnvjfn8tfff6n003cf.fastly-validations.com"
+
+frontend_memcached_node_type   = "cache.t4g.medium"
+shared_redis_cluster_node_type = "cache.t4g.medium"


### PR DESCRIPTION
This adds the common tfvars for the production environment and the production backend files for each of the terraform modules.

This also fixes an issue where cluster services resources failed to come up in the correct order by adding explicit dependency information.