### PR TITLE
Use fewer, bigger nodes.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -53,7 +53,7 @@ variable "force_destroy" {
 variable "workers_instance_types" {
   type        = list(string)
   description = "List of instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
-  default     = ["m6i.2xlarge", "m5.2xlarge", "m6i.xlarge", "m5.xlarge"]
+  default     = ["m6i.4xlarge", "m6a.4xlarge", "m6i.2xlarge", "m6a.2xlarge"]
 }
 
 variable "workers_default_capacity_type" {
@@ -77,13 +77,13 @@ variable "workers_size_min" {
 variable "workers_size_max" {
   type        = number
   description = "Max capacity of managed node autoscale group."
-  default     = 15
+  default     = 12
 }
 
 variable "node_disk_size" {
   type        = number
   description = "Size in GB of the node default volume"
-  default     = 50
+  default     = 60
 }
 
 variable "grafana_db_min_capacity" {


### PR DESCRIPTION
Staging didn't quite fit in the previous maximum of 15 m6i.2xlarge nodes. Rather than just increasing the maximum number of nodes, instead we double the size of the nodes and adjust the ASG maximum to be 1.5 x what we're currently using (i.e. we're allowing cluster-autoscaler to enlarge the cluster by 50% without requiring operator intervention).

With this change, staging fits in 8 m6i.4xlarge nodes with less waste. (It's also likely that bigger nodes give more predictable performance, though I haven't benchmarked this.)

Also remove m5 instance types from the list of alternatives and replace them with m6a, since m6a is much closer in performance characteristics. We're not currently using spot instances anyway, but we might do on integration or staging at some point.

Max pods per node is well within limits and utilisation looks good (see instance details pages under EKS > Clusters > Compute in the AWS web console).

Testing: already applied in staging.