### PR TITLE
Drop a bunch of redundant/not-very-useful log fields.

### DIFF
--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -12,18 +12,57 @@ resource "helm_release" "filebeat" {
   values = [yamlencode({
     filebeatConfig = {
       "filebeat.yml" = yamlencode({
+        processors = [
+          {
+            drop_fields = {
+              ignore_missing = true
+              fields = [
+                "agent",
+              ]
+            }
+          },
+        ]
         "filebeat.inputs" = [
           {
             type  = "container"
             paths = ["/var/log/containers/*.log"]
-            processors = [{
-              add_kubernetes_metadata = {
-                host = "$${NODE_NAME}"
-                matchers = [{
-                  logs_path = { logs_path = "/var/log/containers/" }
-                }]
-              }
-            }]
+            processors = [
+              {
+                add_kubernetes_metadata = {
+                  host = "$${NODE_NAME}"
+                  matchers = [{
+                    logs_path = { logs_path = "/var/log/containers/" }
+                  }]
+                }
+              },
+              {
+                drop_fields = {
+                  ignore_missing = true
+                  fields = [
+                    "log",
+                    "agent",
+                    "kubernetes.labels.app",
+                    "kubernetes.labels.pod-template-hash",
+                    "kubernetes.namespace_labels",
+                    "kubernetes.namespace_uid",
+                    "kubernetes.node.hostname",
+                    "kubernetes.node.labels.beta_kubernetes_io/arch",
+                    "kubernetes.node.labels.beta_kubernetes_io/instance-type",
+                    "kubernetes.node.labels.beta_kubernetes_io/os",
+                    "kubernetes.node.labels.eks_amazonaws_com/nodegroup",
+                    "kubernetes.node.labels.eks_amazonaws_com/nodegroup-image",
+                    "kubernetes.node.labels.failure-domain_beta_kubernetes_io/region",
+                    "kubernetes.node.labels.failure-domain_beta_kubernetes_io/zone",
+                    "kubernetes.node.labels.k8s_io/cloud-provider-aws",
+                    "kubernetes.node.labels.kubernetes_io/hostname",
+                    "kubernetes.node.labels.topology_ebs_csi_aws_com/zone",
+                    "kubernetes.node.labels.topology_kubernetes_io/region",
+                    "kubernetes.node.uid",
+                    "kubernetes.pod.uid",
+                  ]
+                }
+              },
+            ]
           }
         ]
         "output.logstash" = {

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -20,25 +20,21 @@ resource "helm_release" "filebeat" {
               add_kubernetes_metadata = {
                 host = "$${NODE_NAME}"
                 matchers = [{
-                  logs_path = {
-                    logs_path = "/var/log/containers/"
-                  }
+                  logs_path = { logs_path = "/var/log/containers/" }
                 }]
               }
             }]
           }
         ]
-        "output.logstash" : {
-          "hosts" : ["$${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:$${LOGSTASH_PORT:? LOGSTASH_PORT variable is not set}"]
-          "loadbalance" : true
-          "ssl.enabled" : true
+        "output.logstash" = {
+          hosts         = ["$${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:$${LOGSTASH_PORT:? LOGSTASH_PORT variable is not set}"]
+          loadbalance   = true
+          "ssl.enabled" = true
         }
-        "logging.metrics.enabled" : false
-        "http.enabled" : false
-        "logging.level" : "warning"
-        "output.file" : {
-          "enabled" : false
-        }
+        "http.enabled"            = false
+        "logging.metrics.enabled" = false
+        "logging.level"           = "warning"
+        "output.file"             = { "enabled" = false }
       })
     }
     extraEnvs = [


### PR DESCRIPTION
Some of these are plain duplicates; others are just not very useful or can trivially be synthesized from other fields.

Certain fields such as `agent.*` are "global" to Filebeat and have to be dropped in the top-level `processors` section, hence the two different sections in the config.

This should help reduce the pressure on LogIt quota.

Tested: rolled out in integration and staging, logs still being ingested and there's much less noise in the list of fields. Filebeat daemons look happy (`k -n cluster-services log ds/filebeat`).