### PR TITLE
Update secret names in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,9 +37,9 @@
 #       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
 #       environment: ${{ github.event.inputs.environment }}
 #     secrets:
-#       WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}
-#       WEBHOOK_URL: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_URL }}
-#       GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+#       WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
+#       WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}
+#       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 #
 
 
@@ -72,7 +72,7 @@ on:
         required: true
       WEBHOOK_URL:
         required: true
-      GOVUK_CI_GITHUB_API_TOKEN:
+      GH_TOKEN:
         required: true
 
 jobs:
@@ -85,7 +85,7 @@ jobs:
       - name: Check deploy permissions
         id: deploy-permissions
         env:
-          GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TEAM: gov-uk-production-deploy
           GITHUB_USER: ${{ github.triggering_actor }}
         run: |


### PR DESCRIPTION
This updates the secret name for the GitHub Token to be more concise. As this is a reusable workflow - we just care its a GitHub Token, not where its from or its exact name.