### PR TITLE
Update Argo CD from 2.9.4 to 2.9.5.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -44,7 +44,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "5.53.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "5.53.6" # TODO: Dependabot or equivalent so this doesn't get neglected.
   values = [yamlencode({
     global = {
       logging = {


### PR DESCRIPTION
This patch releases fixes the MIME type issues that prevented mutating actions from working in the web UI.