### PR TITLE
Grant nodes access to content-publisher S3 bucket.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/content_publisher_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/content_publisher_s3.tf
@@ -1,0 +1,35 @@
+resource "aws_iam_policy" "content_publisher_s3" {
+  name        = "content_publisher_s3"
+  description = "Read and write to this environment's content-publisher-activestorage bucket."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+        ]
+        Resource = data.terraform_remote_state.infra_content_publisher.outputs.activestorage_s3_bucket_arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:*MultipartUpload*",
+          "s3:*Object",
+          "s3:*ObjectAcl",
+          "s3:*ObjectVersion",
+          "s3:GetObject*Attributes",
+        ]
+        Resource = "${data.terraform_remote_state.infra_content_publisher.outputs.activestorage_s3_bucket_arn}/*"
+      }
+    ]
+  })
+}
+
+# TODO: consider IRSA (pod identity) rather than granting to nodes.
+resource "aws_iam_role_policy_attachment" "content_publisher_s3" {
+  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  policy_arn = aws_iam_policy.content_publisher_s3.arn
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -19,6 +19,15 @@ data "terraform_remote_state" "infra_assets" {
   }
 }
 
+data "terraform_remote_state" "infra_content_publisher" {
+  backend = "s3"
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-content-publisher.tfstate"
+    region = data.aws_region.current.name
+  }
+}
+
 data "terraform_remote_state" "infra_networking" {
   backend = "s3"
   config = {


### PR DESCRIPTION
Content Publisher needs read-write access to an S3 bucket that it uses for file uploads. For now, just grant access to worker nodes as we've done for other apps like asset-manager.

Later (not before launch) we'll consider rolling out IRSA / pod identity.

Tested: applied in integration.

Rollout: depends on https://github.com/alphagov/govuk-aws/pull/1686

Related: https://github.com/alphagov/content-publisher/pull/2705