### PR TITLE
Update usage example for the `set-automatic-deploys` workflow.

### DIFF
--- a/.github/workflows/set-automatic-deploys.yaml
+++ b/.github/workflows/set-automatic-deploys.yaml
@@ -3,16 +3,21 @@
 #
 # name: Set automatic deploys
 #
+# run-name: Set automatic deploys to ${{ inputs.setAutomaticDeploys }} in ${{ inputs.environment }}
+#
 # on:
 #   workflow_dispatch:
 #     inputs:
-#       automaticDeploysEnabled:
-#         description: 'Activate automatic deploys'
+#       setAutomaticDeploys:
+#         description: 'Set automatic deploys'
 #         required: false
-#         default: true
-#         type: boolean
+#         type: choice
+#         options:
+#         - enabled
+#         - disabled
+#         default: 'enabled'
 #       environment:
-#         description: 'Environment to deploy to'
+#         description: 'Environment'
 #         required: true
 #         type: choice
 #         options:
@@ -22,16 +27,16 @@
 #         default: 'integration'
 #
 # jobs:
-#   set_automatic_deploys:
+#   set-automatic-deploys:
 #     name: Set automatic deploys
-#     uses: alphagov/govuk-infrastructure/.github/workflows/set-automatic-deploys-enabled.yaml@main
+#     uses: alphagov/govuk-infrastructure/.github/workflows/set-automatic-deploys.yaml@main
 #     with:
-#       automaticDeploysEnabled: ${{ github.event.inputs.automaticDeploysEnabled == 'true' }}
+#       automaticDeploysEnabled: ${{ github.event.inputs.setAutomaticDeploys == 'enabled' }}
 #       environment: ${{ github.event.inputs.environment }}
 #     secrets:
-#       WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}
-#       WEBHOOK_URL: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_URL }}
-#       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+#       WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
+#       WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}
+#       GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
 
 
 #


### PR DESCRIPTION
This updates the example to reflect recent changes to calling workflows in the app repos.

e.g. https://github.com/alphagov/collections/pull/3041