### PR TITLE
Fix permissions for filebeat (log sender daemonset).

### DIFF
--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -18,6 +18,23 @@ resource "helm_release" "filebeat" {
       "filebeat.yml" = yamlencode(yamldecode(file("${path.module}/filebeat.yml")))
     }
     imageTag = "8.10.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
+    clusterRoleRules = [
+      {
+        apiGroups = [""]
+        resources = ["namespaces", "nodes", "pods"]
+        verbs     = ["get", "list", "watch"]
+      },
+      {
+        apiGroups = ["apps"]
+        resources = ["replicasets"]
+        verbs     = ["get", "list", "watch"]
+      },
+      {
+        apiGroups = ["batch"]
+        resources = ["jobs"]
+        verbs     = ["get", "list", "watch"]
+      }
+    ]
     extraEnvs = [
       {
         name = "LOGSTASH_HOST"


### PR DESCRIPTION
Recent versions of filebeat require get/list/watch on jobs.batch API resources, and it fails in an ugly way if it lacks that permission: it fails to label anything at all, not just stuff that comes from Jobs.

Tested: already rolled out and working.