### PR TITLE
Update to latest ArgoCD, Argo Workflows and dependencies.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -30,7 +30,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.5.6" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.13.8" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     server = {
       # TLS Termination happens at the ALB, the insecure flag prevents Argo
@@ -162,7 +162,7 @@ resource "helm_release" "argo_workflows" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "0.20.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.20.8" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     controller = {
       podSecurityContext = {
@@ -299,9 +299,10 @@ resource "helm_release" "argo_events" {
       nats = {
         versions = [
           {
-            version              = "0.22.1"
-            natsStreamingImage   = "nats-streaming:0.22.1"
-            metricsExporterImage = "natsio/prometheus-nats-exporter:0.8.0"
+            # TODO: Dependabot or similar so this doesn't get neglected.
+            version              = "0.25.2"
+            natsStreamingImage   = "nats-streaming:0.25.2"
+            metricsExporterImage = "natsio/prometheus-nats-exporter:0.10.1"
           }
         ]
       }


### PR DESCRIPTION
Now that we're on Kubernetes 1.23, we can run ArgoCD 2.5 (the latest minor version) without API compatibility issues.

Also update to Workflows 3.43 and the latest NATS releases (dependencies of Argo Events).

Changelogs:
- https://github.com/argoproj/argo-cd/blob/master/CHANGELOG.md
- https://github.com/argoproj/argo-workflows/blob/master/CHANGELOG.md
- https://github.com/nats-io/nats-streaming-server/releases/
- https://github.com/nats-io/prometheus-nats-exporter/releases

Tested: applied in integration.