### PR TITLE
Add back licensify-backend ECR repo

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -66,7 +66,7 @@ locals {
     "statsd",
     "govuk-terraform",
     "search-api-learn-to-rank",
-    "licensify-admin",
+    "licensify-backend",
     "licensify-feed",
     "licensify-frontend",
   ]


### PR DESCRIPTION
Whoops, removed wrong repo - we need this one, not licensify-admin.