### PR TITLE
Set ArgoCD application controller replicas to 1

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -90,8 +90,7 @@ resource "helm_release" "argo_cd" {
     }
 
     controller = {
-      metrics  = local.argo_metrics_config
-      replicas = var.default_desired_ha_replicas
+      metrics = local.argo_metrics_config
     }
 
     repoServer = {


### PR DESCRIPTION
I initially thought it would give HA by setting replicas > 1 but
it does not so reverting.

See also: #710