### PR TITLE
Send only >= error and OOM containerd logs to ELK.

### DIFF
--- a/terraform/deployments/cluster-services/filebeat.yml
+++ b/terraform/deployments/cluster-services/filebeat.yml
@@ -5,7 +5,7 @@ filebeat.inputs:
       - /var/log/messages
     include_lines:
       - 'kernel:'
-      - 'containerd:'
+      - 'containerd:.*(?:level=(?:error|fatal)|TaskOOM)'
   - type: container
     paths:
       - /var/log/containers/*.log


### PR DESCRIPTION
Info and warn are basically just noise; we really just want this for the container ID on TaskOOM events, plus error and fatal just because it's a good idea to have those.

Tested: works in staging