### PR TITLE
Fix TODO: Update curl command, we are on 7.81

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,8 +105,7 @@ jobs:
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
         run: |
-          # TODO: use --fail-with-body instead of -f once curl 7.76 is in GH's ubuntu-latest.
-          curl -fs \
+          curl --fail-with-body --silent \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
             -d "{\"environment\": \"${ENVIRONMENT}\", \"repoName\": \"${REPO_NAME}\", \"imageTag\": \"${IMAGE_TAG}\", \"manualDeploy\": \"${MANUAL_DEPLOY}\"}" \


### PR DESCRIPTION
## What?
As the `ubuntu-latest` GHA runner image is now on Ubuntu 22.04 and [comes pre-packaged with curl 7.81](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md) (correct at time of writing), we can now address the TODO in the Deploy workflow.

* Replaces `-f` with `--fail-with-body`, as suggested by the TODO.
* Swap `-s` for `--silent` for improved legibility.

Hopefully this should result in more useful output in the event of a failure.