### PR TITLE
Update Grafana config psql database to Postgres 13.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -117,6 +117,12 @@ variable "rds_apply_immediately" {
   default     = false
 }
 
+variable "rds_backup_retention_period" {
+  type        = number
+  description = "Backup retention period for Grafana config database, in days."
+  default     = 7
+}
+
 variable "rds_skip_final_snapshot" {
   type        = bool
   description = "If true, allow deletion of RDS instances via Terraform by removing the requirement for a final snapshot to be taken on deletion. Do not enable this in production."

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -33,9 +33,10 @@ shared_redis_cluster_node_type = "cache.m6g.large"
 # Non-production-only access is sufficient to access tools in this cluster.
 github_read_write_team = "alphagov:gov-uk"
 
-grafana_db_auto_pause   = true
-rds_apply_immediately   = true
-rds_skip_final_snapshot = true
+grafana_db_auto_pause       = true
+rds_apply_immediately       = true
+rds_backup_retention_period = 1
+rds_skip_final_snapshot     = true
 
 secrets_recovery_window_in_days = 0
 

--- a/terraform/deployments/variables/staging/common.tfvars
+++ b/terraform/deployments/variables/staging/common.tfvars
@@ -29,6 +29,7 @@ publishing_service_domain = "staging.publishing.service.gov.uk"
 frontend_memcached_node_type   = "cache.t4g.medium"
 shared_redis_cluster_node_type = "cache.t4g.medium"
 
-desired_ha_replicas = 2
+desired_ha_replicas         = 2
+rds_backup_retention_period = 1
 
 ckan_s3_organogram_bucket = "datagovuk-staging-ckan-organogram"


### PR DESCRIPTION
- Update from Postgres 11 to 13.
- Update to the current version of terraform-aws-modules/rds-aurora.
- Reduce automatic snapshot retention to the minimum (1d) in non-prod.

The other changes here are consequences of the module update; see [upgrade guide](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/blob/e054f77/UPGRADE-8.0.md#upgrade-from-v7x-to-v8x) for details.

Tested: applied in staging, restarted Grafana, still authenticates ok, reads its config and generally works.