### PR TITLE
Update test EKS cluster variable to 1.27

### DIFF
--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -1,7 +1,7 @@
 govuk_aws_state_bucket              = "govuk-terraform-steppingstone-test"
 cluster_infrastructure_state_bucket = "govuk-terraform-test"
 
-cluster_version               = 1.23
+cluster_version               = 1.27
 cluster_log_retention_in_days = 7
 workers_default_capacity_type = "SPOT"
 workers_size_desired          = 3


### PR DESCRIPTION
## Description:
- Updates the variable representing the EKS cluster version in the test environment to `1.27`