### PR TITLE
Fix joining sets for users and licensingusers for aws_auth

### DIFF
--- a/terraform/deployments/cluster-services/aws_auth_configmap.tf
+++ b/terraform/deployments/cluster-services/aws_auth_configmap.tf
@@ -41,7 +41,7 @@ locals {
   ]
 
   readonly_configmap_roles = [
-    for arn in concat(data.aws_iam_roles.user.arns, data.aws_iam_roles.licensinguser.arns) : {
+    for arn in setunion(data.aws_iam_roles.user.arns, data.aws_iam_roles.licensinguser.arns) : {
       rolearn  = arn
       username = regex("/(.*-user)$", arn)[0]
       groups   = ["readonly"]

--- a/terraform/deployments/cluster-services/aws_auth_configmap.tf
+++ b/terraform/deployments/cluster-services/aws_auth_configmap.tf
@@ -43,7 +43,7 @@ locals {
   readonly_configmap_roles = [
     for arn in setunion(data.aws_iam_roles.user.arns, data.aws_iam_roles.licensinguser.arns) : {
       rolearn  = arn
-      username = regex("/(.*-user)$", arn)[0]
+      username = regex("/(.*-(user|licensinguser))$", arn)[0]
       groups   = ["readonly"]
     }
   ]


### PR DESCRIPTION
The arns are sets of strings, not lists so cannot use the concat method.