### PR TITLE
Allow traffic from worker nodes to RabbitMQ.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -82,6 +82,16 @@ resource "aws_security_group_rule" "router_mongodb_from_eks_workers" {
   source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
 
+resource "aws_security_group_rule" "rabbitmq_from_eks_workers" {
+  description              = "RabbitMQ LB accepts AMQP requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 5671 # AMQP 1.0
+  to_port                  = 5672 # AMQP 0-9-1
+  protocol                 = "tcp"
+  security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_rabbitmq_elb_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+}
+
 resource "aws_security_group_rule" "shared_docdb_from_eks_workers" {
   description              = "Shared DocumentDB accepts requests from EKS nodes"
   type                     = "ingress"

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -219,6 +219,10 @@ resource "aws_security_group_rule" "ec2_www_origin_from_eks_workers" {
   cidr_blocks       = formatlist("%s/32", data.terraform_remote_state.cluster_infrastructure.outputs.public_nat_gateway_ips)
 }
 
+#
+# EKS Ingress-managed ALBs
+#
+
 resource "aws_security_group" "eks_ingress_www_origin" {
   name        = "eks_ingress_www_origin"
   vpc_id      = data.terraform_remote_state.infra_vpc.outputs.vpc_id


### PR DESCRIPTION
https://www.rabbitmq.com/networking.html#ports

Tested: applied in integration and checked that pods can now connect to RabbitMQ.