### PR TITLE
Remove info-frontend reference

### DIFF
--- a/terraform/deployments/sentry/locals.tf
+++ b/terraform/deployments/sentry/locals.tf
@@ -29,7 +29,6 @@ locals {
     "govuk-sli-collector"      = ["govuk-publishing-platform"],
     "hmrc-manuals-api"         = ["govuk-publishing-platform"],
     "imminence"                = ["govuk-content-interactions-on-platform", "govuk-find-and-view"],
-    "info-frontend"            = ["govuk-find-and-view"],
     "licensify"                = [],
     "link-checker-api"         = ["govuk-publishing-platform"],
     "local-links-manager"      = ["govuk-content-interactions-on-platform", "govuk-find-and-view"],


### PR DESCRIPTION
info-frontend is now retired.

Trello:
https://trello.com/c/sWZM0a38/2387-archive-repo-in-github