### PR TITLE
NAT Gateway New IPs - Security Group Fix

### DIFF
--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -125,3 +125,7 @@ output "clamav_db_efs_id" {
 output "public_nat_gateway_ips" {
   value = [for eip in aws_eip.eks_nat : eip.public_ip]
 }
+
+output "public_licensify_gateway_ips" {
+  value = [for eip in aws_eip.eks_licensify : eip.public_ip]
+}

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -127,5 +127,5 @@ output "public_nat_gateway_ips" {
 }
 
 output "public_licensify_gateway_ips" {
-  value = [for eip in aws_eip.eks_licensify : eip.public_ip]
+  value = [for eip in data.aws_eip.eks_licensify : eip.public_ip]
 }

--- a/terraform/deployments/cluster-infrastructure/vpc.tf
+++ b/terraform/deployments/cluster-infrastructure/vpc.tf
@@ -107,6 +107,11 @@ resource "aws_nat_gateway" "eks" {
   # TODO: depends_on = [aws_internet_gateway.gw] once we've imported the IGW from govuk-aws.
 }
 
+data "aws_eip" "eks_licensify" {
+  for_each = var.eks_licensify_gateways
+  id       = each.value.eip
+}
+
 # Should be skipped on Integration
 resource "aws_nat_gateway" "eks_licensify" {
   for_each      = var.eks_licensify_gateways

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -202,7 +202,7 @@ resource "aws_security_group_rule" "eks_ingress_www_origin_from_eks_nat" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = formatlist("%s/32", data.terraform_remote_state.cluster_infrastructure.outputs.public_nat_gateway_ips)
+  cidr_blocks       = formatlist("%s/32", merge(data.terraform_remote_state.cluster_infrastructure.outputs.public_nat_gateway_ips, data.terraform_remote_state.cluster_infrastructure.outputs.public_licensify_gateway_ips))
   security_group_id = aws_security_group.eks_ingress_www_origin.id
 }
 


### PR DESCRIPTION
## What?
When we added new Gateways and changed the Route tables, the new IPs weren't added to some existing SG rules - this is now causing some issues in Staging.

## How?
By adding the EIP Associations to a Data Resource, we can merge it into the allowed list of IPs.