### PR TITLE
fix argo workflows controller crash looping

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -183,11 +183,11 @@ resource "helm_release" "argo_workflows" {
       resources = {
         requests = {
           cpu    = "100m"
-          memory = "128Mi"
+          memory = "512Mi"
         }
         limits = {
           cpu    = "500m"
-          memory = "512Mi"
+          memory = "1Gi"
         }
       }
     }

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -183,13 +183,14 @@ resource "helm_release" "argo_workflows" {
       resources = {
         requests = {
           cpu    = "100m"
-          memory = "512Mi"
+          memory = "1Gi"
         }
         limits = {
           cpu    = "500m"
-          memory = "1Gi"
+          memory = "2Gi"
         }
       }
+      workflowWorkers = 128
     }
 
     executor = {


### PR DESCRIPTION
Fixes include:
1. increase pod memory due to OOM (out of memory) issue
2. increase no. of workers