### PR TITLE
Use Jetstream instead of Nats streaming server

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -296,13 +296,15 @@ resource "helm_release" "argo_events" {
       replicas = var.default_desired_ha_replicas
     }
     configs = {
-      nats = {
+      jetstream = {
         versions = [
           {
             # TODO: Dependabot or similar so this doesn't get neglected.
-            version              = "0.25.2"
-            natsStreamingImage   = "nats-streaming:0.25.2"
+            version              = "2.9.8"
+            natsImage            = "nats:2.9.8"
             metricsExporterImage = "natsio/prometheus-nats-exporter:0.10.1"
+            configReloaderImage  = "natsio/nats-server-config-reloader:0.7.4"
+            startCommand         = "/nats-server"
           }
         ]
       }


### PR DESCRIPTION
Nats streaming server has been deprecated in favor of Jetstream. Also this fixes an issue with creating new EventBus resources, as they don't support the new versions of Nat streaming server - which [we recently updated to](https://github.com/alphagov/govuk-infrastructure/commit/fd222318bf1c21aab2f8dc347ebc9575ea87ae79).

Deprecation notice: https://docs.nats.io/legacy/stan/intro#:~:text=NATS%20Streaming%20is%20a%20data,with%20the%20core%20NATS%20platform.

Argo Events docs: https://argoproj.github.io/argo-events/concepts/eventbus/