### PR TITLE
Bump Redis cluster to large in integration

### DIFF
--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -30,7 +30,7 @@ external_dns_subdomain    = "eks"
 www_dns_validation_rdata  = "8xpwlbcbmg9qjx9d2v.fastly-validations.com"
 
 frontend_memcached_node_type   = "cache.t4g.micro"
-shared_redis_cluster_node_type = "cache.t4g.medium"
+shared_redis_cluster_node_type = "cache.m6g.large"
 
 # Non-production-only access is sufficient to access tools in this cluster.
 github_read_write_team = "alphagov:gov-uk"


### PR DESCRIPTION
The old redis instance before migration was a [cache.r4.large](https://github.com/alphagov/govuk-aws/blob/main/terraform/projects/app-backend-redis/main.tf#L31). We are bumping the size of this instance to be at least a large so we can run tasks on integration without maxing out the CPU.