### PR TITLE
Don't run 3 Redis replicas for ArgoCD in integration.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -111,7 +111,7 @@ resource "helm_release" "argo_cd" {
     }
 
     redis-ha = {
-      enabled = true
+      enabled = var.argo_redis_ha
     }
 
     notifications = {

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -10,6 +10,12 @@ variable "argo_workflows_namespaces" {
   default     = ["apps"]
 }
 
+variable "argo_redis_ha" {
+  type        = bool
+  description = "Whether to run high-availability (3 replicas) Redis for ArgoCD, instead of 1 replica."
+  default     = true
+}
+
 variable "github_read_write_team" {
   type        = string
   description = "Name of the GitHub team that should have read-write access to Dex SSO-enabled applications"

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -41,6 +41,7 @@ rds_skip_final_snapshot = true
 
 secrets_recovery_window_in_days = 0
 
+argo_redis_ha               = false
 default_desired_ha_replicas = 1
 
 ckan_s3_organogram_bucket = "datagovuk-integration-ckan-organogram"


### PR DESCRIPTION
High-availability Redis for ArgoCD on the integration cluster is overkill; we can live with a potential 1-minute blip in availability once a month or so (probably much less in reality) when there's a zone outage.

ArgoCD treats the cache as volatile, so durability of the cache data is not a factor.
https://www.github.com/argoproj/argo-cd/discussions/6618#discussioncomment-955540

Tested: applied in integration.