### PR TITLE
Fix broken link in docs/README.md.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ environment](create-a-new-environment.md).
 
 ### CI/CD
 
-Tests for govuk-infrastructure run in [GitHub Actions](../../../../actions).
+Tests for govuk-infrastructure run in [GitHub Actions](/alphagov/govuk-infrastructure/actions).
 
 [govuk-aws]: https://github.com/alphagov/govuk-aws
 [govuk-aws-data]: https://github.com/alphagov/govuk-aws-data


### PR DESCRIPTION
Path-relative link to the Actions tab can't work from both `docs/` and `docs/README.md`, so use host-relative. Thought about just removing it, but 🤷