### PR TITLE
Initial tfc-bootstrap config

### DIFF
--- a/terraform/deployments/tfc-bootstrap/main.tf
+++ b/terraform/deployments/tfc-bootstrap/main.tf
@@ -1,0 +1,28 @@
+resource "tfe_workspace" "tfc_bootstrap" {
+  name              = "tfc-bootstrap"
+  description       = "The tfc-bootsrap module is responsible for initialising teraform cloud."
+  working_directory = "/terraform/deployments/tfc-bootstrap/"
+  trigger_patterns  = ["/terraform/deployments/tfc-bootstrap/**/*"]
+  execution_mode    = "local"
+  vcs_repo {
+    identifier                 = "alphagov/govuk-infrastructure"
+    github_app_installation_id = data.tfe_github_app_installation.github.id
+  }
+}
+
+resource "tfe_project" "tfc_configuration" {
+  name = "tfc-configuration"
+}
+
+resource "tfe_workspace" "tfc_configuration" {
+  name              = "tfc-configuration"
+  description       = "The tfc-configuration module is responsible for setting up the terraform cloud configuration."
+  project_id        = tfe_project.tfc_configuration.id
+  working_directory = "/terraform/deployments/tfc-configuration/"
+  trigger_patterns  = ["/terraform/deployments/tfc-configuration/**/*"]
+  vcs_repo {
+    identifier                 = "alphagov/govuk-infrastructure"
+    github_app_installation_id = data.tfe_github_app_installation.github.id
+    branch                     = "main"
+  }
+}

--- a/terraform/deployments/tfc-bootstrap/provider.tf
+++ b/terraform/deployments/tfc-bootstrap/provider.tf
@@ -1,0 +1,23 @@
+terraform {
+  cloud {
+    organization = "govuk"
+    workspaces {
+      name = "tfc-bootstrap"
+    }
+  }
+
+  required_version = "~> 1.5"
+
+  required_providers {
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.47.0"
+    }
+  }
+}
+
+provider "tfe" {
+  hostname     = var.tfc_hostname
+  organization = var.tfc_organization_name
+}
+

--- a/terraform/deployments/tfc-bootstrap/remote.tf
+++ b/terraform/deployments/tfc-bootstrap/remote.tf
@@ -1,0 +1,3 @@
+data "tfe_github_app_installation" "github" {
+  name = "alphagov"
+}

--- a/terraform/deployments/tfc-bootstrap/variables.tf
+++ b/terraform/deployments/tfc-bootstrap/variables.tf
@@ -1,0 +1,11 @@
+variable "tfc_hostname" {
+  type        = string
+  default     = "app.terraform.io"
+  description = "The hostname of the TFC or TFE to use with AWS"
+}
+
+variable "tfc_organization_name" {
+  type        = string
+  default     = "govuk"
+  description = "The name of the Terraform Cloud organization"
+}


### PR DESCRIPTION
tfc-bootstrap is run in local mode the as an initial setup for the tfc-configuration workspace.
tfc-configuration workspace is that is then run in remote mode for the set up the rest of the workspaces as per #990

To run this locally you need to be in the dir and the run 
```
terraform login
terraform init
terraform apply
```

https://trello.com/c/M4fXUvda/3340-update-the-govuk-infrastructure-project-to-use-workspacer-to-set-up-workspaces