### PR TITLE
Build a container image for MongoDB 2.4.

### DIFF
--- a/.github/workflows/build-mongodb-image.yml
+++ b/.github/workflows/build-mongodb-image.yml
@@ -1,0 +1,30 @@
+name: Build and publish MongoDB image to ECR
+
+on:
+  workflow_dispatch:
+    inputs:
+      gitRef:
+        description: 'Commit, tag or branch name to deploy'
+        required: true
+        type: string
+        default: main
+
+  push:
+    branches:
+      - main
+    paths:
+      - images/mongodb/Dockerfile
+  
+  schedule:
+    - cron: '1 22 * * 1'
+
+jobs:
+  build-and-push-image:
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    with:
+      gitRef: ${{ inputs.gitRef || github.ref }}
+      ecrRepositoryName: mongodb
+      dockerfilePath: images/mongodb/Dockerfile
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}

--- a/images/mongodb/Dockerfile
+++ b/images/mongodb/Dockerfile
@@ -1,0 +1,26 @@
+FROM public.ecr.aws/lts/ubuntu:22.04_stable
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+ENV MONGO_VERSION 2.4.14
+ARG mongo_tarball="mongodb-linux-x86_64-$MONGO_VERSION.tgz"
+ARG mongo_url="https://fastdl.mongodb.org/linux/$mongo_tarball"
+
+# hadolint ignore=DL3008
+RUN apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*;
+WORKDIR /tmp
+RUN curl -SsfO "$mongo_url"; \
+    sha256sum -c <(echo "20d319db0396702744aadb18815fd99f37806bbf80afdc078f08af8058b2c7d4  $mongo_tarball"); \
+    tar -xf "$mongo_tarball" -C /usr/local --strip-components=1; \
+    rm -f "$mongo_tarball";
+
+WORKDIR /data/configdb
+WORKDIR /data/db
+RUN useradd -Ur mongodb -d /data; \
+    chown -R mongodb:mongodb /data;
+USER mongodb
+VOLUME /data/db /data/configdb
+EXPOSE 27017
+ENTRYPOINT ["mongod"]
+LABEL org.opencontainers.image.source=https://github.com/alphagov/govuk-infrastructure/tree/main/images/mongodb/

--- a/images/mongodb/Makefile
+++ b/images/mongodb/Makefile
@@ -1,0 +1,8 @@
+# This Makefile is just for convenience when building locally.
+# The production image is built by the GitHub Actions workflow in
+# ../../.github/workflows/build-mongodb-image.yml.
+
+.PHONY: all image
+
+image:
+	docker build -t mongo:2.4 --platform linux/amd64 .

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -42,6 +42,7 @@ locals {
 
   extra_repositories = [
     "github-cli",
+    "mongodb",
     "toolbox",
     "statsd",
     "govuk-terraform",


### PR DESCRIPTION
This is just to give us the option to run our antique version of MongoDB on Kubernetes temporarily until we finish the port of Router API to Postgres. It's helpful to have that flexibility because switching off the old Puppet stack quickly is more important than getting Router API on to Postgres quickly.

The idea would be to run a StatefulSet of these and do a quick stop-and-swap while nobody's publishing anything. ([Ah, the old stop-and-swap](https://github.com/alphagov/govuk-infrastructure/assets/1170635/840cdc5f-49e5-4b30-a377-c6941e5a0b57).)

This thing isn't in the serving path and untrusted input doesn't go anywhere near it, otherwise we wouldn't even be considering this gross workaround. If we do it, it's going to have to come with a hard deadline so that we're not left holding a bag of very stale MongoDB.

Hopefully we can just get the Router API -> Postgres port back on track and not need this, but it's good to have options. Perhaps manifesting the horror of this putative workaround will galvanise the porting effort? We really don't want to find ourselves running this image in 2024. Double plus ungood.

Differences from the [last docker-library/mongo image release](https://github.com/docker-library/mongo/tree/4507e97/2.4):

- image manifest format that works with containerd (so it runs on k8s ≥1.24)
- up-to-date base image, libstdc++, etc. etc.
- we don't care about NUMA (our cluster nodes aren't)
- ditched the entrypoint shell script (we don't need it)
- runs as non-root by default (helps when testing on Docker)

Tested: Router end-to-end tests pass with this image. The failing TF Cloud pre-merge check is unrelated to this PR.