### PR TITLE
Fix filtering of healthcheck log lines.

### DIFF
--- a/terraform/deployments/cluster-services/filebeat.yml
+++ b/terraform/deployments/cluster-services/filebeat.yml
@@ -1,45 +1,45 @@
 filebeat.inputs:
-- paths:
-  - /var/log/containers/*.log
-  processors:
-  - add_kubernetes_metadata:
-      host: ${NODE_NAME}
-      matchers:
-      - logs_path:
-          logs_path: /var/log/containers/
-  - drop_event:
-      when:
-        or:
-        - equals:
-            path: /healthcheck/live
-        - equals:
-            request_uri: /readyz
-  - drop_fields:
-      fields:
-      - log
-      - kubernetes.labels.app
-      - kubernetes.labels.app_kubernetes_io/managed-by
-      - kubernetes.labels.pod-template-hash
-      - kubernetes.namespace_labels
-      - kubernetes.namespace_uid
-      - kubernetes.node.hostname
-      - kubernetes.node.labels.beta_kubernetes_io/arch
-      - kubernetes.node.labels.beta_kubernetes_io/instance-type
-      - kubernetes.node.labels.beta_kubernetes_io/os
-      - kubernetes.node.labels.eks_amazonaws_com/nodegroup
-      - kubernetes.node.labels.eks_amazonaws_com/nodegroup-image
-      - kubernetes.node.labels.failure-domain_beta_kubernetes_io/region
-      - kubernetes.node.labels.failure-domain_beta_kubernetes_io/zone
-      - kubernetes.node.labels.k8s_io/cloud-provider-aws
-      - kubernetes.node.labels.kubernetes_io/hostname
-      - kubernetes.node.labels.kubernetes_io/os
-      - kubernetes.node.labels.topology_ebs_csi_aws_com/zone
-      - kubernetes.node.labels.topology_kubernetes_io/region
-      - kubernetes.node.uid
-      - kubernetes.pod.uid
-      - kubernetes.replicaset
-      ignore_missing: true
-  type: container
+  - paths:
+      - /var/log/containers/*.log
+    processors:
+      - add_kubernetes_metadata:
+          host: ${NODE_NAME}
+          matchers:
+            - logs_path:
+                logs_path: /var/log/containers/
+      - drop_event:
+          when:
+            or:
+              - equals:
+                  path: /healthcheck/live
+              - equals:
+                  request_uri: /readyz
+      - drop_fields:
+          fields:
+            - log
+            - kubernetes.labels.app
+            - kubernetes.labels.app_kubernetes_io/managed-by
+            - kubernetes.labels.pod-template-hash
+            - kubernetes.namespace_labels
+            - kubernetes.namespace_uid
+            - kubernetes.node.hostname
+            - kubernetes.node.labels.beta_kubernetes_io/arch
+            - kubernetes.node.labels.beta_kubernetes_io/instance-type
+            - kubernetes.node.labels.beta_kubernetes_io/os
+            - kubernetes.node.labels.eks_amazonaws_com/nodegroup
+            - kubernetes.node.labels.eks_amazonaws_com/nodegroup-image
+            - kubernetes.node.labels.failure-domain_beta_kubernetes_io/region
+            - kubernetes.node.labels.failure-domain_beta_kubernetes_io/zone
+            - kubernetes.node.labels.k8s_io/cloud-provider-aws
+            - kubernetes.node.labels.kubernetes_io/hostname
+            - kubernetes.node.labels.kubernetes_io/os
+            - kubernetes.node.labels.topology_ebs_csi_aws_com/zone
+            - kubernetes.node.labels.topology_kubernetes_io/region
+            - kubernetes.node.uid
+            - kubernetes.pod.uid
+            - kubernetes.replicaset
+          ignore_missing: true
+    type: container
 http.enabled: false
 logging.level: warning
 logging.metrics.enabled: false
@@ -47,12 +47,11 @@ output.file:
   enabled: false
 output.logstash:
   hosts:
-  - ${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:${LOGSTASH_PORT:? LOGSTASH_PORT
-    variable is not set}
+    - ${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:${LOGSTASH_PORT:? LOGSTASH_PORT variable is not set}
   loadbalance: true
   ssl.enabled: true
 processors:
-- drop_fields:
-    fields:
-    - agent
-    ignore_missing: true
+  - drop_fields:
+      fields:
+        - agent
+      ignore_missing: true

--- a/terraform/deployments/cluster-services/filebeat.yml
+++ b/terraform/deployments/cluster-services/filebeat.yml
@@ -1,19 +1,14 @@
 filebeat.inputs:
   - paths:
       - /var/log/containers/*.log
+    exclude_lines:
+      - '"/readyz"'
     processors:
       - add_kubernetes_metadata:
           host: ${NODE_NAME}
           matchers:
             - logs_path:
                 logs_path: /var/log/containers/
-      - drop_event:
-          when:
-            or:
-              - equals:
-                  path: /healthcheck/live
-              - equals:
-                  request_uri: /readyz
       - drop_fields:
           fields:
             - log

--- a/terraform/deployments/cluster-services/filebeat.yml
+++ b/terraform/deployments/cluster-services/filebeat.yml
@@ -1,5 +1,6 @@
 filebeat.inputs:
-  - paths:
+  - type: container
+    paths:
       - /var/log/containers/*.log
     exclude_lines:
       - '"/readyz"'
@@ -7,9 +8,9 @@ filebeat.inputs:
       - add_kubernetes_metadata:
           host: ${NODE_NAME}
           matchers:
-            - logs_path:
-                logs_path: /var/log/containers/
+            - logs_path.logs_path: /var/log/containers/
       - drop_fields:
+          ignore_missing: true
           fields:
             - log
             - kubernetes.labels.app
@@ -33,20 +34,17 @@ filebeat.inputs:
             - kubernetes.node.uid
             - kubernetes.pod.uid
             - kubernetes.replicaset
-          ignore_missing: true
-    type: container
 http.enabled: false
 logging.level: warning
 logging.metrics.enabled: false
-output.file:
-  enabled: false
+output.file.enabled: false
 output.logstash:
-  hosts:
-    - ${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:${LOGSTASH_PORT:? LOGSTASH_PORT variable is not set}
   loadbalance: true
   ssl.enabled: true
+  hosts:
+    - ${LOGSTASH_HOST:? LOGSTASH_HOST not set}:${LOGSTASH_PORT:? LOGSTASH_PORT not set}
 processors:
   - drop_fields:
+      ignore_missing: true
       fields:
         - agent
-      ignore_missing: true

--- a/terraform/deployments/cluster-services/filebeat.yml
+++ b/terraform/deployments/cluster-services/filebeat.yml
@@ -1,58 +1,58 @@
-"filebeat.inputs":
-- "paths":
-  - "/var/log/containers/*.log"
-  "processors":
-  - "add_kubernetes_metadata":
-      "host": "${NODE_NAME}"
-      "matchers":
-      - "logs_path":
-          "logs_path": "/var/log/containers/"
-  - "drop_event":
-      "when":
-        "or":
-        - "equals":
-            "path": "/healthcheck/live"
-        - "equals":
-            "request_uri": "/readyz"
-  - "drop_fields":
-      "fields":
-      - "log"
-      - "kubernetes.labels.app"
-      - "kubernetes.labels.app_kubernetes_io/managed-by"
-      - "kubernetes.labels.pod-template-hash"
-      - "kubernetes.namespace_labels"
-      - "kubernetes.namespace_uid"
-      - "kubernetes.node.hostname"
-      - "kubernetes.node.labels.beta_kubernetes_io/arch"
-      - "kubernetes.node.labels.beta_kubernetes_io/instance-type"
-      - "kubernetes.node.labels.beta_kubernetes_io/os"
-      - "kubernetes.node.labels.eks_amazonaws_com/nodegroup"
-      - "kubernetes.node.labels.eks_amazonaws_com/nodegroup-image"
-      - "kubernetes.node.labels.failure-domain_beta_kubernetes_io/region"
-      - "kubernetes.node.labels.failure-domain_beta_kubernetes_io/zone"
-      - "kubernetes.node.labels.k8s_io/cloud-provider-aws"
-      - "kubernetes.node.labels.kubernetes_io/hostname"
-      - "kubernetes.node.labels.kubernetes_io/os"
-      - "kubernetes.node.labels.topology_ebs_csi_aws_com/zone"
-      - "kubernetes.node.labels.topology_kubernetes_io/region"
-      - "kubernetes.node.uid"
-      - "kubernetes.pod.uid"
-      - "kubernetes.replicaset"
-      "ignore_missing": true
-  "type": "container"
-"http.enabled": false
-"logging.level": "warning"
-"logging.metrics.enabled": false
-"output.file":
-  "enabled": false
-"output.logstash":
-  "hosts":
-  - "${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:${LOGSTASH_PORT:? LOGSTASH_PORT
-    variable is not set}"
-  "loadbalance": true
-  "ssl.enabled": true
-"processors":
-- "drop_fields":
-    "fields":
-    - "agent"
-    "ignore_missing": true
+filebeat.inputs:
+- paths:
+  - /var/log/containers/*.log
+  processors:
+  - add_kubernetes_metadata:
+      host: ${NODE_NAME}
+      matchers:
+      - logs_path:
+          logs_path: /var/log/containers/
+  - drop_event:
+      when:
+        or:
+        - equals:
+            path: /healthcheck/live
+        - equals:
+            request_uri: /readyz
+  - drop_fields:
+      fields:
+      - log
+      - kubernetes.labels.app
+      - kubernetes.labels.app_kubernetes_io/managed-by
+      - kubernetes.labels.pod-template-hash
+      - kubernetes.namespace_labels
+      - kubernetes.namespace_uid
+      - kubernetes.node.hostname
+      - kubernetes.node.labels.beta_kubernetes_io/arch
+      - kubernetes.node.labels.beta_kubernetes_io/instance-type
+      - kubernetes.node.labels.beta_kubernetes_io/os
+      - kubernetes.node.labels.eks_amazonaws_com/nodegroup
+      - kubernetes.node.labels.eks_amazonaws_com/nodegroup-image
+      - kubernetes.node.labels.failure-domain_beta_kubernetes_io/region
+      - kubernetes.node.labels.failure-domain_beta_kubernetes_io/zone
+      - kubernetes.node.labels.k8s_io/cloud-provider-aws
+      - kubernetes.node.labels.kubernetes_io/hostname
+      - kubernetes.node.labels.kubernetes_io/os
+      - kubernetes.node.labels.topology_ebs_csi_aws_com/zone
+      - kubernetes.node.labels.topology_kubernetes_io/region
+      - kubernetes.node.uid
+      - kubernetes.pod.uid
+      - kubernetes.replicaset
+      ignore_missing: true
+  type: container
+http.enabled: false
+logging.level: warning
+logging.metrics.enabled: false
+output.file:
+  enabled: false
+output.logstash:
+  hosts:
+  - ${LOGSTASH_HOST:? LOGSTASH_HOST variable is not set}:${LOGSTASH_PORT:? LOGSTASH_PORT
+    variable is not set}
+  loadbalance: true
+  ssl.enabled: true
+processors:
+- drop_fields:
+    fields:
+    - agent
+    ignore_missing: true


### PR DESCRIPTION
The decoded JSON fields don't appear to be visible to the condition in drop_event (whether the drop_event is defined for the container input or globally), so let's just use `exclude_lines` on the raw input instead. Fixes #898.

Also just exclude `/readyz` (kubelet -> nginx healthchecks) and not `/healthcheck/live` since the latter is a much smaller proportion of log lines and surprisingly there's some interesting weirdness going on with at least one Ruby app's handling of those 🙃

Standardise the YAML formatting by removing the unnecessary quotes, running it through `yq` to fix the indentation and putting the fields in a more natural order.

The main commit here is [Fix filtering of healthcheck log lines.](https://github.com/alphagov/govuk-infrastructure/commit/19d33d96989eb33e32244fffcbec115d7d1c6906); the rest are pretty mechanical.

Tested: applied in staging; `readyz` logspew is gone and other logs are still flowing. Filebeat daemons still happy (`k -n cluster-services logs ds/filebeat-filebeat`).