### PR TITLE
Update aws-ebs-csi-driver chart to 2.17.2.

### DIFF
--- a/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
@@ -13,7 +13,7 @@ resource "helm_release" "ebs_csi_driver" {
   name       = "aws-ebs-csi-driver"
   namespace  = "kube-system"
   repository = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver"
-  version    = "2.13.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "2.17.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
 
   values = [yamlencode({
     enableVolumeResizing = true


### PR DESCRIPTION
[Changelog](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/CHANGELOG.md#v2172)

This gets rid of the last of our `k8s.gcr.io` stragglers.

Tested: applied in integration.

https://trello.com/c/h3uJvIrK