### PR TITLE
Add reusable GHA workflows for CI

### DIFF
--- a/.github/workflows/ci-cache-dependencies.yaml
+++ b/.github/workflows/ci-cache-dependencies.yaml
@@ -1,0 +1,36 @@
+name: Cache dependencies
+
+on:
+  workflow_call:
+
+jobs:
+  cache-dependencies:
+    name: Cache dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Check package managers
+        id: package-managers
+        run: |
+          if [[ -f ./yarn.lock ]]; then
+              echo "yarn-enabled=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+          if [[ -f ./Gemfile.lock ]]; then
+              echo "bundler-enabled=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Setup Ruby
+        if: ${{ steps.package-managers.outputs.bundler-enabled == 'true' }}
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup Node
+        if: ${{ steps.package-managers.outputs.yarn-enabled == 'true' }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'

--- a/.github/workflows/ci-lint-javascript.yaml
+++ b/.github/workflows/ci-lint-javascript.yaml
@@ -1,0 +1,23 @@
+name: Lint JavaScript
+
+on:
+  workflow_call:
+
+jobs:
+  lint-javascript:
+    name: Lint JavaScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+
+      - name: Install JavaScript dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run linter
+        run: yarn run lint:js

--- a/.github/workflows/ci-lint-ruby.yaml
+++ b/.github/workflows/ci-lint-ruby.yaml
@@ -1,0 +1,20 @@
+name: Lint Ruby
+
+on:
+  workflow_call:
+
+jobs:
+  lint-ruby:
+    name: Lint Ruby
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run RuboCop
+        run: bundle exec rubocop --parallel

--- a/.github/workflows/ci-lint-scss.yaml
+++ b/.github/workflows/ci-lint-scss.yaml
@@ -1,0 +1,24 @@
+name: Lint SCSS
+
+on:
+  workflow_call:
+
+jobs:
+  lint-scss:
+    name: Lint SCSS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Install JavaScript dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run linter
+        run: yarn run lint:scss

--- a/.github/workflows/ci-run-container.yaml
+++ b/.github/workflows/ci-run-container.yaml
@@ -1,0 +1,86 @@
+name: Run container
+
+on:
+  workflow_call:
+    inputs:
+      extraSystemDependencies:
+        description: 'Install additional system dependencies'
+        required: false
+        default: ''
+        type: string
+      enableMongoDB:
+        description: 'Run MongoDB'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  run-container:
+    name: Run container
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+      GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
+      TEST_DATABASE_URL: mysql2://root:root@127.0.0.1:3306/test
+    steps:
+       - name: Setup Redis
+         if: ${{ inputs.enableRedis }}
+         env:
+           REDIS_IMAGE_TAG: 6-alpine
+           REDIS_PORT: 6379
+         run: |
+           # Start container
+           docker run --name redis \
+            --detach \
+            --publish $REDIS_PORT:6379 \
+            --health-cmd "redis-cli ping" \
+            --health-interval 10s \
+            --health-timeout 5s \
+            --health-retries 5 \
+            redis:$REDIS_IMAGE_TAG
+
+           echo "Wait for container '$container_name' to be healthy for max $timeout seconds..."
+           for i in `seq ${timeout}`; do
+               get_health_state
+               state=$?
+               if [ ${state} -eq 0 ]; then
+                   echo "Container is healthy after ${i} seconds."
+                   exit 0
+               fi
+             sleep 1
+           done
+
+           echo "Timeout exceeded. Health status returned: $(docker inspect -f '{{ .State.Health.Status }}' ${container_name})"
+           exit 1
+
+       - name: Setup MySQL
+         id: setup-mysql
+         if: ${{ inputs.enableMySQL }}
+         env:
+           MYSQL_PORT: 3306
+           MYSQL_IMAGE_TAG: 8.0
+         run: |
+           # Stop the MySQL service running on the runner node
+           sudo service mysql stop
+
+           # Start 
+           docker run --name mysql \
+            --detach \
+            --publish $MYSQL_PORT:3306 \
+            --env MYSQL_ROOT_PASSWORD=root \
+            --health-cmd "mysqladmin ping" \
+            --health-start-period 10s \
+            --health-interval 10s \
+            --health-timeout 5s \
+            --health-retries 5 \
+            mysql:$MYSQL_IMAGE_TAG
+
+           # Wait for MySQL to be ready to accept connections
+           sleep 15
+           # Create user for running tests
+           MYSQL_COMMAND="mysql -h 127.0.0.1 -P ${MYSQL_PORT} -u root"
+           $MYSQL_COMMAND -e "CREATE USER '${MYSQL_USERNAME}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';"
+           $MYSQL_COMMAND -e "GRANT ALL PRIVILEGES ON *.* TO '${MYSQL_USERNAME}'@'%' WITH GRANT OPTION;"
+           $MYSQL_COMMAND -e "FLUSH PRIVILEGES;"
+           echo "::set-output name=db-url::mysql2://${MYSQL_USERNAME}:${MYSQL_PASSWORD}@127.0.0.1:3306"
+

--- a/.github/workflows/ci-security-analysis-ruby.yaml
+++ b/.github/workflows/ci-security-analysis-ruby.yaml
@@ -1,0 +1,20 @@
+name: Security Analysis Ruby
+
+on:
+  workflow_call:
+
+jobs:
+  security-analysis-ruby:
+    name: Security Analysis Ruby
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run Brakeman
+        run: bundle exec brakeman . --except CheckRenderInline --quiet

--- a/.github/workflows/ci-test-javascript.yaml
+++ b/.github/workflows/ci-test-javascript.yaml
@@ -1,0 +1,29 @@
+name: Test JavaScript
+
+on:
+  workflow_call:
+
+jobs:
+  test-javascript:
+    name: Test JavaScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Install JavaScript dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        run: yarn run jasmine:ci

--- a/.github/workflows/ci-test-ruby.yaml
+++ b/.github/workflows/ci-test-ruby.yaml
@@ -1,0 +1,195 @@
+name: Test Ruby
+
+on:
+  workflow_call:
+    inputs:
+      extraSystemDependencies:
+        description: 'Install additional system dependencies'
+        required: false
+        default: ''
+        type: string
+      enableMongoDB:
+        description: 'Run MongoDB'
+        required: false
+        default: false
+        type: boolean
+      enableElasticsearch:
+        description: 'Run Elasticsearch'
+        required: false
+        default: false
+        type: boolean
+      enableRedis:
+        description: 'Run Redis'
+        required: false
+        default: false
+        type: boolean
+      enableMySQL:
+        description: 'Run MySQL'
+        required: false
+        default: false
+        type: boolean
+      enablePostgres:
+        description: 'Run Postgres'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  test-ruby:
+    name: Test Ruby
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+      GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
+    steps:
+      - name: Setup MySQL
+        id: setup-mysql
+        if: ${{ inputs.enableMySQL }}
+        env:
+          YSQL_IMAGE_TAG: 8.0
+          MMYSQL_PORT: 3306
+          MYSQL_PASSWORD: root
+          MYSQL_DB: test
+        run: |
+          # Stop the MySQL service running on the runner node
+          sudo service mysql stop
+
+          # Start 
+          docker run --name mysql \
+           --rm --detach \
+           --publish "${MYSQL_PORT}:3306" \
+           --env "MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}" \
+           mysql:${MYSQL_IMAGE_TAG} \
+           --performance-schema=off --innodb_buffer_pool_size=32M \
+           --innodb-log-buffer-size=8M --key_buffer_size=4M
+
+          echo "db-url=mysql2://root:${MYSQL_PASSWORD}@127.0.0.1:${MYSQL_PORT}/${MYSQL_DB}" >> $GITHUB_OUTPUT
+
+      - name: Setup Postrges
+        id: setup-postgres
+        if: ${{ inputs.enablePostgres }}
+        env:
+          POSTGRES_IMAGE_TAG: 13-alpine
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: root
+          POSTGRES_DB: test
+        run: |
+          docker run --name postgres \
+           --rm --detach \
+           --publish "${POSTGRES_PORT}:${POSTGRES_PORT}" \
+           --env "POSTGRES_USER=${POSTGRES_USER}" \
+           --env "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
+           --env "POSTGRES_DB=${POSTGRES_DB}" \
+           postgres:${POSTGRES_IMAGE_TAG}
+
+          echo "db-url=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_PORT}/${POSTGRES_DB}" >> $GITHUB_OUTPUT
+
+      - name: Setup MongoDB
+        if: ${{ inputs.enableMongoDB }}
+        env:
+          MONGODB_PORT: 27017
+          MONGODB_IMAGE_TAG: 2.6
+          MONGODB_DB: ''
+          MONGODB_USERNAME: ''
+          MONGODB_PASSWORD: ''
+        run: |
+          docker run --name mongodb \
+           --rm --detach \
+           --publish "${MONGODB_PORT}:27017" \
+           --env "MONGO_INITDB_DATABASE=${MONGODB_DB}" \
+           --env "MONGO_INITDB_ROOT_USERNAME=${MONGODB_USERNAME}" \
+           --env "MONGO_INITDB_ROOT_PASSWORD=${MONGODB_PASSWORD}" \
+           mongo:${MONGODB_IMAGE_TAG}
+
+      - name: Setup Elasticsearch
+        if: ${{ inputs.enableElasticsearch }}
+        env:
+          ELASTICSEARCH_IMAGE_TAG: 6.7.2
+          ELASTICSEARCH_PORT: 9200
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+          docker network create elastic
+
+          docker run --name="elasticsearch" \
+           --rm --detach \
+           --env "discovery.type=single-node" \
+           --env "bootstrap.memory_lock=true" \
+           --env "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
+           --env "xpack.security.enabled=false" \
+           --env "xpack.license.self_generated.type=basic" \
+           --ulimit "nofile=65536:65536" \
+           --ulimit "memlock=-1:-1" \
+           --publish "${ELASTICSEARCH_PORT}:9200" \
+           --network "elastic" \
+           elasticsearch:${ELASTICSEARCH_IMAGE_TAG}
+
+           sleep 10
+
+      - name: Setup Redis
+        if: ${{ inputs.enableRedis }}
+        env:
+          REDIS_IMAGE_TAG: 6-alpine
+          REDIS_PORT: 6379
+        run: |
+          # Start container
+          docker run --name redis \
+           --rm --detach \
+           --publish "${REDIS_PORT}:6379" \
+           redis:${REDIS_IMAGE_TAG}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Checkout Publishing API (for Content Schemas)
+        uses: actions/checkout@v3
+        with:
+          repository: alphagov/publishing-api
+          ref: deployed-to-production
+          path: vendor/publishing-api
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Check for Yarn
+        id: check-for-yarn
+        run: |
+          YARN_ENABLED=false
+          if [[ -f ./yarn.lock ]]; then
+            YARN_ENABLED=true
+          fi
+
+          echo "present=${YARN_ENABLED}" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Node
+        if: ${{ steps.check-for-yarn.outputs.present == 'true' }}
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+
+      - name: Install JavaScript dependencies
+        if: ${{ steps.check-for-yarn.outputs.present == 'true' }}
+        run: yarn install --frozen-lockfile
+
+      - name: Install additional system dependencies
+        if: ${{ inputs.extraSystemDependencies }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ${{ inputs.extraSystemDependencies }}
+
+      - name: Initialize database
+        if: ${{ inputs.enableMySQL || inputs.enablePostgres || inputs.enableMongoDB }}
+        env:
+          TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url ||  steps.setup-postgres.outputs.db-url }}
+        run: bundle exec rails db:setup
+
+      - name: Run tests
+        env:
+          TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
+        run: bundle exec rake test


### PR DESCRIPTION
This adds workflows that can be used by CI workflows in apps to run the different process required. We are using reusable workflow to help centralise and minimise the amount of config we have to manage. This adds the initial set of jobs that are need by Whitehall for CI.

An example of an app using the workflow: https://github.com/alphagov/whitehall/pull/7155/files
An example of the workflow run: https://github.com/alphagov/whitehall/actions/runs/3697377538

The cache dependencies workflow can be run before other jobs to cache shared dependencies.