### PR TITLE
Remove caching rails assets between commits

### DIFF
--- a/.github/actions/precompile-rails-assets/action.yml
+++ b/.github/actions/precompile-rails-assets/action.yml
@@ -10,10 +10,6 @@ runs:
           public/assets
           tmp/cache/assets/sprockets
         key: rails-assets-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
-        restore-keys: |
-          rails-assets-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
-          rails-assets-cache-${{ runner.os }}-${{ github.ref }}-
-          rails-assets-cache-${{ runner.os }}-
 
     - name: Precompile assets
       env:


### PR DESCRIPTION
This removes extra cache keys that allows GitHub workflows from restoring assets from older commits. This is due to issue when there are old versions of assets for the same source file. The Jasmine test suite will sometimes attempt to test an older asset version.