### PR TITLE
Bump checkout action version for publish-rubygem.yml

### DIFF
--- a/.github/workflows/publish-rubygem.yml
+++ b/.github/workflows/publish-rubygem.yml
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         rubygems: latest


### PR DESCRIPTION
v2 uses the deprecated node12 runtime.