### PR TITLE
Use main git branch for rds-staging

### DIFF
--- a/terraform/deployments/tfc-configuration/rds.tf
+++ b/terraform/deployments/tfc-configuration/rds.tf
@@ -47,7 +47,7 @@ module "rds-staging" {
   project_name = "govuk-infrastructure"
   vcs_repo = {
     identifier     = "alphagov/govuk-infrastructure"
-    branch         = "samsimpson1/rds"
+    branch         = "main"
     oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
   }
 


### PR DESCRIPTION
Plan: https://app.terraform.io/app/govuk/workspaces/rds-staging/runs/run-fGamMHYEac5zq7kB

Plan wants to create a load of cloudwatch metric alarms, these already exist but are all in 'Insufficient Data'. I'm going to delete the currently existing metric alarms before applying this

#1127 