### PR TITLE
Add optional runbook to slack alerts

### DIFF
--- a/terraform/deployments/cluster-services/templates/alertmanager-config.tpl
+++ b/terraform/deployments/cluster-services/templates/alertmanager-config.tpl
@@ -39,6 +39,8 @@ alertmanager:
 
          *Environment:* ${environment}
 
+         *Runbook:* {{ .CommonAnnotations.runbook_url }}
+
          *Expiring tokens:*
 
          {{ range .Alerts -}}


### PR DESCRIPTION
In https://github.com/alphagov/govuk-helm-charts/pull/1314 we add a runbook annotation, which points to the developer docs related to fixing the problem showing up in the alert. This change allows the annotation to be added to the slack card for the alert.

I'm not 100% sure about the conditional - at the moment this slack is only used for the one type of alert, which as per the other PR will always have a runbook variable (if not a value), so 1) maybe we remove it? 2) not 100% sure if it's the right format.