### PR TITLE
Fix aws_auth configmap to reflect authz changes.

### DIFF
--- a/terraform/deployments/cluster-services/remote.tf
+++ b/terraform/deployments/cluster-services/remote.tf
@@ -11,12 +11,3 @@ data "terraform_remote_state" "cluster_infrastructure" {
     region = data.aws_region.current.name
   }
 }
-
-data "terraform_remote_state" "infra_security" {
-  backend = "s3"
-  config = {
-    bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-security.tfstate"
-    region = data.aws_region.current.name
-  }
-}


### PR DESCRIPTION
As of https://github.com/alphagov/govuk-user-reviewer/pull/952 / https://github.com/alphagov/govuk-aws-data/pull/1246, we can no longer fetch an authoritative list of user IAM roles from Terraform state. Instead we just query AWS for them based on the naming convention.

Already tested and applied.