### PR TITLE
trivial: fix inaccurate SG description

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -165,7 +165,7 @@ resource "aws_security_group_rule" "licensify_frontend_from_eks_workers" {
 resource "aws_security_group" "eks_ingress_www_origin" {
   name        = "eks_ingress_www_origin"
   vpc_id      = data.terraform_remote_state.infra_vpc.outputs.vpc_id
-  description = "ALBs serving EKS www-origin ingress (and signon ALBs in non-prod environments)."
+  description = "ALBs serving www-origin.eks ingress."
   tags = {
     Name = "eks_ingress_www_origin"
   }


### PR DESCRIPTION
We no longer use this security group to limit access to non-prod Signon. (We now [just avoid serving Signon on non-`gov.uk` domains](https://github.com/alphagov/govuk-helm-charts/pull/1021).)