### PR TITLE
Update k8s to 1.23

### DIFF
--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -32,7 +32,7 @@ provider "kubernetes" {
   host                   = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_endpoint
   cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster_infrastructure.outputs.cluster_certificate_authority_data)
   exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
+    api_version = "client.authentication.k8s.io/v1"
     command     = "aws"
     args        = ["eks", "get-token", "--cluster-name", data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id]
   }
@@ -45,7 +45,7 @@ provider "helm" {
     host                   = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_endpoint
     cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster_infrastructure.outputs.cluster_certificate_authority_data)
     exec {
-      api_version = "client.authentication.k8s.io/v1beta1"
+      api_version = "client.authentication.k8s.io/v1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id]
     }

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -1,7 +1,7 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-integration"
 cluster_infrastructure_state_bucket = "govuk-terraform-integration"
 
-cluster_version               = 1.21
+cluster_version               = 1.23
 cluster_log_retention_in_days = 7
 
 eks_control_plane_subnets = {

--- a/terraform/deployments/variables/production/common.tfvars
+++ b/terraform/deployments/variables/production/common.tfvars
@@ -1,7 +1,7 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-production"
 cluster_infrastructure_state_bucket = "govuk-terraform-production"
 
-cluster_version               = 1.21
+cluster_version               = 1.23
 cluster_log_retention_in_days = 7
 
 eks_control_plane_subnets = {

--- a/terraform/deployments/variables/staging/common.tfvars
+++ b/terraform/deployments/variables/staging/common.tfvars
@@ -1,7 +1,7 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-staging"
 cluster_infrastructure_state_bucket = "govuk-terraform-staging"
 
-cluster_version               = 1.21
+cluster_version               = 1.23
 cluster_log_retention_in_days = 7
 
 eks_control_plane_subnets = {

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -1,7 +1,7 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-test"
 cluster_infrastructure_state_bucket = "govuk-terraform-test"
 
-cluster_version               = 1.21
+cluster_version               = 1.23
 cluster_log_retention_in_days = 7
 workers_default_capacity_type = "SPOT"
 workers_size_desired          = 3


### PR DESCRIPTION
All environments have already been updated to 1.23. This is to ensure terraform reflects their current state

https://trello.com/c/3xdHyoY5/1032-kubernetes-122-upgrade