### PR TITLE
Update to Argo CD 2.8.1.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -33,7 +33,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.42.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.43.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     global = {
       logging = {


### PR DESCRIPTION
No other action needed, just a straight upgrade in our case since we're good with the new RBAC actions being granted to admins: https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.7-2.8/

Testing: I'll canary in staging first before rolling out elsewhere.