### PR TITLE
Fix links to govuk-helm-charts

### DIFF
--- a/docs/create-a-new-environment.md
+++ b/docs/create-a-new-environment.md
@@ -33,3 +33,5 @@ helm chart of the [govuk-helm-charts] GitHub repository.
 
 Please see the [GOV.UK k8s manual website](https://govuk-k8s-user-docs.publishing.service.gov.uk/)
 for further details on how to operate the platform.
+
+[govuk-helm-charts]: https://github.com/alphagov/govuk-helm-charts

--- a/docs/prerequisite-secrets.md
+++ b/docs/prerequisite-secrets.md
@@ -150,4 +150,4 @@ In addition, there are
    }
    ```
 
-[govuk-helm-charts](https://github.com/alphagov/govuk-helm-charts)
+[govuk-helm-charts]: https://github.com/alphagov/govuk-helm-charts


### PR DESCRIPTION
URL taken from https://github.com/alphagov/govuk-infrastructure/commit/4554c056ce77c0f076a9d85f740b264fb66f04ed#diff-59c2eabb11f73ab634177718ff98116b3a2d89642983ecaa8bbe8a3bfde680efR146