### PR TITLE
Reduce runs of mirror repos job

### DIFF
--- a/.github/workflows/mirror-repos.yml
+++ b/.github/workflows/mirror-repos.yml
@@ -2,7 +2,7 @@ name: "Mirror repositories"
 
 on:
   schedule:
-    - cron:  '0 */2 * * *'
+    - cron:  '30 9,12,15,18 * * 1-5'
   workflow_dispatch: {}
 
 env:


### PR DESCRIPTION
This changes the schedule to only run the job at 9:30, 12:30, 15:30, and 18:30 on from Monday through Friday. This is reduce the number of runs outside of working hrs and also to limit the likelihood of hitting API rate limiting from GitHub (which we've seen running every 2 hrs).