### PR TITLE
Add ECR repo for content-store-postgresql-branch

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -45,6 +45,7 @@ locals {
     "statsd",
     "govuk-terraform",
     "search-api-learn-to-rank",
+    "content-store-postgresql-branch"
   ]
 }
 

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -45,7 +45,7 @@ locals {
     "statsd",
     "govuk-terraform",
     "search-api-learn-to-rank",
-    "content-store-postgresql-branch"
+    "content-store-postgresql-branch",
   ]
 }
 


### PR DESCRIPTION
Add an entry in the ECR `extra_repositories` list to create a repo for `content-store-postgresql-branch`, as part of [migrating content-store to postgresql](https://trello.com/c/C1BQDFTG/502-plan-for-migrating-content-store-off-mongodb).

This will allow us to build two different content-store containers - the original MongoDB version (content-store) and a new version (content-store-postgresql-branch) built from the [`port-to-postgresql` branch of that Git repo](https://github.com/alphagov/content-store/pull/1085).   