### PR TITLE
Log Snyk findings to stdout

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -15,12 +15,7 @@ jobs:
         continue-on-error: true
         run: |
           snyk auth ${{ secrets.SNYK_TOKEN }}
-          snyk code test --json --severity-threshold=high >> snyk-sast.json
-      - name: Archive SAST results
-        uses: actions/upload-artifact@v4
-        with:
-          name: snyk-sast-file
-          path: snyk-sast.json
+          snyk code test --severity-threshold=high
 
   sca:
     permissions:
@@ -33,9 +28,4 @@ jobs:
         continue-on-error: true
         run: |
           snyk auth ${{ secrets.SNYK_TOKEN }}
-          snyk test --json --severity-threshold=high >> snyk-sca.json
-      - name: Archive SCA results
-        uses: actions/upload-artifact@v4
-        with:
-          name: snyk-sca-file
-          path: snyk-sca.json
+          snyk test --severity-threshold=high


### PR DESCRIPTION
Previously we were saving the results to a JSON file and archiving this as a build artefact.

Snyk returns error code 0 if the scan was successful but found no issues. It returns error code 1 if the scan *was successful* but issues were found. This combined with the lack of log output is surprising, and makes it seem like the build failed when it actually succeeded.

As we're not currently using the JSON output anywhere, we can just stop generating it and log the results instead.

Trello: https://trello.com/c/g4Ab1WDT/3393-investigate-snyk-not-scanning-files