### PR TITLE
Enable audit mode for PSS `restricted` profile.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -31,9 +31,9 @@ resource "kubernetes_namespace" "apps" {
       "app.kubernetes.io/managed-by" = "Terraform"
       # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/
       "elbv2.k8s.aws/pod-readiness-gate-inject" = "enabled"
-      "pod-security.kubernetes.io/audit"        = "baseline"
+      "pod-security.kubernetes.io/audit"        = "restricted"
       "pod-security.kubernetes.io/enforce"      = "baseline"
-      "pod-security.kubernetes.io/warn"         = "baseline"
+      "pod-security.kubernetes.io/warn"         = "restricted"
     }
   }
 }


### PR DESCRIPTION
For the integration and staging cluster, this just updates Terraform to reflect the already-running config.

For production, we're enabling audit + user-facing warnings for pods that wouldn't be admitted under the `restricted` profile.

We're not enforcing `restricted` anywhere yet.