### PR TITLE
Manage CodeCommit mirror repositories in Terraform

### DIFF
--- a/terraform/deployments/github/aws_oidc_provider.tf
+++ b/terraform/deployments/github/aws_oidc_provider.tf
@@ -1,0 +1,10 @@
+data "tls_certificate" "github" {
+  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+}
+
+resource "aws_iam_openid_connect_provider" "github_provider" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
+}
+

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -8,9 +8,25 @@ terraform {
 
   required_version = "~> 1.0"
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
     github = {
       source  = "integrations/github"
       version = "~> 5.23"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      project              = "replatforming"
+      repository           = "govuk-infrastructure"
+      terraform_deployment = basename(abspath(path.root))
     }
   }
 }

--- a/terraform/deployments/github/mirror.tf
+++ b/terraform/deployments/github/mirror.tf
@@ -1,6 +1,52 @@
-resource "aws_codecommit_repository" "govuk" {
+resource "aws_codecommit_repository" "govuk_repos" {
   for_each = data.github_repository.govuk
 
   repository_name = each.value.name
   default_branch  = "main"
+}
+
+resource "aws_iam_role" "github_action_mirror_repos_role" {
+  name = "github_action_mirror_repos_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "${aws_iam_openid_connect_provider.github_provider.arn}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "token.actions.githubusercontent.com:sub" : [
+              "repo:alphagov/govuk-infrastructure:ref:refs/heads/main"
+            ]
+          },
+          "StringEquals" : {
+            "token.actions.githubusercontent.com:aud" : "${one(aws_iam_openid_connect_provider.github_provider.client_id_list)}"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "github_action_mirror_repos_policy" {
+  name = "github_action_mirror_repos_policy"
+  role = aws_iam_role.github_action_mirror_repos_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "codecommit:GitPull",
+          "codecommit:GitPush"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
 }

--- a/terraform/deployments/github/mirror.tf
+++ b/terraform/deployments/github/mirror.tf
@@ -1,0 +1,6 @@
+resource "aws_codecommit_repository" "govuk" {
+  for_each = data.github_repository.govuk
+
+  repository_name = each.value.name
+  default_branch  = "main"
+}

--- a/terraform/deployments/github/mirror.tf
+++ b/terraform/deployments/github/mirror.tf
@@ -1,8 +1,18 @@
+data "github_repositories" "govuk_mirrored" {
+  query = "topic:govuk org:alphagov archived:false"
+}
+
+data "github_repository" "govuk_mirrored" {
+  for_each  = toset(data.github_repositories.govuk_mirrored.full_names)
+  full_name = each.key
+}
+
 resource "aws_codecommit_repository" "govuk_repos" {
-  for_each = data.github_repository.govuk
+  for_each = data.github_repository.govuk_mirrored
 
   repository_name = each.value.name
-  default_branch  = "main"
+  description     = each.value.description
+  default_branch  = each.value.default_branch
 }
 
 resource "aws_iam_role" "github_action_mirror_repos_role" {

--- a/terraform/deployments/github/mirror.tf
+++ b/terraform/deployments/github/mirror.tf
@@ -13,6 +13,10 @@ resource "aws_codecommit_repository" "govuk_repos" {
   repository_name = each.value.name
   description     = each.value.description
   default_branch  = each.value.default_branch
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_iam_role" "github_action_mirror_repos_role" {


### PR DESCRIPTION
This replaces the functionality in the govuk-repo-mirror scripts to create CodeCommit repositories for each of the repositories in GitHub.

https://github.com/alphagov/govuk-repo-mirror/blob/main/ensure_aws_repos_exist

This is vastly simpler to do in Terraform.