### PR TITLE
Clean up github-cli container image.

### DIFF
--- a/images/github-cli/Dockerfile
+++ b/images/github-cli/Dockerfile
@@ -1,29 +1,31 @@
-ARG base_image=bitnami/minideb:latest
+FROM public.ecr.aws/lts/ubuntu:22.04_stable
+ARG TARGETARCH
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-FROM ${base_image}
-
-RUN apt-get update -qq && apt-get install -y ca-certificates git wget
+ENV DEBIAN_FRONTEND=noninteractive
 
 ADD https://cli.github.com/packages/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends \
-    gh \
-    awscli \
-    podman 
+    apt-get install -qy --no-install-recommends \
+        ca-certificates gh git curl awscli podman && \
+    rm -fr /var/lib/apt/lists/*
 
-RUN aws --version && podman --version
+RUN curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}.tar.gz" \
+    | tar -xzf - && \
+    mv "yq_linux_${TARGETARCH}" /usr/bin/yq
 
-RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64.tar.gz -O - |  tar xz && mv yq_linux_amd64 /usr/bin/yq
+# Crude smoke test.
+RUN aws --version && \
+    gh --version && \
+    podman --version && \
+    yq --version
 
-RUN groupadd -g 1001 -r user && useradd -u 1001 -m -r -g user user
+RUN groupadd -g 1001 user && \
+    useradd -mu 1001 -g user user
 
-ENV HOME=/home/user
-
-RUN chown -R user:user $HOME
-WORKDIR $HOME
-
+WORKDIR /home/user
 USER user
-
-CMD /bin/bash
+CMD ["/bin/bash"]
+LABEL org.opencontainers.image.source=https://github.com/alphagov/govuk-infrastructure/tree/main/images/github-cli/


### PR DESCRIPTION
- Switch from minideb to Ubuntu LTS.
- Don't hardcode `amd64`. Haven't tested ARM but at least it has a chance of working now.
- Set non-interactive mode for apt-get so that it doesn't get stuck waiting for input.
- Set OCI source label.
- Fix a bunch of lints: pipefail, removing apt-get catalogue etc.

Tested: builds and runs locally with docker.