### PR TITLE
Update argo bootstrap target repo for datagovuk

### DIFF
--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -1,7 +1,7 @@
 # Installs and configures Dex, a federated OpenID Connect provider
 
 locals {
-  dex_host = "dex.${local.external_dns_zone_name}"
+  dex_host                  = "dex.${local.external_dns_zone_name}"
   alertmanager_host         = "alertmanager.${local.external_dns_zone_name}"
   grafana_host              = "grafana.${local.external_dns_zone_name}"
   prometheus_host           = "prometheus.${local.external_dns_zone_name}"

--- a/terraform/deployments/datagovuk-infrastructure/argo_bootstrap.tf
+++ b/terraform/deployments/datagovuk-infrastructure/argo_bootstrap.tf
@@ -3,7 +3,7 @@ resource "helm_release" "argo_bootstrap" {
   name             = "datagovuk-argo-bootstrap"
   namespace        = local.services_ns
   create_namespace = true
-  repository       = "https://alphagov.github.io/govuk-ckan-charts/"
+  repository       = "https://alphagov.github.io/govuk-dgu-charts/"
   version          = "1.0.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     environment = var.govuk_environment


### PR DESCRIPTION
## What

DGU PaaS apps will be migrated to the same repository to make it easier to manage the datagovuk stack so the govuk-ckan-charts repo is has been forked to govuk-dgu-charts to make the move without interrupting the service.

## Reference 

https://trello.com/c/nz3X804Y/1237-deploy-dgu-paas-apps-onto-integration-cluster