### PR TITLE
Grant more permissions over the govuk-*-assets S3 buckets.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/asset_manager_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/asset_manager_s3.tf
@@ -6,17 +6,21 @@ resource "aws_iam_policy" "asset_manager_s3" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = "s3:ListBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+        ]
         Resource = data.terraform_remote_state.infra_assets.outputs.asset_manager_bucket_arn
       },
       {
         Effect = "Allow"
         Action = [
-          "s3:PutObjectAcl",
-          "s3:PutObject",
-          "s3:GetObject",
-          "s3:DeleteObject",
+          "s3:*MultipartUpload*",
+          "s3:*Object",
+          "s3:*ObjectAcl",
+          "s3:*ObjectVersion",
+          "s3:GetObject*Attributes",
         ]
         Resource = "${data.terraform_remote_state.infra_assets.outputs.asset_manager_bucket_arn}/*"
       }


### PR DESCRIPTION
Not all of these are used right now, but they could easily be needed in future with relatively small changes, like enabling or disabling versioning on the assets buckets.

Tested: uploading assets succeeds as far as `state: "uploaded"`.

https://trello.com/c/moEiT5BG