### PR TITLE
Remedial Security work - Enable EKS secret encryption 

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -52,6 +52,13 @@ module "eks" {
     "api", "audit", "authenticator", "controllerManager", "scheduler"
   ]
 
+  cluster_encryption_config = [
+    {
+      provider_key_arn = aws_kms_key.eks.arn
+      resources        = ["secrets"]
+    }
+  ]
+
   # We're just using the cluster primary SG as created by EKS.
   create_cluster_security_group = false
   create_node_security_group    = false
@@ -82,6 +89,12 @@ module "eks" {
       }
     }
   }
+}
+
+resource "aws_kms_key" "eks" {
+  description             = "EKS Secret Encryption Key"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 # TODO: move these into module.eks once it supports cluster addons, i.e. once


### PR DESCRIPTION
A low risk security issue was flagged, by external pen test - _secrets encryption disabled_.

This Change enables EKS secrets encryption.

```Enabling secrets encryption allows you to use AWS Key Management Service (KMS) keys to provide envelope encryption of Kubernetes secrets stored in etcd for your cluster.```

This change has been tested in Integration with no issues detected.

https://trello.com/c/YdWwpAec/949-remedial-security-work-secrets-encryption-needs-to-be-enabled-in-eks