### PR TITLE
Add Fastly CDN config docs

### DIFF
--- a/docs/setting-up-content-delivery-network.md
+++ b/docs/setting-up-content-delivery-network.md
@@ -1,0 +1,31 @@
+# Content Delivery Network (CDN) - Fastly
+
+GOV.UK uses Fastly as its Content Delivery Network (CDN).
+
+## Setting-up
+
+To setup Fastly, log into the Fastly web management [portal](https://manage.fastly.com/).
+
+### TLS certificate
+
+1. Choose a domain that users will use to reach your GOV.UK environment, e.g.
+   the GOV.UK EKS platform uses domain with format `www.eks.<environment>.govuk.digital`
+2. Create a Fastly/letsencrypt TLS certificate for your chosen domain and attach
+   it to the "govuk" TLS configuration. Further details are available [here](https://docs.fastly.com/en/guides/serving-https-traffic-using-fastly-managed-certificates)
+3. You will be asked to create a CNAME to point to a specific given address, you should use
+   this address as the value of the variable `www_dns_validation_rdata` in the `commons.yaml` file
+   of the environment you are deploying, e.g. for integration it is located [here](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/variables/integration/common.tfvars)
+
+
+### CDN service
+
+1. In the Fastly portal, create a new CDN service, e.g. `<environment> GOV.UK EKS`.
+   You should use the same domain that you have chosen above. Make a note of the new service ID.
+2. Create a pull request in the [GitHub repo](https://github.com/alphagov/govuk-cdn-config-secrets)
+   with a new service under `www-eks`. You can use this previous [pull request](https://github.com/alphagov/govuk-cdn-config-secrets/pull/151)
+   as example.
+3. The Fastly CDN service is currently configured by running the Jenkins `Deploy_CDN`
+   job in the relevant EC2 Jenkins instance of the particular GOV.UK environment
+   where you want to deploy. You should deploy your changes by running `www-eks`
+   vhost version of that job. Further details on how to deploy deploy CDN changes
+   are available [here](https://docs.publishing.service.gov.uk/manual/cdn.html)

--- a/terraform/docs/applying-terraform.md
+++ b/terraform/docs/applying-terraform.md
@@ -12,6 +12,9 @@ files](../terraform/deployments/variables). To create a new environment, you
 will need to copy the variables directory for an existing environment (e.g.
 [integration](../deployments/variables/integration)) and modify as
 appropriate.
+    1. `cluster-infrastructure` deployment assumes that there is a Fastly CDN service
+       and requires a value (`www_dns_validation_rdata`) for creating the DNS validation of the Fastly domain. You can
+       either use a dummy value or look at setting up the [CDN service](../../docs/setting-up-content-delivery-network.md)
 1. Each of the deployments (except `ecr`) requires a [backend config
 file](https://www.terraform.io/docs/language/settings/backends/configuration.html#partial-configuration)
 You can use an existing backend file as a template.


### PR DESCRIPTION
Add specific CDN config docs for GOV.UK EKS platform.

Ref:
1. [trello card](https://trello.com/c/udCYYyPn/953-document-and-create-fastly-for-production)