### PR TITLE
Remove a few more not-useful log fields.

### DIFF
--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -40,8 +40,8 @@ resource "helm_release" "filebeat" {
                   ignore_missing = true
                   fields = [
                     "log",
-                    "agent",
-                    "kubernetes.labels.app",
+                    "kubernetes.labels.app", # Prefer app_kubernetes_io/name.
+                    "kubernetes.labels.app_kubernetes_io/managed-by",
                     "kubernetes.labels.pod-template-hash",
                     "kubernetes.namespace_labels",
                     "kubernetes.namespace_uid",
@@ -55,10 +55,12 @@ resource "helm_release" "filebeat" {
                     "kubernetes.node.labels.failure-domain_beta_kubernetes_io/zone",
                     "kubernetes.node.labels.k8s_io/cloud-provider-aws",
                     "kubernetes.node.labels.kubernetes_io/hostname",
+                    "kubernetes.node.labels.kubernetes_io/os",
                     "kubernetes.node.labels.topology_ebs_csi_aws_com/zone",
                     "kubernetes.node.labels.topology_kubernetes_io/region",
                     "kubernetes.node.uid",
                     "kubernetes.pod.uid",
+                    "kubernetes.replicaset",
                   ]
                 }
               },


### PR DESCRIPTION
- Drop `replicaset`; it's a strict substring of the pod name.
- Drop `managed-by`; it's set to Helm even when it's actually Argo CD, so it's misleading as well as useless. We still have the Helm chart name/version anyway.
- Drop `kubernetes.io/os`; we don't run Windows or macOS nodes.
- Forgot to remove `agent` from the source-specific fields after adding to global.
- Comment to signpost people to `app.kubernetes.io/name` in case anyone wonders why the "app" label is missing. (We only add the duplicate `app` label for convenience on our own stuff when interacting with kubectl; `app.kubernetes.io/name` is more widely used so it's the one to use when querying logs.)

Tested: as for #896 (applied in integration).