### PR TITLE
Fix image tag output job in build image workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -48,7 +48,7 @@ on:
     outputs:
       imageTag:
         description: "The image tag for the built image"
-        value: ${{ jobs.publish.outputs.imageTag }}
+        value: ${{ jobs.build-and-push-image.outputs.imageTag }}
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
The workflow output reference the incorrect job id. This meant the imageTag output was not being set and failing other workflows that used the output e.g. trigger deploy.