### PR TITLE
Add jq to the github-cli utility image.

### DIFF
--- a/images/github-cli/Dockerfile
+++ b/images/github-cli/Dockerfile
@@ -1,31 +1,42 @@
 FROM public.ecr.aws/lts/ubuntu:22.04_stable
 ARG TARGETARCH
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ADD https://cli.github.com/packages/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg
-RUN chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
-RUN apt-get update -qq && \
+ARG github_apt_repo=https://cli.github.com/packages
+ARG keyrings_dir=/usr/share/keyrings
+WORKDIR $keyrings_dir
+# hadolint ignore=DL3020
+ADD ${github_apt_repo}/githubcli-archive-keyring.gpg githubcli-archive.gpg
+# hadolint ignore=DL3008
+RUN apt-get update -qq ; \
+    apt-get install -qy --no-install-recommends ca-certificates ; \
+    chmod 644 githubcli-archive.gpg ; \
+    echo "deb [arch=${TARGETARCH} signed-by=${keyrings_dir}/githubcli-archive.gpg] ${github_apt_repo} stable main" > /etc/apt/sources.list.d/github-cli.list ; \
+    apt-get update -qq ; \
     apt-get install -qy --no-install-recommends \
-        ca-certificates gh git curl awscli jq && \
+        awscli curl gh git jq ; \
     rm -fr /var/lib/apt/lists/*
 
-RUN curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}.tar.gz" \
-    | tar -xzf - && \
-    mv "yq_linux_${TARGETARCH}" /usr/bin/yq
+ARG yq_package_url=https://github.com/mikefarah/yq/releases/latest/download
+ARG yq_binary="yq_linux_${TARGETARCH}"
+WORKDIR /tmp
+RUN curl -fsSL "${yq_package_url}/${yq_binary}.tar.gz" \
+        | tar -xzf - ; \
+    cp "${yq_binary}" /usr/bin/yq ; \
+    rm -fr /tmp/*
 
-# Crude smoke test.
-RUN aws --version && \
-    gh --version && \
-    jq --version && \
-    yq --version
-
-RUN groupadd -g 1001 user && \
+RUN groupadd -g 1001 user ; \
     useradd -mu 1001 -g user user
-
 WORKDIR /home/user
 USER user
+
+# Crude smoke test.
+RUN aws --version ; \
+    gh --version ; \
+    jq --version ; \
+    yq --version
+
 CMD ["/bin/bash"]
 LABEL org.opencontainers.image.source=https://github.com/alphagov/govuk-infrastructure/tree/main/images/github-cli/

--- a/images/github-cli/Dockerfile
+++ b/images/github-cli/Dockerfile
@@ -9,7 +9,7 @@ RUN chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
 RUN apt-get update -qq && \
     apt-get install -qy --no-install-recommends \
-        ca-certificates gh git curl awscli && \
+        ca-certificates gh git curl awscli jq && \
     rm -fr /var/lib/apt/lists/*
 
 RUN curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}.tar.gz" \
@@ -19,6 +19,7 @@ RUN curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linu
 # Crude smoke test.
 RUN aws --version && \
     gh --version && \
+    jq --version && \
     yq --version
 
 RUN groupadd -g 1001 user && \


### PR DESCRIPTION
We need `[jq](https://github.com/jqlang/jq)` for the upcoming Elasticsearch index environment sync cronjob and this image is otherwise a good fit for it.

Also clean up the rest of the Dockerfile while we're there:

- Fail on undefined shell variables (`set -u`).
- Use `set -e` and `;` instead of `&&` to chain commands.
- Fix a cert validation warning when fetching the GitHub Apt repo, by installing the `ca-certificates` beforehand.
- Avoid repeating some URLs and paths.