### PR TITLE
Adding pod security standards enforce baseline label to Apps namespace.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -20,6 +20,7 @@ resource "kubernetes_namespace" "apps" {
       # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/
       "elbv2.k8s.aws/pod-readiness-gate-inject" = "enabled"
       "pod-security.kubernetes.io/audit"        = "baseline"
+      "pod-security.kubernetes.io/enforce"      = "baseline"
       "pod-security.kubernetes.io/warn"         = "baseline"
     }
   }


### PR DESCRIPTION
This has been manually added to all environments using the below command:
`kubectl label --overwrite ns apps pod-security.kubernetes.io/enforce=baseline`

I will be running terraform before merging this change.

Tested:
Rolling update was carried out in Integration.
After applying i have checked through Kube API Audit logs for any violations - non where reported.

https://trello.com/c/UONzAfZu/1212-apply-pss-baseline-policy-to-apps-namesapce