### PR TITLE
Only build non-existing ECR images

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -86,6 +86,15 @@ jobs:
           LATEST_GIT_SHA=$(git ls-remote origin HEAD | cut -f 1)
           IMAGE_TAG_ARGS="-t ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
 
+          check_image_in_ecr() {
+            aws ecr describe-images --repository-name="${1}" --image-ids=imageTag="${2}"
+          }
+
+          if check_image_in_ecr "${ECR_REPOSITORY}" "${IMAGE_TAG}"; then
+            echo "found existing image ${ECR_REPOSITORY}:${IMAGE_TAG} in registry, will not build image again"
+            exit 0
+          fi
+
           if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]; then
             IMAGE_TAG_ARGS+=" -t ${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
           fi

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -194,6 +194,7 @@ resource "aws_iam_user_policy" "github_ecr_user_policy" {
           "ecr:GetDownloadUrlForLayer",
           "ecr:BatchGetImage",
           "ecr:BatchCheckLayerAvailability",
+          "ecr:DescribeImages",
           "ecr:PutImage",
           "ecr:InitiateLayerUpload",
           "ecr:UploadLayerPart",
@@ -236,7 +237,7 @@ resource "aws_ecr_lifecycle_policy" "ecr_lifecycle_policy" {
             "action": {
                 "type": "expire"
             }
-        }            
+        }
     ]
   }
 EOF


### PR DESCRIPTION
If an ECR image exists, we do not build it again.

Future work:
Right now we use the tag to determine whether to rebuild or not and the tag comes from GitHub repo. This logic may need to be changed when images are rebuild due to base image changes due to updates.

Ref:
1. [trello card](https://trello.com/c/nFlcYHdt/1005-dont-re-build-image-if-already-existing)
2. [stack overflow](https://stackoverflow.com/questions/30543409/how-to-check-if-a-docker-image-with-a-specific-tag-exist-locally)