### PR TITLE
Add setup node composite action

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,0 +1,14 @@
+name: 'Setup Node'
+description: 'Install Node and yarn dependencies'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'yarn'
+
+    - name: Install JavaScript dependencies
+      shell: bash
+      run: yarn install --frozen-lockfile

--- a/.github/workflows/jasmine.yaml
+++ b/.github/workflows/jasmine.yaml
@@ -24,13 +24,7 @@ jobs:
           bundler-cache: true
 
       - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'yarn'
-
-      - name: Install JavaScript dependencies
-        run: yarn install --frozen-lockfile
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
 
       - name: Precompile Rails assets
         if: ${{ inputs.useWithRails }}

--- a/.github/workflows/precompile-rails-assets.yaml
+++ b/.github/workflows/precompile-rails-assets.yaml
@@ -17,13 +17,7 @@ jobs:
           bundler-cache: true
 
       - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'yarn'
-
-      - name: Install JavaScript dependencies
-        run: yarn install --frozen-lockfile
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
 
       - name: Precompile assets
         uses: alphagov/govuk-infrastructure/.github/actions/precompile-rails-assets@main

--- a/.github/workflows/standardx.yaml
+++ b/.github/workflows/standardx.yaml
@@ -18,13 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'yarn'
-
-      - name: Install JavaScript dependencies
-        run: yarn install --frozen-lockfile
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
 
       - name: Run Standardx
         run: yarn run standardx ${{ inputs.files }}

--- a/.github/workflows/stylelint.yaml
+++ b/.github/workflows/stylelint.yaml
@@ -18,13 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'yarn'
-
-      - name: Install JavaScript dependencies
-        run: yarn install --frozen-lockfile
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
 
       - name: Run Stylelint
         run: yarn run stylelint ${{ inputs.files }}


### PR DESCRIPTION
This action wraps logic to install nodejs and yarn dependencies into a single step, as we rarely do one without the other. This also gives us a common place to set configuration.