### PR TITLE
Fix an inconsistent/confusing filename.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/search_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_iam.tf
@@ -1,5 +1,6 @@
-# TODO: instead of granting write access to nodes, use IRSA (IAM Roles for
-# Service Accounts aka pod identity) so that only search-api containers can write.
+# TODO: instead of granting access to nodes, use IRSA (IAM Roles for Service
+# Accounts aka pod identity) to grant access specifically to Search.
+
 resource "aws_iam_role_policy_attachment" "search_relevancy_s3_eks_policy_attachment" {
   role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
   policy_arn = data.terraform_remote_state.app_search.outputs.search_relevancy_s3_policy_arn


### PR DESCRIPTION
The rest of the files in govuk-publishing-infrastructure are generally named along the lines of `<name of app>_<thing being configured>.tf`. The `app_` prefix on this filename was superfluous.

Also fix up a bit of copy-paste in the file comment.

No diff.