### PR TITLE
Add podman and aws-cli to gh image

### DIFF
--- a/images/github-cli/Dockerfile
+++ b/images/github-cli/Dockerfile
@@ -7,7 +7,13 @@ RUN apt-get update -qq && apt-get install -y ca-certificates git wget
 ADD https://cli.github.com/packages/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
-RUN apt-get update -qq && apt-get install -y gh
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+    gh \
+    awscli \
+    podman 
+
+RUN aws --version && podman --version
 
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64.tar.gz -O - |  tar xz && mv yq_linux_amd64 /usr/bin/yq
 


### PR DESCRIPTION
To make use of the new update-image-tag script, we need aws-cli and podman to execute the calls to ECR.


Testing:
Dockerfile was built locally with no issues.
`$docker exec -i 156576912bbf aws --version
aws-cli/1.19.1 Python/3.9.2 Linux/5.10.104-linuxkit botocore/1.20.0
$docker exec -i 156576912bbf podman --version
podman version 3.0.1`