### PR TITLE
Add explicit permissions for image build workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -31,6 +31,7 @@ jobs:
       imageTag: ${{ steps.determine-image-tag.outputs.imageTag }}
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This is permission is need to allow the workflow to checkout the repository if being called from a private repository.

This change will require all calling workflows to pass the same permissions.