### PR TITLE
Enable remote write reciever on the Prometheus server

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -354,7 +354,8 @@ resource "helm_release" "kube_prometheus_stack" {
               }
             }
           }
-          externalUrl = "https://${local.prometheus_host}"
+          externalUrl               = "https://${local.prometheus_host}"
+          enableRemoteWriteReceiver = true
         }
       }
       kube_state_metrics = {


### PR DESCRIPTION
This is used by Grafana Tempo to write trace metrics, which are then used by the service graph feature.