### PR TITLE
Add IAM Role Service Account to retag images

### DIFF
--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -53,6 +53,16 @@ output "cluster_endpoint" {
   value       = module.eks.cluster_endpoint
 }
 
+output "cluster_oidc_provider" {
+  description = "The OpenID Connect provider for the EKS cluster (without https://)"
+  value       = module.eks.oidc_provider
+}
+
+output "cluster_oidc_provider_arn" {
+  description = "The ARN of the OpenID Connect provider for the EKS cluster."
+  value       = module.eks.oidc_provider_arn
+}
+
 output "cluster_services_namespace" {
   description = "The namespace for cluster services."
   value       = local.cluster_services_namespace

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -135,6 +135,7 @@ resource "helm_release" "argo_bootstrap" {
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.
+    awsAccountId     = data.aws_caller_identity.current.account_id
     govukEnvironment = var.govuk_environment
     argocdUrl        = "https://${local.argo_host}"
     argoWorkflowsUrl = "https://${local.argo_workflows_host}"
@@ -142,6 +143,12 @@ resource "helm_release" "argo_bootstrap" {
     rbacTeams = {
       read_only  = var.github_read_only_team
       read_write = var.github_read_write_team
+    }
+    iamRoleServiceAccounts = {
+      tagImageWorkflow = {
+        name       = local.tag_image_service_account_name
+        iamRoleArn = module.tag_image_iam_role.iam_role_arn
+      }
     }
   })]
 }

--- a/terraform/deployments/cluster-services/argo_workflows.tf
+++ b/terraform/deployments/cluster-services/argo_workflows.tf
@@ -1,0 +1,44 @@
+locals {
+  tag_image_service_account_name = "add-tag-to-image-workflow"
+}
+
+module "tag_image_iam_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.5"
+
+  role_name        = "${local.tag_image_service_account_name}-${data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id}"
+  role_description = "Role for the add-tag-to-image Argo Workflow. Corresponds to ${local.tag_image_service_account_name} k8s ServiceAccount."
+
+  oidc_providers = {
+    main = {
+      provider_arn               = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_oidc_provider_arn
+      namespace_service_accounts = ["${var.apps_namespace}:${local.tag_image_service_account_name}"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "tag_image" {
+  statement {
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:PutImage",
+    ]
+    resources = ["arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*"]
+  }
+}
+
+resource "aws_iam_policy" "tag_image" {
+  name        = "tag_image"
+  description = "Allows Argo Workflows to tag images."
+  policy      = data.aws_iam_policy_document.tag_image.json
+}
+
+resource "aws_iam_role_policy_attachment" "tag_image" {
+  role       = module.tag_image_iam_role.iam_role_name
+  policy_arn = aws_iam_policy.tag_image.arn
+}


### PR DESCRIPTION
This creates an IAM Role that gives permissions needed to retag existing images in AWS ECR. This is used by a Argo Workflow via Service Account which will add `deployed-to-<env>` tag to images that have been deployed. https://github.com/alphagov/govuk-helm-charts/pull/629

Tested by deploying with Terraform and using Service Account to push tag.