### PR TITLE
Avoid logging healthcheck requests to Logit.

### DIFF
--- a/terraform/deployments/cluster-services/filebeat.yml
+++ b/terraform/deployments/cluster-services/filebeat.yml
@@ -1,0 +1,51 @@
+"filebeat.inputs":
+- "paths":
+  - "/var/log/containers/*.log"
+  "processors":
+  - "add_kubernetes_metadata":
+      "host": "${NODE_NAME}"
+      "matchers":
+      - "logs_path":
+          "logs_path": "/var/log/containers/"
+  - "drop_fields":
+      "fields":
+      - "log"
+      - "kubernetes.labels.app"
+      - "kubernetes.labels.app_kubernetes_io/managed-by"
+      - "kubernetes.labels.pod-template-hash"
+      - "kubernetes.namespace_labels"
+      - "kubernetes.namespace_uid"
+      - "kubernetes.node.hostname"
+      - "kubernetes.node.labels.beta_kubernetes_io/arch"
+      - "kubernetes.node.labels.beta_kubernetes_io/instance-type"
+      - "kubernetes.node.labels.beta_kubernetes_io/os"
+      - "kubernetes.node.labels.eks_amazonaws_com/nodegroup"
+      - "kubernetes.node.labels.eks_amazonaws_com/nodegroup-image"
+      - "kubernetes.node.labels.failure-domain_beta_kubernetes_io/region"
+      - "kubernetes.node.labels.failure-domain_beta_kubernetes_io/zone"
+      - "kubernetes.node.labels.k8s_io/cloud-provider-aws"
+      - "kubernetes.node.labels.kubernetes_io/hostname"
+      - "kubernetes.node.labels.kubernetes_io/os"
+      - "kubernetes.node.labels.topology_ebs_csi_aws_com/zone"
+      - "kubernetes.node.labels.topology_kubernetes_io/region"
+      - "kubernetes.node.uid"
+      - "kubernetes.pod.uid"
+      - "kubernetes.replicaset"
+      "ignore_missing": true
+  "type": "container"
+"http.enabled": false
+"logging.level": "warning"
+"logging.metrics.enabled": false
+"output.file":
+  "enabled": false
+"output.logstash":
+  "hosts":
+  - "${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:${LOGSTASH_PORT:? LOGSTASH_PORT
+    variable is not set}"
+  "loadbalance": true
+  "ssl.enabled": true
+"processors":
+- "drop_fields":
+    "fields":
+    - "agent"
+    "ignore_missing": true

--- a/terraform/deployments/cluster-services/filebeat.yml
+++ b/terraform/deployments/cluster-services/filebeat.yml
@@ -7,6 +7,13 @@
       "matchers":
       - "logs_path":
           "logs_path": "/var/log/containers/"
+  - "drop_event":
+      "when":
+        "or":
+        - "equals":
+            "path": "/healthcheck/live"
+        - "equals":
+            "request_uri": "/readyz"
   - "drop_fields":
       "fields":
       - "log"

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -1,82 +1,20 @@
-# logging.tf manages Filebeat, which ships logs to Logit, a managed ELK stack.
+# logging.tf manages Filebeat, which ships logs to Logit.io, a managed ELK stack.
 
 resource "helm_release" "filebeat" {
   depends_on = [helm_release.cluster_secrets]
 
-  name             = "filebeat"
-  repository       = "https://helm.elastic.co"
-  chart            = "filebeat"
+  name       = "filebeat"
+  repository = "https://helm.elastic.co"
+  chart      = "filebeat"
+  # TODO: stop using this unmaintained chart by updating to filebeat v8 (final
+  # version of the deprecated chart), then switching to the eck-beats operator:
+  # https://github.com/elastic/cloud-on-k8s/blob/main/deploy/eck-stack/charts/eck-beats/Chart.yaml
   version          = "7.17.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({
     filebeatConfig = {
-      "filebeat.yml" = yamlencode({
-        processors = [
-          {
-            drop_fields = {
-              ignore_missing = true
-              fields = [
-                "agent",
-              ]
-            }
-          },
-        ]
-        "filebeat.inputs" = [
-          {
-            type  = "container"
-            paths = ["/var/log/containers/*.log"]
-            processors = [
-              {
-                add_kubernetes_metadata = {
-                  host = "$${NODE_NAME}"
-                  matchers = [{
-                    logs_path = { logs_path = "/var/log/containers/" }
-                  }]
-                }
-              },
-              {
-                drop_fields = {
-                  ignore_missing = true
-                  fields = [
-                    "log",
-                    "kubernetes.labels.app", # Prefer app_kubernetes_io/name.
-                    "kubernetes.labels.app_kubernetes_io/managed-by",
-                    "kubernetes.labels.pod-template-hash",
-                    "kubernetes.namespace_labels",
-                    "kubernetes.namespace_uid",
-                    "kubernetes.node.hostname",
-                    "kubernetes.node.labels.beta_kubernetes_io/arch",
-                    "kubernetes.node.labels.beta_kubernetes_io/instance-type",
-                    "kubernetes.node.labels.beta_kubernetes_io/os",
-                    "kubernetes.node.labels.eks_amazonaws_com/nodegroup",
-                    "kubernetes.node.labels.eks_amazonaws_com/nodegroup-image",
-                    "kubernetes.node.labels.failure-domain_beta_kubernetes_io/region",
-                    "kubernetes.node.labels.failure-domain_beta_kubernetes_io/zone",
-                    "kubernetes.node.labels.k8s_io/cloud-provider-aws",
-                    "kubernetes.node.labels.kubernetes_io/hostname",
-                    "kubernetes.node.labels.kubernetes_io/os",
-                    "kubernetes.node.labels.topology_ebs_csi_aws_com/zone",
-                    "kubernetes.node.labels.topology_kubernetes_io/region",
-                    "kubernetes.node.uid",
-                    "kubernetes.pod.uid",
-                    "kubernetes.replicaset",
-                  ]
-                }
-              },
-            ]
-          }
-        ]
-        "output.logstash" = {
-          hosts         = ["$${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:$${LOGSTASH_PORT:? LOGSTASH_PORT variable is not set}"]
-          loadbalance   = true
-          "ssl.enabled" = true
-        }
-        "http.enabled"            = false
-        "logging.metrics.enabled" = false
-        "logging.level"           = "warning"
-        "output.file"             = { "enabled" = false }
-      })
+      "filebeat.yml" = yamlencode(yamldecode(file("${path.module}/filebeat.yml")))
     }
     extraEnvs = [
       {


### PR DESCRIPTION
These are a non-negligible fraction of log traffic and they just clutter up query results (or complicate queries by trying to exclude them), so let's not pay for the inconvenience.

This won't stop us debugging healthchecks if we ever need to; it's easier to look directly at `kubectl log` etc. for that because it's real-time.

Also switch from the nasty HCL-encoded YAML to plain YAML for representing the Filebeat config. (Separate commit for ease of reviewing.)

Tested: applied in staging.