### PR TITLE
Adding pod secruity standard labels and removing PSP policy

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -19,6 +19,7 @@ resource "kubernetes_namespace" "apps" {
       "app.kubernetes.io/managed-by" = "Terraform"
       # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/
       "elbv2.k8s.aws/pod-readiness-gate-inject" = "enabled"
+      "pod-security.kubernetes.io/warn" = "baseline"
     }
   }
 }

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -19,7 +19,8 @@ resource "kubernetes_namespace" "apps" {
       "app.kubernetes.io/managed-by" = "Terraform"
       # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/
       "elbv2.k8s.aws/pod-readiness-gate-inject" = "enabled"
-      "pod-security.kubernetes.io/warn" = "baseline"
+      "pod-security.kubernetes.io/audit"        = "baseline"
+      "pod-security.kubernetes.io/warn"         = "baseline"
     }
   }
 }

--- a/terraform/deployments/cluster-services/pod_security_policy.tf
+++ b/terraform/deployments/cluster-services/pod_security_policy.tf
@@ -1,6 +1,0 @@
-resource "helm_release" "pod_security_policy" {
-  name       = "psp"
-  chart      = "cluster-security"
-  repository = "https://alphagov.github.io/govuk-helm-charts/"
-  namespace  = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_services_namespace
-}


### PR DESCRIPTION
Adding Baseline Pod Security Standard namespace labels in Apps namespace.

PSS labels with WARN and AUDIT set Restrict will be added after further testing

Removing unused PSP policy.

Further reading:
https://aws.github.io/aws-eks-best-practices/security/docs/pods/#restrict-the-containers-that-can-run-as-privileged
https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/

This has been applied to both integration and staging.

https://trello.com/c/LY2qKSfi/1142-psp-to-pss-migration-prerequisite-for-k8s-125