### PR TITLE
Update container logs path to reflect dockerd->containerd.

### DIFF
--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -15,13 +15,13 @@ resource "helm_release" "filebeat" {
         "filebeat.inputs" = [
           {
             type  = "container"
-            paths = ["/var/lib/docker/containers/*/*.log"]
+            paths = ["/var/log/containers/*.log"]
             processors = [{
               add_kubernetes_metadata = {
                 host = "$${NODE_NAME}"
                 matchers = [{
                   logs_path = {
-                    logs_path = "/var/lib/docker/containers/"
+                    logs_path = "/var/log/containers/"
                   }
                 }]
               }


### PR DESCRIPTION
Because of the removal of Dockershim in k8s 1.24, Amazon has switched EKS from dockerd to containerd in that release. This results in container log files being written to a different directory on the kubelet.