### PR TITLE
Update External Secrets Operator to 0.6.0.

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -7,7 +7,7 @@ resource "helm_release" "external_secrets" {
   name             = "external-secrets"
   repository       = "https://charts.external-secrets.io"
   chart            = "external-secrets"
-  version          = "0.5.9" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.6.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({


### PR DESCRIPTION
Changelog: https://github.com/external-secrets/external-secrets/releases/tag/v0.6.0

Rollout: needs `terraform apply`.