### PR TITLE
Remove disused govuk-ruby Dockerfiles.

### DIFF
--- a/docker/images/govuk-ruby/2.6.6/buster/Dockerfile
+++ b/docker/images/govuk-ruby/2.6.6/buster/Dockerfile
@@ -1,2 +1,0 @@
-FROM ruby:2.6.6
-RUN apt-get update -qq && apt-get upgrade -y

--- a/docker/images/govuk-ruby/2.7.2/buster/Dockerfile
+++ b/docker/images/govuk-ruby/2.7.2/buster/Dockerfile
@@ -1,2 +1,0 @@
-FROM ruby:2.7.2
-RUN apt-get update -qq && apt-get upgrade -y

--- a/docker/images/govuk-ruby/2.7.3/buster/Dockerfile
+++ b/docker/images/govuk-ruby/2.7.3/buster/Dockerfile
@@ -1,2 +1,0 @@
-FROM ruby:2.7.3
-RUN apt-get update -qq && apt-get upgrade -y

--- a/docker/images/signon-resources/Dockerfile
+++ b/docker/images/signon-resources/Dockerfile
@@ -1,7 +1,6 @@
 ARG base_image=ruby:2.7.5-slim
 FROM ${base_image}
-# TODO: use the govuk-ruby base/builder images once they're ready, so that we
-# can avoid bloating the image with package updates.
+# TODO: use https://github.com/alphagov/govuk-ruby-images and stop running apt-get update here.
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential && apt-get clean
 
 ENV INFRA_HOME /src

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -45,9 +45,6 @@ locals {
     "signon-resources",
     "statsd",
     "govuk-terraform",
-    "govuk-ruby-2.7.2",
-    "govuk-ruby-2.7.3",
-    "govuk-ruby-2.6.6",
   ]
 }
 


### PR DESCRIPTION
These were replaced by https://github.com/alphagov/govuk-ruby-images quite a while back.

I couldn't find any references to these left in alphagov apart from a couple of TODOs, so I'm not expecting any issues deleting them.