### PR TITLE
Fix image build cronjobs.

### DIFF
--- a/.github/workflows/build-clamav-image.yml
+++ b/.github/workflows/build-clamav-image.yml
@@ -1,4 +1,4 @@
-name: Build and publish clamav image to ECR
+name: Build and push ClamAV image to ECR
 
 on:
   workflow_dispatch:
@@ -16,7 +16,7 @@ on:
       - "images/clamav/**"
   
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: '19 2 * * 1'
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/build-clamav-image.yml
+++ b/.github/workflows/build-clamav-image.yml
@@ -25,3 +25,6 @@ jobs:
       gitRef: ${{ inputs.gitRef || github.ref }}
       ecrRepositoryName: clamav
       dockerfilePath: images/clamav/Dockerfile
+    permissions:
+      id-token: write
+      contents: read

--- a/.github/workflows/build-mongodb-image.yml
+++ b/.github/workflows/build-mongodb-image.yml
@@ -1,4 +1,4 @@
-name: Build and publish MongoDB image to ECR
+name: Build and push MongoDB image to ECR
 
 on:
   workflow_dispatch:
@@ -16,7 +16,7 @@ on:
       - images/mongodb/Dockerfile
   
   schedule:
-    - cron: '1 22 * * 1'
+    - cron: '28 3 * * 1'
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/build-mongodb-image.yml
+++ b/.github/workflows/build-mongodb-image.yml
@@ -25,3 +25,6 @@ jobs:
       gitRef: ${{ inputs.gitRef || github.ref }}
       ecrRepositoryName: mongodb
       dockerfilePath: images/mongodb/Dockerfile
+    permissions:
+      id-token: write
+      contents: read

--- a/.github/workflows/build-toolbox-image.yml
+++ b/.github/workflows/build-toolbox-image.yml
@@ -1,4 +1,4 @@
-name: Build and publish toolbox image to ECR
+name: Build and push toolbox image to ECR
 
 on:
   workflow_dispatch:
@@ -16,7 +16,7 @@ on:
       - "images/toolbox/Dockerfile"
   
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: '8 2 * * 1'
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/build-toolbox-image.yml
+++ b/.github/workflows/build-toolbox-image.yml
@@ -25,3 +25,6 @@ jobs:
       gitRef: ${{ inputs.gitRef || github.ref }}
       ecrRepositoryName: toolbox
       dockerfilePath: images/toolbox/Dockerfile
+    permissions:
+      id-token: write
+      contents: read


### PR DESCRIPTION
Update their permissions to work with the current version of the reusable build/push workflow.

Failures looked like: `Error calling workflow 'alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main'. The nested job 'build-and-push-image' is requesting 'id-token: write', but is only allowed 'id-token: none'.`

While we're there, spread out the cronjob timings and use the same terminology in the workflow names as the reusable workflow.

Test runs:
 - [toolbox](https://github.com/alphagov/govuk-infrastructure/actions/runs/7886451763)
 - [MongoDB](https://github.com/alphagov/govuk-infrastructure/actions/runs/7886453927)
 - [ClamAV](https://github.com/alphagov/govuk-infrastructure/actions/runs/7886442722)