### PR TITLE
Rename github-cli image to toolbox

### DIFF
--- a/.github/workflows/build-toolbox-image.yml
+++ b/.github/workflows/build-toolbox-image.yml
@@ -1,4 +1,4 @@
-name: Build and publish github-cli image to ECR
+name: Build and publish toolbox image to ECR
 
 on:
   workflow_dispatch:
@@ -13,7 +13,7 @@ on:
     branches:
       - main
     paths:
-      - "images/github-cli/Dockerfile"
+      - "images/toolbox/Dockerfile"
   
   schedule:
     - cron: '0 0 * * 1'
@@ -23,8 +23,8 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
-      ecrRepositoryName: github-cli
-      dockerfilePath: images/github-cli/Dockerfile
+      ecrRepositoryName: toolbox
+      dockerfilePath: images/toolbox/Dockerfile
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}

--- a/images/toolbox/Dockerfile
+++ b/images/toolbox/Dockerfile
@@ -49,4 +49,4 @@ RUN aws --version ; \
     yq --version
 
 CMD ["/bin/bash"]
-LABEL org.opencontainers.image.source=https://github.com/alphagov/govuk-infrastructure/tree/main/images/github-cli/
+LABEL org.opencontainers.image.source=https://github.com/alphagov/govuk-infrastructure/tree/main/images/toolbox/

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -42,6 +42,7 @@ locals {
 
   extra_repositories = [
     "github-cli",
+    "toolbox",
     "statsd",
     "govuk-terraform",
     "search-api-learn-to-rank",


### PR DESCRIPTION
This name better reflects its multi purpose nature. This image now contains many general purpose tools for a range of different functions, not longer exclusively for github-cli.