### PR TITLE
Productionise Prometheus/Alertmanager config.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -37,7 +37,7 @@ resource "helm_release" "argo_cd" {
       # server from upgrading the request after TLS termination.
       extraArgs = ["--insecure"]
 
-      replicas = var.default_desired_ha_replicas
+      replicas = var.desired_ha_replicas
 
       ingress = {
         enabled = true
@@ -99,11 +99,11 @@ resource "helm_release" "argo_cd" {
 
     repoServer = {
       metrics  = local.argo_metrics_config
-      replicas = var.default_desired_ha_replicas
+      replicas = var.desired_ha_replicas
     }
 
     applicationSet = {
-      replicaCount = var.default_desired_ha_replicas
+      replicaCount = var.desired_ha_replicas
     }
 
     dex = {
@@ -215,7 +215,7 @@ resource "helm_release" "argo_workflows" {
         }
       }
       workflowWorkers = 128
-      replicas        = var.default_desired_ha_replicas
+      replicas        = var.desired_ha_replicas
     }
 
     executor = {
@@ -278,7 +278,7 @@ resource "helm_release" "argo_workflows" {
           memory = "512Mi"
         }
       }
-      replicas = var.default_desired_ha_replicas
+      replicas = var.desired_ha_replicas
     }
   })]
 }
@@ -293,7 +293,7 @@ resource "helm_release" "argo_events" {
   values = [yamlencode({
     namespace = local.services_ns
     controller = {
-      replicas = var.default_desired_ha_replicas
+      replicas = var.desired_ha_replicas
     }
     configs = {
       jetstream = {

--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -21,7 +21,7 @@ resource "helm_release" "aws_lb_controller" {
         "eks.amazonaws.com/role-arn" = data.terraform_remote_state.cluster_infrastructure.outputs.aws_lb_controller_role_arn
       }
     }
-    replicaCount = var.default_desired_ha_replicas
+    replicaCount = var.desired_ha_replicas
   })]
 }
 

--- a/terraform/deployments/cluster-services/cluster_autoscaler.tf
+++ b/terraform/deployments/cluster-services/cluster_autoscaler.tf
@@ -31,6 +31,6 @@ resource "helm_release" "cluster_autoscaler" {
     extraArgs = {
       balance-similar-node-groups = true
     }
-    replicaCount = var.default_desired_ha_replicas
+    replicaCount = var.desired_ha_replicas
   })]
 }

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -13,7 +13,7 @@ resource "helm_release" "dex" {
   repository       = "https://charts.dexidp.io"
   version          = "0.9.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
-    replicaCount = var.default_desired_ha_replicas
+    replicaCount = var.desired_ha_replicas
     config = {
       issuer = "https://${local.dex_host}"
 

--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -25,7 +25,7 @@ resource "helm_release" "external_dns" {
     domainFilters      = [data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_name]
     interval           = "5m"
     triggerLoopOnEvent = true
-    replicaCount       = var.default_desired_ha_replicas
+    replicaCount       = var.desired_ha_replicas
     # TODO: hook up Prometheus metrics (metrics.enabled, metrics.podAnnotations etc.)
   })]
 }

--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -11,7 +11,7 @@ resource "helm_release" "external_secrets" {
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({
-    replicaCount = var.default_desired_ha_replicas
+    replicaCount = var.desired_ha_replicas
     serviceAccount = {
       name = data.terraform_remote_state.cluster_infrastructure.outputs.external_secrets_service_account_name
       annotations = {
@@ -19,10 +19,10 @@ resource "helm_release" "external_secrets" {
       }
     }
     certController = {
-      replicaCount = var.default_desired_ha_replicas
+      replicaCount = var.desired_ha_replicas
     }
     webhook = {
-      replicaCount = var.default_desired_ha_replicas
+      replicaCount = var.desired_ha_replicas
     }
   })]
 }

--- a/terraform/deployments/cluster-services/fastly_exporter.tf
+++ b/terraform/deployments/cluster-services/fastly_exporter.tf
@@ -7,6 +7,6 @@ resource "helm_release" "fastly-exporter" {
   namespace        = local.monitoring_ns
   create_namespace = true
   values = [yamlencode({
-    replicaCount = var.default_desired_ha_replicas
+    replicaCount = var.desired_ha_replicas
   })]
 }

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -1,4 +1,5 @@
-# Installs Prometheus Operator, Prometheus, Prometheus rules, Grafana, Grafana dashboards, and Prometheus CRDs
+# Installs Prometheus Operator, Prometheus, Prometheus rules, Grafana (with
+# some default dashboards) and Prometheus CRDs.
 
 data "aws_secretsmanager_secret" "alertmanager-pagerduty" {
   name = "govuk/alertmanager/pagerduty-routing-key"
@@ -303,13 +304,28 @@ resource "helm_release" "kube_prometheus_stack" {
               values   = []
             }]
           }
-          podMonitorSelectorNilUsesHelmValues     = false
+          podMonitorSelectorNilUsesHelmValues = false
+          serviceMonitorNamespaceSelector = {
+            matchExpressions = [{
+              key      = "no_monitor"
+              operator = "DoesNotExist"
+              values   = []
+            }]
+          }
           serviceMonitorSelectorNilUsesHelmValues = false
           replicas                                = var.default_desired_ha_replicas
           podDisruptionBudget = {
             enabled = var.default_desired_ha_replicas > 1
           }
           podAntiAffinity = var.default_desired_ha_replicas > 1 ? "hard" : ""
+          probeNamespaceSelector = {
+            matchExpressions = [{
+              key      = "no_monitor"
+              operator = "DoesNotExist"
+              values   = []
+            }]
+          }
+          probeSelectorNilUsesHelmValues = false
           retention                      = "90d"
           storageSpec = {
             volumeClaimTemplate = {

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -265,6 +265,7 @@ resource "helm_release" "kube_prometheus_stack" {
           podDisruptionBudget = {
             enabled = var.default_desired_ha_replicas > 1
           }
+          podAntiAffinity = var.default_desired_ha_replicas > 1 ? "hard" : ""
           storage = {
             volumeClaimTemplate = {
               spec = {
@@ -305,6 +306,7 @@ resource "helm_release" "kube_prometheus_stack" {
           podDisruptionBudget = {
             enabled = var.default_desired_ha_replicas > 1
           }
+          podAntiAffinity = var.default_desired_ha_replicas > 1 ? "hard" : ""
           storageSpec = {
             volumeClaimTemplate = {
               spec = {

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -154,7 +154,7 @@ resource "helm_release" "kube_prometheus_stack" {
     yamlencode({
       grafana = {
         defaultDashboardsTimezone = "Europe/London"
-        replicas                  = var.default_desired_ha_replicas
+        replicas                  = var.desired_ha_replicas
         ingress = {
           enabled  = true
           hosts    = [local.grafana_host]
@@ -262,11 +262,9 @@ resource "helm_release" "kube_prometheus_stack" {
       }
       alertmanager = {
         alertmanagerSpec = {
-          replicas = var.default_desired_ha_replicas
-          podDisruptionBudget = {
-            enabled = var.default_desired_ha_replicas > 1
-          }
-          podAntiAffinity = var.default_desired_ha_replicas > 1 ? "hard" : ""
+          replicas            = var.desired_ha_replicas
+          podDisruptionBudget = { enabled = var.desired_ha_replicas > 1 }
+          podAntiAffinity     = var.desired_ha_replicas > 1 ? "hard" : ""
           storage = {
             volumeClaimTemplate = {
               spec = {
@@ -313,11 +311,9 @@ resource "helm_release" "kube_prometheus_stack" {
             }]
           }
           serviceMonitorSelectorNilUsesHelmValues = false
-          replicas                                = var.default_desired_ha_replicas
-          podDisruptionBudget = {
-            enabled = var.default_desired_ha_replicas > 1
-          }
-          podAntiAffinity = var.default_desired_ha_replicas > 1 ? "hard" : ""
+          replicas                                = var.desired_ha_replicas
+          podDisruptionBudget                     = { enabled = var.desired_ha_replicas > 1 }
+          podAntiAffinity                         = var.desired_ha_replicas > 1 ? "hard" : ""
           probeNamespaceSelector = {
             matchExpressions = [{
               key      = "no_monitor"

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -284,6 +284,9 @@ resource "helm_release" "kube_prometheus_stack" {
         # Match all PrometheusRules cluster-wide. (If an app/team needs a separate
         # Prom instance, it almost certainly needs a separate EKS cluster too.)
         prometheusSpec = {
+          scrapeInterval     = "1m"
+          evaluationInterval = "1m"
+          scrapeTimeout      = "15s"
           ruleNamespaceSelector = {
             matchExpressions = [{
               key      = "no_monitor"
@@ -307,6 +310,7 @@ resource "helm_release" "kube_prometheus_stack" {
             enabled = var.default_desired_ha_replicas > 1
           }
           podAntiAffinity = var.default_desired_ha_replicas > 1 ? "hard" : ""
+          retention                      = "90d"
           storageSpec = {
             volumeClaimTemplate = {
               spec = {

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -262,6 +262,9 @@ resource "helm_release" "kube_prometheus_stack" {
       alertmanager = {
         alertmanagerSpec = {
           replicas = var.default_desired_ha_replicas
+          podDisruptionBudget = {
+            enabled = var.default_desired_ha_replicas > 1
+          }
           storage = {
             volumeClaimTemplate = {
               spec = {
@@ -299,6 +302,9 @@ resource "helm_release" "kube_prometheus_stack" {
           podMonitorSelectorNilUsesHelmValues     = false
           serviceMonitorSelectorNilUsesHelmValues = false
           replicas                                = var.default_desired_ha_replicas
+          podDisruptionBudget = {
+            enabled = var.default_desired_ha_replicas > 1
+          }
           storageSpec = {
             volumeClaimTemplate = {
               spec = {

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -49,7 +49,7 @@ variable "dex_github_orgs_teams" {
   default     = [{ name = "alphagov", teams = ["gov-uk-production-deploy"] }]
 }
 
-variable "default_desired_ha_replicas" {
+variable "desired_ha_replicas" {
   type        = number
   description = "Default number of desired replicas for high availability"
   default     = 3

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -41,7 +41,7 @@ rds_skip_final_snapshot = true
 
 secrets_recovery_window_in_days = 0
 
-argo_redis_ha               = false
-default_desired_ha_replicas = 1
+argo_redis_ha       = false
+desired_ha_replicas = 1
 
 ckan_s3_organogram_bucket = "datagovuk-integration-ckan-organogram"

--- a/terraform/deployments/variables/staging/common.tfvars
+++ b/terraform/deployments/variables/staging/common.tfvars
@@ -31,6 +31,6 @@ www_dns_validation_rdata  = "fnvjfn8tfff6n003cf.fastly-validations.com"
 frontend_memcached_node_type   = "cache.t4g.medium"
 shared_redis_cluster_node_type = "cache.t4g.medium"
 
-default_desired_ha_replicas = 2
+desired_ha_replicas = 2
 
 ckan_s3_organogram_bucket = "datagovuk-staging-ckan-organogram"

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -42,6 +42,7 @@ rds_skip_final_snapshot = true
 
 secrets_recovery_window_in_days = 0
 
-default_desired_ha_replicas = 1
+argo_redis_ha       = false
+desired_ha_replicas = 1
 
 ckan_s3_organogram_bucket = "datagovuk-test-ckan-organogram"


### PR DESCRIPTION
- Enable the kube-prometheus-stack chart's default PodDisruptionBudget for Prometheus and Alertmanager. The default is `minAvailable: 1`, which is fine.
- Set pod anti-affinity for Prometheus and Alertmanager so they can't end up with multiple replicas on the same node.
- Increase Prometheus metrics rentention from 10 days to 90 days and set the sampling (and eval) interval to 1 minute.
- Enable the use of ServiceMonitors and Probes in any namespace, like we already do for PodMonitors.
- Fix a weird variable name.

We only want PDB and anti-affinity where we're running more than one replica, i.e. in staging and production.