### PR TITLE
Fix namespace of IAM Role Service Account for workflows

### DIFF
--- a/terraform/deployments/cluster-services/argo_workflows.tf
+++ b/terraform/deployments/cluster-services/argo_workflows.tf
@@ -12,7 +12,7 @@ module "tag_image_iam_role" {
   oidc_providers = {
     main = {
       provider_arn               = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_oidc_provider_arn
-      namespace_service_accounts = ["${var.apps_namespace}:${local.tag_image_service_account_name}"]
+      namespace_service_accounts = ["${local.services_ns}:${local.tag_image_service_account_name}"]
     }
   }
 }


### PR DESCRIPTION
Workflows now run in the cluster services namespace instead of the apps namespace. This updates the IAM Role Service Account to be used by workflows in cluster-services.

This is used by the "add tag to image" workflow, which needs push permissions to AWS ECR.