### PR TITLE
Add support to disable Brakeman for CI

### DIFF
--- a/.github/workflows/test-rails.yaml
+++ b/.github/workflows/test-rails.yaml
@@ -65,6 +65,11 @@ on:
         required: false
         default: ''
         type: string
+      runBrakeman:
+        description: 'Run Brakeman'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   test:
@@ -106,6 +111,7 @@ jobs:
          run: yarn install --frozen-lockfile
 
        - name: Run Brakeman
+         if: inputs.runBrakeman
          run: bundle exec brakeman . --except CheckRenderInline
 
        - name: Setup MongoDB


### PR DESCRIPTION
This adds a new boolean input `runBrakeman` that can be used to disable the Brakeman step. This is needed to re-use this workflow with applications such as search-api which isn't a Rails app, hence doesn't have support to be analysed by Brakeman. The CI workflow should be renamed more generally, as it can be used to test non-rails apps.