### PR TITLE
Team rename: s/replatforming/platform-engineering/

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There are also docs in [terraform/docs/](terraform/docs/) and inline READMEs in 
 
 ## Team
 
-GOV.UK Replatforming team looks after this repo. If you're inside GDS, you can find us in [#govuk-replatforming](https://gds.slack.com/archives/C013F737737) or view our [kanban board](https://trello.com/b/u4FCzm53/).
+[GOV.UK Platform Engineering team](https://github.com/orgs/alphagov/teams/gov-uk-platform-engineering) looks after this repo. If you're inside GDS, you can find us in [#govuk-platform-engineering](https://gds.slack.com/channels/govuk-platform-engineering) or view our [kanban board](https://trello.com/b/u4FCzm53/).
 
 ## Licence
 

--- a/terraform/docs/tagging-guide.md
+++ b/terraform/docs/tagging-guide.md
@@ -21,7 +21,7 @@ The common column distinguishes between Tags that have been added as part of an 
 
 
 # Tag Policy
-- Below example of a correct local tag definition for the non common **Tag Key** Name. 
+- Below example of a correct local tag definition for the non common **Tag Key** Name.
 ```
 tags = merge(
     local.additional_tags,
@@ -29,7 +29,7 @@ tags = merge(
       Name = "publisher-${var.environment}-${local.workspace}"
     }
 ```
-- Below example of a correct module tag definition for the non common **Tag Key** Name 
+- Below example of a correct module tag definition for the non common **Tag Key** Name
 ```
 tags = merge(
     var.additional_tags,
@@ -52,22 +52,22 @@ locals {
 }
 ```
 
-**IMPORTANT :-** 
-- The **Key** attribute **Name** should start with an Uppercase letter and the rest should be lowercase with no spaces. 
+**IMPORTANT :-**
+- The **Key** attribute **Name** should start with an Uppercase letter and the rest should be lowercase with no spaces.
 - The **Value** attribute should be lowercase and no spaces however hyphens can be used.
 
-**NOTES :-** 
+**NOTES :-**
 - All listed resources from below should be made compliant.
 - Common Tags have been added as **locals** with in the deployment terraform **main** file.
-- This tagging strategy should ideally be replicated to other and new yet to be deployed environments such as **integration**.
+- This tagging strategy should ideally be replicated to other and new yet to be deployed environments such as **integration**
 
-# AWS Resources 
+# AWS Resources
 ## Can be tagged
 The following lists the resources that **should** be tagged:-
 
 - AWS::EC2::SecurityGroup
 - AWS::EC2::Subnet
-- AWS::ECR::Repository 
+- AWS::ECR::Repository
 - AWS::ECS::Cluster
 - AWS::ECS::Service
 - AWS::ECS::TaskDefinition

--- a/terraform/docs/tagging-guide.md
+++ b/terraform/docs/tagging-guide.md
@@ -1,5 +1,5 @@
 # Overview
-This document will describe the tagging strategy to be used within Replatforming terraform code which will be used to create resources in the AWS environment infrastructure.
+This document will describe the tagging strategy to be used within govuk-infrastructure Terraform code which will be used to create resources in the AWS environment infrastructure.
 
 Tagging is required so that cost and resource utilisation can be processed, with an added benefit of AWS console **Tag Key** searching.
 


### PR DESCRIPTION
GOV.UK Replatforming team is now GOV.UK Platform Engineering team.

Also fix the line endings in tagging-guide.md, which had somehow ended up as CRLF.