### PR TITLE
Change namespace of IAM Role Service Account back to "apps"

### DIFF
--- a/terraform/deployments/cluster-services/argo_workflows.tf
+++ b/terraform/deployments/cluster-services/argo_workflows.tf
@@ -12,7 +12,7 @@ module "tag_image_iam_role" {
   oidc_providers = {
     main = {
       provider_arn               = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_oidc_provider_arn
-      namespace_service_accounts = ["${local.services_ns}:${local.tag_image_service_account_name}"]
+      namespace_service_accounts = ["${var.apps_namespace}:${local.tag_image_service_account_name}"]
     }
   }
 }


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#779 as we've switched back to the "apps" namespace.