### PR TITLE
GC Argo Workflows after 3d, including failures.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -151,7 +151,9 @@ resource "helm_release" "argo_workflows" {
         spec = {
           activeDeadlineSeconds = 7200
           ttlStrategy = {
-            secondsAfterSuccess = 432000
+            secondsAfterFailure    = 259200
+            secondsAfterSuccess    = 259200
+            secondsAfterCompletion = 259200
           }
           podGC = {
             strategy = "OnWorkflowSuccess"


### PR DESCRIPTION
We weren't garbage-collecting failed workflows at all, which makes the tools hard to use and consumes resources unnecessarily.