### PR TITLE
Fix GitHub deployment

### DIFF
--- a/terraform/deployments/github/README.md
+++ b/terraform/deployments/github/README.md
@@ -26,12 +26,7 @@ Our intent is to replace govuk-saas-config with Terraform configuration.
 
 ## Applying Terraform
 
-**Warning**
-Any new resource "github_actions_organization_secret_repositories" that has been
-created in the GitHub Web UI before will be overwritten and set to an empty
-secret.
-
-1. Generate access token
+1. Generate access token, needs to be a GitHub admin for `alphagov` org
   1. Go to https://github.com/settings/tokens/new
   2. Create a new token with permissions `admin:org` and `public_repo`
 2. Configure Terraform

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -30,6 +30,12 @@ data "github_repository" "govuk" {
   full_name = each.key
 }
 
+#
+# Only the list of repositories which will have access to a secret is created/modified
+# here, the secret should have been created in the GitHub UI in advance by a
+# GitHub Admin.
+#
+
 resource "github_actions_organization_secret_repositories" "aws_govuk_ecr_access_key_id" {
   secret_name             = "AWS_GOVUK_ECR_ACCESS_KEY_ID"
   selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
@@ -45,14 +51,12 @@ resource "github_actions_organization_secret_repositories" "ci_user_github_api_t
   selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
 }
 
-resource "github_actions_organization_secret" "argo_events_webhook_token" {
+resource "github_actions_organization_secret_repositories" "argo_events_webhook_token" {
   secret_name             = "GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN"
-  visibility              = "selected"
   selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
 }
 
-resource "github_actions_organization_secret" "argo_events_webhook_url" {
+resource "github_actions_organization_secret_repositories" "argo_events_webhook_url" {
   secret_name             = "GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_URL"
-  visibility              = "selected"
   selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
 }


### PR DESCRIPTION
fixes:
1. add to the README.md that the GitHub token creator must be an
   `alphagov` org admin
2. fixes to #704, create only list of repos which has access to secret,
   rather than the secret themselves. This is what prior art is doing.