### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,10 +1,25 @@
 # USAGE
 # -----
 #
+# name: Deploy
+#
 # on:
 #   workflow_dispatch:
-#     branches:
-#       - main
+#     inputs:
+#       gitRef:
+#         description: 'Commit, tag or branch name to deploy'
+#         required: true
+#         type: string
+#         default: 'main'
+#       environment:
+#         description: 'Environment to deploy to'
+#         required: true
+#         type: choice
+#         options:
+#         - integration
+#         - staging
+#         - production
+#         default: 'integration'
 #   push:
 #     branches:
 #       - main
@@ -12,13 +27,23 @@
 #       - "Jenkinsfile"
 #       - ".git**"
 #
+#
 # jobs:
-#   deploy-to-eks:
+#   trigger-deploy:
+#     name: Trigger deploy to ${{ github.event.inputs.environment }}
+#     needs: build-and-publish-image
 #     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
+#     with:
+#       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
+#       workflowTrigger: ${{ github.event_name }}
+#       environment: ${{ github.event.inputs.environment }}
 #     secrets:
-#       WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
-#       WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+#       WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}
+#       WEBHOOK_URL: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_URL }}
 #       GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+#
+
+
 #
 # REUSABLE WORKFLOW
 # -----------------
@@ -33,10 +58,10 @@ on:
         required: false
         default: ${{ github.sha }}
         type: string
-      manualDeploy:
-        description: 'Whether it is a manual deployment'
-        required: false
-        default: "false"
+      workflowTrigger:
+        description: 'event which triggered workflow'
+        required: true
+        default: "push"
         type: string
       appName:
         description: 'Name of the app being deployed'
@@ -66,7 +91,7 @@ jobs:
           ENVIRONMENT: ${{ inputs.environment }}
           IMAGE_TAG: ${{ inputs.imageTag }}
           REPO_NAME: ${{ inputs.appName }}
-          MANUAL_DEPLOY: ${{ inputs.manualDeploy }}
+          MANUAL_DEPLOY: ${{ github.event_name == 'workflow_dispatch' }}
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
           GITHUB_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
@@ -79,7 +104,7 @@ jobs:
               -H "Content-Type: application/json" \
               -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
               -d "{\"environment\": \"${ENVIRONMENT}\", \"repoName\": \"${REPO_NAME}\", \"imageTag\": \"${IMAGE_TAG}\", \"manualDeploy\": \"${MANUAL_DEPLOY}\"}" \
-              "${WEBHOOK_URL}"
+              "${WEBHOOK_URL}/update-image-tag"
           # else
           #   echo '::error title="Insufficient permissions to deploy"::The user needs to be a member of the GOV.UK Production Deploy GitHub team to deploy.'
           #   exit 1

--- a/.github/workflows/set-automatic-deploys-enabled.yaml
+++ b/.github/workflows/set-automatic-deploys-enabled.yaml
@@ -7,12 +7,12 @@
 #   workflow_dispatch:
 #     inputs:
 #       resetImageTag:
-#         description: 'Whether to reset image tag to main'
+#         description: 'Reset image tag to main'
 #         required: false
 #         default: false
 #         type: boolean
 #       automaticDeploysEnabled:
-#         description: 'Set whether automatic deploys is active or not'
+#         description: 'Activate automatic deploys'
 #         required: false
 #         default: true
 #         type: boolean
@@ -35,9 +35,14 @@
 #       automaticDeploysEnabled: ${{ github.event.inputs.automaticDeploysEnabled == 'true' }}
 #       environment: ${{ github.event.inputs.environment }}
 #     secrets:
-#       WEBHOOK_TOKEN: ${{ secrets.ARGO_EVENTS_WEBHOOK_TOKEN }}
+#       WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}
 #       WEBHOOK_URL: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_URL }}
 #       GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+
+
+#
+# REUSABLE WORKFLOW
+# -----------------
 
 name: Set automatic_deploys_enabled (optionally image_tag too)
 
@@ -45,12 +50,12 @@ on:
   workflow_call:
     inputs:
       resetImageTag:
-        description: 'Whether to reset image tag to main'
+        description: 'Reset image tag to main'
         required: false
         default: false
         type: boolean
       automaticDeploysEnabled:
-        description: 'Set whether automatic deploys is active or not'
+        description: 'Activate automatic deploys'
         required: true
         default: true
         type: boolean

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -128,7 +128,7 @@ resource "helm_release" "argo_services" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
-  version          = "0.1.15" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.1.17" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.


### PR DESCRIPTION
- rename argo_events secret from:
  1. ARGO_EVENTS_WEBHOOK_TOKEN to
     GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN
  2. ARGO_EVENTS_WEBHOOK_URL to
     GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_URL

for deploy:
 1. fix reusable workflow usage
 2. manualDeploy is found from github event_name

for automatic_deploys:
 1. fix some descrptions