### PR TITLE
Change Licensify ECR Registries to Kebab-Case

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -51,11 +51,11 @@ locals {
     "govuk-terraform",
     "search-api-learn-to-rank",
     "content-store-postgresql-branch",
-    "licensify/admin",
-    "licensify/backend",
-    "licensify/dummyservices",
-    "licensify/feed",
-    "licensify/frontend",
+    "licensify-admin",
+    "licensify-backend",
+    "licensify-dummyservices",
+    "licensify-feed",
+    "licensify-frontend",
   ]
 }
 


### PR DESCRIPTION
## What?
This switches the Licensify Service ECR Registry names from Slash/Case to Kebab-Case to be more consistent with the other GOV.UK Apps and Services being deployed by Argo.