### PR TITLE
Remove legacy stackname "blue" CNAMEs for RDS instances.

### DIFF
--- a/terraform/deployments/rds/variables.tf
+++ b/terraform/deployments/rds/variables.tf
@@ -102,8 +102,3 @@ variable "terraform_delete_rds_timeout" {
   description = "Set the timeout time for AWS RDS deletion."
   default     = "2h"
 }
-
-variable "internal_zone_name" {
-  type        = string
-  description = "The name of the Route53 zone that contains internal records"
-}


### PR DESCRIPTION
Nothing refers to these legacy `<db>.blue.<env>.govuk-internal.digital` CNAMEs any more as of #1183.

While we're there, rename the TF resources for the remaining CNAMEs for clarity.