### PR TITLE
Specify external URL for prometheus and alertmanager

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -269,6 +269,7 @@ resource "helm_release" "kube_prometheus_stack" {
               }
             }
           }
+          externalUrl = "https://${local.alertmanager_host}"
         }
       }
       prometheus = {
@@ -305,6 +306,7 @@ resource "helm_release" "kube_prometheus_stack" {
               }
             }
           }
+          externalUrl = "https://${local.prometheus_host}"
         }
       }
       kube_state_metrics = {


### PR DESCRIPTION
This fixes internal URLs appearing in PagerDuty and on the Alertmanager UI