### PR TITLE
Gem publish workflow be resilient to out of order executions

### DIFF
--- a/.github/workflows/publish-rubygem.yaml
+++ b/.github/workflows/publish-rubygem.yaml
@@ -63,10 +63,15 @@ jobs:
         if [ "$GEM_VERSION" != "$GEM_NAME (${VERSION})" ]; then
           gem build ${GEM_NAME}.gemspec
           gem push "${GEM_NAME}-${VERSION}.gem"
+        else
+          echo "Skipping gem publish because version (${VERSION}) is already published"
         fi
+
         if ! git ls-remote --tags --exit-code origin v${VERSION}; then
           git tag v${VERSION}
           git push --tags
+        else
+          echo "Skipping git tagging because tag (v${VERSION}) already exists"
         fi
     - if: ${{ github.sha != steps.fetch_default_branch_head.outputs.sha }}
       name: "Skip publish: commit is not HEAD of default branch"

--- a/.github/workflows/publish-rubygem.yaml
+++ b/.github/workflows/publish-rubygem.yaml
@@ -49,7 +49,12 @@ jobs:
       with:
         rubygems: latest
         bundler-cache: true
-    - env:
+    - name: "Determine HEAD of default branch"
+      id: fetch_default_branch_head
+      run: echo "::set-output name=sha::$(git ls-remote origin HEAD | cut -f 1)"
+    - if: ${{ github.sha == steps.fetch_default_branch_head.outputs.sha }}
+      name: "Check if gem needs publishing"
+      env:
         GEM_NAME: ${{ inputs.gem_name }}
         GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
       run: |
@@ -63,3 +68,7 @@ jobs:
           git tag v${VERSION}
           git push --tags
         fi
+    - if: ${{ github.sha != steps.fetch_default_branch_head.outputs.sha }}
+      name: "Skip publish: commit is not HEAD of default branch"
+      run: |
+        echo "Skipping publish because commit (${GITHUB_SHA}) isn't the HEAD of the default branch (${{ steps.fetch_default_branch_head.outputs.sha }})"

--- a/.github/workflows/publish-rubygem.yaml
+++ b/.github/workflows/publish-rubygem.yaml
@@ -58,20 +58,20 @@ jobs:
         GEM_NAME: ${{ inputs.gem_name }}
         GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
       run: |
-        VERSION=$(ruby -e "puts eval(File.read('$GEM_NAME.gemspec')).version")
-        GEM_VERSION=$(gem list --exact --remote $GEM_NAME)
-        if [ "$GEM_VERSION" != "$GEM_NAME (${VERSION})" ]; then
+        LOCAL_VERSION=$(ruby -e "puts eval(File.read('$GEM_NAME.gemspec')).version")
+        REMOTE_VERSION=$(gem list --exact --remote $GEM_NAME)
+        if [ "$REMOTE_VERSION" != "$GEM_NAME (${LOCAL_VERSION})" ]; then
           gem build ${GEM_NAME}.gemspec
-          gem push "${GEM_NAME}-${VERSION}.gem"
+          gem push "${GEM_NAME}-${LOCAL_VERSION}.gem"
         else
-          echo "Skipping gem publish because version (${VERSION}) is already published"
+          echo "Skipping gem publish because version (${LOCAL_VERSION}) is already published"
         fi
 
-        if ! git ls-remote --tags --exit-code origin v${VERSION}; then
-          git tag v${VERSION}
+        if ! git ls-remote --tags --exit-code origin v${LOCAL_VERSION}; then
+          git tag v${LOCAL_VERSION}
           git push --tags
         else
-          echo "Skipping git tagging because tag (v${VERSION}) already exists"
+          echo "Skipping git tagging because tag (v${LOCAL_VERSION}) already exists"
         fi
     - if: ${{ github.sha != steps.fetch_default_branch_head.outputs.sha }}
       name: "Skip publish: commit is not HEAD of default branch"


### PR DESCRIPTION
This is to resolve a situation where this publish workflow can produce errors when GitHub actions don't run in the order of merges. To handle this scenario (and likely some similar ones) it performs a check that the commit which is being built is the HEAD commit of the default branch of the repo.

It also does minor hygiene of this code. Adding additional information that is printed out and making variable names clearer.

There is an example run of this workflow on the govspeak gem: https://github.com/alphagov/govspeak/runs/7308887077?check_suite_focus=true

There's a bunch more info in the first commit about approaches consider.