### PR TITLE
Explicitly reference the default workflow role

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -195,6 +195,8 @@ resource "helm_release" "argo_workflows" {
       workflowNamespaces = concat([local.services_ns], var.argo_workflows_namespaces)
       workflowDefaults = {
         spec = {
+          # The default service account is managed by argo-services in govuk-helm-charts
+          serviceAccountName    = "argo-workflow-default"
           activeDeadlineSeconds = 7200
           ttlStrategy = {
             secondsAfterFailure    = 259200


### PR DESCRIPTION
This sets the default Role used by workflows, previous the default Role for the namespace was used implicitly.