### PR TITLE
Workflow users can provide additional image tags

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -18,6 +18,9 @@ on:
         required: false
         type: string
         default: ${{ github.sha }}
+      additionalImageTags:
+        required: false
+        type: string
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -60,6 +63,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecrRepositoryName }}
           INPUT_REF: ${{ inputs.gitRef }}
+          ADDITIONAL_IMAGE_TAGS: ${{ inputs.additionalImageTags }}
         run: |
           LOCAL_HEAD_SHA="$(git rev-parse HEAD)"
           REMOTE_HEAD_SHA=$(git ls-remote origin HEAD | cut -f 1)
@@ -78,6 +82,13 @@ jobs:
             FULL_IMAGE_TAG_LIST+=("${ECR_REGISTRY}/${ECR_REPOSITORY}:latest")
           else
             echo "Local commit is different to the repository HEAD so skipping the latest tag (local: ${LOCAL_HEAD_SHA} remote: ${REMOTE_HEAD_SHA})"
+          fi
+
+          if [ -n "${ADDITIONAL_IMAGE_TAGS}" ]; then
+            arr=("${ADDITIONAL_IMAGE_TAGS}")
+            for tag in ${arr[@]}; do
+              FULL_IMAGE_TAG_LIST+=("${ECR_REGISTRY}/${ECR_REPOSITORY}:${tag}")
+            done
           fi
 
           echo "imageTag=${IMAGE_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
https://trello.com/c/jDSDGNyn/814-measure-and-record-our-publishing-latency-sli

It takes a space-separated string.

This change is motivated by a desire to deploy separate images to each environment but for a non-app project (i.e. doesn't use Argo workflows or `image-tags`).

We only need a single additional image tag on our specific project, but to me, the future proofness of this option felt like it outweighed the additional complexity.

(I've tested this with an empty value, a single tag and multiple tags, and it's shown up with/without them as expected in ECR for all of them.)