### PR TITLE
Add input for MongoDB version for GitHub Action

### DIFF
--- a/.github/actions/setup-mongodb/action.yaml
+++ b/.github/actions/setup-mongodb/action.yaml
@@ -1,12 +1,17 @@
 name: 'Setup MongoDB'
 description: 'Create a new MongoDB database'
+inputs:
+  version:
+    description: 'Version of MongoDB to use'
+    required: false
+    default: '2.6'
 runs:
   using: "composite"
   steps:
     - name: Start container
       env:
         MONGODB_PORT: 27017
-        MONGODB_IMAGE_TAG: 2.6
+        MONGODB_IMAGE_TAG: ${{ inputs.version }}
         MONGODB_DB: ''
         MONGODB_USERNAME: ''
         MONGODB_PASSWORD: ''


### PR DESCRIPTION
This allows the workflow to specify which version of MongoDB to use when using the composite action.