### PR TITLE
Fix gem auto-release workflow

### DIFF
--- a/.github/workflows/autorelease-rubygem.yml
+++ b/.github/workflows/autorelease-rubygem.yml
@@ -41,7 +41,7 @@ jobs:
         bundler-cache: true
     - name: "Determine HEAD of default branch"
       id: fetch_default_branch_head
-      run: echo "sha=$(git rev-parse origin/HEAD)" >> "$GITHUB_OUTPUT"
+      run: echo "sha=$(git ls-remote origin HEAD | cut -f 1)" >> "$GITHUB_OUTPUT"
     - if: github.sha == steps.fetch_default_branch_head.outputs.sha
       name: "Auto-release rubygem"
       env:


### PR DESCRIPTION
[Trello card](https://trello.com/c/bYVP288R/3447-5-automate-release-of-new-gem-versions)

One of the code review suggestions on #1173 seems to have broken this (my bad, I should've tested before accepting the suggestion!)

[Example failed run](https://github.com/alphagov/gds_zendesk/actions/runs/8343504631/job/22833831374):

> fatal: ambiguous argument 'origin/HEAD': unknown revision or path not in the working tree.