### PR TITLE
Update Argo CD to 2.7.11.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -33,7 +33,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.37.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.42.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     global = {
       logging = {


### PR DESCRIPTION
2.8 is out today, so let's update to the latest patch release first.

Tested: running in staging.