### PR TITLE
Update Argo CD from 2.9.2 to 2.9.4.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -44,7 +44,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.51.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.53.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     global = {
       logging = {


### PR DESCRIPTION
This addresses [GHSA-92mw-q256-5vwg].

[Release notes](https://github.com/argoproj/argo-cd/releases/tag/v2.9.4).

[GHSA-92mw-q256-5vwg]: https://github.com/argoproj/argo-cd/security/advisories/GHSA-92mw-q256-5vwg

Tested: applied in staging.