### PR TITLE
Update Argo CD from 2.8.6 to 2.9.2.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -45,7 +45,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.50.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.51.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     global = {
       logging = {


### PR DESCRIPTION
[Release notes](https://github.com/argoproj/argo-cd/releases)

Tested: installed in staging via `helm upgrade`; deleted the `release` app and Argo CD created everything again as expected. Promotions from staging->prod also still work.