### PR TITLE
Upgrade of EKS cluster version from 1.24 to 1.25.

### DIFF
--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -1,7 +1,7 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-integration"
 cluster_infrastructure_state_bucket = "govuk-terraform-integration"
 
-cluster_version               = 1.24
+cluster_version               = 1.25
 cluster_log_retention_in_days = 7
 
 eks_control_plane_subnets = {

--- a/terraform/deployments/variables/production/common.tfvars
+++ b/terraform/deployments/variables/production/common.tfvars
@@ -1,7 +1,7 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-production"
 cluster_infrastructure_state_bucket = "govuk-terraform-production"
 
-cluster_version               = 1.24
+cluster_version               = 1.25
 cluster_log_retention_in_days = 7
 
 eks_control_plane_subnets = {

--- a/terraform/deployments/variables/staging/common.tfvars
+++ b/terraform/deployments/variables/staging/common.tfvars
@@ -1,7 +1,7 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-staging"
 cluster_infrastructure_state_bucket = "govuk-terraform-staging"
 
-cluster_version               = 1.24
+cluster_version               = 1.25
 cluster_log_retention_in_days = 7
 
 eks_control_plane_subnets = {


### PR DESCRIPTION
The upgrade itself was done using the AWS UI.
- Control plane update in all ENVS from 1.24 > 1.25.
- EKS addons update to Latest version available.
- Managed node group AMI update

https://trello.com/c/81sXzmYs/1143-upgrade-to-k8s-125-control-plane-and-nodes