### PR TITLE
Update K8s authentication API version

### DIFF
--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -32,10 +32,7 @@ provider "kubernetes" {
   host                   = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_endpoint
   cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster_infrastructure.outputs.cluster_certificate_authority_data)
   exec {
-    # TODO: use `client.authentication.k8s.io/v1beta1` once aws eks get-token
-    # supports it (again). As of aws-cli 2.2.30 it still only supports
-    # v1alpha1. https://github.com/aws/aws-cli/pull/6309
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     args        = ["eks", "get-token", "--cluster-name", data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id]
   }
@@ -48,7 +45,7 @@ provider "helm" {
     host                   = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_endpoint
     cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster_infrastructure.outputs.cluster_certificate_authority_data)
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id]
     }


### PR DESCRIPTION
This has recently been updated and requires the new version to authenticate with the API server.