### PR TITLE
Update aws-ebs-csi-driver to latest release (v1.10).

### DIFF
--- a/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
@@ -3,7 +3,7 @@ resource "helm_release" "csi_driver" {
   name       = "aws-ebs-csi-driver"
   namespace  = "kube-system"
   repository = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver"
-  version    = "2.6.8" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "2.9.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
 
   values = [yamlencode({
     enableVolumeResizing = true


### PR DESCRIPTION
No breaking changes in either the chart or the binaries. 1.10 driver is still compatible with any supported k8s version.

https://github.com/kubernetes-sigs/aws-ebs-csi-driver#kubernetes-compatibility-matrix

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/CHANGELOG.md#v290

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md#v1100