### PR TITLE
Change size of shared Redis in staging

### DIFF
--- a/terraform/deployments/variables/staging/common.tfvars
+++ b/terraform/deployments/variables/staging/common.tfvars
@@ -27,7 +27,7 @@ govuk_environment = "staging"
 publishing_service_domain = "staging.publishing.service.gov.uk"
 
 frontend_memcached_node_type   = "cache.t4g.medium"
-shared_redis_cluster_node_type = "cache.t4g.medium"
+shared_redis_cluster_node_type = "cache.m6g.large"
 
 desired_ha_replicas         = 2
 rds_backup_retention_period = 1


### PR DESCRIPTION
We are currently using `cache.t4g.medium` for the shared Redis in staging. This provides 3.09GB of memory.

Over the last weekend, we saw instances of the staging Redis run out of memory when batch jobs were running.  This only occurred in the staging environment.

Therefore changing the size to `cache.m6g.large`, which matches integration and gives 6.38GB of memory.

[Trello card](https://trello.com/c/CmEfJRuS)