### PR TITLE
Allow Terraform to destroy CodeCommit mirrors

### DIFF
--- a/terraform/deployments/github/mirror.tf
+++ b/terraform/deployments/github/mirror.tf
@@ -4,10 +4,6 @@ resource "aws_codecommit_repository" "govuk_repos" {
   repository_name = each.value.name
   description     = each.value.description
   default_branch  = each.value.default_branch
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_iam_role" "github_action_mirror_repos_role" {


### PR DESCRIPTION
This removes the lifecycle rule to prevent Terraform destroying CodeCommit repositories, which was a safety mechanism. However, we would now like to fully manage our mirrors using Terraform, and have agreed that our CodeCommit mirrors are not long term backups, just replicas of our source code, incase GitHub was temporarily unavailable.