### PR TITLE
Fix `Calculate new verion tag` release step.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           show-progress: false
           ref: ${{ github.event.workflow_run.head_commit.id }}
 


### PR DESCRIPTION
Just do a full checkout for now.

More fallout from #1165.