### PR TITLE
Add AWS resources search-analytics-page-load GitHub Action

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/github_oidc_provider.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/github_oidc_provider.tf
@@ -1,0 +1,10 @@
+data "tls_certificate" "github" {
+  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+}
+
+resource "aws_iam_openid_connect_provider" "github_provider" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
+}
+

--- a/terraform/deployments/govuk-publishing-infrastructure/search_analytics_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_analytics_s3.tf
@@ -1,0 +1,82 @@
+resource "aws_s3_bucket" "search_analytics" {
+  bucket        = "govuk-search-analytics-${var.govuk_environment}"
+  force_destroy = var.force_destroy
+  tags = {
+    Name        = "Search analytics reports for ${var.govuk_environment}"
+    Environment = var.govuk_environment
+  }
+}
+
+resource "aws_s3_bucket_versioning" "search_analytics" {
+  bucket = aws_s3_bucket.search_analytics.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_policy" "search_analytics" {
+  bucket = aws_s3_bucket.search_analytics.id
+  policy = data.aws_iam_policy_document.search_analytics.json
+}
+
+resource "aws_iam_role" "search_analytics_github_action_role" {
+  name = "search_analytics_github_action_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "${aws_iam_openid_connect_provider.github_provider.arn}"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "token.actions.githubusercontent.com:sub" : [
+              "repo:alphagov/search-analytics:ref:refs/heads/main"
+            ],
+            "token.actions.githubusercontent.com:aud" : "${one(aws_iam_openid_connect_provider.github_provider.client_id_list)}"
+          },
+        }
+      }
+    ]
+  })
+}
+
+# TODO: instead of granting write access to nodes, use IRSA (IAM Roles for
+# Service Accounts aka pod identity).
+data "aws_iam_policy_document" "search_analytics" {
+  statement {
+    sid = "EKSNodesCanList"
+    principals {
+      type        = "AWS"
+      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+    }
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.search_analytics.arn]
+  }
+  statement {
+    sid = "EKSNodesCanReadAndWrite"
+    principals {
+      type        = "AWS"
+      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = ["${aws_s3_bucket.search_analytics.arn}/*"]
+  }
+  statement {
+    sid = "GitHubCanWrite"
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.search_analytics_github_action_role.arn]
+    }
+    actions = [
+      "s3:PutObject",
+    ]
+    resources = ["${aws_s3_bucket.search_analytics.arn}/*"]
+  }
+}
+
+


### PR DESCRIPTION
This creates a S3 bucket and IAM Role for access to the bucket that is used by the Export analytics GitHub Actions workflow in the search-analytics repo.