### PR TITLE
Increase startup wait time for MySQL in CI

### DIFF
--- a/.github/workflows/test-rails.yaml
+++ b/.github/workflows/test-rails.yaml
@@ -154,7 +154,7 @@ jobs:
            docker run --name mysql --publish "${MYSQL_PORT}:3306" --detach --env MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.0
 
            # Wait for MySQL to be ready to accept connections
-           sleep 10
+           sleep 15
 
            # Create user for running tests
            MYSQL_COMMAND="mysql -h 127.0.0.1 -P ${MYSQL_PORT} -u root"


### PR DESCRIPTION
On occasion 10s has not been long enough for MySQL to start and had cause subsequent connection failure issue, ultimately causing CI to fail. This is a quick fix to increase wait time to reduced the flaky-ness of CI. The long term fix is to add a docker healthcheck and poll until the check is healthy to continue.