### PR TITLE
Reduce logging for filebeat to resolve OOM errors.

### DIFF
--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -28,14 +28,16 @@ resource "helm_release" "filebeat" {
             }]
           }
         ]
-
         "output.logstash" : {
           "hosts" : ["$${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:$${LOGSTASH_PORT:? LOGSTASH_PORT variable is not set}"]
           "loadbalance" : true
           "ssl.enabled" : true
         }
-        "logging.files" : {
-          "keepfiles" : 7
+        "logging.metrics.enabled" : false
+        "http.enabled" : false
+        "logging.level" : "warn"
+        "output.file" : {
+          "enabled" : false
         }
       })
     }

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -34,6 +34,9 @@ resource "helm_release" "filebeat" {
           "loadbalance" : true
           "ssl.enabled" : true
         }
+        "logging.files" : {
+          "keepfiles" : 7
+        }
       })
     }
     extraEnvs = [


### PR DESCRIPTION
Added file rotation to see if this stops the OOM restarts on the filebeat pods. 
We've manually applied this to staging for now, will check this in week and if its sorted will apply.