### PR TITLE
Fix missing image tag output when skip build

### DIFF
--- a/.github/workflows/ci-ecr.yaml
+++ b/.github/workflows/ci-ecr.yaml
@@ -92,6 +92,7 @@ jobs:
 
           if check_image_in_ecr "${ECR_REPOSITORY}" "${IMAGE_TAG}"; then
             echo "found existing image ${ECR_REPOSITORY}:${IMAGE_TAG} in registry, will not build image again"
+            echo "::set-output name=imageTag::${IMAGE_TAG}"
             exit 0
           fi
 


### PR DESCRIPTION
Logic was added to skip rebuilding an image that already exists - however it failed to output the image tag which is used by the deployment step.