### PR TITLE
Use tfe_outputs for govuk-publishing-infrastucture

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/app_assets_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/app_assets_s3.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "app_assets" {
     sid = "EKSNodesCanList"
     principals {
       type        = "AWS"
-      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+      identifiers = [data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_arn]
     }
     actions   = ["s3:ListBucket"]
     resources = [aws_s3_bucket.app_assets.arn]
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "app_assets" {
     sid = "EKSNodesCanWrite"
     principals {
       type        = "AWS"
-      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+      identifiers = [data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_arn]
     }
     actions   = ["s3:GetObject", "s3:PutObject"]
     resources = ["${aws_s3_bucket.app_assets.arn}/*"]

--- a/terraform/deployments/govuk-publishing-infrastructure/asset_manager_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/asset_manager_s3.tf
@@ -29,6 +29,6 @@ resource "aws_iam_policy" "asset_manager_s3" {
 }
 
 resource "aws_iam_role_policy_attachment" "asset_manager_s3" {
-  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  role       = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_name
   policy_arn = aws_iam_policy.asset_manager_s3.arn
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/content_publisher_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/content_publisher_s3.tf
@@ -30,6 +30,6 @@ resource "aws_iam_policy" "content_publisher_s3" {
 
 # TODO: consider IRSA (pod identity) rather than granting to nodes.
 resource "aws_iam_role_policy_attachment" "content_publisher_s3" {
-  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  role       = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_name
   policy_arn = aws_iam_policy.content_publisher_s3.arn
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/csvs_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/csvs_s3.tf
@@ -42,6 +42,6 @@ resource "aws_iam_policy" "write_csvs_buckets" {
 
 # TODO: consider IRSA (pod identity) rather than granting to nodes.
 resource "aws_iam_role_policy_attachment" "write_csvs_buckets" {
-  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  role       = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_name
   policy_arn = aws_iam_policy.write_csvs_buckets.arn
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/db_backup_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/db_backup_s3.tf
@@ -11,14 +11,14 @@ module "db_backup_iam_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.20"
 
-  role_name            = "${local.db_backup_service_account_name}-${data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id}"
+  role_name            = "${local.db_backup_service_account_name}-${data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id}"
   role_description     = "Role for database backup jobs. Corresponds to ${local.db_backup_service_account_name} k8s ServiceAccount."
   max_session_duration = 28800
 
   role_policy_arns = { policy = aws_iam_policy.db_backup_s3.arn }
   oidc_providers = {
     main = {
-      provider_arn               = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_oidc_provider_arn
+      provider_arn               = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_oidc_provider_arn
       namespace_service_accounts = ["apps:${local.db_backup_service_account_name}"]
     }
   }

--- a/terraform/deployments/govuk-publishing-infrastructure/locations_api_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/locations_api_s3.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "location_api_import_csvs" {
     sid = "EKSNodesCanList"
     principals {
       type        = "AWS"
-      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+      identifiers = [data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_arn]
     }
     actions   = ["s3:ListBucket"]
     resources = [aws_s3_bucket.location_api_import_csvs.arn]
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "location_api_import_csvs" {
     sid = "EKSNodesCanWrite"
     principals {
       type        = "AWS"
-      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+      identifiers = [data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_arn]
     }
     actions   = ["s3:GetObject", "s3:PutObject"]
     resources = ["${aws_s3_bucket.location_api_import_csvs.arn}/*"]

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -15,6 +15,10 @@ terraform {
       source  = "fastly/fastly"
       version = "~> 2.1"
     }
+    tfe = {
+      source = "hashicorp/tfe"
+      version = "0.51.1"
+    }
   }
 }
 
@@ -45,6 +49,10 @@ provider "random" {}
 # an API key is needed but 'fake' seems to work.
 provider "fastly" {
   api_key = "fake"
+}
+
+# This will use credentials provided by `terraform login`
+provider "tfe" {
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -16,7 +16,7 @@ terraform {
       version = "~> 2.1"
     }
     tfe = {
-      source = "hashicorp/tfe"
+      source  = "hashicorp/tfe"
       version = "0.51.1"
     }
   }

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -19,10 +19,10 @@ terraform {
 }
 
 locals {
-  cluster_name         = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id
+  cluster_name         = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id
   vpc_id               = data.terraform_remote_state.infra_networking.outputs.vpc_id
   internal_dns_zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
-  external_dns_zone_id = data.terraform_remote_state.cluster_infrastructure.outputs.external_dns_zone_id
+  external_dns_zone_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.external_dns_zone_id
   elasticache_subnets  = data.terraform_remote_state.infra_networking.outputs.private_subnet_elasticache_ids
 
   default_tags = {

--- a/terraform/deployments/govuk-publishing-infrastructure/publishing_api_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/publishing_api_s3.tf
@@ -31,6 +31,6 @@ resource "aws_iam_policy" "publishing_api_s3" {
 
 # TODO: consider IRSA (pod identity) rather than granting to nodes.
 resource "aws_iam_role_policy_attachment" "publishing_api_s3" {
-  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  role       = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_name
   policy_arn = aws_iam_policy.publishing_api_s3.arn
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -12,7 +12,7 @@ data "aws_region" "current" {}
 
 data "tfe_outputs" "cluster_infrastructure" {
   organization = "govuk"
-  workspace = "cluster-infrastructure-${var.govuk_environment}"
+  workspace    = "cluster-infrastructure-${var.govuk_environment}"
 }
 
 data "terraform_remote_state" "infra_assets" {

--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -1,13 +1,18 @@
 data "aws_region" "current" {}
 
-data "terraform_remote_state" "cluster_infrastructure" {
-  backend   = "s3"
-  workspace = terraform.workspace
-  config = {
-    bucket = var.cluster_infrastructure_state_bucket
-    key    = "projects/cluster-infrastructure.tfstate"
-    region = data.aws_region.current.name
-  }
+# data "terraform_remote_state" "cluster_infrastructure" {
+#   backend   = "s3"
+#   workspace = terraform.workspace
+#   config = {
+#     bucket = var.cluster_infrastructure_state_bucket
+#     key    = "projects/cluster-infrastructure.tfstate"
+#     region = data.aws_region.current.name
+#   }
+# }
+
+data "tfe_outputs" "cluster_infrastructure" {
+  organization = "govuk"
+  workspace = "cluster-infrastructure-${var.govuk_environment}"
 }
 
 data "terraform_remote_state" "infra_assets" {

--- a/terraform/deployments/govuk-publishing-infrastructure/search_analytics_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_analytics_s3.tf
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "search_analytics" {
     sid = "EKSNodesCanList"
     principals {
       type        = "AWS"
-      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+      identifiers = [data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_arn]
     }
     actions   = ["s3:ListBucket"]
     resources = [aws_s3_bucket.search_analytics.arn]
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "search_analytics" {
     sid = "EKSNodesCanReadAndWrite"
     principals {
       type        = "AWS"
-      identifiers = [data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_arn]
+      identifiers = [data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_arn]
     }
     actions   = ["s3:GetObject", "s3:PutObject"]
     resources = ["${aws_s3_bucket.search_analytics.arn}/*"]

--- a/terraform/deployments/govuk-publishing-infrastructure/search_api_learn_to_rank_role.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_api_learn_to_rank_role.tf
@@ -6,12 +6,12 @@ module "learn_to_rank_job_iam_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.20"
 
-  role_name        = "${local.learn_to_rank_service_account_name}-${data.terraform_remote_state.cluster_infrastructure.outputs.cluster_id}"
+  role_name        = "${local.learn_to_rank_service_account_name}-${data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id}"
   role_description = "Role for the Search API Learn to rank job. Corresponds to ${local.learn_to_rank_service_account_name} k8s ServiceAccount."
 
   oidc_providers = {
     main = {
-      provider_arn               = data.terraform_remote_state.cluster_infrastructure.outputs.cluster_oidc_provider_arn
+      provider_arn               = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_oidc_provider_arn
       namespace_service_accounts = ["apps:${local.learn_to_rank_service_account_name}"]
     }
   }

--- a/terraform/deployments/govuk-publishing-infrastructure/search_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_iam.tf
@@ -2,16 +2,16 @@
 # Accounts aka pod identity) to grant access specifically to Search.
 
 resource "aws_iam_role_policy_attachment" "search_relevancy_s3_eks_policy_attachment" {
-  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  role       = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_name
   policy_arn = data.terraform_remote_state.app_search.outputs.search_relevancy_s3_policy_arn
 }
 
 resource "aws_iam_role_policy_attachment" "sitemaps_s3_eks_policy_attachment" {
-  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  role       = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_name
   policy_arn = data.terraform_remote_state.app_search.outputs.sitemaps_s3_policy_arn
 }
 
 resource "aws_iam_role_policy_attachment" "search_api_sagemaker_attachment" {
-  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  role       = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_name
   policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/govuk-${var.govuk_environment}-search-use-sagemaker-policy"
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "shared_redis_cluster_from_any" {
   to_port                  = 6379
   protocol                 = "tcp"
   security_group_id        = aws_security_group.shared_redis_cluster.id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 #
@@ -58,7 +58,7 @@ resource "aws_security_group_rule" "frontend_memcached_from_eks_workers" {
   to_port                  = 11211
   protocol                 = "tcp"
   security_group_id        = aws_security_group.frontend_memcached.id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 #
@@ -72,7 +72,7 @@ resource "aws_security_group_rule" "mongodb_from_eks_workers" {
   to_port                  = 27017
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_mongo_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 resource "aws_security_group_rule" "router_mongodb_from_eks_workers" {
@@ -82,7 +82,7 @@ resource "aws_security_group_rule" "router_mongodb_from_eks_workers" {
   to_port                  = 27017
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_router-backend_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 resource "aws_security_group_rule" "rabbitmq_from_eks_workers" {
@@ -92,7 +92,7 @@ resource "aws_security_group_rule" "rabbitmq_from_eks_workers" {
   to_port                  = 5672 # AMQP 0-9-1
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_rabbitmq_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 resource "aws_security_group_rule" "shared_docdb_from_eks_workers" {
@@ -102,7 +102,7 @@ resource "aws_security_group_rule" "shared_docdb_from_eks_workers" {
   to_port                  = 27017
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_shared_documentdb_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 resource "aws_security_group_rule" "licensify_docdb_from_eks_workers" {
@@ -112,7 +112,7 @@ resource "aws_security_group_rule" "licensify_docdb_from_eks_workers" {
   to_port                  = 27017
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_licensify_documentdb_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 resource "aws_security_group_rule" "postgres_from_eks_workers" {
@@ -127,7 +127,7 @@ resource "aws_security_group_rule" "postgres_from_eks_workers" {
   to_port                  = 5432
   protocol                 = "tcp"
   security_group_id        = each.value
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 resource "aws_security_group_rule" "mysql_from_eks_workers" {
@@ -138,7 +138,7 @@ resource "aws_security_group_rule" "mysql_from_eks_workers" {
   to_port                  = 3306
   protocol                 = "tcp"
   security_group_id        = each.value
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 resource "aws_security_group_rule" "elasticsearch_from_eks_workers" {
@@ -148,7 +148,7 @@ resource "aws_security_group_rule" "elasticsearch_from_eks_workers" {
   to_port                  = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_elasticsearch6_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 resource "aws_security_group_rule" "efs_from_eks_workers" {
@@ -158,7 +158,7 @@ resource "aws_security_group_rule" "efs_from_eks_workers" {
   to_port                  = 2049
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_asset-master-efs_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 resource "aws_security_group_rule" "licensify_frontend_from_eks_workers" {
@@ -168,7 +168,7 @@ resource "aws_security_group_rule" "licensify_frontend_from_eks_workers" {
   to_port                  = 443
   protocol                 = "tcp"
   security_group_id        = data.terraform_remote_state.infra_security_groups.outputs.sg_licensify-frontend_internal_lb_id
-  source_security_group_id = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
 #
@@ -202,7 +202,19 @@ resource "aws_security_group_rule" "eks_ingress_www_origin_from_eks_nat" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = formatlist("%s/32", merge(data.terraform_remote_state.cluster_infrastructure.outputs.public_nat_gateway_ips, data.terraform_remote_state.cluster_infrastructure.outputs.public_licensify_gateway_ips))
+  cidr_blocks       = formatlist("%s/32", data.tfe_outputs.cluster_infrastructure.nonsensitive_values.public_nat_gateway_ips)
+  security_group_id = aws_security_group.eks_ingress_www_origin.id
+}
+
+resource "aws_security_group_rule" "eks_ingress_www_origin_from_eks_licensify_nat" {
+  count = length(data.tfe_outputs.cluster_infrastructure.nonsensitive_values.public_licensify_gateway_ips) > 0 ? 1 : 0
+
+  description       = "EKS ingress www-origin accepts requests from EKS Licensing NAT gateways"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = formatlist("%s/32", data.tfe_outputs.cluster_infrastructure.nonsensitive_values.public_licensify_gateway_ips)
   security_group_id = aws_security_group.eks_ingress_www_origin.id
 }
 
@@ -243,6 +255,6 @@ resource "aws_security_group_rule" "eks_workers_from_eks_ingress_www_origin" {
   from_port                = 0
   to_port                  = 65535
   protocol                 = "tcp"
-  security_group_id        = data.terraform_remote_state.cluster_infrastructure.outputs.node_security_group_id
+  security_group_id        = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
   source_security_group_id = aws_security_group.eks_ingress_www_origin.id
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/transition_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/transition_s3.tf
@@ -20,6 +20,6 @@ resource "aws_iam_policy" "transition_s3" {
 
 # TODO: consider IRSA (pod identity) rather than granting to nodes.
 resource "aws_iam_role_policy_attachment" "transition_s3" {
-  role       = data.terraform_remote_state.cluster_infrastructure.outputs.worker_iam_role_name
+  role       = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_name
   policy_arn = aws_iam_policy.transition_s3.arn
 }


### PR DESCRIPTION
## What?
The cluster-infrastructure Terraform has been migrated to TF Cloud (TF Enterprise), which also manages its state.

This means that anything else not yet in Terraform Cloud needs to be pointed to the location of the new backend state. Such as the govuk-publishing-infra TF.