### PR TITLE
Update Argo CD chart to 5.46.8.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -33,7 +33,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.46.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.46.8" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     global = {
       logging = {


### PR DESCRIPTION
This updates Redis to 7.0.13, which fixes CVE-2022-48174 (not a practical issue for us, but helps to keep the noise down).