### PR TITLE
Update clamav config to write logs to stdout

### DIFF
--- a/images/clamav/Dockerfile
+++ b/images/clamav/Dockerfile
@@ -2,6 +2,10 @@ FROM clamav/clamav-debian:1.2
 
 COPY "./images/clamav/scripts/unprivileged-entrypoint.sh" "/unpriv-init"
 
+RUN sed -i 's/^LogFile .*/LogFile \/dev\/stdout/' /etc/clamav/clamd.conf && \
+    sed -i 's/^LogFile .*/LogFile \/dev\/stdout/' /etc/clamav/clamav-milter.conf && \
+    sed -i 's/^UpdateLogFile .*/UpdateLogFile \/dev\/stdout/' /etc/clamav/freshclam.conf
+
 RUN chown -R clamav:clamav /var/lib/clamav
 RUN chown -R clamav:clamav /unpriv-init
 


### PR DESCRIPTION
This adds a step to the Dockerfile that changes the config file of clamav to write logs to stdout.

Tested.