### PR TITLE
Fix target git ref in Releases workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_commit.id }}
 
       - name: Find latest version tag
         id: find-last-tag
@@ -71,6 +73,6 @@ jobs:
               repo: context.repo.repo,
               tag_name: newTag,
               name: newTag,
-              target_commitish: context.sha,
+              target_commitish: '${{ github.event.workflow_run.head_commit.id}}',
               make_latest: "legacy",
             });


### PR DESCRIPTION
This fixes an issue whereby the same commit can be tagged with different versions. The Release workflow is triggered by a workflow_run from a successful CI workflow. However, git reference associated with release run isn't the same ref targeted by the CI. By default the ref is just the branch name, so the Release workflow was reference the HEAD of the main branch. Therefore, it will try to tag the latest commit rather than the commit from the merge commit (which CI was targetting).

This fixes updates the checkout ref and target commit for the Release with an explict reference to the commit sha of the CI workflow run.