### PR TITLE
Fix ability to log into Grafana via GitHub SSO.

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -25,6 +25,8 @@ locals {
   } : { name = k, value = v }]
 }
 
+resource "random_password" "grafana_admin" { length = 24 }
+
 resource "helm_release" "prometheus_oauth2_proxy" {
   depends_on       = [helm_release.dex]
   name             = "prometheus-oauth2-proxy"
@@ -185,6 +187,7 @@ resource "helm_release" "kube_prometheus_stack" {
             "alb.ingress.kubernetes.io/load-balancer-name" = "grafana"
           })
         }
+        adminPassword = random_password.grafana_admin.result
         "grafana.ini" = {
           auth = {
             oauth_auto_login                  = true

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -187,8 +187,9 @@ resource "helm_release" "kube_prometheus_stack" {
         }
         "grafana.ini" = {
           auth = {
-            oauth_auto_login = true
-          },
+            oauth_auto_login                  = true
+            oauth_allow_insecure_email_lookup = true
+          }
           "auth.generic_oauth" = {
             name                  = "GitHub"
             enabled               = true


### PR DESCRIPTION
Fix `Login Failed` / `user already exists` error that prevented SSO logins since upgrading to Grafana 10.

https://www.github.com/grafana/grafana/issues/70203#issuecomment-1612823390

Longer-term, we should switch from `generic_oauth` (via Dex) to [Grafana's GitHub auth plugin](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/github/).

Also ensure via Terraform that the Grafana `admin` user always has a strong, random password. (We can't ditch the admin user entirely because we need a way in when GitHub is down.)

Tested: already applied.