### PR TITLE
Add Elasticsearch stack to CI workflow

### DIFF
--- a/.github/workflows/test-rails.yaml
+++ b/.github/workflows/test-rails.yaml
@@ -37,6 +37,11 @@ on:
         required: false
         default: false
         type: boolean
+      requiresElasticsearch:
+        description: 'Run Elasticsearch'
+        required: false
+        default: false
+        type: boolean
       requiresRedis:
         description: 'Run Redis'
         required: false
@@ -97,6 +102,20 @@ jobs:
          uses: supercharge/mongodb-github-action@1.7.0
          with:
            mongodb-version: 2.6
+
+       - name: Configure sysctl limits
+         if: ${{ inputs.requiresElasticsearch }}
+         run: |
+           sudo swapoff -a
+           sudo sysctl -w vm.swappiness=1
+           sudo sysctl -w fs.file-max=262144
+           sudo sysctl -w vm.max_map_count=262144
+
+       - name: Setup Elasticsearch
+         if: ${{ inputs.requiresElasticsearch }}
+         uses: elastic/elastic-github-actions/elasticsearch@562b8b6ae4677da97273ff6bc4d630ce96ecbaa5
+         with:
+           stack-version: 6.7.0
 
        - name: Setup Redis
          if: ${{ inputs.requiresRedis }}


### PR DESCRIPTION
This allows application that use Elasticsearch to use the CI GitHub Action workflow.