### PR TITLE
Upgrade setup node action to install nodeJS version 18

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
 
     - name: Install JavaScript dependencies


### PR DESCRIPTION
This brings the GitHub action environment into line with the node version installed in GOV.UK Ruby docker images.

See https://gds.slack.com/archives/C013F737737/p1700239465332899 for full context