### PR TITLE
Enable Snyk SCA scans across all ecosystems

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -28,4 +28,4 @@ jobs:
         continue-on-error: true
         run: |
           snyk auth ${{ secrets.SNYK_TOKEN }}
-          snyk test --severity-threshold=high
+          snyk test --severity-threshold=high --all-projects --detection-depth=1


### PR DESCRIPTION
By default, `snyk test` will only scan a single manifest file. We have to set `--all-projects` to make it consider multiple manifests (e.g. both `Gemfile.lock` and `yarn.lock`).

We set `--detection-depth=1` to prevent Snyk from considering manifest files outside of the root directory.