### PR TITLE
Fetch latest release tag more robustly.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,13 @@ jobs:
       - name: Find latest version tag
         id: find-last-tag
         run: |
-          git fetch --tags --deepen=100
+          last_tag=$(
+            git ls-remote -q --exit-code --tags --sort=-version:refname origin 'v*' |
+            head -1 | grep -Eo 'v[0-9]+'
+          )
 
-          last_tag=$(git describe --tags --match "v*" --abbrev=0)
-
-          if [ -z "$last_tag" ]; then
-            echo "No previous tag found."
+          if [[ ! "$last_tag" =~ ^v[0-9]*$ ]]; then
+            echo "No valid previous tag found. last_tag=$last_tag"
             exit 1
           fi
 


### PR DESCRIPTION
The previous implementation failed when it encountered two or more release tags at the same commit. Make it robust to that edge case. Also saves an unnecessary deep fetch from remote.

This time, avoid implicitly enabling `-o pipefail` by specifying `shell: bash`. We don't want to error out on SIGPIPE, because `| head` relies on it.

Second attempt at #1163.

Tested: step succeeded on [test run](https://github.com/alphagov/release/actions/runs/8173438604/job/22345905901#step:3:13). The following step (`Check is merge commit`) fails because the tip of the test branch isn't a merge commit (i.e. that's just an artefact of the contrived test scenario).