### PR TITLE
Add Sentry project for `govuk-sli-collector`

### DIFF
--- a/terraform/deployments/sentry/locals.tf
+++ b/terraform/deployments/sentry/locals.tf
@@ -26,6 +26,7 @@ locals {
     "frontend"                 = ["govuk-find-and-view"],
     "government-frontend"      = ["govuk-find-and-view"],
     "govspeak-preview"         = ["govuk-publishing-platform"],
+    "govuk-sli-collector"      = ["govuk-publishing-platform"],
     "hmrc-manuals-api"         = ["govuk-publishing-platform"],
     "imminence"                = ["govuk-content-interactions-on-platform", "govuk-find-and-view"],
     "info-frontend"            = ["govuk-find-and-view"],


### PR DESCRIPTION
I wasn't aware that this existed and I'm still not sure what it's going to do. But I noticed that other projects are here and assume that this should be, too.

I've actually already created the project in Sentry*. After seeing this, I renamed it to start with "app-", though I don't know if that'll help or hinder.

*https://govuk.sentry.io/settings/projects/app-govuk-sli-collector/