### PR TITLE
tag ecr role, repository policy and service account annotation introduced

### DIFF
--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -125,3 +125,7 @@ output "clamav_db_efs_id" {
 output "public_nat_gateway_ips" {
   value = [for eip in aws_eip.eks_nat : eip.public_ip]
 }
+
+output "tag_ecr_iam_role_arn" {
+  value = module.tag_ecr_images_iam_role.iam_role_arn
+}

--- a/terraform/deployments/cluster-infrastructure/tag_ecr_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/tag_ecr_iam.tf
@@ -1,0 +1,31 @@
+module "tag_ecr_images_iam_role" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "~> 4.0"
+  create_role                   = true
+  role_name                     = "tag_ecr_images"
+  role_description              = "IAM role for 'argo-workflow' service account to assume"
+  provider_url                  = module.eks.oidc_provider
+  role_policy_arns              = [aws_iam_policy.tag_ecr_images.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:apps:argo-workflow"]
+}
+data "aws_iam_policy_document" "tag_ecr_images" {
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:PutImage",
+      "ecr:TagResource"
+    ]
+    resources = ["arn:aws:ecr:${data.aws_region.current.name}:172025368201:repository/*"]
+  }
+}
+resource "aws_iam_policy" "tag_ecr_images" {
+  name   = "tag_ecr_images"
+  policy = data.aws_iam_policy_document.tag_ecr_images.json
+}

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -227,6 +227,9 @@ resource "helm_release" "argo_workflows" {
     workflow = {
       serviceAccount = {
         create = true
+        annotations = {
+          "eks.amazonaws.com/role-arn" = data.terraform_remote_state.cluster_infrastructure.outputs.tag_ecr_iam_role_arn
+        }
       }
     }
 


### PR DESCRIPTION
https://trello.com/c/MK34KlBn/980-lifecycle-rules-for-ecr-to-clean-up-images

A new IAM role that is assumable by the service account associated with update-image-tag workflow, the production ECR repositories need a new policy to allow tagging