### PR TITLE
Remove a WAF rule that was blocking Pingdom checks

### DIFF
--- a/terraform/deployments/cloudfront/main.tf
+++ b/terraform/deployments/cloudfront/main.tf
@@ -192,28 +192,6 @@ resource "aws_wafv2_web_acl" "cdn_poc_govuk" {
   }
 
   rule {
-    name     = "AWS-AWSManagedRulesAnonymousIpList"
-    priority = 0
-
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        vendor_name = "AWS"
-        name        = "AWSManagedRulesAnonymousIpList"
-      }
-    }
-
-    visibility_config {
-      sampled_requests_enabled   = true
-      cloudwatch_metrics_enabled = true
-      metric_name                = "AWS-AWSManagedRulesAnonymousIpList"
-    }
-  }
-
-  rule {
     name     = "AWS-AWSManagedRulesAmazonIpReputationList"
     priority = 1
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/8MyYIQXu/3306-configure-pingdom-checks-for-new-cloudfront-distributions-3)

The `AWSManagedRulesAnonymousIpList` rule was blocking Pingdom's servers from checking whether or not our failover CloudFront distributions are online.

> The Anonymous IP list rule group contains rules to block requests from services that permit the obfuscation of viewer identity. These include requests from VPNs, proxies, Tor nodes, and web hosting providers. This rule group is useful if you want to filter out viewers that might be trying to hide their identity from your application. Blocking the IP addresses of these services can help mitigate bots and evasion of geographic restrictions.

https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html#aws-managed-rule-groups-ip-rep-anonymous