### PR TITLE
Tune cluster-autoscaler settings to allow scaledown.

### DIFF
--- a/terraform/deployments/cluster-services/cluster_autoscaler.tf
+++ b/terraform/deployments/cluster-services/cluster_autoscaler.tf
@@ -29,7 +29,9 @@ resource "helm_release" "cluster_autoscaler" {
       enabled     = true
     }
     extraArgs = {
-      balance-similar-node-groups = true
+      balance-similar-node-groups      = true
+      scale-down-utilization-threshold = "0.55"
+      skip-nodes-with-local-storage    = false
     }
     replicaCount = var.desired_ha_replicas
   })]


### PR DESCRIPTION
- Slightly increase the utilisation threshold at which CA will consider a node for removal.
- Allow eviction of pods which have local storage. This should let CA actually scale down now. We don't care about local storage; anything using it is already working under the assumption that local storage won't persist.

Kudos to @samsimpson1 for spotting the problem here!

Tested: applied in integration and staging. CA is now logging things like `I0417 17:06:38.289292 1 scale_down.go:828] ip-10-12-34-173.eu-west-1.compute.internal was unneeded for 2m41.133602943s`, so it's looking good.