### PR TITLE
Update kube-prometheus-stack and drop some unused high-cardinality metrics.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -142,7 +142,7 @@ resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"
-  version          = "47.0.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "47.3.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
   values = [

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -152,15 +152,17 @@ resource "helm_release" "kube_prometheus_stack" {
         alertmanager_host = local.alertmanager_host
     }),
     yamlencode({
+      kubeApiServer         = { enabled = false }
       kubeControllerManager = { enabled = false }
       kubeEtcd              = { enabled = false }
       kubeScheduler         = { enabled = false }
       defaultRules = {
         rules = {
-          kubeApiserverBurnrate  = false
-          kubeApiserverHistogram = false
-          kubeApiserverSlos      = false
-          network                = false
+          kubeApiserverAvailbility = false
+          kubeApiserverBurnrate    = false
+          kubeApiserverHistogram   = false
+          kubeApiserverSlos        = false
+          network                  = false
         }
         disabled = {
           KubePodNotReady           = true


### PR DESCRIPTION
- Update kube-prometheus-stack to the latest minor release.
- Stop scraping kube-apiserver, which it turns out is surprisingly expensive and we were only doing because it's enabled by default in kube-prometheus-stack. We're not actually using any of those metrics.

```
k -n monitoring exec sts/prometheus-kube-prometheus-stack-prometheus -- \
    promtool tsdb analyze /prometheus
...
Highest cardinality metric names:
11682 apiserver_request_slo_duration_seconds_bucket
8015 http_request_duration_seconds
7992 router_backend_handler_response_duration_seconds_bucket
7510 apiserver_request_duration_seconds_bucket
6875 http_request_queue_duration_seconds
6844 container_memory_failures_total
5664 etcd_request_duration_seconds_bucket
4641 grpc_server_handled_total
4360 kube_pod_status_phase
4360 kube_pod_status_reason
3616 apiserver_response_sizes_bucket
```

Tested: applied in staging.