### PR TITLE
Fix full tag list for build and push image workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -89,7 +89,7 @@ jobs:
 
           # Add latest tag if most recent commit
           if [ "${REMOTE_HEAD_SHA}" = "${LOCAL_HEAD_SHA}" ]; then
-            FULL_IMAGE_TAG_LIST+="${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+            FULL_IMAGE_TAG_LIST+=("${ECR_REGISTRY}/${ECR_REPOSITORY}:latest")
           fi
 
           echo "imageTag=${IMAGE_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
There was an error when determining the full list of tags to apply to an image. The script was incorrectly appending the latest tag to the bash array.