### PR TITLE
Send PROMOTE_DEPLOYMENT variable to argo workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,11 +102,18 @@ jobs:
           IMAGE_TAG: ${{ inputs.imageTag }}
           REPO_NAME: ${{ inputs.appName }}
           MANUAL_DEPLOY: ${{ github.event_name == 'workflow_dispatch' }}
+          PROMOTE_DEPLOYMENT: ${{ github.event_name == 'workflow_run' }}
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
         run: |
           curl --fail-with-body --silent \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
-            -d "{\"environment\": \"${ENVIRONMENT}\", \"repoName\": \"${REPO_NAME}\", \"imageTag\": \"${IMAGE_TAG}\", \"manualDeploy\": \"${MANUAL_DEPLOY}\"}" \
+            -d "{
+              \"environment\": \"${ENVIRONMENT}\",
+              \"repoName\": \"${REPO_NAME}\",
+              \"imageTag\": \"${IMAGE_TAG}\",
+              \"manualDeploy\": \"${MANUAL_DEPLOY}\",
+              \"promoteDeployment\": \"${PROMOTE_DEPLOYMENT}\"
+            }" \
             "${WEBHOOK_URL}/update-image-tag"


### PR DESCRIPTION
This adds an extra attribute sent to argo workflow for the deployment pipeline. PROMOTE_DEPLOYMENT is essentially the inverse to "MANUAL_DEPLOY". This allows us to be explicit when we want to promote deployment and make the logic confusing by not having to use the inverse of MANUAL_DEPLOY.