### PR TITLE
Allow cross-communication between EKS and EC2 www-origins

### DIFF
--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -121,3 +121,7 @@ output "monitoring_namespace" {
 output "clamav_db_efs_id" {
   value = aws_efs_file_system.clamav-db.id
 }
+
+output "public_nat_gateway_ips" {
+  value = [for eip in aws_eip.eks_nat : eip.public_ip]
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -11,6 +11,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.1"
     }
+    fastly = {
+      source  = "fastly/fastly"
+      version = "~> 2.1"
+    }
   }
 }
 
@@ -34,3 +38,9 @@ provider "aws" {
 }
 
 provider "random" {}
+
+# used by the fastly ip ranges provider.
+# an API key is needed but 'fake' seems to work.
+provider "fastly" {
+  api_key = "fake"
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/outputs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/outputs.tf
@@ -1,3 +1,7 @@
 output "shared_redis_cluster_host" {
   value = aws_route53_record.shared_redis_cluster.fqdn
 }
+
+output "eks_ingress_www_origin_security_group_name" {
+  value = aws_security_group.eks_ingress_www_origin.name
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -80,3 +80,5 @@ data "terraform_remote_state" "app_search" {
     region = data.aws_region.current.name
   }
 }
+
+data "fastly_ip_ranges" "fastly" {}

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -207,3 +207,75 @@ resource "aws_security_group_rule" "licensify_frontend_from_eks_workers" {
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_licensify-frontend_internal_lb_id
   source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
+
+# TODO: Remove after EC2 GOV.UK decommissioned
+resource "aws_security_group_rule" "ec2_www_origin_from_eks_workers" {
+  description       = "EC2 www-origin accepts requests from EKS NAT gateways"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = data.terraform_remote_state.infra_security_groups.outputs.sg_cache_external_elb_id
+  cidr_blocks       = formatlist("%s/32", data.terraform_remote_state.cluster_infrastructure.outputs.public_nat_gateway_ips)
+}
+
+resource "aws_security_group" "eks_ingress_www_origin" {
+  name        = "eks_ingress_www_origin"
+  vpc_id      = data.terraform_remote_state.infra_vpc.outputs.vpc_id
+  description = "Security group of of EKS ingress www origin"
+  tags = {
+    Name = "eks_ingress_www_origin"
+  }
+}
+
+# TODO: Remove after EC2 GOV.UK decommissioned
+resource "aws_security_group_rule" "eks_ingress_www_origin_from_ec2_nat" {
+  description       = "EKS ingress www-origin accepts requests from EC2 NAT gateways"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = formatlist("%s/32", data.terraform_remote_state.infra_networking.outputs.nat_gateway_elastic_ips_list)
+  security_group_id = aws_security_group.eks_ingress_www_origin.id
+}
+
+resource "aws_security_group_rule" "eks_ingress_www_origin_from_office_and_fastly_https" {
+  description       = "EKS ingress www-origin accepts requests from office and Fastly"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = concat(data.terraform_remote_state.infra_security_groups.outputs.public_nat_gateway_ips, data.fastly_ip_ranges.fastly.cidr_blocks)
+  security_group_id = aws_security_group.eks_ingress_www_origin.id
+}
+
+resource "aws_security_group_rule" "eks_ingress_www_origin_from_office_and_fastly_http" {
+  description       = "EKS ingress www-origin accepts requests from office and Fastly"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = concat(data.terraform_remote_state.infra_security_groups.outputs.public_nat_gateway_ips, data.fastly_ip_ranges.fastly.cidr_blocks)
+  security_group_id = aws_security_group.eks_ingress_www_origin.id
+}
+
+resource "aws_security_group_rule" "eks_ingress_www_origin_to_any_any" {
+  description       = "EKS ingress www-origin sends requests to anywhere over any protocol"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.eks_ingress_www_origin.id
+}
+
+resource "aws_security_group_rule" "eks_workers_from_eks_ingress_www_origin" {
+  description = "EKS workers accepts requests from EKS ingress www-origin"
+  type        = "ingress"
+  # TODO: it might be possible to restrict that
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = aws_security_group.eks_ingress_www_origin.id
+}


### PR DESCRIPTION
For traffic splitting experiment, communication between the
EKS ad EC2 www-origins should be allowed since only one origin
sometimes have the required rails assets so the other origin has
to go and fetch it from there if it gets such a request.

Breaking changes:
1. Before EKS integration www-origin did not have an IP blocklist,
   it now does. It is now similar to the EC2 one. Did not want to
   complicate the code by making an exception.

Caveats:
1. Integration origins is still password protected, maybe we should
   remove this as the IP block list is sufficient. Otherwise, this
   will complicate the code for cross-communication for rails assets.