### PR TITLE
Drop some more not-useful log fields.

### DIFF
--- a/terraform/deployments/cluster-services/filebeat.yml
+++ b/terraform/deployments/cluster-services/filebeat.yml
@@ -12,6 +12,7 @@ filebeat.inputs:
       - drop_fields:
           ignore_missing: true
           fields:
+            - container.runtime
             - log
             - kubernetes.labels.app
             - kubernetes.labels.app_kubernetes_io/managed-by
@@ -22,6 +23,7 @@ filebeat.inputs:
             - kubernetes.node.labels.beta_kubernetes_io/arch
             - kubernetes.node.labels.beta_kubernetes_io/instance-type
             - kubernetes.node.labels.beta_kubernetes_io/os
+            - kubernetes.node.labels.eks_amazonaws_com/capacityType
             - kubernetes.node.labels.eks_amazonaws_com/nodegroup
             - kubernetes.node.labels.eks_amazonaws_com/nodegroup-image
             - kubernetes.node.labels.failure-domain_beta_kubernetes_io/region
@@ -29,6 +31,7 @@ filebeat.inputs:
             - kubernetes.node.labels.k8s_io/cloud-provider-aws
             - kubernetes.node.labels.kubernetes_io/hostname
             - kubernetes.node.labels.kubernetes_io/os
+            - kubernetes.node.labels.node_kubernetes_io/instance-type
             - kubernetes.node.labels.topology_ebs_csi_aws_com/zone
             - kubernetes.node.labels.topology_kubernetes_io/region
             - kubernetes.node.uid
@@ -48,3 +51,5 @@ processors:
       ignore_missing: true
       fields:
         - agent
+        - host
+        - input


### PR DESCRIPTION
These fields have identical values in every log message from the last 7 days in production, are highly unlikely to change in the foreseeable future and unlikely to be of interest even if they do change. `instance-type` is an exception to this, but that one's not worth logging because we already have `node.labels.kubernetes_io/arch` for when we start moving to arm64 nodes.

Tested: deployed in staging.