### PR TITLE
Minor fixes for mongodb image build.

### DIFF
--- a/images/mongodb/Dockerfile
+++ b/images/mongodb/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -SsfO "$mongo_url"; \
 
 WORKDIR /data/configdb
 WORKDIR /data/db
-RUN useradd -Ur mongodb -d /data; \
+RUN useradd -Ur mongodb -u 999 -d /data; \
     chown -R mongodb:mongodb /data;
 USER mongodb
 VOLUME /data/db /data/configdb

--- a/images/mongodb/Makefile
+++ b/images/mongodb/Makefile
@@ -5,4 +5,4 @@
 .PHONY: all image
 
 image:
-	docker build -t mongo:2.6 --platform linux/amd64 .
+	docker build -t mongodb:2.6 --platform linux/amd64 .


### PR DESCRIPTION
- Fix the tag name in the Makefile for local builds. (The real thing is built on GitHub and already uses the right tag.)
- Specify the (existing) uid explicitly rather than letting it be assigned the next available one (which in theory depends on the base image, though it's unlikely to change in practice).