### PR TITLE
WIP: Add branch protection to 'main'

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -111,6 +111,28 @@ resource "github_team_repository" "govuk_repos" {
   permission = "push"
 }
 
+resource "github_branch_protection" "govuk_repos" {
+  for_each       = { for repo in local.auto_configurable_repos : repo.name => repo }
+  repository_id  = each.value.name
+  pattern        = "main"
+  enforce_admins = true
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  # TODO: handle differing status check requirements
+  required_status_checks {
+    contexts = [
+      "Lint SCSS / Run Stylelint",
+      "Security Analysis / Run Brakeman",
+      "Lint Ruby / Run RuboCop",
+      "Lint JavaScript / Run Standardx",
+      "Test JavaScript / Run Jasmine",
+      "Test Ruby / Run RSpec"
+    ]
+  }
+}
+
 #
 # Only the list of repositories which will have access to a secret is created/modified
 # here, the secret should have been created in the GitHub UI in advance by a


### PR DESCRIPTION
WIP: automatically mark each of the "CI" workflow jobs as "required". Comes with complexities around inconsistent jobs and names across different repositories.

Alternatively, we could explore other approaches, such as automatically triggering [a workflow that reports on the overall outcome of the 'CI' workflow](https://github.com/ChrisBAshton/ci-checker/pull/1) - we could then simply mark this 'meta' workflow as "required". But this comes with its own complexities (exporting the triggering commit sha from the CI workflow, passing it to the meta workflow, and then having the meta workflow use the GitHub API to create a status check associated with that sha).

Trello: https://trello.com/c/mojlsebq/3074-kill-off-govuk-saas-config