### PR TITLE
Add Slack notification for expiring signon tokens

### DIFF
--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -9,6 +9,15 @@ data "aws_secretsmanager_secret_version" "alertmanager-pagerduty" {
   secret_id = data.aws_secretsmanager_secret.alertmanager-pagerduty.id
 }
 
+data "aws_secretsmanager_secret" "alertmanager-slack" {
+  name = "govuk/slack-webhook-url"
+}
+
+data "aws_secretsmanager_secret_version" "alertmanager-slack" {
+  secret_id = data.aws_secretsmanager_secret.alertmanager-slack.id
+}
+
+
 locals {
   alertmanager_host         = "alertmanager.${local.external_dns_zone_name}"
   grafana_host              = "grafana.${local.external_dns_zone_name}"
@@ -151,7 +160,9 @@ resource "helm_release" "kube_prometheus_stack" {
     templatefile("${path.module}/templates/alertmanager-config.tpl",
       {
         routing_key       = data.aws_secretsmanager_secret_version.alertmanager-pagerduty.secret_string,
+        slack_api_url     = jsondecode(data.aws_secretsmanager_secret_version.alertmanager-slack.secret_string)["url"],
         alertmanager_host = local.alertmanager_host
+        environment       = var.govuk_environment
     }),
     yamlencode({
       kubeApiServer         = { enabled = false }

--- a/terraform/deployments/cluster-services/kube_prometheus_stack.tf
+++ b/terraform/deployments/cluster-services/kube_prometheus_stack.tf
@@ -144,7 +144,7 @@ resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"
   chart            = "kube-prometheus-stack"
-  version          = "47.3.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "47.6.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.monitoring_ns
   create_namespace = true
   values = [


### PR DESCRIPTION
This configures alertmanger to send a slack message to 2ndline at most once a day if there are any signon api_user tokens that will expire in less than 2 weeks.