### PR TITLE
Extend timeout for `helm upgrade` from 5m to 20m.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -49,6 +49,7 @@ resource "helm_release" "argo_cd" {
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
   version          = "6.4.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     global = {
       logging = {
@@ -158,6 +159,7 @@ resource "helm_release" "argo_bootstrap" {
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
   version          = "0.3.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
     # there is only one per AWS account.
@@ -186,6 +188,7 @@ resource "helm_release" "argo_workflows" {
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
   version          = "0.40.11" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     controller = {
       podSecurityContext = { runAsNonRoot = true }
@@ -305,6 +308,7 @@ resource "helm_release" "argo_events" {
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
   version          = "2.4.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     namespace  = local.services_ns
     controller = { replicas = var.desired_ha_replicas }

--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -12,6 +12,7 @@ resource "helm_release" "aws_lb_controller" {
   version          = "1.4.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace        = local.services_ns
   create_namespace = true
+  timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     clusterName      = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id
     defaultSSLPolicy = "ELBSecurityPolicy-TLS13-1-2-2021-06" # TLS 1.3, backward compatible with 1.2
@@ -30,4 +31,5 @@ resource "helm_release" "aws_lb_ingress_class" {
   repository = "https://alphagov.github.io/govuk-helm-charts/"
   chart      = "ingress-class"
   version    = "0.1.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  timeout    = var.helm_timeout_seconds
 }

--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -12,6 +12,7 @@ resource "helm_release" "cluster_secret_store" {
   chart      = "cluster-secret-store"
   version    = "0.1.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
   namespace  = local.services_ns
+  timeout    = var.helm_timeout_seconds
   values = [yamlencode({
     awsRegion          = data.aws_region.current.name
     serviceAccountName = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.external_secrets_service_account_name
@@ -34,4 +35,5 @@ resource "helm_release" "cluster_secrets" {
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
   version    = "0.9.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  timeout    = var.helm_timeout_seconds
 }

--- a/terraform/deployments/cluster-services/kubescape.tf
+++ b/terraform/deployments/cluster-services/kubescape.tf
@@ -13,6 +13,7 @@ resource "helm_release" "kubescape" {
   create_namespace = true
   repository       = "https://armosec.github.io/armo-helm/"
   version          = "1.7.18"
+  timeout          = var.helm_timeout_seconds
   set {
     name  = "clusterName"
     value = "govuk-${var.govuk_environment}"

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -10,6 +10,7 @@ resource "helm_release" "filebeat" {
   version          = "8.5.1"
   namespace        = local.services_ns
   create_namespace = true
+  timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     daemonset = { secretMounts = [] }
     filebeatConfig = {

--- a/terraform/deployments/cluster-services/tempo.tf
+++ b/terraform/deployments/cluster-services/tempo.tf
@@ -40,6 +40,7 @@ resource "helm_release" "tempo" {
   namespace  = local.monitoring_ns
   repository = "https://grafana.github.io/helm-charts"
   version    = "1.7.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  timeout    = var.helm_timeout_seconds
   values = [yamlencode({
     reportingEnabled = false
 

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -28,6 +28,12 @@ variable "github_read_only_team" {
   default     = "alphagov:gov-uk"
 }
 
+variable "helm_timeout_seconds" {
+  type        = number
+  description = "Timeout for helm install/upgrade operations."
+  default     = "1200"
+}
+
 variable "govuk_aws_state_bucket" {
   type        = string
   description = "Name of the S3 bucket used for govuk-aws's Terraform state."


### PR DESCRIPTION
Several of these charts typically take longer than 5m to roll out because of healthchecks and rolling updates.

This should reduce toil from needing to manually retry failed Terrform apply runs in TFC.