### PR TITLE
Update Argo CD to 2.8.6.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -33,7 +33,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.47.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.50.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     global = {
       logging = {


### PR DESCRIPTION
From our perspective this basically just updates a bunch of the underlying golang libraries, but without [breaking the notification controller][1] this time 🙃

[1]: https://www.github.com/argoproj/argo-cd/issues/16169