### PR TITLE
Update to latest Prometheus/Alertmanager/Grafana/oauth2-proxy.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -29,7 +29,7 @@ resource "helm_release" "prometheus_oauth2_proxy" {
   name             = "prometheus-oauth2-proxy"
   repository       = "https://oauth2-proxy.github.io/manifests"
   chart            = "oauth2-proxy"
-  version          = "6.2.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "6.5.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
 
@@ -85,7 +85,7 @@ resource "helm_release" "alertmanager_oauth2_proxy" {
   name             = "alertmanager-oauth2-proxy"
   repository       = "https://oauth2-proxy.github.io/manifests"
   chart            = "oauth2-proxy"
-  version          = "6.2.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "6.5.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
 
@@ -135,12 +135,13 @@ resource "helm_release" "alertmanager_oauth2_proxy" {
     ])
   })]
 }
+
 resource "helm_release" "kube_prometheus_stack" {
   depends_on       = [helm_release.dex]
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"
-  version          = "39.7.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "42.3.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
   values = [
@@ -260,9 +261,7 @@ resource "helm_release" "kube_prometheus_stack" {
                 storageClassName = "ebs-sc"
                 accessModes      = ["ReadWriteOnce"]
                 resources = {
-                  requests = {
-                    storage = "10Gi"
-                  }
+                  requests = { storage = "10Gi" }
                 }
               }
             }
@@ -298,9 +297,7 @@ resource "helm_release" "kube_prometheus_stack" {
                 storageClassName = "ebs-sc"
                 accessModes      = ["ReadWriteOnce"]
                 resources = {
-                  requests = {
-                    storage = "50Gi"
-                  }
+                  requests = { storage = "50Gi" }
                 }
               }
             }
@@ -308,9 +305,7 @@ resource "helm_release" "kube_prometheus_stack" {
         }
       }
       kube_state_metrics = {
-        selfMonitor = {
-          enabled = true
-        }
+        selfMonitor = { enabled = true }
       }
     })
   ]


### PR DESCRIPTION
### Changelogs

  - [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-41x-to-42x)
  - [oauth2-proxy](https://github.com/oauth2-proxy/manifests/tree/main/helm/oauth2-proxy#upgrading-an-existing-release-to-a-new-major-version) (no breaking changes)

### Rollout

1. Switch to the monitoring namespace:

    ```sh
    kubectl ns monitoring
    ```

1. Update the CRDs per the release notes.

    ```sh
    kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
    kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
    kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
    kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
    kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
    kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
    kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
    kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
    ```

1. Delete the node-exporter daemonset, per the release notes.

    ```sh
    kubectl delete daemonset -l app=prometheus-node-exporter
    ```

1. Delete the kube-state-metrics deployment, otherwise Helm tries to patch an immutable field.

    ```sh
    kubectl delete deploy/kube-prometheus-stack-kube-state-metrics
    ```

1. Upgrade the chart (using Helm, because the error handling sucks when doing it via Terraform).

    ```sh
    helm repo update prometheus-community
    helm upgrade -i kube-prometheus-stack prometheus-community/kube-prometheus-stack --version 42.3.0
    ```

1. `terraform apply`.

    ```sh
    tf init -backend-config=${ENV?}.backend -reconfigure -upgrade && \
      tf apply \
        -var-file ../variables/common.tfvars \
        -var-file ../variables/${ENV?}/common.tfvars
    ```

### Testing

Rolled out to the staging cluster.