### PR TITLE
Set allowed version of NATS Jetstream image

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -295,5 +295,19 @@ resource "helm_release" "argo_events" {
     controller = {
       replicas = var.desired_ha_replicas
     }
+    configs = {
+      jetstream = {
+        versions = [
+          {
+            # TODO: Dependabot or similar so this doesn't get neglected.
+            version              = "2.9.8"
+            natsImage            = "nats:2.9.8"
+            metricsExporterImage = "natsio/prometheus-nats-exporter:0.10.1"
+            configReloaderImage  = "natsio/nats-server-config-reloader:0.7.4"
+            startCommand         = "/nats-server"
+          }
+        ]
+      }
+    }
   })]
 }


### PR DESCRIPTION
When starting the eventbus, its tries to use a specific version of the NATS Jetstream image. The default config only allows use of the image tagged latest, and hence the eventbus fails to start. Explicitly allowing this version for now as a quick fix, until we figure out how to not specify a specific allowed version.