### PR TITLE
Fix Grafana SSO auth with GitHub

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -165,18 +165,18 @@ resource "helm_release" "kube_prometheus_stack" {
         "grafana.ini" = {
           auth = {
             oauth_auto_login = true
-            generic_oauth = {
-              name                  = "GitHub"
-              enabled               = true
-              allow_sign_up         = true
-              auth_url              = "https://${local.dex_host}/auth"
-              token_url             = "https://${local.dex_host}/token"
-              api_url               = "https://${local.dex_host}/userinfo"
-              scopes                = "openid profile email groups"
-              role_attribute_path   = "contains(groups[*], '${var.github_read_write_team}') && 'Admin' || contains(groups[*], '${var.github_read_only_team}') && 'Viewer'"
-              role_attribute_strict = true
-            }
           },
+          "auth.generic_oauth" = {
+            name                  = "GitHub"
+            enabled               = true
+            allow_sign_up         = true
+            auth_url              = "https://${local.dex_host}/auth"
+            token_url             = "https://${local.dex_host}/token"
+            api_url               = "https://${local.dex_host}/userinfo"
+            scopes                = "openid profile email groups"
+            role_attribute_path   = "contains(groups[*], '${var.github_read_write_team}') && 'Admin' || contains(groups[*], '${var.github_read_only_team}') && 'Viewer'"
+            role_attribute_strict = true
+          }
           server = {
             domain   = local.grafana_host
             root_url = "https://%(domain)s"


### PR DESCRIPTION
Fix formatting of the config by unnesting `generic_oauth` from `auth` as it should be discrete key of `auth.generic_oauth`.