### PR TITLE
Revert "Fetch latest release tag more robustly."

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,13 @@ jobs:
 
       - name: Find latest version tag
         id: find-last-tag
-        shell: bash
         run: |
-          last_tag=$(
-            git ls-remote -q --exit-code --tags --sort=-version:refname origin 'v*' |
-            head -1 | grep -Eo 'v[0-9]+'
-          )
+          git fetch --tags --deepen=100
 
-          if [[ ! "$last_tag" =~ ^v[0-9]*$ ]]; then
-            echo "No valid previous tag found. last_tag=$last_tag"
+          last_tag=$(git describe --tags --match "v*" --abbrev=0)
+
+          if [ -z "$last_tag" ]; then
+            echo "No previous tag found."
             exit 1
           fi
 


### PR DESCRIPTION
New script worked locally in isolation but [doesn't work on GHA](https://github.com/alphagov/release/actions/runs/8172393510/job/22342816859#step:3:10). Roll it back for now.

Reverts alphagov/govuk-infrastructure#1163