### PR TITLE
Update to last version of armo-components chart.

### DIFF
--- a/terraform/deployments/cluster-services/kubescape.tf
+++ b/terraform/deployments/cluster-services/kubescape.tf
@@ -12,7 +12,7 @@ resource "helm_release" "kubescape" {
   namespace        = "armo-system"
   create_namespace = true
   repository       = "https://armosec.github.io/armo-helm/"
-  version          = "1.7.6"
+  version          = "1.7.18"
   set {
     name  = "clusterName"
     value = "govuk-${var.govuk_environment}"


### PR DESCRIPTION
This chart is no longer maintained and we need to switch to https://github.com/kubescape/helm-charts instead, but let's start by updating it to the final version first.