### PR TITLE
Add Grafana Tempo for distributed tracing

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -280,6 +280,19 @@ resource "helm_release" "kube_prometheus_stack" {
             authType      = "default"
             defaultRegion = data.aws_region.current.name
           }
+          },
+          {
+            name     = "Tempo"
+            type     = "tempo"
+            access   = "proxy"
+            uid      = "tempo"
+            editable = false
+            url      = "http://tempo-query-frontend.${local.monitoring_ns}.svc.cluster.local:3100"
+            jsonData = {
+              serviceMap = {
+                datasourceUid = "prometheus"
+              }
+            }
         }]
       }
       alertmanager = {

--- a/terraform/deployments/cluster-services/tempo.tf
+++ b/terraform/deployments/cluster-services/tempo.tf
@@ -1,0 +1,51 @@
+locals {
+  tempo_service_account = "tempo"
+  cluster_name          = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
+}
+
+resource "aws_s3_bucket" "tempo" {
+  bucket = "govuk-${var.govuk_environment}-tempo"
+}
+
+module "tempo_iam_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
+  version = "~> 5.27"
+
+  role_name        = "${local.tempo_service_account}-${local.cluster_name}"
+  role_description = "Role for Tempo to access AWS data sources. Corresponds to ${local.tempo_service_account} k8s ServiceAccount."
+  role_policy_arns = {
+    TempoPolicy = aws_iam_policy.tempo.arn
+  }
+
+  cluster_service_accounts = {
+    "${local.cluster_name}" = ["${local.monitoring_ns}:${local.tempo_service_account}"]
+  }
+}
+
+resource "aws_iam_policy" "tempo" {
+  name        = "tempo-${local.cluster_name}"
+  description = "Allows Tempo to access AWS data sources."
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "TempoPermissions",
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:DeleteObject",
+          "s3:GetObjectTagging",
+          "s3:PutObjectTagging"
+        ],
+        "Resource" : [
+          "${aws_s3_bucket.tempo.arn}/*",
+          "${aws_s3_bucket.tempo.arn}"
+        ]
+      }
+    ]
+  })
+}
+


### PR DESCRIPTION
This adds Terraform to deploy the Grafana Tempo helm chart (a distributed tracing tool) in to our EKS clusters. It has Terraform to create the relevant S3 bucket and IAM Role (used as the backing store).

Grafana Tempo integrates with our existing Grafana UI and is relative cheap/simple to run compared to other tracing tools (e.g. Jaeger/Zipkin/Sentry). Running it will allow us to better evaluate the value we get from tracing tools, and specifically if Tempo is the correct tool for us.

To send traces OpenTelemetry instrumentation need to be added/enabled to applications. We've shipped support for [OpenTelemetry instrumentation in govuk_app_config](https://github.com/alphagov/govuk_app_config/pull/303). This has been enabled and tested in integration.