### PR TITLE
Fix datagovuk security group

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/security.tf
+++ b/terraform/deployments/datagovuk-infrastructure/security.tf
@@ -1,7 +1,4 @@
 resource "aws_security_group_rule" "postgres_from_eks_workers" {
-  for_each = merge(data.terraform_remote_state.app_govuk_rds.outputs.sg_rds, {
-    "ckan_primary" = data.terraform_remote_state.infra_security_groups.outputs.sg_ckan_id
-  })
   description              = "Database accepts requests from EKS nodes"
   type                     = "ingress"
   from_port                = 5432

--- a/terraform/deployments/datagovuk-infrastructure/security.tf
+++ b/terraform/deployments/datagovuk-infrastructure/security.tf
@@ -7,3 +7,13 @@ resource "aws_security_group_rule" "postgres_from_eks_workers" {
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_ckan_id
   source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
 }
+
+resource "aws_security_group_rule" "redis_from_eks_workers" {
+  description              = "Redis accepts requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_backend-redis_id
+  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+}


### PR DESCRIPTION
- Remove the for-each merge of existing outputs as this causes problems with duplicates
- Adds a rule to allow redis to get requests from the EKS nodes