### PR TITLE
Make CloudFront include Host header in cache key

### DIFF
--- a/terraform/deployments/cloudfront/main.tf
+++ b/terraform/deployments/cloudfront/main.tf
@@ -153,7 +153,10 @@ resource "aws_cloudfront_cache_policy" "no-cookies" {
       cookie_behavior = "none"
     }
     headers_config {
-      header_behavior = "none"
+      header_behavior = "whitelist"
+      headers {
+        items = ["Host"]
+      }
     }
     query_strings_config {
       query_string_behavior = "all"


### PR DESCRIPTION
[Trello card](https://trello.com/c/t8NjzYuC/3355-investigate-why-our-failover-cloudfront-distributions-are-broken)

Our CloudFront failover distributions have publicly accessible domain names (e.g. `xyz.cloudfront.net`). If a user visits any of these URLs, the request is forwarded to origin, which returns an HTTP 404 (because the host is unrecognised), which CloudFront caches.

Prior to this PR, future requests made to the same path but with the correct `Host` header (e.g. `www.gov.uk`) would then serve the cached HTTP 404, instead of the correct response.

This PR configures CloudFront to include the value of the `Host` header in the cache key, so that requests made to the distribution with different `Host` headers are considered different requests, and are cached separately.