### PR TITLE
Add precompile Rails assets composite action and workflow 

### DIFF
--- a/.github/actions/precompile-rails-assets/action.yaml
+++ b/.github/actions/precompile-rails-assets/action.yaml
@@ -1,0 +1,27 @@
+name: Precompile Rails assets
+description: 'Precompile assets and cache'
+runs:
+  using: "composite"
+  steps:
+    - name: Assets cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          public/assets
+          tmp/cache/assets/sprockets
+        key: ${{ runner.os }}-rails-assets-${{ github.ref }}-${{ hashFiles('app/assets/**/*', '**/Gemfile.lock', '**/yarn.lock', 'config/**/*') }}
+        restore-keys: |
+          ${{ runner.os }}-rails-assets-${{ github.ref }}
+
+    - name: Precompile assets
+      env:
+        RAILS_ENV: test
+      shell: bash
+      run: bundle exec rails assets:precompile
+
+    # Remove unused assets (potentially restored by previous cache) so they are not cached again.
+    - name: Remove old compiled assets
+      env:
+        RAILS_ENV: test
+      shell: bash
+      run: bundle exec rails assets:clean

--- a/.github/workflows/jasmine.yaml
+++ b/.github/workflows/jasmine.yaml
@@ -34,9 +34,7 @@ jobs:
 
       - name: Precompile Rails assets
         if: ${{ inputs.useWithRails }}
-        env:
-          RAILS_ENV: test
-        run: bundle exec rails assets:precompile
+        uses: alphagov/govuk-infrastructure/.github/actions/precompile-rails-assets@composite-actions
 
       - name: Run Jasmine
         run: yarn run jasmine-browser-runner runSpecs

--- a/.github/workflows/precompile-rails-assets.yaml
+++ b/.github/workflows/precompile-rails-assets.yaml
@@ -1,24 +1,17 @@
-name: Run Jasmine
+name: Precompile Rails assets
 
 on:
   workflow_call:
-    inputs:
-      useWithRails:
-        description: 'Enable for use with Rails'
-        required: false
-        default: false
-        type: boolean
 
 jobs:
-  run-jasmine:
-    name: Run Jasmine
+  precompile-assets:
+    name: Precompile Rails assets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Setup Ruby
-        if: ${{ inputs.useWithRails }}
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -32,9 +25,5 @@ jobs:
       - name: Install JavaScript dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Precompile Rails assets
-        if: ${{ inputs.useWithRails }}
+      - name: Precompile assets
         uses: alphagov/govuk-infrastructure/.github/actions/precompile-rails-assets@main
-
-      - name: Run Jasmine
-        run: yarn run jasmine-browser-runner runSpecs


### PR DESCRIPTION
This PR adds two reusable components for GitHub Actions:

- A composite action that encapsulates the logic to precompile Rails assets and cache them for other workflows
- A workflow that can be used as a job to precompiles assets. Usefully as a caching step and to test if assets precompile successfully.

