### PR TITLE
Remove workflowTrigger parameter from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,7 +35,6 @@
 #     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
 #     with:
 #       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
-#       workflowTrigger: ${{ github.event_name }}
 #       environment: ${{ github.event.inputs.environment }}
 #     secrets:
 #       WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}
@@ -57,11 +56,6 @@ on:
         description: 'An image tag to deploy'
         required: false
         default: ${{ github.sha }}
-        type: string
-      workflowTrigger:
-        description: 'event which triggered workflow'
-        required: true
-        default: "push"
         type: string
       appName:
         description: 'Name of the app being deployed'


### PR DESCRIPTION
This parameter is unused and can be removed.