### PR TITLE
Fix ArgoCD application controller

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -92,6 +92,12 @@ resource "helm_release" "argo_cd" {
     controller = {
       metrics  = local.argo_metrics_config
       replicas = var.default_desired_ha_replicas
+      env = [
+        {
+          name  = "ARGOCD_CONTROLLER_REPLICAS"
+          value = tostring(var.default_desired_ha_replicas)
+        }
+      ]
     }
 
     repoServer = {


### PR DESCRIPTION
Sometimes an app fails to sync in ArgoCD because it is waiting for
the pre-sync hook to finish. This may be due to HA being switched on
by setting the replicas > 2 and the env `ARGOCD_CONTROLLER_REPLICAS`
not set. This PR solves may solve this issue, or at least the config
is consistent to what is recommended.

Ref:
1. [helm docs](https://github.com/argoproj/argo-helm/blob/79b109e7d94fcdc43346ae82e74b47654e163770/charts/argo-cd/values.yaml#L108)
2. [argocd HA guide](https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#argocd-application-controller)