### PR TITLE
Avoid buggy Terraform/AWS error handling on SG rule changes.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -195,21 +195,11 @@ resource "aws_security_group_rule" "eks_ingress_www_origin_from_eks_nat" {
   security_group_id = aws_security_group.eks_ingress_www_origin.id
 }
 
-resource "aws_security_group_rule" "eks_ingress_www_origin_from_office_and_fastly_https" {
-  description       = "EKS ingress www-origin accepts requests from office and Fastly"
-  type              = "ingress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = concat(data.terraform_remote_state.infra_security_groups.outputs.office_ips, data.fastly_ip_ranges.fastly.cidr_blocks)
-  security_group_id = aws_security_group.eks_ingress_www_origin.id
-}
-
 resource "aws_security_group_rule" "eks_ingress_www_origin_from_office_and_fastly_http" {
   description       = "EKS ingress www-origin accepts requests from office and Fastly"
   type              = "ingress"
   from_port         = 80
-  to_port           = 80
+  to_port           = 443
   protocol          = "tcp"
   cidr_blocks       = concat(data.terraform_remote_state.infra_security_groups.outputs.office_ips, data.fastly_ip_ranges.fastly.cidr_blocks)
   security_group_id = aws_security_group.eks_ingress_www_origin.id

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -168,7 +168,7 @@ resource "aws_security_group_rule" "licensify_frontend_from_eks_workers" {
 resource "aws_security_group" "eks_ingress_www_origin" {
   name        = "eks_ingress_www_origin"
   vpc_id      = data.terraform_remote_state.infra_vpc.outputs.vpc_id
-  description = "ALBs serving www-origin.eks ingress."
+  description = "ALBs serving EKS www-origin ingress (and signon ALBs in non-prod environments)."
   tags = {
     Name = "eks_ingress_www_origin"
   }


### PR DESCRIPTION
See commits for details. What a palaver.

Note to self: don't try to use Terraform to change the description field on a security group. In fact, best avoid using the description field altogether because it's inexplicably immutable. (Why, Amazon, whyyyy?)

Tested: un-f***s staging. Happily we never tried to apply the previous version in prod :)