### PR TITLE
SCA scans on PR and push to check for new vulnerabilities

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,37 @@
+name: "Dependabot Scan"
+
+on:
+  workflow_call:
+
+jobs:
+  dependency-review-pr:
+    if: ${{github.event_name == 'pull_request'}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+
+      - name: 'Review changes to repository supply chain'
+        uses: actions/dependency-review-action@v3
+        with:
+          # Fails only on critical findings as it is not possible to pass the build altogether
+          fail-on-severity: critical
+
+  dependency-review-push:
+    if: ${{github.event_name == 'push'}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+        with:
+          # Checkout this revision and the previous one
+          fetch-depth: 2
+
+      - name: 'Review changes to repository supply chain'
+        uses: actions/dependency-review-action@v3
+        with:
+          # Fails only on critical findings as it is not possible to pass the build altogether
+          fail-on-severity: critical
+          # Set the latest commit as the head-ref and the former as the base-ref for comparison
+          base-ref: refs/heads/main~1
+          head-ref: refs/heads/main


### PR DESCRIPTION
A reusable workflow for run dependency review scan on PR and push actions to check for new vulnerabilities being added to the supply chain as part of the change. 

https://trello.com/c/BmET7H34/3326-add-dependabot-scan-to-ci-pipelines