### PR TITLE
Add Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ There are also docs in the [terraform/docs](./terraform/docs) and directories.
 ### Who we are
 
 We're the GOV.UK Replatforming team, discovering the future of GOV.UK's infrastructure, one line of code at a time. You can find us in #govuk-replatforming on the GDS Slack, and our [(internal) Trello board exists](https://trello.com/b/u4FCzm53/).
+
+## Licence
+
+[MIT License](LICENCE)


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence