### PR TITLE
Handle duplicate search results from GitHub in mirror-repos workflow.

### DIFF
--- a/.github/workflows/mirror-repos.yml
+++ b/.github/workflows/mirror-repos.yml
@@ -18,7 +18,7 @@ jobs:
       ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.1
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a  # v4.0.1
         with:
           role-to-assume: arn:aws:iam::900804735337:role/github_action_mirror_repos_role
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/mirror-repos.yml
+++ b/.github/workflows/mirror-repos.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          GITHUB_REPOS=$(gh search repos --owner alphagov --topic=govuk --archived=false --json=name -L 500 -q '. | map(.name) | join(" ")')
+          GITHUB_REPOS=$(gh search repos --owner alphagov --topic=govuk --archived=false --json=name -L 500 -q '[.[].name] | unique | join(" ")')
           echo "github-repos=${GITHUB_REPOS}" >> "$GITHUB_OUTPUT"
 
       - name: Sync repositories


### PR DESCRIPTION
`gh search repos` can apparently return duplicates. The script falls over when it encounters a given repo for a second time, because the `git clone` chokes on the preexisting directory.

Also pin the commit sha for `aws-actions/configure-aws-credentials`, since it's no more hassle now that we have Dependabot looking at action versions.

(I couldn't figure out how to test this before merge, cos it won't read the auth secret for `configure-aws-credentials` when I trigger it via workflow_dispatch.)