### PR TITLE
Update Argo CD and Events charts.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -32,7 +32,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.26.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.36.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     server = {
       # TLS Termination happens at the ALB, the insecure flag prevents Argo
@@ -291,7 +291,7 @@ resource "helm_release" "argo_events" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "2.1.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "2.3.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     namespace = local.services_ns
     controller = {

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -95,26 +95,16 @@ resource "helm_release" "argo_cd" {
       metrics = local.argo_metrics_config
     }
 
-    controller = {
-      metrics = local.argo_metrics_config
-    }
+    controller = { metrics = local.argo_metrics_config }
 
     repoServer = {
       metrics  = local.argo_metrics_config
       replicas = var.desired_ha_replicas
     }
 
-    applicationSet = {
-      replicaCount = var.desired_ha_replicas
-    }
-
-    dex = {
-      enabled = false
-    }
-
-    redis-ha = {
-      enabled = var.argo_redis_ha
-    }
+    applicationSet = { replicaCount = var.desired_ha_replicas }
+    dex            = { enabled = false }
+    redis-ha       = { enabled = var.argo_redis_ha }
 
     notifications = {
       argocdUrl = "https://${local.argo_host}"
@@ -167,9 +157,7 @@ resource "helm_release" "argo_workflows" {
   version          = "0.22.13" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     controller = {
-      podSecurityContext = {
-        runAsNonRoot = true
-      }
+      podSecurityContext = { runAsNonRoot = true }
       workflowNamespaces = concat([local.services_ns], var.argo_workflows_namespaces)
       workflowDefaults = {
         spec = {
@@ -179,9 +167,7 @@ resource "helm_release" "argo_workflows" {
             secondsAfterSuccess    = 259200
             secondsAfterCompletion = 259200
           }
-          podGC = {
-            strategy = "OnWorkflowSuccess"
-          }
+          podGC = { strategy = "OnWorkflowSuccess" }
           securityContext = {
             runAsNonRoot = true
             runAsUser    = 1001
@@ -234,9 +220,7 @@ resource "helm_release" "argo_workflows" {
     }
 
     workflow = {
-      serviceAccount = {
-        create = true
-      }
+      serviceAccount = { create = true }
     }
 
     server = {
@@ -266,9 +250,7 @@ resource "helm_release" "argo_workflows" {
         }
         redirectUrl = "https://${local.argo_workflows_host}/oauth2/callback"
         scopes      = ["groups"]
-        rbac = {
-          enabled = true
-        }
+        rbac        = { enabled = true }
       }
       resources = {
         requests = {
@@ -293,10 +275,8 @@ resource "helm_release" "argo_events" {
   repository       = "https://argoproj.github.io/argo-helm"
   version          = "2.3.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
-    namespace = local.services_ns
-    controller = {
-      replicas = var.desired_ha_replicas
-    }
+    namespace  = local.services_ns
+    controller = { replicas = var.desired_ha_replicas }
     configs = {
       jetstream = {
         versions = [


### PR DESCRIPTION
No compatibility issues for our usage.

Also tidy up some formatting while we're there.

Changelogs:

- https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.6-2.7/
- https://github.com/argoproj/argo-events/releases

Not updating Argo Workflows in this PR because it seems to have some incompatible changes to the command-line flags.