### PR TITLE
Fix a turnup dependency graph issue for fastly_exporter.

### DIFF
--- a/terraform/deployments/cluster-services/fastly_exporter.tf
+++ b/terraform/deployments/cluster-services/fastly_exporter.tf
@@ -1,5 +1,5 @@
 resource "helm_release" "fastly-exporter" {
-  depends_on       = [helm_release.cluster_secrets]
+  depends_on       = [helm_release.kube_prometheus_stack]
   name             = "fastly-exporter"
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
   chart            = "fastly-exporter"


### PR DESCRIPTION
The Fastly exporter depends on the monitoring CRDs installed by kube-prometheus-stack.

`cluster_secrets` is a transitive dependency of `kube_prometheus_stack` so we don't really need to specify it here (since that dependency is unlikely ever to change).

Tested: applied successfully in integration.