### PR TITLE
Add minor version to postgres backing service

### DIFF
--- a/.github/actions/setup-postgres/action.yaml
+++ b/.github/actions/setup-postgres/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: Start container
       id: start-container
       env:
-        POSTGRES_IMAGE_TAG: 13-alpine
+        POSTGRES_IMAGE_TAG: 13.7-alpine
         POSTGRES_PORT: 5432
         POSTGRES_USER: root
         POSTGRES_PASSWORD: root


### PR DESCRIPTION
We are using exactly 13.7 in production for all applications that use postgres. Pinning the minor version to be sure we're testing against the exact version we're using. In future we should add an input to allow workflows to specify which version to use.