### PR TITLE
Remove last Licensify EIP and NAT Gateway references

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -24,11 +24,6 @@ variable "eks_control_plane_subnets" {
   description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the public subnets for the EKS cluster's apiserver."
 }
 
-variable "eks_licensify_gateways" {
-  type        = map(object({ az = string, cidr = string, eip = string }))
-  description = "Map of {subnet_name: {az=<az>, cidr=<cidr>, eip=<eip>}} for the NAT Gateways needed for use by Licensify Traffic in the EKS cluster.."
-}
-
 variable "eks_private_subnets" {
   type        = map(object({ az = string, cidr = string }))
   description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the private subnets for the EKS cluster's nodes and pods."

--- a/terraform/deployments/cluster-infrastructure/vpc.tf
+++ b/terraform/deployments/cluster-infrastructure/vpc.tf
@@ -93,14 +93,14 @@ resource "aws_route" "public_internet_gateway" {
 }
 
 resource "aws_eip" "eks_nat" {
-  for_each = length(var.eks_licensify_gateways) == 0 ? var.eks_public_subnets : var.eks_licensify_gateways
+  for_each = var.eks_public_subnets
   domain   = "vpc"
   tags     = { Name = "${var.cluster_name}-eks-nat-${each.key}" }
   # TODO: depends_on = [aws_internet_gateway.gw] once we've imported the IGW from govuk-aws.
 }
 
 resource "aws_nat_gateway" "eks" {
-  for_each      = length(var.eks_licensify_gateways) == 0 ? var.eks_public_subnets : var.eks_licensify_gateways
+  for_each      = var.eks_public_subnets
   allocation_id = aws_eip.eks_nat[each.key].id
   subnet_id     = aws_subnet.eks_public[each.key].id
   tags          = { Name = "${var.cluster_name}-eks-${each.key}" }

--- a/terraform/deployments/cluster-infrastructure/vpc.tf
+++ b/terraform/deployments/cluster-infrastructure/vpc.tf
@@ -107,11 +107,6 @@ resource "aws_nat_gateway" "eks" {
   # TODO: depends_on = [aws_internet_gateway.gw] once we've imported the IGW from govuk-aws.
 }
 
-moved {
-  from = aws_nat_gateway.eks_licensify
-  to   = aws_nat_gateway.eks
-}
-
 # Private subnets and associated resources. The private subnets contain the
 # worker nodes and the pods.
 

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -187,14 +187,14 @@ resource "aws_security_group_rule" "eks_ingress_www_origin_from_eks_nat" {
 }
 
 resource "aws_security_group_rule" "eks_ingress_www_origin_from_eks_licensify_nat" {
-  count = length(data.tfe_outputs.cluster_infrastructure.nonsensitive_values.public_licensify_gateway_ips) > 0 ? 1 : 0
+  count = var.govuk_environment == "integration" ? 0 : 1
 
   description       = "EKS ingress www-origin accepts requests from EKS Licensing NAT gateways"
   type              = "ingress"
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = formatlist("%s/32", data.tfe_outputs.cluster_infrastructure.nonsensitive_values.public_licensify_gateway_ips)
+  cidr_blocks       = formatlist("%s/32", data.tfe_outputs.cluster_infrastructure.nonsensitive_values.public_nat_gateway_ips)
   security_group_id = aws_security_group.eks_ingress_www_origin.id
 }
 

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -15,8 +15,6 @@ module "variable-set-integration" {
       c = { az = "eu-west-1c", cidr = "10.1.19.32/28" }
     }
 
-    eks_licensify_gateways = {}
-
     eks_public_subnets = {
       a = { az = "eu-west-1a", cidr = "10.1.20.0/24" }
       b = { az = "eu-west-1b", cidr = "10.1.21.0/24" }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -15,12 +15,6 @@ module "variable-set-production" {
       c = { az = "eu-west-1c", cidr = "10.13.19.32/28" }
     }
 
-    eks_licensify_gateways = {
-      a = { az = "eu-west-1a", cidr = "10.13.20.0/24", eip = "eipalloc-054c895a7e019c1f3" }
-      b = { az = "eu-west-1b", cidr = "10.13.21.0/24", eip = "eipalloc-0d5465010fda7ba1d" }
-      c = { az = "eu-west-1c", cidr = "10.13.22.0/24", eip = "eipalloc-083611260a167ea49" }
-    }
-
     eks_public_subnets = {
       a = { az = "eu-west-1a", cidr = "10.13.20.0/24" }
       b = { az = "eu-west-1b", cidr = "10.13.21.0/24" }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -15,12 +15,6 @@ module "variable-set-staging" {
       c = { az = "eu-west-1c", cidr = "10.12.19.32/28" }
     }
 
-    eks_licensify_gateways = {
-      a = { az = "eu-west-1a", cidr = "10.12.20.0/24", eip = "eipalloc-0c15477b55906cc2c" }
-      b = { az = "eu-west-1b", cidr = "10.12.21.0/24", eip = "eipalloc-0a08b03e7bb1202df" }
-      c = { az = "eu-west-1c", cidr = "10.12.22.0/24", eip = "eipalloc-0eb4541bf8dc33dc6" }
-    }
-
     eks_public_subnets = {
       a = { az = "eu-west-1a", cidr = "10.12.20.0/24" }
       b = { az = "eu-west-1b", cidr = "10.12.21.0/24" }


### PR DESCRIPTION
These resources have been renamed to remove the licensify reference and now are managed as resources called:
- aws-eks-nats
- aws-eks-eips

