### PR TITLE
Patch integration RDS instances on Sun instead of Mon.

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -39,6 +39,7 @@ module "variable-set-integration" {
     github_read_write_team = "alphagov:gov-uk"
 
     grafana_db_auto_pause       = true
+    maintenance_window          = "Sun:04:00-Sun:06:00"
     rds_apply_immediately       = true
     rds_backup_retention_period = 1
     rds_skip_final_snapshot     = true


### PR DESCRIPTION
This avoids aborting the [nightly Whitehall restore](https://github.com/alphagov/govuk-helm-charts/blob/d040f2b/charts/db-backup/values.yaml#L739) ("data sync") on Monday mornings when there's an RDS patch.

See also https://github.com/alphagov/govuk-helm-charts/pull/1849.