### PR TITLE
Use build-and-push-image in build-github-cli

### DIFF
--- a/.github/workflows/build-github-cli-image.yaml
+++ b/.github/workflows/build-github-cli-image.yaml
@@ -1,13 +1,22 @@
 name: Build and publish github-cli image to ECR
 
 on:
+
   workflow_dispatch:
+    branches:
+      - main
     inputs:
       gitRef:
         description: 'Commit, tag or branch name to deploy'
         required: true
         type: string
         default: 'main'
+
+  push:
+    branches:
+      - main
+    paths:
+      - "images/github-cli/Dockerfile"
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/build-github-cli-image.yaml
+++ b/.github/workflows/build-github-cli-image.yaml
@@ -2,21 +2,20 @@ name: Build and publish github-cli image to ECR
 
 on:
   workflow_dispatch:
-    branches:
-      - main
-  push:
-    branches:
-      - main
-    paths:
-      - "images/github-cli/Dockerfile"
+    inputs:
+      gitRef:
+        description: 'Commit, tag or branch name to deploy'
+        required: true
+        type: string
+        default: 'main'
 
 jobs:
-  build-publish-image-to-ecr:
-    uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
+  build-and-push-image:
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yaml@main
     with:
-      ecr_repository_name: github-cli
-      dockerfile_path: images/github-cli/Dockerfile
-      gitRef: ${{ github.event.inputs.gitRef }}
+      gitRef: ${{ inputs.gitRef || github.ref }}
+      ecrRepositoryName: github-cli
+      dockerfilePath: images/github-cli/Dockerfile
     secrets:
-      AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
-      AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-github-cli-image.yaml
+++ b/.github/workflows/build-github-cli-image.yaml
@@ -17,5 +17,5 @@ jobs:
       ecrRepositoryName: github-cli
       dockerfilePath: images/github-cli/Dockerfile
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
ci-ecr was removed in #769 in favour of build-and-push-image.yaml which was added in #763. This workflow was missed in the update.

It looks like the github-cli image has since disappeared from the registry - not sure if that's a problem with the image retention policy, or whether it was accidentally deleted some other way...