### PR TITLE
Make GitHub CI user token available to Dependabot

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -141,3 +141,8 @@ resource "github_actions_organization_secret_repositories" "argo_events_webhook_
   secret_name             = "GOVUK_ARGO_EVENTS_WEBHOOK_URL"
   selected_repository_ids = [for repo in local.deployable_repos : repo.repo_id]
 }
+
+resource "github_dependabot_organization_secret_repositories" "ci_user_github_api_token_dependabot" {
+  secret_name             = "GOVUK_CI_GITHUB_API_TOKEN"
+  selected_repository_ids = [for repo in local.deployable_repos : repo.repo_id]
+}


### PR DESCRIPTION
As of version 4 of [`delete-artifact`](https://github.com/GeekyEggo/delete-artifact), a GitHub API token is required to remove artifacts, which we are doing as part of the CI pipeline.

This secret is included for access by GitHub Actions triggered events, but is not available to Dependabot.

Therefore this step fails on PRs raised by dependabot.

This makes the secret accessible to dependabot.

[Trello card](https://trello.com/c/ngFoCxYX)