### PR TITLE
Add reusable workflow to auto-release rubygems

### DIFF
--- a/.github/workflows/autorelease-rubygem.yml
+++ b/.github/workflows/autorelease-rubygem.yml
@@ -8,10 +8,9 @@
 #
 # jobs:
 #   autorelease:
-#     permissions:
-#       contents: write
-#       pull-requests: write
 #     uses: alphagov/govuk-infrastructure/.github/workflows/autorelease-rubygem.yml@main
+#     secrets:
+#       GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
 
 name: Auto-release Rubygem
 
@@ -22,19 +21,20 @@ on:
         required: false
         type: string
         default: ${{ github.event.repository.name }}
+    secrets:
+      GH_TOKEN:
+        required: true
 
 jobs:
   release:
     name: Release Gem
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         show-progress: false
+        token: ${{ secrets.GH_TOKEN }}
     - uses: ruby/setup-ruby@v1
       with:
         rubygems: latest
@@ -46,7 +46,7 @@ jobs:
       name: "Auto-release rubygem"
       env:
         GEM_NAME: ${{ inputs.gem_name }}
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
         set -euo pipefail
 

--- a/.github/workflows/autorelease-rubygem.yml
+++ b/.github/workflows/autorelease-rubygem.yml
@@ -1,0 +1,96 @@
+# USAGE
+# -----
+#
+# on:
+#   workflow_dispatch: {}
+#   schedule:
+#     - cron: '00 13 * * 2'
+#
+# jobs:
+#   autorelease:
+#     permissions:
+#       contents: write
+#       pull-requests: write
+#     uses: alphagov/govuk-infrastructure/.github/workflows/autorelease-rubygem.yml@main
+
+name: Auto-release Rubygem
+
+on:
+  workflow_call:
+    inputs:
+      gem_name:
+        required: false
+        type: string
+        default: ${{ github.event.repository.name }}
+
+jobs:
+  release:
+    name: Release Gem
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        show-progress: false
+    - uses: ruby/setup-ruby@v1
+      with:
+        rubygems: latest
+        bundler-cache: true
+    - name: "Determine HEAD of default branch"
+      id: fetch_default_branch_head
+      run: echo "sha=$(git ls-remote origin HEAD | cut -f 1)" >> "$GITHUB_OUTPUT"
+    - if: github.sha == steps.fetch_default_branch_head.outputs.sha
+      name: "Auto-release rubygem"
+      env:
+        GEM_NAME: ${{ inputs.gem_name }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        CURR_VERSION=$(ruby -e "puts eval(File.read('$GEM_NAME.gemspec')).version")
+        NEXT_VERSION=$(echo $CURR_VERSION | cut -d . -f1).$(echo $CURR_VERSION | cut -d . -f2).$(( $(echo $CURR_VERSION | cut -d . -f3) + 1 ))
+        BRANCH="release-$NEXT_VERSION"
+        PR_TITLE="Release v$NEXT_VERSION"
+        PR_DESCRIPTION="This is an automated PR to bump the version number to $NEXT_VERSION. This is a patch-level bump, as the only changes since v$CURR_VERSION are dependency updates made by Dependabot."
+
+        if ! [ -f CHANGELOG.md ]; then
+          echo "CHANGELOG.md does not exist. Exiting."
+          exit 0
+        fi
+
+        if ! grep -qR --include "version.rb" $CURR_VERSION; then
+          echo "Can't find a version.rb containing the string '$CURR_VERSION'. Exiting."
+          exit 0
+        fi
+
+        if git ls-remote --exit-code origin refs/heads/$BRANCH > /dev/null; then
+          echo "Branch 'release-$NEXT_VERSION' already exists on the remote. Exiting."
+          exit 0
+        fi
+
+        if [ "$(git log v$CURR_VERSION..main --no-merges --format=format:%an | sort | uniq)" != "dependabot[bot]" ]; then
+          echo "Gem has no unreleased changes, or those changes include commits from users other than Dependabot. Exiting."
+          exit 0
+        fi
+
+        find . -type f -iname version.rb -exec sed -i "s/$CURR_VERSION/$NEXT_VERSION/g" {} \;
+
+        printf "# v$NEXT_VERSION\n\n* Update dependencies\n\n" | cat - CHANGELOG.md > NEW_CHANGELOG.md
+        mv NEW_CHANGELOG.md CHANGELOG.md
+
+        git config --global user.name "GOV.UK Continuous Integration User"
+        git config --global user.email "govuk-ci@users.noreply.github.com"
+
+        git checkout -b $BRANCH
+        git add .
+        git commit -m "$PR_TITLE"
+        git push origin $BRANCH
+
+        gh pr create -H $BRANCH --title "$PR_TITLE" --body "$PR_DESCRIPTION"
+    - if: github.sha != steps.fetch_default_branch_head.outputs.sha
+      name: "Skip release: commit is not HEAD of default branch"
+      run: |
+        echo "Skipping release because commit (${GITHUB_SHA}) isn't the HEAD of the default branch (${{ steps.fetch_default_branch_head.outputs.sha }})"

--- a/.github/workflows/autorelease-rubygem.yml
+++ b/.github/workflows/autorelease-rubygem.yml
@@ -41,7 +41,7 @@ jobs:
         bundler-cache: true
     - name: "Determine HEAD of default branch"
       id: fetch_default_branch_head
-      run: echo "sha=$(git ls-remote origin HEAD | cut -f 1)" >> "$GITHUB_OUTPUT"
+      run: echo "sha=$(git rev-parse origin/HEAD)" >> "$GITHUB_OUTPUT"
     - if: github.sha == steps.fetch_default_branch_head.outputs.sha
       name: "Auto-release rubygem"
       env:
@@ -78,7 +78,7 @@ jobs:
 
         find . -type f -iname version.rb -exec sed -i "s/$CURR_VERSION/$NEXT_VERSION/g" {} \;
 
-        printf "# v$NEXT_VERSION\n\n* Update dependencies\n\n" | cat - CHANGELOG.md > NEW_CHANGELOG.md
+        printf "# $NEXT_VERSION\n\n* Update dependencies\n\n" | cat - CHANGELOG.md > NEW_CHANGELOG.md
         mv NEW_CHANGELOG.md CHANGELOG.md
 
         git config --global user.name "GOV.UK Continuous Integration User"


### PR DESCRIPTION
[Trello card](https://trello.com/c/bYVP288R/3447-5-automate-release-of-new-gem-versions)

This reusable workflow, intended to be added to Ruby gem repos on a weekly schedule, will automatically raise a PR to perform a patch-level version bump if (and only if) the gem has unreleased changes, and all of those changes were authored by Dependabot. After a developer approves and merges that PR, the [publish-rubygem workflow](https://github.com/alphagov/govuk-infrastructure/blob/main/.github/workflows/publish-rubygem.yml) will automatically publish the next release to Rubygems.

This has been [tested on a dummy repo](https://github.com/robinjam/auto-release-test/pull/3) outside of alphagov. My intention is to first roll it out to PSR-owned repos, so that we can debug any teething issues before rolling it out more widely.