### PR TITLE
Fix size and AZ diversity of redis/memcache in production.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
@@ -23,6 +23,7 @@ resource "aws_elasticache_replication_group" "shared_redis_cluster" {
   node_type                  = var.shared_redis_cluster_node_type
   num_cache_clusters         = 2
   automatic_failover_enabled = true
+  multi_az_enabled           = true
   parameter_group_name       = "default.redis6.x"
   engine_version             = "6.x"
   subnet_group_name          = aws_elasticache_subnet_group.shared_redis_cluster.name

--- a/terraform/deployments/variables/production/common.tfvars
+++ b/terraform/deployments/variables/production/common.tfvars
@@ -29,5 +29,5 @@ external_dns_subdomain    = "eks"
 
 www_dns_validation_rdata = "sb6euj4c7g7s54y1pi.fastly-validations.com"
 
-frontend_memcached_node_type   = "cache.t4g.medium"
-shared_redis_cluster_node_type = "cache.t4g.medium"
+frontend_memcached_node_type   = "cache.r6g.large"
+shared_redis_cluster_node_type = "cache.r6g.xlarge"


### PR DESCRIPTION
See commits for more details.

* Fix sizes of memcached and redis in prod. Not setting them the same in staging at this time, because they're expensive (and we don't have any evidence to justify turning up yet more big, hardly-utilised storage clusters in staging).
* Enable multi-AZ for the redis cluster in prod.