### PR TITLE
Upsize the Sidekiq Redis in staging.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
@@ -11,26 +11,22 @@ resource "aws_security_group" "shared_redis_cluster" {
   name        = local.shared_redis_name
   vpc_id      = local.vpc_id
   description = "${local.shared_redis_name} Redis cluster"
-  tags = {
-    Name = local.shared_redis_name
-  }
+  tags        = { Name = local.shared_redis_name }
 }
 
 resource "aws_elasticache_replication_group" "shared_redis_cluster" {
   apply_immediately          = var.govuk_environment != "production"
   replication_group_id       = local.shared_redis_name
-  description                = "${local.shared_redis_name} Redis cluster with Redis master and replica"
+  description                = "Redis for Sidekiq queues"
   node_type                  = var.shared_redis_cluster_node_type
-  num_cache_clusters         = 2
-  automatic_failover_enabled = true
-  multi_az_enabled           = true
+  num_cache_clusters         = var.govuk_environment == "production" ? 2 : 1
+  automatic_failover_enabled = var.govuk_environment == "production"
+  multi_az_enabled           = var.govuk_environment == "production"
   parameter_group_name       = "default.redis6.x"
   engine_version             = "6.x"
   subnet_group_name          = aws_elasticache_subnet_group.shared_redis_cluster.name
   security_group_ids         = [aws_security_group.shared_redis_cluster.id]
-  tags = {
-    Name = local.shared_redis_name
-  }
+  tags                       = { Name = local.shared_redis_name }
 }
 
 resource "aws_route53_record" "shared_redis_cluster" {

--- a/terraform/deployments/variables/staging/common.tfvars
+++ b/terraform/deployments/variables/staging/common.tfvars
@@ -27,7 +27,7 @@ govuk_environment = "staging"
 publishing_service_domain = "staging.publishing.service.gov.uk"
 
 frontend_memcached_node_type   = "cache.t4g.medium"
-shared_redis_cluster_node_type = "cache.t4g.medium"
+shared_redis_cluster_node_type = "cache.r6g.large"
 
 desired_ha_replicas         = 2
 rds_backup_retention_period = 1


### PR DESCRIPTION
- Use r6g.large (13 GiB) for staging instead of t4g.medium (3 GiB).
- Don't bother with standby instances in nonprod — not worth it at all. Offsets some of the cost of the bigger instance in staging.

This makes staging 50% the size of prod instead of ~10%, so it should serve as a more useful canary for some of the large one-off jobs that have been going on recently.

Already applied.