### PR TITLE
Add permissions check for deployments

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -86,7 +86,26 @@ jobs:
     name: Update image tag
     runs-on: ubuntu-latest
     steps:
-      - name: Send webhook
+      - name: Check deploy permissions
+        id: deploy-permissions
+        env:
+          ENVIRONMENT: ${{ inputs.environment || 'integration' }}
+          GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+          GITHUB_TEAM: gov-uk-production-deploy
+          GITHUB_USER: ${{ github.triggering_actor }}
+        run: |
+          # Check actor has permission to deploy
+          TEAM_MEMBERSHIP=$(gh api orgs/alphagov/teams/${GITHUB_TEAM}/memberships/${GITHUB_USER} -q .state || echo "false")
+
+          if [[ "${TEAM_MEMBERSHIP}" = "active" || "${ENVIRONMENT}" = 'integration' ]]; then
+            echo "::set-output name=authorised::true"
+          else
+            echo '::error title=Insufficient permissions to deploy::User ${{ github.triggering_actor }} needs to be a member of the GOV.UK Production Deploy team'
+            exit 1
+          fi
+
+      - name: Trigger Argo Workflows
+        if: ${{ steps.deploy-permissions.outputs.authorised == 'true' }}
         env:
           ENVIRONMENT: ${{ inputs.environment || 'integration' }}
           IMAGE_TAG: ${{ inputs.imageTag }}
@@ -94,18 +113,9 @@ jobs:
           MANUAL_DEPLOY: ${{ github.event_name == 'workflow_dispatch' }}
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-          GITHUB_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
         run: |
-          # Check actor has permission to deploy
-          DEPLOY_TEAM_MEMBERSHIP=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/orgs/alphagov/teams/gov-uk-production-deploy/memberships/${{ github.actor }} | jq -r '.state')
-
-          #if [[ "${DEPLOY_TEAM_MEMBERSHIP}" = "active" ]]; then
-            curl -s \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
-              -d "{\"environment\": \"${ENVIRONMENT}\", \"repoName\": \"${REPO_NAME}\", \"imageTag\": \"${IMAGE_TAG}\", \"manualDeploy\": \"${MANUAL_DEPLOY}\"}" \
-              "${WEBHOOK_URL}/update-image-tag"
-          # else
-          #   echo '::error title="Insufficient permissions to deploy"::The user needs to be a member of the GOV.UK Production Deploy GitHub team to deploy.'
-          #   exit 1
-          # fi
+          curl -s \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
+            -d "{\"environment\": \"${ENVIRONMENT}\", \"repoName\": \"${REPO_NAME}\", \"imageTag\": \"${IMAGE_TAG}\", \"manualDeploy\": \"${MANUAL_DEPLOY}\"}" \
+            "${WEBHOOK_URL}/update-image-tag"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -85,29 +85,26 @@ jobs:
   update-image-tag:
     name: Update image tag
     runs-on: ubuntu-latest
+    env:
+      ENVIRONMENT: ${{ inputs.environment || 'integration' }}
     steps:
       - name: Check deploy permissions
         id: deploy-permissions
         env:
-          ENVIRONMENT: ${{ inputs.environment || 'integration' }}
           GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
           GITHUB_TEAM: gov-uk-production-deploy
           GITHUB_USER: ${{ github.triggering_actor }}
         run: |
-          # Check actor has permission to deploy
           TEAM_MEMBERSHIP=$(gh api orgs/alphagov/teams/${GITHUB_TEAM}/memberships/${GITHUB_USER} -q .state || echo "false")
 
-          if [[ "${TEAM_MEMBERSHIP}" = "active" || "${ENVIRONMENT}" = 'integration' ]]; then
-            echo "::set-output name=authorised::true"
-          else
+          if ! [[ "${TEAM_MEMBERSHIP}" = "active" || "${ENVIRONMENT}" = 'integration' ]]; then
             echo '::error title=Insufficient permissions to deploy::User ${{ github.triggering_actor }} needs to be a member of the GOV.UK Production Deploy team'
             exit 1
           fi
 
       - name: Trigger Argo Workflows
-        if: ${{ steps.deploy-permissions.outputs.authorised == 'true' }}
+        if: steps.deploy-permissions.outcome == 'success'
         env:
-          ENVIRONMENT: ${{ inputs.environment || 'integration' }}
           IMAGE_TAG: ${{ inputs.imageTag }}
           REPO_NAME: ${{ inputs.appName }}
           MANUAL_DEPLOY: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
This adds a permissions check in the deployment re-usable GitHub Action workflow. The check prevents user who are not members of the GOV.UK Production Deploy team to deploy. This is a simply check to prevent those user from accidentally deploy.