### PR TITLE
Additional NAT Gateways for Licensify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile ~/.gitignore_global
 .terraform
-.vscode
 *.tfstate
 *.tfstate.backup
 *.lock.hcl

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile ~/.gitignore_global
 .terraform
+.vscode
 *.tfstate
 *.tfstate.backup
 *.lock.hcl

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -24,6 +24,11 @@ variable "eks_control_plane_subnets" {
   description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the public subnets for the EKS cluster's apiserver."
 }
 
+variable "eks_licensify_gateways" {
+  type        = map(object({ az = string, cidr = string, eip = string }))
+  description = "Map of {subnet_name: {az=<az>, cidr=<cidr>, eip=<eip>}} for the NAT Gateways needed for use by Licensify Traffic in the EKS cluster.."
+}
+
 variable "eks_private_subnets" {
   type        = map(object({ az = string, cidr = string }))
   description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the private subnets for the EKS cluster's nodes and pods."

--- a/terraform/deployments/cluster-infrastructure/vpc.tf
+++ b/terraform/deployments/cluster-infrastructure/vpc.tf
@@ -107,6 +107,15 @@ resource "aws_nat_gateway" "eks" {
   # TODO: depends_on = [aws_internet_gateway.gw] once we've imported the IGW from govuk-aws.
 }
 
+# Should be skipped on Integration
+resource "aws_nat_gateway" "eks_licensify" {
+  for_each      = var.eks_licensify_gateways
+  allocation_id = each.value.eip
+  subnet_id     = aws_subnet.eks_public[each.key].id
+  tags          = { Name = "${var.cluster_name}-eks-licensify-${each.key}" }
+  # TODO: depends_on = [aws_internet_gateway.gw] once we've imported the IGW from govuk-aws.
+}
+
 
 # Private subnets and associated resources. The private subnets contain the
 # worker nodes and the pods.

--- a/terraform/deployments/tfc-configuration/cluster-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/cluster-infrastructure.tf
@@ -33,6 +33,8 @@ module "cluster-infrastructure-integration" {
       b = { az = "eu-west-1b", cidr = "10.1.19.16/28" }
       c = { az = "eu-west-1c", cidr = "10.1.19.32/28" }
     }
+    # Intentionally empty in Integration
+    eks_licensify_gateways = {} 
     eks_public_subnets = {
       a = { az = "eu-west-1a", cidr = "10.1.20.0/24" }
       b = { az = "eu-west-1b", cidr = "10.1.21.0/24" }
@@ -91,6 +93,11 @@ module "cluster-infrastructure-staging" {
       b = { az = "eu-west-1b", cidr = "10.12.19.16/28" }
       c = { az = "eu-west-1c", cidr = "10.12.19.32/28" }
     }
+    eks_licensify_gateways = {
+      a = { az = "eu-west-1a", cidr = "10.12.20.0/24", eip = "eipalloc-0c15477b55906cc2c" }
+      b = { az = "eu-west-1b", cidr = "10.12.21.0/24", eip = "eipalloc-0a08b03e7bb1202df" }
+      c = { az = "eu-west-1c", cidr = "10.12.22.0/24", eip = "eipalloc-0eb4541bf8dc33dc6" }
+    }
     eks_public_subnets = {
       a = { az = "eu-west-1a", cidr = "10.12.20.0/24" }
       b = { az = "eu-west-1b", cidr = "10.12.21.0/24" }
@@ -140,6 +147,8 @@ module "cluster-infrastructure-production" {
       b = { az = "eu-west-1b", cidr = "10.13.19.16/28" }
       c = { az = "eu-west-1c", cidr = "10.13.19.32/28" }
     }
+    # TODO: Set up in Production when Ready.
+    eks_licensify_gateways = {} 
     eks_public_subnets = {
       a = { az = "eu-west-1a", cidr = "10.13.20.0/24" }
       b = { az = "eu-west-1b", cidr = "10.13.21.0/24" }

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -10,6 +10,8 @@ eks_control_plane_subnets = {
   c = { az = "eu-west-1c", cidr = "10.1.19.32/28" }
 }
 
+eks_licensify_gateways = {}
+
 eks_public_subnets = {
   a = { az = "eu-west-1a", cidr = "10.1.20.0/24" }
   b = { az = "eu-west-1b", cidr = "10.1.21.0/24" }

--- a/terraform/deployments/variables/production/common.tfvars
+++ b/terraform/deployments/variables/production/common.tfvars
@@ -10,6 +10,8 @@ eks_control_plane_subnets = {
   c = { az = "eu-west-1c", cidr = "10.13.19.32/28" }
 }
 
+eks_licensify_gateways = {}
+
 eks_public_subnets = {
   a = { az = "eu-west-1a", cidr = "10.13.20.0/24" }
   b = { az = "eu-west-1b", cidr = "10.13.21.0/24" }

--- a/terraform/deployments/variables/staging/common.tfvars
+++ b/terraform/deployments/variables/staging/common.tfvars
@@ -10,6 +10,12 @@ eks_control_plane_subnets = {
   c = { az = "eu-west-1c", cidr = "10.12.19.32/28" }
 }
 
+eks_licensify_gateways = {
+  a = { az = "eu-west-1a", cidr = "10.12.20.0/24", eip = "eipalloc-0c15477b55906cc2c" }
+  b = { az = "eu-west-1b", cidr = "10.12.21.0/24", eip = "eipalloc-0a08b03e7bb1202df" }
+  c = { az = "eu-west-1c", cidr = "10.12.22.0/24", eip = "eipalloc-0eb4541bf8dc33dc6" }
+}
+
 eks_public_subnets = {
   a = { az = "eu-west-1a", cidr = "10.12.20.0/24" }
   b = { az = "eu-west-1b", cidr = "10.12.21.0/24" }

--- a/terraform/deployments/variables/test/common.tfvars
+++ b/terraform/deployments/variables/test/common.tfvars
@@ -12,6 +12,8 @@ eks_control_plane_subnets = {
   c = { az = "eu-west-1c", cidr = "10.200.19.32/28" }
 }
 
+eks_licensify_gateways = {}
+
 eks_public_subnets = {
   a = { az = "eu-west-1a", cidr = "10.200.20.0/24" }
   b = { az = "eu-west-1b", cidr = "10.200.21.0/24" }


### PR DESCRIPTION
## What?
This creates a set of additional NAT Gateways (currently in Staging only) that we can attach the reserved Elastic IPs to allow the Licensing app to talk to Civica once it is live in EKS.

Routes will come once the Gateways have been created and EIPs attached.

## TF Plan
Here is the TF Plan Output: https://app.terraform.io/app/govuk/workspaces/cluster-infrastructure-staging/runs/run-BFjVWKZtuS6eg5uv