### PR TITLE
Fix build and push image tagging

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -96,7 +96,7 @@ jobs:
           fi
 
           echo "imageTag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
-          echo "fullImageTagList=${FULL_IMAGE_TAG_LIST}" >> $GITHUB_OUTPUT
+          echo "fullImageTagList=${FULL_IMAGE_TAG_LIST[@]}" >> $GITHUB_OUTPUT
 
       - name: Check for existing image
         id: existing-image

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -138,4 +138,4 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecrRepositoryName }}
         run: |
-          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}" -a
+          docker push --all-tags "${ECR_REGISTRY}/${ECR_REPOSITORY}"

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -122,9 +122,14 @@ jobs:
           FULL_IMAGE_TAG_LIST: ${{ steps.determine-image-tag.outputs.fullImageTagList }}
           DOCKER_BUILDKIT: "1"
         run: |
-          FULL_IMAGE_TAG_LIST=(`echo ${FULL_IMAGE_TAG_LIST}`)
+          set -x
 
-          docker build ${FULL_IMAGE_TAG_LIST[@]/#/-t } ${{ inputs.additionalBuildArgs }} -f ${{ inputs.dockerfilePath }} .
+          docker_tag_flags=()
+          for tag in $FULL_IMAGE_TAG_LIST; do
+            docker_tag_flags+=(-t "${tag}")
+          done
+
+          docker build ${docker_tag_flags[@]} ${{ inputs.additionalBuildArgs }} -f ${{ inputs.dockerfilePath }} .
 
       - name: Push image
         if: steps.build-image.conclusion == 'success'


### PR DESCRIPTION
This fixes a bug where only the first image tag would be pushed to ECR, not all of them. The cause was an inaccuracy in bash syntax (that would have worked fine in zsh):
    
In bash `echo "${array}"` only prints the first item in the array, not the whole thing (note, this is different in zshell).
    
This meant that `echo "fullImageTagList=${FULL_IMAGE_TAG_LIST}" >> $GITHUB_OUTPUT` was only collecting the first tag, not the full tag list.

I've also taken the opportunity to clarify the rest of the code handling this array a little bit, as I found it quite difficult to work out what this code was doing at first.