### PR TITLE
Fix the Node 12 deprecation warning for configure-aws-creds.

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -64,7 +64,7 @@ jobs:
           ref: ${{ inputs.gitRef }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           # TODO: Remove long-lived keys and switch to OIDC once https://github.com/github/roadmap/issues/249 lands.
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
See https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning