### PR TITLE
Fix path to init script for clamav Dockerfile

### DIFF
--- a/images/clamav/Dockerfile
+++ b/images/clamav/Dockerfile
@@ -1,6 +1,6 @@
 FROM clamav/clamav-debian:1.2
 
-COPY "./scripts/unprivileged-entrypoint.sh" "/unpriv-init"
+COPY "./images/clamav/scripts/unprivileged-entrypoint.sh" "/unpriv-init"
 
 RUN chown -R clamav:clamav /var/lib/clamav
 RUN chown -R clamav:clamav /unpriv-init


### PR DESCRIPTION
This needs to relative to the top level directory, as thats where GitHub Actions runs the docker build command from.