### PR TITLE
Fix deploy reusable workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: Send webhook
         env:
-          ENVIRONMENT: ${{ inputs.environment }}
+          ENVIRONMENT: ${{ inputs.environment || 'integration' }}
           IMAGE_TAG: ${{ inputs.imageTag }}
           REPO_NAME: ${{ inputs.appName }}
           MANUAL_DEPLOY: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
This is default env value is needed since it was remove in the app
workflow, e.g. [here](https://github.com/alphagov/frontend/commit/d49f684cdd102f85e86b88dd85b4e7c49aa23a9a)