### PR TITLE
Change Rails CI workflow to not test JavaScript by default

### DIFF
--- a/.github/workflows/test-rails.yaml
+++ b/.github/workflows/test-rails.yaml
@@ -30,7 +30,7 @@ on:
       requiresJavaScript:
         description: 'Install Node, Yarn and JavaScript dependencies'
         required: false
-        default: true
+        default: false
         type: boolean
       requiresMongoDB:
         description: 'Run MongoDB'


### PR DESCRIPTION
This changes the default value for requiresJavascript parameter in the test-rails workflow. This is to make the parameter usage consistent and predictable.