### PR TITLE
Move GitHub project to Terraform Cloud

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -1,5 +1,10 @@
 terraform {
-  backend "s3" {}
+  cloud {
+    organization = "govuk"
+    workspaces {
+      name = "GitHub"
+    }
+  }
 
   required_version = "~> 1.0"
   required_providers {

--- a/terraform/deployments/github/production.backend
+++ b/terraform/deployments/github/production.backend
@@ -1,5 +1,0 @@
-bucket  = "govuk-terraform-production"
-key     = "projects/github.tfstate"
-encrypt = true
-region  = "eu-west-1"
-dynamodb_table = "terraform-lock"


### PR DESCRIPTION
This allows us to use Terraform Cloud to plan and apply the Terraform to conifgure GitHub instead of doing it locally.