### PR TITLE
Query list of GitHub repositories once

### DIFF
--- a/terraform/deployments/github/mirror.tf
+++ b/terraform/deployments/github/mirror.tf
@@ -1,14 +1,5 @@
-data "github_repositories" "govuk_mirrored" {
-  query = "topic:govuk org:alphagov archived:false"
-}
-
-data "github_repository" "govuk_mirrored" {
-  for_each  = toset(data.github_repositories.govuk_mirrored.full_names)
-  full_name = each.key
-}
-
 resource "aws_codecommit_repository" "govuk_repos" {
-  for_each = data.github_repository.govuk_mirrored
+  for_each = data.github_repository.govuk
 
   repository_name = each.value.name
   description     = each.value.description


### PR DESCRIPTION
This reduces the number of API calls to GitHub to get details for each of the govuk repos. Instead querying GitHub for two sets of Terraform GitHub repository resources, we query for one set and then generate the second set by filtering. This is possible becuase the deployable repos are a subset of all the repos that we need to mirror.