### PR TITLE
Fix build and push github-cli image workflow

### DIFF
--- a/.github/workflows/build-github-cli-image.yml
+++ b/.github/workflows/build-github-cli-image.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build-and-push-image:
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yaml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
       ecrRepositoryName: github-cli

--- a/.github/workflows/build-github-cli-image.yml
+++ b/.github/workflows/build-github-cli-image.yml
@@ -1,10 +1,7 @@
 name: Build and publish github-cli image to ECR
 
 on:
-
   workflow_dispatch:
-    branches:
-      - main
     inputs:
       gitRef:
         description: 'Commit, tag or branch name to deploy'


### PR DESCRIPTION
The key `branches` doesn't apply to a workflow_dispatch trigger and the reference to the build and push workflow had the wrong extension (e.g. yaml instead of yml).