### PR TITLE
Request a 3h AWS token in mirror-repos workflow.

### DIFF
--- a/.github/workflows/mirror-repos.yml
+++ b/.github/workflows/mirror-repos.yml
@@ -23,6 +23,7 @@ jobs:
           role-to-assume: arn:aws:iam::900804735337:role/github_action_mirror_repos_role
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: GitHubActionMirrorRepos
+          role-duration-seconds: 10800
 
       - name: Get repos
         id: get-repos


### PR DESCRIPTION
[aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) now defaults to 1h STS token validity instead of 6h, so request a token that's valid at least until the next run is scheduled to start.

(It's typically been taking ~45m lately.)