### PR TITLE
Add workflow for creating a release

### DIFF
--- a/.github/workflows/add-version-tag.yml
+++ b/.github/workflows/add-version-tag.yml
@@ -1,0 +1,84 @@
+name: Add version tag
+
+on:
+  workflow_call:
+
+concurrency: ${{ github.workflow }}
+
+jobs:
+  add-version-tag:
+    name: Add version tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Find latest version tag
+        id: find-last-tag
+        run: |
+          git fetch --tags --deepen=100
+
+          last_tag=$(git tag --list "v*" --merged HEAD --sort=-committerdate | head -n 1)
+
+          if [ -z "$last_tag" ]; then
+            echo "No previous tag found."
+            exit 1
+          fi
+
+          echo "result=$last_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate version tag
+        id: calculate-tag
+        run: |
+          last_tag="${{ steps.find-last-tag.outputs.result }}"
+
+          # Get the list of merge commits
+          merge_commits=$(git rev-list --merges "$last_tag"..HEAD)
+
+          # Get the hash of the current commit
+          current_commit=$(git rev-parse --verify HEAD)
+
+          # Check if the current commit is in the list of merge commits
+          if ! echo "$merge_commits" | grep -q "$current_commit"; then
+            echo "The current commit is not a merge commit."
+            exit 1
+          fi
+
+          # Count the number of merge commits
+          merge_count=$(echo "$merge_commits" | wc -l)
+
+          # Remove v prefix
+          version=${last_tag#v}
+
+          # Increase the version by the merge count
+          ((version+=merge_count))
+
+          # Construct the new version tag
+          new_tag="v${version}"
+
+          echo "result=$new_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Add git tag
+        uses: actions/github-script@v6
+        with:
+          retries: 3
+          script: |
+            const newTag = '${{steps.calculate-tag.outputs.result}}'
+
+            // Create tag reference
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${newTag}`,
+              sha: context.sha,
+            });
+
+            // Create an annotated tag, otherwise the ref is only a lightweight tag
+            await github.rest.git.createTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: newTag,
+              message: `Automated version tag ${newTag}`,
+              object: context.sha,
+              type: 'commit',
+            });

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -80,11 +80,17 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecrRepositoryName }}
+          INPUT_REF: ${{ inputs.gitRef }}
         run: |
           LOCAL_HEAD_SHA="$(git rev-parse HEAD)"
           REMOTE_HEAD_SHA=$(git ls-remote origin HEAD | cut -f 1)
 
-          IMAGE_TAG="release-${LOCAL_HEAD_SHA}"
+          if [[ "${INPUT_REF}" == v* ]]; then
+            IMAGE_TAG="${INPUT_REF}"
+          else
+            IMAGE_TAG="release-${LOCAL_HEAD_SHA}"
+          fi
+
           FULL_IMAGE_TAG_LIST=("${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}")
 
           # Add latest tag if most recent commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,14 @@
-name: Add version tag
+name: Release
 
 on:
   workflow_call:
-
-concurrency: ${{ github.workflow }}
+    secrets:
+      GH_TOKEN:
+        required: true
 
 jobs:
-  add-version-tag:
-    name: Add version tag
+  release:
+    name: Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -18,7 +19,7 @@ jobs:
         run: |
           git fetch --tags --deepen=100
 
-          last_tag=$(git tag --list "v*" --merged HEAD --sort=-committerdate | head -n 1)
+          last_tag=$(git describe --tags --match "v*" --abbrev=0)
 
           if [ -z "$last_tag" ]; then
             echo "No previous tag found."
@@ -27,28 +28,27 @@ jobs:
 
           echo "result=$last_tag" >> "$GITHUB_OUTPUT"
 
-      - name: Calculate version tag
-        id: calculate-tag
+      - name: Check is merge commit
         run: |
-          last_tag="${{ steps.find-last-tag.outputs.result }}"
-
-          # Get the list of merge commits
-          merge_commits=$(git rev-list --merges "$last_tag"..HEAD)
-
-          # Get the hash of the current commit
-          current_commit=$(git rev-parse --verify HEAD)
-
-          # Check if the current commit is in the list of merge commits
-          if ! echo "$merge_commits" | grep -q "$current_commit"; then
+          # Commits with more than 1 parent are merge commits
+          if [[ $(git cat-file -p HEAD | grep -c parent) -le 1 ]]; then
             echo "The current commit is not a merge commit."
             exit 1
           fi
 
-          # Count the number of merge commits
-          merge_count=$(echo "$merge_commits" | wc -l)
+      - name: Calculate new version tag
+        id: calculate-tag
+        run: |
+          last_tag="${{ steps.find-last-tag.outputs.result }}"
 
           # Remove v prefix
           version=${last_tag#v}
+
+          # Get the list of merge commits
+          merge_commits=$(git rev-list --merges "$last_tag"..HEAD)
+
+          # Count the number of merge commits
+          merge_count=$(echo "$merge_commits" | wc -l)
 
           # Increase the version by the merge count
           ((version+=merge_count))
@@ -58,27 +58,19 @@ jobs:
 
           echo "result=$new_tag" >> "$GITHUB_OUTPUT"
 
-      - name: Add git tag
+      - name: Create GitHub Release
         uses: actions/github-script@v6
         with:
           retries: 3
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const newTag = '${{steps.calculate-tag.outputs.result}}'
 
-            // Create tag reference
-            await github.rest.git.createRef({
+            await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: `refs/tags/${newTag}`,
-              sha: context.sha,
-            });
-
-            // Create an annotated tag, otherwise the ref is only a lightweight tag
-            await github.rest.git.createTag({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag: newTag,
-              message: `Automated version tag ${newTag}`,
-              object: context.sha,
-              type: 'commit',
+              tag_name: newTag,
+              name: newTag,
+              target_commitish: context.sha,
+              make_latest: "legacy",
             });

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -255,6 +255,19 @@ resource "aws_ecr_lifecycle_policy" "ecr_lifecycle_policy" {
       },
       {
         "rulePriority" : 4,
+        "description" : "Keep last 20 images with tag prefix v",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "tagPrefixList" : ["v"],
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 20
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      },
+      {
+        "rulePriority" : 5,
         "description" : "Expire images older than 30 days",
         "selection" : {
           "tagStatus" : "any",


### PR DESCRIPTION
This GitHub Action workflow can be called from our application repositories to create a GitHub Release and add a git tag with the version. The versioning pattern tags each merge commit that has passed its status checks in sequential order with the format `v<number>`. SemVer compatible format was not used as brings no practical benefit yet, however versioning format can always be updated in future.

The workflow assumes a pre-existing version tag in which it calculates the next version number from. The workflow calculates the version number as last version tag number + the number of merge commit. This allows the worklfow to be idepotent and independent of workflow run order (which can be an issue for GitHub Actions).