### PR TITLE
Update External Secrets Operator to 0.7.2.

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -7,7 +7,7 @@ resource "helm_release" "external_secrets" {
   name             = "external-secrets"
   repository       = "https://charts.external-secrets.io"
   chart            = "external-secrets"
-  version          = "0.6.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.7.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({


### PR DESCRIPTION
Update External Secrets Operator from 0.6.0 to 0.7.2.

Doesn't seem to be any API changes between those releases.

Changelog: https://github.com/external-secrets/external-secrets/releases

Tested: applied on the integration cluster, externalsecrets deployments came up healthy, deleted a managed Secret and observed the controller re-create it.