### PR TITLE
Make Snyk SCA scans skippable

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -2,6 +2,12 @@ name: SNYK security analysis
 
 on:
   workflow_call:
+    inputs:
+      skip_sca:
+        description: 'Skip Software Component Analysis'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   sast:
@@ -34,6 +40,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    if: ${{ ! inputs.skip_sca }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/UNfbKmbK/3460-skip-snyk-sca-scans-for-all-gem-library-repos)

Software Component Analysis doesn't really make sense for gems (or indeed any type of library), so let's make it skippable.