### PR TITLE
Enable GitHub annotations for RuboCop

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -17,4 +17,4 @@ jobs:
           bundler-cache: true
 
       - name: Run RuboCop
-        run: bundle exec rubocop --parallel
+        run: bundle exec rubocop --parallel --format github --format progress


### PR DESCRIPTION
This make RuboCop output annotations that can be interpreted by GitHub and displayed with in the GitHub Check UI.

<img width="1359" alt="image" src="https://user-images.githubusercontent.com/11051676/211602452-56c3642e-e8aa-4dcd-a84c-85826492cc7c.png">
