### PR TITLE
Grant access to processed Transition logs.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/transition_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/transition_s3.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_policy" "transition_s3" {
+  name        = "transition_s3"
+  description = "Read the processed CDN request logs for transitioned site redirects."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+          "s3:GetObject",
+        ]
+        Resource = "arn:aws:s3:::govuk-${var.govuk_environment}-transition-fastly-logs*"
+      }
+    ]
+  })
+}
+
+# TODO: consider IRSA (pod identity) rather than granting to nodes.
+resource "aws_iam_role_policy_attachment" "transition_s3" {
+  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  policy_arn = aws_iam_policy.transition_s3.arn
+}


### PR DESCRIPTION
The transition app has a periodic job that reads these from S3.

See https://github.com/alphagov/transition/pull/1272

Rollout: applied in all three accounts.