### PR TITLE
Use argo-bootstrap instead of argo-services

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -123,23 +123,22 @@ resource "helm_release" "argo_cd" {
   })]
 }
 
-resource "helm_release" "argo_services" {
+resource "helm_release" "argo_bootstrap" {
   # Relies on CRDs
   depends_on       = [helm_release.argo_cd, helm_release.argo_events]
-  chart            = "argo-services"
-  name             = "argo-services"
+  chart            = "argo-bootstrap"
+  name             = "argo-bootstrap"
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
-  version          = "0.2.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.1.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.
-    govukEnvironment     = var.govuk_environment
-    argocdUrl            = "https://${local.argo_host}"
-    argoWorkflowsUrl     = "https://${local.argo_workflows_host}"
-    argoEventsHost       = local.argo_events_host
-    enableWebhookIngress = (var.govuk_environment == "integration")
+    govukEnvironment = var.govuk_environment
+    argocdUrl        = "https://${local.argo_host}"
+    argoWorkflowsUrl = "https://${local.argo_workflows_host}"
+    argoEventsHost   = local.argo_events_host
     rbacTeams = {
       read_only  = var.github_read_only_team
       read_write = var.github_read_write_team


### PR DESCRIPTION
This updates the reference to the chart used to bootstrap ArgoCD. The chart had been renamed govuk-helm-charts and versioning re-set. We no longer need to set enableWebhookIngress value as this is now managed in ArgoCD.