### PR TITLE
update docs following production cluster turn up

### DIFF
--- a/docs/create-a-new-environment.md
+++ b/docs/create-a-new-environment.md
@@ -23,40 +23,13 @@ The Terraform code is organised into several [root
 modules](https://www.terraform.io/docs/language/modules/#the-root-module),
 which we call [deployments](../terraform/deployments).
 
-Some of these deployments require external [tfvars
-files](../terraform/deployments/variables). To create a new environment, you
-will need to copy the variables directory for an existing environment (e.g.
-[integration](../terraform/deployments/variables/integration)) and modify as
-appropriate.
-
-
-There are some dependencies between the root modules. The order to deploy them is:
-
-1. [`ecr`](../terraform/deployments/ecr): creates the ECR container registry from
-   which the cluster pull container images. There is a single registry for all
-   of the environments (to avoid consistency problems with image tags and
-   having to copy images between registries), so this module is not deployed
-   per-environment.
-1. [`terraform-lock`](../terraform/deployments/terraform-lock): creates the
-   DynamoDB table which Terraform uses to control concurrent access to the
-   state files in S3.
-1. [`cluster-infrastructure`](../terraform/deployments/cluster-infrastructure)
-   creates the AWS resources for the cluster.
-1. [`cluster-services`](../terraform/deployments/cluster-services)
-   deploys the base services into the cluster.
-1. [`govuk-publishing-infrastructure`](../terraform/deployments/govuk-publishing-infrastructure)
-   creates AWS resources specific to the GOV.UK apps where we are not yet
-   able to manage those resources via Kubernetes.
-
-Each these root modules (except `ecr`) requires a [backend config
-file](https://www.terraform.io/docs/language/settings/backends/configuration.html#partial-configuration)
-You can use an existing backend file as a template.
-
 To deploy the root modules, see [Applying Terraform](../terraform/docs/applying-terraform.md).
 
+## GOV.UK apps deployment
 
-## `cluster-services` deployment
+GOV.UK apps are deployed by ArgoCD and the config is stored in the
+[argocd-apps](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/argocd-apps)
+helm chart of the [govuk-helm-charts] GitHub repository.
 
-There are some [prerequisite secrets](prerequisite-secrets.md)
-which are not generated automatically. Create these secrets before running
-`terraform apply` for the first time.
+Please see the [GOV.UK k8s manual website](https://govuk-k8s-user-docs.publishing.service.gov.uk/)
+for further details on how to operate the platform.

--- a/docs/prerequisite-secrets.md
+++ b/docs/prerequisite-secrets.md
@@ -1,6 +1,8 @@
 # Prerequisite Secrets
 
 The platform requires some prerequisite secrets in order to fully function.
+These secrets are stores in AWS Secret Manager, further info about the integration
+of the k8s platform platform with AWS Secret Manager is available [here](kubernetes-external-secrets.md)
 
 The secrets listed here are either:
 1. externally generated in external systems and imported into our platform. E.g.
@@ -8,6 +10,18 @@ The secrets listed here are either:
 2. generated manually and used between different components of our platform.
    We don't have a method yet to autogenerate these. E.g. OAUTH shared secret between
    ArgoCD (continuous delivery tool) and Dex (federated OpenID Connect provider).
+3. GOV.UK app specific secrets which are referred to in
+   [govuk-apps-conf](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/govuk-apps-conf/templates/external-secrets)
+   helm chart of the [govuk-helm-charts] GitHub repository. These are usually copied across from
+   from [govuk-secrets](https://github.com/alphagov/govuk-secrets)
+
+The canonical source of all the platform secrets required are listed
+[here](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/cluster-secrets/templates)
+in the [govuk-helm-charts] GitHub repository.
+
+The purpose of this document is to provide information about:
+1. how these secrets are generated/obtained exactly
+2. the JSON format to use when adding the secrets to AWS Secret Manager
 
 The format of secret is given below to aid creation from scratch:  
 `name of the secret in AWS Secrets Manager`: Description
@@ -19,53 +33,114 @@ The format of secret is given below to aid creation from scratch:
 }
 ```
 
+In addition, there are
 
-## Externally generated secrets
 
-1. `govuk/dex/github`: shared OAUTH secret between Dex and GitHub. Obtained via
-   GitHub admin portal.
+## Externally generated platform secrets
+
+
+1. `govuk/dex/github`: shared OAUTH secret between Dex and GitHub.
+   Created via GitHub admin portal.
 
    ```
    {
-     clientID: <secret_1>,
-     clientSecret: <secret_2>
+     "clientID": "<secret_1>",
+     "clientSecret": "<secret_2>"
    }
    ```
 
-## Manually generated secrets
+2. `govuk/logit-host`: used by FileBeat in Kubernetes cluster to access the Logit stack.
+  Obtained from the Logit portal.
+
+  ```
+  {
+    "host": "<secret_1>",
+    "port": "<secret_2>
+  }
+  ```
+
+3. `govuk/slack-webhook-url`: Slack url used to post on Slack channel `#govuk-deploy-alerts`
+  Obtained from GDS/CO IT which manages Slack.
+
+ ```
+ {
+   url": "<secret_1>"
+ }
+ ```
+
+
+## Manually generated platform secrets
 
 1. `govuk/dex/argocd`: shared OAUTH secret between Dex and ArgoCD.
+    Can be generated manually using for example `openssl rand -hex 16`.
 
    ```
    {
-     clientID: <secret_1>,
-     clientSecret: <secret_2>
+     "clientID": "<secret_1>",
+     "clientSecret": "<secret_2>"
    }
    ```
 
 2. `govuk/dex/argo-workflows`: shared OAUTH secret between Dex and Argo-workflows.
+   Can be generated manually using for example `openssl rand -hex 16`.
 
    ```
    {
-     clientID: <secret_1>,
-     clientSecret: <secret_2>
+     "clientID": "<secret_1>",
+     "clientSecret": "<secret_2>"
    }
    ```
 
 3. `govuk/dex/grafana`: shared OAUTH secret between Dex and Grafana.
+   Can be generated manually using for example `openssl rand -hex 16`.
 
     ```
     {
-      clientID: <secret_1>,
-      clientSecret: <secret_2>
+      "clientID": "<secret_1>",
+      "clientSecret": "<secret_2>"
     }
     ```
 
 4. `govuk/dex/alert-manager`: shared OAUTH secret between Dex and Alert Manager.
+   Can be generated manually using for example `openssl rand -hex 16`.
 
    ```
    {
-     clientID: <secret_1>,
-     clientSecret: <secret_2>
+     "clientID": "<secret_1>",
+     "clientSecret": "<secret_2>",
+     :cookieSecret": "<secret_3>"
    }
    ```
+
+5. `govuk/dex/prometheus`: shared OAUTH secret between Dex and Alert Manager.
+  Can be generated manually using for example `openssl rand -hex 16`.
+
+  ```
+  {
+    "clientID": "<secret_1>",
+    "clientSecret": "<secret_2>",
+    cookieSecret: <secret_3>
+  }
+  ```
+
+6. `govuk/fastly/api`: used by Fastly exporter in k8s to scrape Fastly metrics.
+   Created in the Fastly management web console by creating a user which has access
+   only to the fastly service associated with a particular GOV.UK environment.
+
+   ```
+   {
+     "token": "<secret_1>"
+   }
+   ```
+
+7. `govuk/github/govuk-ci`: used by ArgoCD to access GOV.UK GitHub repos.
+   Created via GitHub portal of user `govuk-ci`.
+
+   ```
+   {
+     "token": "<secret_1>",
+     "username": "govuk-ci"
+   }
+   ```
+
+[govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts)

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -38,6 +38,9 @@ the old configuration, please see the [govuk-aws] repository.
 
 We use [Terraform] to manage AWS resources.
 
+You can create a new GOV.UK k8s environment by following the guidance in
+[here](create-a-new-environment.md)
+
 ### CI/CD
 
 Tests for govuk-infrastructure happen in GitHub Actions.

--- a/terraform/docs/applying-terraform.md
+++ b/terraform/docs/applying-terraform.md
@@ -5,6 +5,20 @@ The EKS cluster is deployed via Terraform in two stages. See [adr-3] for backgro
 - `cluster-infrastructure` is concerned only with setting-up the EKS cluster and associated AWS resources (such as the worker groups and auto-scaling groups).
 - `cluster-services` is concerned only with setting up the Kubernetes resources and configuration for base services, including the `aws-auth` ConfigMap, ingress controller, etc.
 
+## Prerequisites
+
+1. Some of the deployments below require external [tfvars
+files](../terraform/deployments/variables). To create a new environment, you
+will need to copy the variables directory for an existing environment (e.g.
+[integration](../deployments/variables/integration)) and modify as
+appropriate.
+1. Each of the deployments (except `ecr`) requires a [backend config
+file](https://www.terraform.io/docs/language/settings/backends/configuration.html#partial-configuration)
+You can use an existing backend file as a template.
+1. `cluster-services` deployment requires some [prerequisite secrets](../../docs/prerequisite-secrets.md)
+which are not generated automatically. Create these secrets before running
+`terraform apply` for the first time.
+
 ## Deployment
 
 **We no longer have any deployment automation for Terraform** (since the demise of Big Concourse).
@@ -13,12 +27,21 @@ For testing before merging to `main`, we can run Terraform locally against the t
 
 When turning up from scratch, deploy the root modules in this order:
 
-1. `terraform-lock`
-1. `ecr` (test and production accounts only)
-1. `cluster-infrastructure`
+1. [`terraform-lock`](../deployments/terraform-lock): creates the
+   DynamoDB table which Terraform uses to control concurrent access to the
+   state files in S3.
+1. [`ecr`](../deployments/ecr) (test and production accounts only): creates the ECR container registry from
+   which the cluster pull container images. There is a single registry for all
+   of the environments (to avoid consistency problems with image tags and
+   having to copy images between registries), so this module is not deployed
+   per-environment.
+1. [`cluster-infrastructure`](../deployments/cluster-infrastructure): creates the AWS resources for the cluster.
 1. Delete the `aws-auth` configmap by running `gds aws govuk-${ENV?}-admin -- aws eks update-kubeconfig --name govuk && kubectl -n kube-system delete cm aws-auth`. This is a workaround for the problem that one of the AWS-managed EKS addons creates a default aws-auth configmap which then either needs to be imported into Terraform or deleted.
-1. `govuk-publishing-infrastructure`
-1. `cluster-services`
+1. [`govuk-publishing-infrastructure`](../deployments/govuk-publishing-infrastructure): creates AWS resources specific to the GOV.UK apps where we are not yet
+able to manage those resources via Kubernetes.
+1. [`cluster-services`](../deployments/cluster-services): deploys the base services into the cluster.
+1. Create the Signon API token as a k8s secret by running `kubectl -n apps create secret generic signon-auth-token --from-literal=token=$(openssl rand -base64 40)`. This will allow
+`signon-resources` to create/export tokens from `signon`, see [here](../../docs/signon-secrets.md) for further details.
 
 ### `cluster-infrastructure`, `cluster-services` or `govuk-publishing-infrastructure` modules
 


### PR DESCRIPTION
Main changes:
1. move the terraform section from `create-a-new-environment.md` and consolidate in `applying-terraform.md`
2. update docs about secrets to include all 3 types of secrets and information about format of the platform secrets
3. link in `applying-terraform.md` that there needs to bootstrap signon/signon-resources