### PR TITLE
Add composite actions for backing services

### DIFF
--- a/.github/actions/setup-elasticsearch/action.yaml
+++ b/.github/actions/setup-elasticsearch/action.yaml
@@ -1,0 +1,37 @@
+name: 'Setup Elasticsearch'
+description: 'Create a new Elasticsearch instance'
+runs:
+  using: "composite"
+  steps:
+    - name: Configure sysctl limits
+      shell: bash
+      run: |
+        sudo swapoff -a
+        sudo sysctl -w vm.swappiness=1
+        sudo sysctl -w fs.file-max=262144
+        sudo sysctl -w vm.max_map_count=262144
+
+    - name: Create network
+      shell: bash
+      run: docker network create elastic
+
+    - name: Start container
+      env:
+        ELASTICSEARCH_IMAGE_TAG: 6.7.2
+        ELASTICSEARCH_PORT: 9200
+      shell: bash
+      run: |
+        docker run --name="elasticsearch" \
+         --rm --detach \
+         --env "discovery.type=single-node" \
+         --env "bootstrap.memory_lock=true" \
+         --env "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
+         --env "xpack.security.enabled=false" \
+         --env "xpack.license.self_generated.type=basic" \
+         --ulimit "nofile=65536:65536" \
+         --ulimit "memlock=-1:-1" \
+         --publish "${ELASTICSEARCH_PORT}:9200" \
+         --network "elastic" \
+         elasticsearch:${ELASTICSEARCH_IMAGE_TAG}
+         
+         sleep 10

--- a/.github/actions/setup-mongodb/action.yaml
+++ b/.github/actions/setup-mongodb/action.yaml
@@ -1,0 +1,21 @@
+name: 'Setup MongoDB'
+description: 'Create a new MongoDB database'
+runs:
+  using: "composite"
+  steps:
+    - name: Start container
+      env:
+        MONGODB_PORT: 27017
+        MONGODB_IMAGE_TAG: 2.6
+        MONGODB_DB: ''
+        MONGODB_USERNAME: ''
+        MONGODB_PASSWORD: ''
+      shell: bash
+      run: |
+        docker run --name mongodb \
+         --rm --detach \
+         --publish "${MONGODB_PORT}:27017" \
+         --env "MONGO_INITDB_DATABASE=${MONGODB_DB}" \
+         --env "MONGO_INITDB_ROOT_USERNAME=${MONGODB_USERNAME}" \
+         --env "MONGO_INITDB_ROOT_PASSWORD=${MONGODB_PASSWORD}" \
+         mongo:${MONGODB_IMAGE_TAG}

--- a/.github/actions/setup-mysql/action.yaml
+++ b/.github/actions/setup-mysql/action.yaml
@@ -1,0 +1,37 @@
+name: 'Setup MySQL'
+description: 'Create a new MySQL database'
+outputs:
+  db-url:
+    description: "The URL to connect to the database"
+    value: ${{ steps.generate-url.outputs.db-url }}
+runs:
+  using: "composite"
+  steps:
+    - name: Stop MySQL on host
+      shell: bash
+      run: sudo service mysql stop
+
+    - name: Start container
+      env:
+        MYSQL_IMAGE_TAG: 8.0
+        MYSQL_PORT: 3306
+        MYSQL_PASSWORD: root
+        MYSQL_DB: test
+      shell: bash
+      run: |
+        docker run --name mysql \
+         --rm --detach \
+         --publish "${MYSQL_PORT}:3306" \
+         --env "MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}" \
+         mysql:${MYSQL_IMAGE_TAG} \
+         --performance-schema=off --innodb_buffer_pool_size=32M \
+         --innodb-log-buffer-size=8M --key_buffer_size=4M
+
+    - name: Generate database URL
+      id: generate-url
+      env:
+        MYSQL_PORT: 3306
+        MYSQL_PASSWORD: root
+        MYSQL_DB: test
+      shell: bash
+      run: echo "db-url=mysql2://root:${MYSQL_PASSWORD}@127.0.0.1:${MYSQL_PORT}/${MYSQL_DB}" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-postgres/action.yaml
+++ b/.github/actions/setup-postgres/action.yaml
@@ -1,0 +1,36 @@
+name: 'Setup Postgres'
+description: 'Create a new Postgres database'
+outputs:
+  db-url:
+    description: "The URL to connect to the database"
+    value: ${{ steps.generate-url.outputs.db-url }}
+runs:
+  using: "composite"
+  steps:
+    - name: Start container
+      id: start-container
+      env:
+        POSTGRES_IMAGE_TAG: 13-alpine
+        POSTGRES_PORT: 5432
+        POSTGRES_USER: root
+        POSTGRES_PASSWORD: root
+        POSTGRES_DB: test
+      shell: bash
+      run: |
+        docker run --name postgres \
+         --rm --detach \
+         --publish "${POSTGRES_PORT}:${POSTGRES_PORT}" \
+         --env "POSTGRES_USER=${POSTGRES_USER}" \
+         --env "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
+         --env "POSTGRES_DB=${POSTGRES_DB}" \
+         postgres:${POSTGRES_IMAGE_TAG}
+
+    - name: Generate database URL
+      id: generate-url
+      env:
+        POSTGRES_PORT: 5432
+        POSTGRES_USER: root
+        POSTGRES_PASSWORD: root
+        POSTGRES_DB: test
+      shell: bash
+      run: echo "db-url=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_PORT}/${POSTGRES_DB}" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-redis/action.yaml
+++ b/.github/actions/setup-redis/action.yaml
@@ -1,0 +1,16 @@
+name: 'Setup Redis'
+description: 'Create new Redis database'
+runs:
+  using: "composite"
+  steps:
+    - name: Start Redis container
+      env:
+        REDIS_IMAGE_TAG: 6-alpine
+        REDIS_PORT: 6379
+      shell: bash
+      run: |
+        # Start container
+        docker run --name redis \
+         --rm --detach \
+         --publish "${REDIS_PORT}:6379" \
+         redis:${REDIS_IMAGE_TAG}

--- a/.github/workflows/ci-test-ruby.yaml
+++ b/.github/workflows/ci-test-ruby.yaml
@@ -104,31 +104,7 @@ jobs:
 
       - name: Setup Elasticsearch
         if: ${{ inputs.enableElasticsearch }}
-        env:
-          ELASTICSEARCH_IMAGE_TAG: 6.7.2
-          ELASTICSEARCH_PORT: 9200
-        run: |
-          sudo swapoff -a
-          sudo sysctl -w vm.swappiness=1
-          sudo sysctl -w fs.file-max=262144
-          sudo sysctl -w vm.max_map_count=262144
-
-          docker network create elastic
-
-          docker run --name="elasticsearch" \
-           --rm --detach \
-           --env "discovery.type=single-node" \
-           --env "bootstrap.memory_lock=true" \
-           --env "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
-           --env "xpack.security.enabled=false" \
-           --env "xpack.license.self_generated.type=basic" \
-           --ulimit "nofile=65536:65536" \
-           --ulimit "memlock=-1:-1" \
-           --publish "${ELASTICSEARCH_PORT}:9200" \
-           --network "elastic" \
-           elasticsearch:${ELASTICSEARCH_IMAGE_TAG}
-
-           sleep 10
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-elasticsearch@main
 
       - name: Setup Redis
         if: ${{ inputs.enableRedis }}

--- a/.github/workflows/ci-test-ruby.yaml
+++ b/.github/workflows/ci-test-ruby.yaml
@@ -68,22 +68,7 @@ jobs:
       - name: Setup Postrges
         id: setup-postgres
         if: ${{ inputs.enablePostgres }}
-        env:
-          POSTGRES_IMAGE_TAG: 13-alpine
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD: root
-          POSTGRES_DB: test
-        run: |
-          docker run --name postgres \
-           --rm --detach \
-           --publish "${POSTGRES_PORT}:${POSTGRES_PORT}" \
-           --env "POSTGRES_USER=${POSTGRES_USER}" \
-           --env "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
-           --env "POSTGRES_DB=${POSTGRES_DB}" \
-           postgres:${POSTGRES_IMAGE_TAG}
-
-          echo "db-url=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_PORT}/${POSTGRES_DB}" >> $GITHUB_OUTPUT
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-postgres@main
 
       - name: Setup MongoDB
         if: ${{ inputs.enableMongoDB }}

--- a/.github/workflows/ci-test-ruby.yaml
+++ b/.github/workflows/ci-test-ruby.yaml
@@ -45,25 +45,7 @@ jobs:
       - name: Setup MySQL
         id: setup-mysql
         if: ${{ inputs.enableMySQL }}
-        env:
-          MYSQL_IMAGE_TAG: 8.0
-          MYSQL_PORT: 3306
-          MYSQL_PASSWORD: root
-          MYSQL_DB: test
-        run: |
-          # Stop the MySQL service running on the runner node
-          sudo service mysql stop
-
-          # Start 
-          docker run --name mysql \
-           --rm --detach \
-           --publish "${MYSQL_PORT}:3306" \
-           --env "MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}" \
-           mysql:${MYSQL_IMAGE_TAG} \
-           --performance-schema=off --innodb_buffer_pool_size=32M \
-           --innodb-log-buffer-size=8M --key_buffer_size=4M
-
-          echo "db-url=mysql2://root:${MYSQL_PASSWORD}@127.0.0.1:${MYSQL_PORT}/${MYSQL_DB}" >> $GITHUB_OUTPUT
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-mysql@main
 
       - name: Setup Postrges
         id: setup-postgres

--- a/.github/workflows/ci-test-ruby.yaml
+++ b/.github/workflows/ci-test-ruby.yaml
@@ -87,20 +87,7 @@ jobs:
 
       - name: Setup MongoDB
         if: ${{ inputs.enableMongoDB }}
-        env:
-          MONGODB_PORT: 27017
-          MONGODB_IMAGE_TAG: 2.6
-          MONGODB_DB: ''
-          MONGODB_USERNAME: ''
-          MONGODB_PASSWORD: ''
-        run: |
-          docker run --name mongodb \
-           --rm --detach \
-           --publish "${MONGODB_PORT}:27017" \
-           --env "MONGO_INITDB_DATABASE=${MONGODB_DB}" \
-           --env "MONGO_INITDB_ROOT_USERNAME=${MONGODB_USERNAME}" \
-           --env "MONGO_INITDB_ROOT_PASSWORD=${MONGODB_PASSWORD}" \
-           mongo:${MONGODB_IMAGE_TAG}
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main
 
       - name: Setup Elasticsearch
         if: ${{ inputs.enableElasticsearch }}

--- a/.github/workflows/ci-test-ruby.yaml
+++ b/.github/workflows/ci-test-ruby.yaml
@@ -80,15 +80,7 @@ jobs:
 
       - name: Setup Redis
         if: ${{ inputs.enableRedis }}
-        env:
-          REDIS_IMAGE_TAG: 6-alpine
-          REDIS_PORT: 6379
-        run: |
-          # Start container
-          docker run --name redis \
-           --rm --detach \
-           --publish "${REDIS_PORT}:6379" \
-           redis:${REDIS_IMAGE_TAG}
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-rails.yaml
+++ b/.github/workflows/test-rails.yaml
@@ -120,19 +120,9 @@ jobs:
          with:
            mongodb-version: 2.6
 
-       - name: Configure sysctl limits
-         if: ${{ inputs.requiresElasticsearch }}
-         run: |
-           sudo swapoff -a
-           sudo sysctl -w vm.swappiness=1
-           sudo sysctl -w fs.file-max=262144
-           sudo sysctl -w vm.max_map_count=262144
-
        - name: Setup Elasticsearch
          if: ${{ inputs.requiresElasticsearch }}
-         uses: elastic/elastic-github-actions/elasticsearch@562b8b6ae4677da97273ff6bc4d630ce96ecbaa5
-         with:
-           stack-version: 6.7.0
+         uses: alphagov/govuk-infrastructure/.github/actions/setup-elasticsearch@main
 
        - name: Setup Redis
          if: ${{ inputs.requiresRedis }}


### PR DESCRIPTION
This adds composite action definitions for GitHub Actions that can be used by other workflows to set up the following backing services:

- Redis
- MySQL
- Postgres
- Elasticsearch
- MongoDB

They are needed for CI workflows to run tests for applications. These backing services rely on creating a docker container. In future we can improve this by adding health checks to the containers and waiting for services until they're functional. We will probably also want to allow the ability to use an input to specify the container version. 