### PR TITLE
Set Grafana replicas to 3 for prod/staging

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -139,6 +139,7 @@ resource "helm_release" "kube_prometheus_stack" {
   values = [yamlencode({
     grafana = {
       defaultDashboardsTimezone = "Europe/London"
+      replicas                  = var.default_desired_ha_replicas
       ingress = {
         enabled  = true
         hosts    = [local.grafana_host]


### PR DESCRIPTION
https://trello.com/c/GRjRW2rb/960-set-grafana-replicas-to-3-for-prod-staging

Overide the grafana subchart in kube-prometheus-stack/values.yaml to use new desired_ha_replicas variable.

https://github.com/grafana/helm-charts/blob/21291e74e2462b3ec22da5863b96ff420ffb9f9d/charts/grafana/values.yaml#L25
