### PR TITLE
Route Staging EKS onto the new NAT Gateways

### DIFF
--- a/terraform/deployments/cluster-infrastructure/vpc.tf
+++ b/terraform/deployments/cluster-infrastructure/vpc.tf
@@ -49,7 +49,7 @@ resource "aws_route" "eks_control_plane_nat" {
   for_each               = var.eks_control_plane_subnets
   route_table_id         = aws_route_table.eks_control_plane[each.key].id
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.eks[each.key].id
+  nat_gateway_id         = aws_nat_gateway.eks_licensify[each.key].id
   timeouts {
     create = local.route_create_timeout
   }
@@ -149,6 +149,6 @@ resource "aws_route" "eks_private_nat" {
   for_each               = var.eks_private_subnets
   route_table_id         = aws_route_table.eks_private[each.key].id
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.eks[each.key].id
+  nat_gateway_id         = aws_nat_gateway.eks_licensify[each.key].id
   timeouts { create = local.route_create_timeout }
 }

--- a/terraform/deployments/tfc-configuration/cluster-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/cluster-infrastructure.tf
@@ -34,7 +34,7 @@ module "cluster-infrastructure-integration" {
       c = { az = "eu-west-1c", cidr = "10.1.19.32/28" }
     }
     # Intentionally empty in Integration
-    eks_licensify_gateways = {} 
+    eks_licensify_gateways = {}
     eks_public_subnets = {
       a = { az = "eu-west-1a", cidr = "10.1.20.0/24" }
       b = { az = "eu-west-1b", cidr = "10.1.21.0/24" }
@@ -148,7 +148,7 @@ module "cluster-infrastructure-production" {
       c = { az = "eu-west-1c", cidr = "10.13.19.32/28" }
     }
     # TODO: Set up in Production when Ready.
-    eks_licensify_gateways = {} 
+    eks_licensify_gateways = {}
     eks_public_subnets = {
       a = { az = "eu-west-1a", cidr = "10.13.20.0/24" }
       b = { az = "eu-west-1b", cidr = "10.13.21.0/24" }

--- a/terraform/deployments/variables/integration/common.tfvars
+++ b/terraform/deployments/variables/integration/common.tfvars
@@ -10,7 +10,11 @@ eks_control_plane_subnets = {
   c = { az = "eu-west-1c", cidr = "10.1.19.32/28" }
 }
 
-eks_licensify_gateways = {}
+eks_licensify_gateways = {
+  a = { az = "eu-west-1a", cidr = "10.1.20.0/24", eip = "eipalloc-089a8992b681613b0" }
+  b = { az = "eu-west-1b", cidr = "10.1.21.0/24", eip = "eipalloc-0ab1a007f974bd7a9" }
+  c = { az = "eu-west-1c", cidr = "10.1.22.0/24", eip = "eipalloc-079ae4b8dd0785851" }
+}
 
 eks_public_subnets = {
   a = { az = "eu-west-1a", cidr = "10.1.20.0/24" }

--- a/terraform/deployments/variables/production/common.tfvars
+++ b/terraform/deployments/variables/production/common.tfvars
@@ -10,7 +10,11 @@ eks_control_plane_subnets = {
   c = { az = "eu-west-1c", cidr = "10.13.19.32/28" }
 }
 
-eks_licensify_gateways = {}
+eks_licensify_gateways = {
+  b = { az = "eu-west-1b", cidr = "10.13.21.0/24", eip = "eipalloc-0d5465010fda7ba1d" }
+  a = { az = "eu-west-1a", cidr = "10.13.20.0/24", eip = "eipalloc-054c895a7e019c1f3" }
+  c = { az = "eu-west-1c", cidr = "10.13.22.0/24", eip = "eipalloc-083611260a167ea49" }
+}
 
 eks_public_subnets = {
   a = { az = "eu-west-1a", cidr = "10.13.20.0/24" }

--- a/terraform/deployments/variables/production/common.tfvars
+++ b/terraform/deployments/variables/production/common.tfvars
@@ -11,8 +11,8 @@ eks_control_plane_subnets = {
 }
 
 eks_licensify_gateways = {
-  b = { az = "eu-west-1b", cidr = "10.13.21.0/24", eip = "eipalloc-0d5465010fda7ba1d" }
   a = { az = "eu-west-1a", cidr = "10.13.20.0/24", eip = "eipalloc-054c895a7e019c1f3" }
+  b = { az = "eu-west-1b", cidr = "10.13.21.0/24", eip = "eipalloc-0d5465010fda7ba1d" }
   c = { az = "eu-west-1c", cidr = "10.13.22.0/24", eip = "eipalloc-083611260a167ea49" }
 }
 


### PR DESCRIPTION
## What?
As setting up a route specifically for Civica (for Licensify) would be too cumbersome, it might just be easier to route all of our traffic immediately through the new NAT Gateways. So let's give that a try!

## TF Output
...can be viewed here (if you have permission):  
https://app.terraform.io/app/govuk/workspaces/cluster-infrastructure-staging/runs/run-kxHrtVBKALuKHihc