### PR TITLE
Revert to Argo CD 2.8.4.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -33,7 +33,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.48.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.47.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     global = {
       logging = {


### PR DESCRIPTION
Argo CD 2.8.5 is broken: https://github.com/argoproj/argo-cd/issues/16169

Rollout: already done everywhere (`helm -n cluster-services upgrade argo-cd argo/argo-cd --version 5.47.0`).