### PR TITLE
Block spammy deprecation warning.

### DIFF
--- a/terraform/deployments/cluster-services/filebeat.yml
+++ b/terraform/deployments/cluster-services/filebeat.yml
@@ -11,6 +11,8 @@ filebeat.inputs:
       - /var/log/containers/*.log
     exclude_lines:
       - '"/readyz"'
+      # https://github.com/alphagov/bouncer/issues/461
+      - 'DEPRECATION WARNING.*clear_active_connections'
     processors:
       - add_kubernetes_metadata:
           host: ${NODE_NAME}


### PR DESCRIPTION
This was eating our logit.io quota.

Filed https://github.com/alphagov/bouncer/issues/461 to track the underlying fix.

Tested: applied in prod, logspew stopped, other messages still flowing.