### PR TITLE
Update Argo Workflows from 3.5.4 to 3.5.5.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -185,7 +185,7 @@ resource "helm_release" "argo_workflows" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "0.40.11" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.40.14" # TODO: Dependabot or equivalent so this doesn't get neglected.
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     controller = {


### PR DESCRIPTION
https://github.com/argoproj/argo-workflows/blob/main/CHANGELOG.md#v355-2024-02-29

Tested: updated staging via `helm upgrade`, checked workflow-controller and workflows-server logs + web UI.