### PR TITLE
Use GitHub App credentials for GitHub Provider

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -15,9 +15,14 @@ terraform {
   }
 }
 
-# NOTE: Uses GITHUB_TOKEN env var, an OAuth / Personal Access Token, for auth
 provider "github" {
   owner = "alphagov"
+
+  app_auth {
+    id              = var.github_app_id              # or `GITHUB_APP_ID`
+    installation_id = var.github_app_installation_id # or `GITHUB_APP_INSTALLATION_ID`
+    pem_file        = var.github_app_pem_file        # or `GITHUB_APP_PEM_FILE`
+  }
 }
 
 #

--- a/terraform/deployments/github/variables.tf
+++ b/terraform/deployments/github/variables.tf
@@ -1,0 +1,14 @@
+variable "github_app_id" {
+  type        = string
+  description = "The id of the GitHub App used for authentication."
+}
+
+variable "github_app_installation_id" {
+  type        = string
+  description = "The id of the installation of the GitHub App used for authentication."
+}
+
+variable "github_app_pem_file" {
+  type        = string
+  description = "The private key to sign access token requests."
+}


### PR DESCRIPTION
This allows terraform to use a GitHub App creds to access GitHub instead of a Personal Token, which needs to be assigned to a specific user.