### PR TITLE
Fix image tags generation for non released versions

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        id: local-head
+
       - name: Determine image tags
         id: meta
         uses: docker/metadata-action@v5
@@ -62,7 +65,7 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }}
           tags: |
             type=raw,priority=500,value=${{ inputs.gitRef }},enable=${{ startsWith(inputs.gitRef, 'v') }}
-            type=sha,priority=300,prefix=,format=long,enable=${{ !startsWith(inputs.gitRef, 'v') }}
+            type=raw,priority=400,value=${{ steps.local-head.outputs.sha }},enable=${{ !startsWith(inputs.gitRef, 'v') }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
When trying to deploy an gitRef that wasn't a release version (i.e. not `v*`), for example a branch deploy, the sha used as the image tag incorrectly referenced the HEAD commit on main. This was because the docker/metadata action generates the sha tag using the `github.sha` workflow context. For workflow dispatch events this is the HEAD of main.

This fix now finds the SHA of the local head for the sha image tag.