### PR TITLE
annotated argo-workflow sa with push-to-ecr role arn

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -227,6 +227,9 @@ resource "helm_release" "argo_workflows" {
     workflow = {
       serviceAccount = {
         create = true
+        annotations = {
+          "eks.amazonaws.com/role-arn" = data.terraform_remote_state.ecr.outputs.aws_iam_role_push_to_ecr_role_arn
+        }
       }
     }
 

--- a/terraform/deployments/ecr/outputs.tf
+++ b/terraform/deployments/ecr/outputs.tf
@@ -1,0 +1,4 @@
+output "push_to_ecr_role_arn" {
+  description = "ARN of the push to ECR role"
+  value       = aws_iam_role.push_to_ecr.arn
+}


### PR DESCRIPTION
So that the update-image-tag pod can make calls to ECR, it will assume the SA that has the iam-role associated.
This service account seemed convenient to use as it exists in the same namespace the update-image-tag pods are created in.