### PR TITLE
changed from 'warn' to 'warning' to fix crashloop errors

### DIFF
--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -35,7 +35,7 @@ resource "helm_release" "filebeat" {
         }
         "logging.metrics.enabled" : false
         "http.enabled" : false
-        "logging.level" : "warn"
+        "logging.level" : "warning"
         "output.file" : {
           "enabled" : false
         }


### PR DESCRIPTION
Had the incorrect value for the logging.level key, 
`# Available log levels are: error, warning, info, debug
#logging.level: info`
Updated the configmap in staging, scaled down/up the daemonset and now all the pods are running fine.