### PR TITLE
Add -content-data-siteimprove-sitemaps S3 access

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/csvs_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/csvs_s3.tf
@@ -8,6 +8,7 @@ data "aws_iam_policy_document" "write_csvs_buckets" {
     resources = [
       aws_s3_bucket.publisher_csvs.arn,
       "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-csvs",
+      "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-siteimprove-sitemaps",
       "arn:aws:s3:::govuk-${var.govuk_environment}-specialist-publisher-csvs",
       "arn:aws:s3:::govuk-${var.govuk_environment}-support-api-csvs",
       "arn:aws:s3:::govuk-${var.govuk_environment}-whitehall-csvs"
@@ -26,6 +27,7 @@ data "aws_iam_policy_document" "write_csvs_buckets" {
     resources = [
       "${aws_s3_bucket.publisher_csvs.arn}/*",
       "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-csvs/*",
+      "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-siteimprove-sitemaps",
       "arn:aws:s3:::govuk-${var.govuk_environment}-specialist-publisher-csvs/*",
       "arn:aws:s3:::govuk-${var.govuk_environment}-support-api-csvs/*",
       "arn:aws:s3:::govuk-${var.govuk_environment}-whitehall-csvs/*"

--- a/terraform/deployments/govuk-publishing-infrastructure/csvs_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/csvs_s3.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "write_csvs_buckets" {
     resources = [
       "${aws_s3_bucket.publisher_csvs.arn}/*",
       "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-csvs/*",
-      "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-siteimprove-sitemaps",
+      "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-siteimprove-sitemaps/*",
       "arn:aws:s3:::govuk-${var.govuk_environment}-specialist-publisher-csvs/*",
       "arn:aws:s3:::govuk-${var.govuk_environment}-support-api-csvs/*",
       "arn:aws:s3:::govuk-${var.govuk_environment}-whitehall-csvs/*"


### PR DESCRIPTION

Adds permissions for the -content-data-siteimprove-sitemaps S3 buckets so that content data admin can write selected sitemaps into them (https://github.com/alphagov/content-data-admin/pull/1368)

Added to the csvs_s3 file for the moment so that they're together with the other content-data permissions when these files get tidied up.