### PR TITLE
update lifecycle rule for new deployed-to-production tag

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -214,34 +214,51 @@ resource "aws_ecr_lifecycle_policy" "ecr_lifecycle_policy" {
     "rules" : [
       {
         "rulePriority" : 1,
-        "description" : "Rule 1",
+        "description" : "Keep last 100 images with tag prefix deployed-to",
         "selection" : {
           "tagStatus" : "tagged",
           "tagPrefixList" : ["deployed-to"],
           "countType" : "imageCountMoreThan",
-          "countNumber" : 1
+          "countNumber" : 100
         },
         "action" : {
           "type" : "expire"
-        },
-        "rulePriority" : 2,
-        "description" : "Expire images older than 30 days",
+        }
+      },
+      {
+         "rulePriority": 2,
+         "description": "Expire untagged images older than 1 day",
+         "selection": {
+             "tagStatus": "untagged",
+             "countType": "sinceImagePushed",
+             "countUnit": "days",
+             "countNumber": 1
+         },
+         "action": {
+             "type": "expire"
+         }
+      },
+      {
+        "rulePriority" : 3,
+        "description" : "Keep last 20 images with tag prefix release_",
         "selection" : {
           "tagStatus" : "tagged",
+          "tagPrefixList" : ["release_"],
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 20
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      },
+      {
+        "rulePriority" : 4,
+        "description" : "Expire images older than 30 days",
+        "selection" : {
+          "tagStatus" : "any",
           "countType" : "sinceImagePushed",
           "countUnit" : "days",
           "countNumber" : 30
-        },
-        "action" : {
-          "type" : "expire"
-        },
-        "rulePriority" : 3,
-        "description" : "Keep last 20 images",
-        "selection" : {
-          "tagStatus" : "tagged",
-          "tagPrefixList" : ["v"],
-          "countType" : "imageCountMoreThan",
-          "countNumber" : 20
         },
         "action" : {
           "type" : "expire"

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -210,36 +210,45 @@ resource "aws_ecr_lifecycle_policy" "ecr_lifecycle_policy" {
   for_each   = toset([for repo in local.repositories : aws_ecr_repository.repositories[repo].name])
   repository = each.key
 
-  policy = <<EOF
-  {
-    "rules": [
-        {
-            "rulePriority": 1,
-            "description": "Expire images older than 30 days",
-            "selection": {
-                "tagStatus": "untagged",
-                "countType": "sinceImagePushed",
-                "countUnit": "days",
-                "countNumber": 30
-            },
-            "action": {
-                "type": "expire"
-            },
-            "rulePriority": 1,
-            "description": "Keep last 20 images",
-            "selection": {
-                "tagStatus": "tagged",
-                "tagPrefixList": ["v"],
-                "countType": "imageCountMoreThan",
-                "countNumber": 20
-            },
-            "action": {
-                "type": "expire"
-            }
+  policy = jsonencode({
+    "rules" : [
+      {
+        "rulePriority" : 1,
+        "description" : "Rule 1",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "tagPrefixList" : ["deployed-to"],
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 1
+        },
+        "action" : {
+          "type" : "expire"
+        },
+        "rulePriority" : 2,
+        "description" : "Expire images older than 30 days",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "countType" : "sinceImagePushed",
+          "countUnit" : "days",
+          "countNumber" : 30
+        },
+        "action" : {
+          "type" : "expire"
+        },
+        "rulePriority" : 3,
+        "description" : "Keep last 20 images",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "tagPrefixList" : ["v"],
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 20
+        },
+        "action" : {
+          "type" : "expire"
         }
+      }
     ]
-  }
-EOF
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "pull_from_ecr" {


### PR DESCRIPTION
https://trello.com/c/MK34KlBn/980-lifecycle-rules-for-ecr-to-clean-up-images

This is a lifecycle rule that applies to all repositories in production ECR,
Rule priorities are set in this way so any in-use images, which are tagged with 'deployed-to-{{env}}' are retained.
Untagged images are expired and so are images older than 30 days.