### PR TITLE
Use ISO date format in Grafana.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -185,6 +185,10 @@ resource "helm_release" "kube_prometheus_stack" {
             type     = "postgres"
             ssl_mode = "disable"
           }
+          date_formats = {
+            interval_hour = "YYYY-MM-DD HH:mm"
+            interval_day  = "YYYY-MM-DD"
+          }
         }
         envValueFrom = {
           "GF_AUTH_GENERIC_OAUTH_CLIENT_ID" = {


### PR DESCRIPTION
This avoids confusion on short dates that appear on time axis labels. Grafana uses `mm/dd hh:MM` for these by default, which is ambiguous outside the US.

Tested: applied in integration, axis labels look ok and are no longer ambiguous. (Pick any dashboard, set time window to > 1 day and should see the new format.)