### PR TITLE
Reduce Argo CD logspew + update to latest point release.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -34,6 +34,13 @@ resource "helm_release" "argo_cd" {
   repository       = "https://argoproj.github.io/argo-helm"
   version          = "5.36.14" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
+    global = {
+      logging = {
+        format = "json"
+        level  = "warn"
+      }
+    }
+
     server = {
       # TLS Termination happens at the ALB, the insecure flag prevents Argo
       # server from upgrading the request after TLS termination.

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -32,7 +32,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.36.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.36.14" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     server = {
       # TLS Termination happens at the ALB, the insecure flag prevents Argo


### PR DESCRIPTION
Argo CD notifications-controller and repo-server are quite noisy at `loglevel=info` and are the 9th and 10th noisiest workloads in the integration environment (19th and 20th in production). We don't need these info logs so let's not pay to store them. This should help towards getting us back under our log quota in LogIt.

Also set the log format to JSON so that the logs are easier to search.

Tested: running in integration.