### PR TITLE
Enable the AWS LB controller pod readiness gate in `ns/apps`.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -14,8 +14,12 @@ locals {
 
 resource "kubernetes_namespace" "apps" {
   metadata {
-    name   = var.apps_namespace
-    labels = { "app.kubernetes.io/managed-by" = "Terraform" }
+    name = var.apps_namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "Terraform"
+      # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/
+      "elbv2.k8s.aws/pod-readiness-gate-inject" = "enabled"
+    }
   }
 }
 


### PR DESCRIPTION
See https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/

This should:
* eliminate the small availability blips that we've seen on rolling update in a few cases
* shake out any remaining misconfigured healthchecks that might be lurking

I had no idea that Amazon doesn't enable this by default, though you could say by now I ought to know better 😅