### PR TITLE
Remove unused ECR repos

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -66,10 +66,7 @@ locals {
     "statsd",
     "govuk-terraform",
     "search-api-learn-to-rank",
-    "content-store-postgresql-branch",
     "licensify-admin",
-    "licensify-backend",
-    "licensify-dummyservices",
     "licensify-feed",
     "licensify-frontend",
   ]


### PR DESCRIPTION
We don't deploy or use these images anymore.