### PR TITLE
Fix a perpetual diff in RDS engine params (maybe).

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -199,7 +199,7 @@ module "variable-set-rds-integration" {
           log_min_duration_statement           = { value = "10000" }
           log_statement                        = { value = "all" }
           deadlock_timeout                     = { value = 2500 }
-          log_lock_waits                       = { value = true }
+          log_lock_waits                       = { value = 1 }
         }
         engine_params_family = "postgres13"
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -238,7 +238,7 @@ module "variable-set-rds-production" {
           log_min_duration_statement           = { value = "10000" }
           log_statement                        = { value = "all" }
           deadlock_timeout                     = { value = 2500 }
-          log_lock_waits                       = { value = true }
+          log_lock_waits                       = { value = 1 }
         }
         engine_params_family = "postgres13"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -211,7 +211,7 @@ module "variable-set-rds-staging" {
           log_min_duration_statement           = { value = "10000" }
           log_statement                        = { value = "all" }
           deadlock_timeout                     = { value = 2500 }
-          log_lock_waits                       = { value = true }
+          log_lock_waits                       = { value = 1 }
         }
         engine_params_family = "postgres13"
 


### PR DESCRIPTION
The provider seems to have a bug where it accepts `true` but isn't smart enough to tell that that's the same as the `1` that comes back from the API when it's comparing against the stored state.