### PR TITLE
Add manual trigger for mirror-repos GHA

### DIFF
--- a/.github/workflows/mirror-repos.yml
+++ b/.github/workflows/mirror-repos.yml
@@ -3,6 +3,7 @@ name: "Mirror repositories"
 on:
   schedule:
     - cron:  '0 */2 * * *'
+  workflow_dispatch: {}
 
 env:
   AWS_REGION : eu-west-2


### PR DESCRIPTION
This allows the mirror-repo workflow to be manual triggered to help with debugging and in-case we ever need to manual trigger it.