### PR TITLE
Remove tagging images with edge

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -62,8 +62,7 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }}
           tags: |
             type=raw,priority=500,value=${{ inputs.gitRef }},enable=${{ startsWith(inputs.gitRef, 'v') }}
-            type=edge,priority=300
-            type=sha,priority=100,enable=${{ !startsWith(inputs.gitRef, 'v') }}
+            type=sha,priority=300,enable=${{ !startsWith(inputs.gitRef, 'v') }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
This was a new tag added with intention to replicate the "latest" tag to represent the latest commit for a the default branch. However the behaviour wasn't as expected and tags the latest commit for any branch.