### PR TITLE
Cluster-services Workspaces

### DIFF
--- a/terraform/deployments/tfc-configuration/cluster-services.tf
+++ b/terraform/deployments/tfc-configuration/cluster-services.tf
@@ -1,0 +1,39 @@
+module "cluster-services-integration" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.9.0"
+
+  organization      = var.organization
+  workspace_name    = "cluster-services-integration"
+  workspace_desc    = "The cluster-services module is responsible for the AWS resources which constitute the EKS cluster."
+  workspace_tags    = ["integration", "cluster-services", "eks", "aws"]
+  terraform_version = "1.5.2"
+  execution_mode    = "remote"
+  working_directory = "/terraform/deployments/cluster-services/"
+  trigger_patterns  = ["/terraform/deployments/cluster-services/**/*"]
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production" = "write",
+    "GOV.UK Production"     = "write"
+  }
+
+  tfvars = {
+    cluster_infrastructure_state_bucket = "govuk-terraform-integration"
+    govuk_environment                   = "integration"
+    github_read_write_team              = "alphagov:gov-uk"
+    argo_redis_ha                       = false
+    desired_ha_replicas                 = 1
+  }
+
+  # Variable Sets must already exist
+  variable_set_names = [
+    "aws-credentials-integration"
+  ]
+
+}


### PR DESCRIPTION
First pass at starting the Cluster services Workspaces.

Updated _tfc-configuration_ workspace **VCS branch** = `cluster-services-workspaces` to allow for new workspaces to  to be updated from this branch untill integration/staging/prod are ready. Change back to main after this PR has been merged. https://app.terraform.io/app/govuk/workspaces/tfc-configuration/settings/version-control

See #990 for state merge instructions

See also https://github.com/alphagov/govuk-infrastructure/pull/1030

https://trello.com/c/M4fXUvda/3340-update-the-govuk-infrastructure-project-to-use-workspacer-to-set-up-workspaces