### PR TITLE
Fix www-origin security groups

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -245,7 +245,7 @@ resource "aws_security_group_rule" "eks_ingress_www_origin_from_office_and_fastl
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = concat(formatlist("%s/32", data.terraform_remote_state.cluster_infrastructure.outputs.public_nat_gateway_ips), data.fastly_ip_ranges.fastly.cidr_blocks)
+  cidr_blocks       = concat(data.terraform_remote_state.infra_security_groups.outputs.office_ips, data.fastly_ip_ranges.fastly.cidr_blocks)
   security_group_id = aws_security_group.eks_ingress_www_origin.id
 }
 
@@ -255,7 +255,7 @@ resource "aws_security_group_rule" "eks_ingress_www_origin_from_office_and_fastl
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
-  cidr_blocks       = concat(formatlist("%s/32", data.terraform_remote_state.cluster_infrastructure.outputs.public_nat_gateway_ips), data.fastly_ip_ranges.fastly.cidr_blocks)
+  cidr_blocks       = concat(data.terraform_remote_state.infra_security_groups.outputs.office_ips, data.fastly_ip_ranges.fastly.cidr_blocks)
   security_group_id = aws_security_group.eks_ingress_www_origin.id
 }
 


### PR DESCRIPTION
For some reason, the wrong list were concanated for www-origin office and fastly security groups.

This fixes that, tested in integration