### PR TITLE
Make Snyk SCA scan failures block builds

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: snyk/actions/setup@master
       - name: Snyk Supply Chain Test
-        continue-on-error: true
         run: |
           snyk auth ${{ secrets.SNYK_TOKEN }}
           snyk test --severity-threshold=high --all-projects --detection-depth=1


### PR DESCRIPTION
[Trello card](https://trello.com/c/I5jfSH7Z/3445-3-ensure-failed-sca-scans-block-merging)

This is a requirement before we can implement [RFC-167][], "Allow automatic patching of all dependencies".

If this change causes problems on any our repos, we could temporarily patch those repos (and those repos only) to refer to the previous version of this workflow instead of `@main`. For example:

```yaml
jobs:
  snyk-security:
    name: SNYK security analysis
    uses: alphagov/govuk-infrastructure/.github/workflows/snyk-security.yml@533143ddd823518b97165a4a80c2995e9ffe980a
    secrets: inherit
```

[RFC-167]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#sufficient-security-scanning