### PR TITLE
Run fewer monitoring replicas in integration and staging.

### DIFF
--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -41,6 +41,6 @@ rds_skip_final_snapshot = true
 
 secrets_recovery_window_in_days = 0
 
-default_desired_ha_replicas = 2
+default_desired_ha_replicas = 1
 
 ckan_s3_organogram_bucket = "datagovuk-integration-ckan-organogram"

--- a/terraform/deployments/variables/staging/common.tfvars
+++ b/terraform/deployments/variables/staging/common.tfvars
@@ -31,4 +31,6 @@ www_dns_validation_rdata  = "fnvjfn8tfff6n003cf.fastly-validations.com"
 frontend_memcached_node_type   = "cache.t4g.medium"
 shared_redis_cluster_node_type = "cache.t4g.medium"
 
+default_desired_ha_replicas = 2
+
 ckan_s3_organogram_bucket = "datagovuk-staging-ckan-organogram"


### PR DESCRIPTION
It's completely fine if a zone outage causes a couple of minutes of dropped metrics in integration, so it's not worth the extra compute resources to run multiple replicas.

Also, we don't need three replicas in staging. The important thing is that staging has more than one replica, so that it's running the same configuration as production. There's no practical advantage to running 3 replicas rather than 2; it just uses more resources unnecessarily.

This change also applies to some of the other base cluster services, but those are even less sensitive to evictions so there's no issue there.

We'll still run 3 replicas (across three zones) in production, because we want monitoring to be maximally available there and we want to avoid dropping metrics as far as reasonably possible.