### PR TITLE
Improve build and push image workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -1,0 +1,107 @@
+# USAGE
+# -----
+#
+# on:
+#   workflow_dispatch: {}
+#   push:
+#     branches:
+#       - main
+#     paths-ignore:
+#       - "Jenkinsfile"
+#       - ".git**"
+#
+# jobs:
+#   build-publish-image-to-ecr:
+#     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
+#     secrets:
+#       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+#       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+
+
+# REUSABLE WORKFLOW
+# -----------------
+name: Build and push image
+
+on:
+  workflow_call:
+    inputs:
+      ecr_repository_name:
+        required: false
+        type: string
+        default: ${{ github.event.repository.name }}
+      dockerfile_path:
+        required: false
+        type: string
+        default: Dockerfile
+      additional_build_args:
+        required: false
+        type: string
+      gitRef:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+    secrets:
+      AWS_GOVUK_ECR_ACCESS_KEY_ID:
+        required: true
+      AWS_GOVUK_ECR_SECRET_ACCESS_KEY:
+        required: true
+    outputs:
+      imageTag:
+        description: "The image tag for the built image"
+        value: ${{ jobs.publish.outputs.imageTag }}
+
+jobs:
+  publish:
+    name: Build
+    runs-on: ubuntu-latest
+    outputs:
+      imageTag: ${{ steps.build-image.outputs.imageTag }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.gitRef }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          # TODO: Remove long-lived keys and switch to OIDC once https://github.com/github/roadmap/issues/249 lands.
+          aws-access-key-id: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ inputs.ecr_repository_name }}
+          DOCKER_BUILDKIT: "1"
+        run: |
+          IMAGE_TAG=$(git rev-parse HEAD)
+          LATEST_GIT_SHA=$(git ls-remote origin HEAD | cut -f 1)
+          IMAGE_TAG_ARGS="-t ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+
+          check_image_in_ecr() {
+            aws ecr describe-images --repository-name="${1}" --image-ids=imageTag="${2}"
+          }
+
+          if check_image_in_ecr "${ECR_REPOSITORY}" "${IMAGE_TAG}"; then
+            echo "found existing image ${ECR_REPOSITORY}:${IMAGE_TAG} in registry, will not build image again"
+            echo "::set-output name=imageTag::${IMAGE_TAG}"
+            exit 0
+          fi
+
+          if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]; then
+            IMAGE_TAG_ARGS+=" -t ${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+          fi
+
+          # Build a docker container and push it to ECR
+          docker build ${IMAGE_TAG_ARGS} ${{ inputs.additional_build_args }} -f ${{ inputs.dockerfile_path }} .
+          echo "Pushing image to ECR..."
+          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}" -a
+          echo "::set-output name=imageTag::${IMAGE_TAG}"

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -55,13 +55,19 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     outputs:
-      imageTag: ${{ steps.build-image.outputs.imageTag }}
+      imageTag: ${{ steps.determine-image-tag.outputs.imageTag }}
     steps:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v2
         with:
           ref: ${{ inputs.gitRef }}
+
+      - name: Determine image tag
+        id: determine-image-tag
+        run: |
+          IMAGE_TAG=$(git rev-parse HEAD)
+          echo "imageTag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -80,9 +86,9 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecrRepositoryName }}
+          IMAGE_TAG: ${{ steps.determine-image-tag.outputs.imageTag }}
           DOCKER_BUILDKIT: "1"
         run: |
-          IMAGE_TAG=$(git rev-parse HEAD)
           LATEST_GIT_SHA=$(git ls-remote origin HEAD | cut -f 1)
           IMAGE_TAG_ARGS="-t ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
 
@@ -92,7 +98,6 @@ jobs:
 
           if check_image_in_ecr "${ECR_REPOSITORY}" "${IMAGE_TAG}"; then
             echo "found existing image ${ECR_REPOSITORY}:${IMAGE_TAG} in registry, will not build image again"
-            echo "::set-output name=imageTag::${IMAGE_TAG}"
             exit 0
           fi
 
@@ -104,4 +109,3 @@ jobs:
           docker build ${IMAGE_TAG_ARGS} ${{ inputs.additionalBuildArgs }} -f ${{ inputs.dockerfilePath }} .
           echo "Pushing image to ECR..."
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}" -a
-          echo "::set-output name=imageTag::${IMAGE_TAG}"

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -81,7 +81,25 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      - name: Check for existing image
+        id: existing-image
+        env:
+          ECR_REPOSITORY: ${{ inputs.ecrRepositoryName }}
+          IMAGE_TAG: ${{ steps.determine-image-tag.outputs.imageTag }}
+        run: |
+          check_image_in_ecr() {
+            aws ecr describe-images --repository-name="${1}" --image-ids=imageTag="${2}" 2> /dev/null
+          }
+
+          if check_image_in_ecr "${ECR_REPOSITORY}" "${IMAGE_TAG}"; then
+            echo "Found existing image in ${ECR_REPOSITORY} with the tag ${IMAGE_TAG}. Will not build image again."
+            echo "present=true" >> $GITHUB_OUTPUT
+          else
+            echo "present=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build, tag, and push image to Amazon ECR
+        if: steps.existing-image.outputs.present == 'false'
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -91,15 +109,6 @@ jobs:
         run: |
           LATEST_GIT_SHA=$(git ls-remote origin HEAD | cut -f 1)
           IMAGE_TAG_ARGS="-t ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
-
-          check_image_in_ecr() {
-            aws ecr describe-images --repository-name="${1}" --image-ids=imageTag="${2}"
-          }
-
-          if check_image_in_ecr "${ECR_REPOSITORY}" "${IMAGE_TAG}"; then
-            echo "found existing image ${ECR_REPOSITORY}:${IMAGE_TAG} in registry, will not build image again"
-            exit 0
-          fi
 
           if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]; then
             IMAGE_TAG_ARGS+=" -t ${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -98,7 +98,7 @@ jobs:
             echo "present=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build, tag, and push image to Amazon ECR
+      - name: Build image
         if: steps.existing-image.outputs.present == 'false'
         id: build-image
         env:
@@ -114,7 +114,13 @@ jobs:
             IMAGE_TAG_ARGS+=" -t ${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
           fi
 
-          # Build a docker container and push it to ECR
           docker build ${IMAGE_TAG_ARGS} ${{ inputs.additionalBuildArgs }} -f ${{ inputs.dockerfilePath }} .
-          echo "Pushing image to ECR..."
+
+      - name: Push image
+        if: steps.build-image.conclusion == 'success'
+        id: push-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ inputs.ecrRepositoryName }}
+        run: |
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}" -a

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -51,8 +51,8 @@ on:
         value: ${{ jobs.publish.outputs.imageTag }}
 
 jobs:
-  publish:
-    name: Build
+  build-and-push-image:
+    name: Build and push image
     runs-on: ubuntu-latest
     outputs:
       imageTag: ${{ steps.build-image.outputs.imageTag }}

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -63,12 +63,6 @@ jobs:
         with:
           ref: ${{ inputs.gitRef }}
 
-      - name: Determine image tag
-        id: determine-image-tag
-        run: |
-          IMAGE_TAG=$(git rev-parse HEAD)
-          echo "imageTag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -80,6 +74,26 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Determine image tag
+        id: determine-image-tag
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ inputs.ecrRepositoryName }}
+        run: |
+          LOCAL_HEAD_SHA="$(git rev-parse HEAD)"
+          REMOTE_HEAD_SHA=$(git ls-remote origin HEAD | cut -f 1)
+
+          IMAGE_TAG="release-${LOCAL_HEAD_SHA}"
+          FULL_IMAGE_TAG_LIST=("${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}")
+
+          # Add latest tag if most recent commit
+          if [ "${REMOTE_HEAD_SHA}" = "${LOCAL_HEAD_SHA}" ]; then
+            FULL_IMAGE_TAG_LIST+="${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+          fi
+
+          echo "imageTag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "fullImageTagList=${FULL_IMAGE_TAG_LIST}" >> $GITHUB_OUTPUT
 
       - name: Check for existing image
         id: existing-image
@@ -102,19 +116,12 @@ jobs:
         if: steps.existing-image.outputs.present == 'false'
         id: build-image
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ inputs.ecrRepositoryName }}
-          IMAGE_TAG: ${{ steps.determine-image-tag.outputs.imageTag }}
+          FULL_IMAGE_TAG_LIST: ${{ steps.determine-image-tag.outputs.fullImageTagList }}
           DOCKER_BUILDKIT: "1"
         run: |
-          LATEST_GIT_SHA=$(git ls-remote origin HEAD | cut -f 1)
-          IMAGE_TAG_ARGS="-t ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+          FULL_IMAGE_TAG_LIST=(`echo ${FULL_IMAGE_TAG_LIST}`)
 
-          if [ "${LATEST_GIT_SHA}" = "${IMAGE_TAG}" ]; then
-            IMAGE_TAG_ARGS+=" -t ${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
-          fi
-
-          docker build ${IMAGE_TAG_ARGS} ${{ inputs.additionalBuildArgs }} -f ${{ inputs.dockerfilePath }} .
+          docker build ${FULL_IMAGE_TAG_LIST[@]/#/-t } ${{ inputs.additionalBuildArgs }} -f ${{ inputs.dockerfilePath }} .
 
       - name: Push image
         if: steps.build-image.conclusion == 'success'

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.gitRef }}
 

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -14,8 +14,8 @@
 #   build-publish-image-to-ecr:
 #     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
 #     secrets:
-#       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
-#       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+#       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 
 # REUSABLE WORKFLOW
@@ -41,9 +41,9 @@ on:
         type: string
         default: ${{ github.sha }}
     secrets:
-      AWS_GOVUK_ECR_ACCESS_KEY_ID:
+      AWS_ACCESS_KEY_ID:
         required: true
-      AWS_GOVUK_ECR_SECRET_ACCESS_KEY:
+      AWS_SECRET_ACCESS_KEY:
         required: true
     outputs:
       imageTag:
@@ -67,8 +67,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           # TODO: Remove long-lived keys and switch to OIDC once https://github.com/github/roadmap/issues/249 lands.
-          aws-access-key-id: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
 
       - name: Login to Amazon ECR

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -25,15 +25,15 @@ name: Build and push image
 on:
   workflow_call:
     inputs:
-      ecr_repository_name:
+      ecrRepositoryName:
         required: false
         type: string
         default: ${{ github.event.repository.name }}
-      dockerfile_path:
+      dockerfilePath:
         required: false
         type: string
         default: Dockerfile
-      additional_build_args:
+      additionalBuildArgs:
         required: false
         type: string
       gitRef:
@@ -79,7 +79,7 @@ jobs:
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ inputs.ecr_repository_name }}
+          ECR_REPOSITORY: ${{ inputs.ecrRepositoryName }}
           DOCKER_BUILDKIT: "1"
         run: |
           IMAGE_TAG=$(git rev-parse HEAD)
@@ -101,7 +101,7 @@ jobs:
           fi
 
           # Build a docker container and push it to ECR
-          docker build ${IMAGE_TAG_ARGS} ${{ inputs.additional_build_args }} -f ${{ inputs.dockerfile_path }} .
+          docker build ${IMAGE_TAG_ARGS} ${{ inputs.additionalBuildArgs }} -f ${{ inputs.dockerfilePath }} .
           echo "Pushing image to ECR..."
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}" -a
           echo "::set-output name=imageTag::${IMAGE_TAG}"


### PR DESCRIPTION
This PR introduces a new workflow `build-and-push-image` to ultimately replace the `ci-ecr` workflow. (Functionally the workflows do the same thing: build an image, then push it to AWS ECR.)

The main improvement of the new workflow is that the tasks are split into separate steps:
- determine image tag value
- check for existing image
- build image
- push image

This improves the status visibility of the workflow in the GitHub UI, you can more easily see the result of a particular step.

Other improvements include variable naming simplification and consistency and updating dependency versions.

A later PR will remove the existing ci-ecr workflow, once the depending workflows (application deployment workflows) have been migrated over. 

Workflow has been tested by [running a deploy workflow on Frontend.](https://github.com/alphagov/frontend/actions/runs/3280522419/jobs/5401404393) 