### PR TITLE
Use bigger nodes in production.

### DIFF
--- a/terraform/deployments/variables/production/common.tfvars
+++ b/terraform/deployments/variables/production/common.tfvars
@@ -29,6 +29,7 @@ external_dns_subdomain    = "eks"
 
 www_dns_validation_rdata = "sb6euj4c7g7s54y1pi.fastly-validations.com"
 
+workers_instance_types         = ["m6i.8xlarge", "m6a.8xlarge"]
 frontend_memcached_node_type   = "cache.r6g.large"
 shared_redis_cluster_node_type = "cache.r6g.xlarge"
 


### PR DESCRIPTION
The production workload doesn't fit in 12 nodes, so let's make them bigger again. We might revisit this after launch after we've done some tuning of resource requests, but for now this should make it easier to scale up if we need to.

Already applied.