### PR TITLE
Add cron schedule to run once a week at 00:00 Monday

### DIFF
--- a/.github/workflows/build-github-cli-image.yml
+++ b/.github/workflows/build-github-cli-image.yml
@@ -14,6 +14,9 @@ on:
       - main
     paths:
       - "images/github-cli/Dockerfile"
+  
+  schedule:
+    - cron: '0 0 * * 1'
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
Current lifecycle rules delete the image after 30days. 
Running this build once a week will keep the image up-to-date and stop issues where theres no image.


https://trello.com/c/P0Ff5SDZ/1141-lifecycle-rules-keep-deleting-github-cli-image