### PR TITLE
Run a Prometheus pushgateway for ephemeral jobs.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -363,3 +363,26 @@ resource "helm_release" "kube_prometheus_stack" {
     })
   ]
 }
+
+resource "helm_release" "pushgateway" {
+  name             = "prometheus-pushgateway"
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus-pushgateway"
+  version          = "2.1.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  namespace        = local.monitoring_ns
+  create_namespace = true
+  values = [
+    yamlencode({
+      resources = {
+        requests = {
+          cpu    = "50m"
+          memory = "256Mi"
+        }
+        limits = {
+          cpu    = "200m"
+          memory = "512Mi"
+        }
+      }
+    })
+  ]
+}


### PR DESCRIPTION
Surprisingly, kube-prometheus-stack [doesn't include pushgateway](https://www.github.com/prometheus-community/helm-charts/issues/2030) 🤷

(It's not ideal that we're managing these things via Terraform, but it's probably less confusing to keep pushgateway alongside the rest of the Prometheus components for now until we move it all to Argo CD.)

Tested: comes up ok in integration.


```
k -n monitoring get svc prometheus-pushgateway
NAME                     TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
prometheus-pushgateway   ClusterIP   172.20.243.70   <none>        9091/TCP   93s
```