### PR TITLE
Add locations_api_import_csvs S3 bucket for ONSPD import prototype

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/locations_api_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/locations_api_s3.tf
@@ -1,0 +1,44 @@
+resource "aws_s3_bucket" "location_api_import_csvs" {
+  bucket        = "govuk-${var.govuk_environment}-locations-api-import-csvs"
+  force_destroy = var.force_destroy
+  tags = {
+    Name        = "CSVs used for importing postcode information into Locations API in ${var.govuk_environment}"
+    Environment = var.govuk_environment
+  }
+}
+
+resource "aws_s3_bucket_versioning" "location_api_import_csvs" {
+  bucket = aws_s3_bucket.location_api_import_csvs.id
+  versioning_configuration { status = "Suspended" }
+}
+
+resource "aws_s3_bucket_policy" "location_api_import_csvs" {
+  bucket = aws_s3_bucket.location_api_import_csvs.id
+  policy = data.aws_iam_policy_document.location_api_import_csvs.json
+}
+
+# TODO: instead of granting write access to nodes, use IRSA (IAM Roles for
+# Service Accounts aka pod identity) so that only locations-api can write.
+data "aws_iam_policy_document" "location_api_import_csvs" {
+  statement {
+    sid = "EKSNodesCanList"
+    principals {
+      type        = "AWS"
+      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+    }
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.location_api_import_csvs.arn]
+  }
+  statement {
+    sid = "EKSNodesCanWrite"
+    principals {
+      type        = "AWS"
+      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["${aws_s3_bucket.location_api_import_csvs.arn}/*"]
+  }
+}


### PR DESCRIPTION
Adds an S3 bucket with list/read/write open only to EKS Nodes to store ONS multi-part Postcode data files that workers can use to import Large User / Retired postcode information into Locations-API.

https://trello.com/c/nLhD5e2N/1872-spike-into-using-onspd-data-to-fill-in-postcode-gaps-in-locations-api