### PR TITLE
Add generic lint GitHub actions

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -1,0 +1,15 @@
+name: Run lint:js
+
+jobs:
+  run-lint-js:
+    name: Run lint:js
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
+
+      - name: Run lint:js
+        run: yarn run lint:js

--- a/.github/workflows/lint-prettier.yaml
+++ b/.github/workflows/lint-prettier.yaml
@@ -1,0 +1,15 @@
+name: Run lint:prettier
+
+jobs:
+  run-lint-prettier:
+    name: Run lint:prettier
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
+
+      - name: Run lint:prettier
+        run: yarn run lint:prettier

--- a/.github/workflows/lint-scss.yml
+++ b/.github/workflows/lint-scss.yml
@@ -1,0 +1,15 @@
+name: Run lint:scss
+
+jobs:
+  run-lint-scss:
+    name: Run lint:scss
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
+
+      - name: Run lint:scss
+        run: yarn run lint:scss


### PR DESCRIPTION
# What
- Add actions for `yarn run lint:js`, `yarn run lint:scss` and `yarn run lint:prettier`

# Why
- We're introducing new linting to Whitehall, https://github.com/alphagov/whitehall/pull/8178, based on `govuk-frontend`
- The existing lint actions specify the exact command to run
- These new actions allow applications to configure their own linting whilst still running in parallel