### PR TITLE
Fix Cluster worker instance type list

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -59,7 +59,7 @@ variable "force_destroy" {
 variable "workers_instance_types" {
   type        = list(string)
   description = "List of instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
-  default     = ["m6i.2xlarge", "m5.2xlarge", "m6i.xlarge", "m5.2xlarge"]
+  default     = ["m6i.2xlarge", "m5.2xlarge", "m6i.xlarge", "m5.xlarge"]
 }
 
 variable "workers_default_capacity_type" {


### PR DESCRIPTION
There was a bug where an element was repeated twice in the list,
this caused constant diffs in the terraform and terraform
destroying and creating node groups on each apply.

Trello card: https://trello.com/c/dZgRACDP/956-investigate-why-terraform-always-wants-to-destroy-and-create-a-new-node-group

Co-authored-by: nadeem.sabri@digital.cabinet-office.gov.uk