### PR TITLE
Update kube-prometheus-stack and remove some info alerts we don't care about.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -152,6 +152,26 @@ resource "helm_release" "kube_prometheus_stack" {
         alertmanager_host = local.alertmanager_host
     }),
     yamlencode({
+      kubeControllerManager = { enabled = false }
+      kubeEtcd              = { enabled = false }
+      kubeScheduler         = { enabled = false }
+      defaultRules = {
+        rules = {
+          kubeApiserverBurnrate  = false
+          kubeApiserverHistogram = false
+          kubeApiserverSlos      = false
+          network                = false
+        }
+        disabled = {
+          KubePodNotReady           = true
+          NodeRAIDDegraded          = true
+          NodeNetworkReceiveErrs    = true
+          NodeNetworkTransmitErrs   = true
+          NodeClockSkewDetected     = true
+          NodeClockNotSynchronising = true
+          NodeRAIDDiskFailure       = true
+        }
+      }
       grafana = {
         defaultDashboardsTimezone = "Europe/London"
         replicas                  = var.desired_ha_replicas

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -142,7 +142,7 @@ resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"
-  version          = "45.4.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "45.7.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
   values = [


### PR DESCRIPTION
These rules/alerts are either noisy (like `KubePodNotReady`) or trying to monitor something that we don't have (like `NodeRAID*`) or don't own (like etcd and other control plane components).

For now I've erred on the side of leaving stuff in on the off chance that it might give useful info; we can always do some further pruning later.

No breaking changes in the chart upgrade.

Tested: applied in [integration](https://prometheus.eks.integration.govuk.digital/alerts).