### PR TITLE
Update kube-prometheus-stack and oauth2-proxy.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -141,7 +141,7 @@ resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"
-  version          = "42.3.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "45.4.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
   values = [

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -29,7 +29,7 @@ resource "helm_release" "prometheus_oauth2_proxy" {
   name             = "prometheus-oauth2-proxy"
   repository       = "https://oauth2-proxy.github.io/manifests"
   chart            = "oauth2-proxy"
-  version          = "6.5.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "6.9.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
 
@@ -85,7 +85,7 @@ resource "helm_release" "alertmanager_oauth2_proxy" {
   name             = "alertmanager-oauth2-proxy"
   repository       = "https://oauth2-proxy.github.io/manifests"
   chart            = "oauth2-proxy"
-  version          = "6.5.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "6.9.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
 


### PR DESCRIPTION
- Update kube-prometheus-stack chart from 42.3 to 45.4.
- Update oauth2-proxy chart from 6.5 to 6.9.1 (application version 7.3 to 7.4).

Tested: rolled out to the staging cluster, looks healthy.

Rollout: [CRDs need updating](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#upgrading-chart) before apply.