### PR TITLE
Update Argo CD from 2.5 to 2.6.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -30,7 +30,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.13.8" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.24.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     server = {
       # TLS Termination happens at the ALB, the insecure flag prevents Argo


### PR DESCRIPTION
No breaking changes.

Upgrade guide: https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.5-2.6/
Chart changelog: https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd#changelog