### PR TITLE
Add ECR repository for Search API LTR image

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -44,6 +44,7 @@ locals {
     "github-cli",
     "statsd",
     "govuk-terraform",
+    "search-api-learn-to-rank",
   ]
 }
 


### PR DESCRIPTION
This repository is for the addition image required for the python dependencies for the Search API Learn to rank process.