### PR TITLE
Add HA via replicas to cluster autoscaler

### DIFF
--- a/terraform/deployments/cluster-services/cluster_autoscaler.tf
+++ b/terraform/deployments/cluster-services/cluster_autoscaler.tf
@@ -31,5 +31,6 @@ resource "helm_release" "cluster_autoscaler" {
     extraArgs = {
       balance-similar-node-groups = true
     }
+    replicaCount = var.default_desired_ha_replicas
   })]
 }


### PR DESCRIPTION
Similar to #683, we add HA by adding replicas.

Note that leader election is already active here:
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca