### PR TITLE
Revert "Make Snyk SCA scan failures block builds"

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: snyk/actions/setup@master
       - name: Snyk Supply Chain Test
+        continue-on-error: true
         run: |
           snyk auth ${{ secrets.SNYK_TOKEN }}
           snyk test --severity-threshold=high --all-projects --detection-depth=1


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#1167

Some repos still aren't configured properly, so we can't make these scans blocking yet. Slack thread: https://gds.slack.com/archives/CAB4Q3QBW/p1710168742382059