### PR TITLE
Add TFC workspaces for DGU; migrate organogram bucket from govuk-aws

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/organogram_bucket.tf
+++ b/terraform/deployments/datagovuk-infrastructure/organogram_bucket.tf
@@ -1,0 +1,59 @@
+data "fastly_ip_ranges" "fastly" {}
+
+data "aws_iam_policy_document" "s3_fastly_read_policy_doc" {
+  statement {
+    sid     = "S3FastlyReadBucket"
+    actions = ["s3:GetObject"]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.datagovuk-organogram.id}",
+      "arn:aws:s3:::${aws_s3_bucket.datagovuk-organogram.id}/*",
+    ]
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = data.fastly_ip_ranges.fastly.cidr_blocks
+    }
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "datagovuk-organogram" {
+  bucket = "datagovuk-${var.govuk_environment}-ckan-organogram"
+  tags   = { Name = "datagovuk-${var.govuk_environment}-ckan-organogram" }
+}
+
+resource "aws_s3_bucket_versioning" "datagovuk_organogram" {
+  bucket = aws_s3_bucket.datagovuk-organogram.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_logging" "datagovuk_organogram" {
+  bucket        = aws_s3_bucket.datagovuk-organogram.id
+  target_bucket = data.terraform_remote_state.infra_monitoring.outputs.aws_logging_bucket_id
+  target_prefix = "s3/datagovuk-${var.govuk_environment}-ckan-organogram/"
+}
+
+resource "aws_s3_bucket_cors_configuration" "datagovuk_organogram" {
+  bucket = aws_s3_bucket.datagovuk-organogram.id
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = [
+      "https://data.gov.uk",
+      "https://staging.data.gov.uk",
+      "https://www.staging.data.gov.uk",
+      "https://integration.data.gov.uk",
+      "https://www.integration.data.gov.uk",
+      "https://find.eks.production.govuk.digital",
+      "https://find.eks.integration.govuk.digital",
+      "https://find.eks.staging.govuk.digital"
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "govuk_datagovuk_organogram_read_policy" {
+  bucket = aws_s3_bucket.datagovuk-organogram.id
+  policy = data.aws_iam_policy_document.s3_fastly_read_policy_doc.json
+}

--- a/terraform/deployments/tfc-configuration/datagovuk-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/datagovuk-infrastructure.tf
@@ -1,0 +1,93 @@
+module "datagovuk-infrastructure-integration" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.9.0"
+
+  organization      = var.organization
+  workspace_name    = "datagovuk-infrastructure-integration"
+  workspace_desc    = "The datagovuk-infrastructure module is responsible for the AWS resources which constitute the EKS cluster."
+  workspace_tags    = ["integration", "datagovuk-infrastructure", "eks", "aws"]
+  terraform_version = "1.7.0"
+  execution_mode    = "remote"
+  working_directory = "/terraform/deployments/datagovuk-infrastructure/"
+  trigger_patterns  = ["/terraform/deployments/datagovuk-infrastructure/**/*"]
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "samsimpson1/govuk-aws"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production" = "write"
+    "GOV.UK Production"     = "write"
+  }
+
+  variable_set_names = [
+    "aws-credentials-integration",
+    "common",
+    "common-integration"
+  ]
+}
+
+module "datagovuk-infrastructure-staging" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.9.0"
+
+  organization      = var.organization
+  workspace_name    = "datagovuk-infrastructure-staging"
+  workspace_desc    = "The datagovuk-infrastructure module is responsible for the AWS resources which constitute the EKS cluster."
+  workspace_tags    = ["staging", "datagovuk-infrastructure", "eks", "aws"]
+  terraform_version = "1.7.0"
+  execution_mode    = "remote"
+  working_directory = "/terraform/deployments/datagovuk-infrastructure/"
+  trigger_patterns  = ["/terraform/deployments/datagovuk-infrastructure/**/*"]
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "samsimpson1/govuk-aws"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Production" = "write"
+  }
+
+  variable_set_names = [
+    "aws-credentials-staging",
+    "common",
+    "common-staging"
+  ]
+}
+
+module "datagovuk-infrastructure-production" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.9.0"
+
+  organization      = var.organization
+  workspace_name    = "datagovuk-infrastructure-production"
+  workspace_desc    = "The datagovuk-infrastructure module is responsible for the AWS resources which constitute the EKS cluster."
+  workspace_tags    = ["production", "datagovuk-infrastructure", "eks", "aws"]
+  terraform_version = "1.7.0"
+  execution_mode    = "remote"
+  working_directory = "/terraform/deployments/datagovuk-infrastructure/"
+  trigger_patterns  = ["/terraform/deployments/datagovuk-infrastructure/**/*"]
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "samsimpson1/govuk-aws"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Production" = "write"
+  }
+
+  variable_set_names = [
+    "aws-credentials-production",
+    "common",
+    "common-production"
+  ]
+}


### PR DESCRIPTION
Somehow missed this during the initial TFC migration

Also includes an S3 bucket from govuk-aws (this part is probably broken, I will fix it once the TFC workspaces are done)