### PR TITLE
Add permisions to DescribeImages to tag-image role

### DIFF
--- a/terraform/deployments/cluster-services/argo_workflows.tf
+++ b/terraform/deployments/cluster-services/argo_workflows.tf
@@ -26,6 +26,7 @@ data "aws_iam_policy_document" "tag_image" {
   statement {
     actions = [
       "ecr:BatchGetImage",
+      "ecr:DescribeImages",
       "ecr:PutImage",
     ]
     resources = ["arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*"]


### PR DESCRIPTION
This allows the Argo Workflow that retags images to check whether image is already tagged with the desired tag. This allows the workflow to exit gracefully, rather than presenting as "failed" to retag the image.