### PR TITLE
Fix SNYK security analysis workflow

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -17,7 +17,7 @@ jobs:
           snyk auth ${{ secrets.SNYK_TOKEN }}
           snyk code test --json --severity-threshold=high >> snyk-sast.json
       - name: Archive SAST results
-        uses: actions/upload-artifacts@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snyk-sast-file
           path: snyk-sast.json
@@ -35,7 +35,7 @@ jobs:
           snyk auth ${{ secrets.SNYK_TOKEN }}
           snyk test --json --severity-threshold=high >> snyk-sca.json
       - name: Archive SCA results
-        uses: actions/upload-artifacts@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snyk-sca-file
           path: snyk-sca.json

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -13,10 +13,8 @@ jobs:
       - uses: snyk/actions/setup@master
       - name: Snyk Code Test
         continue-on-error: true
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
-          snyk auth ${{SNYK_TOKEN}}
+          snyk auth ${{ secrets.SNYK_TOKEN }}
           snyk code test --json --severity-threshold=high >> snyk-sast.json
       - name: Archive SAST results
         uses: actions/upload-artifacts@v3
@@ -33,10 +31,8 @@ jobs:
       - uses: snyk/actions/setup@master
       - name: Snyk Supply Chain Test
         continue-on-error: true
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
-          snyk auth ${{SNYK_TOKEN}}
+          snyk auth ${{ secrets.SNYK_TOKEN }}
           snyk test --json --severity-threshold=high >> snyk-sca.json
       - name: Archive SCA results
         uses: actions/upload-artifacts@v3


### PR DESCRIPTION
Environment variables set in an env context defined at the workflow level in the caller workflow are not propagated to the called workflow. However we can use secrets instead.

More details:
- https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#limitations
- https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

Fixes `Unable to resolve action actions/upload-artifacts, repository not found` [error](https://github.com/alphagov/seal/actions/runs/7288889890) and updates the workflow to use the latest version

Tested: https://github.com/alphagov/seal/actions/runs/7288889890

[Trello card](https://trello.com/c/RPICx1Qm/3366-add-snyk-sast-and-sca-scans-to-all-govuk-repos-2)