### PR TITLE
Enable Docker password masking.

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
 
       - name: Determine image tag
         id: determine-image-tag


### PR DESCRIPTION
amazon-ecr-login 1.7 introduced a feature that allows masking the Docker password so that it can't accidentally be written to logs etc.

This wasn't a problem for us anyway (the Docker password doesn't appear in the output unless you go out of your way to print it or run the action in debug mode, neither of which we've done), so really this just:

 - enables a new, defence-in-depth feature
 - gets rid of the misleadingly scary-looking (but actually benign) `Warning: Your docker password is not masked.` message in the build log.