### PR TITLE
Add metrics relabel for CKAN

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -339,6 +339,11 @@ resource "helm_release" "kube_prometheus_stack" {
       }
       kube_state_metrics = {
         selfMonitor = { enabled = true }
+        metricRelabelings = {
+          action      = "labelmap"
+          regex       = "^flask_(.*)"
+          replacement = "${1}"
+        }
       }
     })
   ]


### PR DESCRIPTION
## What

Relabel the CKAN metrics so that existing dashboards can be used in grafana to pick them up.

## Reference 

https://trello.com/c/3ARO34au/1149-relabel-ckan-metrics-to-match-ruby-app-metrics