### PR TITLE
Remove disused tfvars from RDS workspaces.

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -61,8 +61,6 @@ module "variable-set-rds-integration" {
   name = "rds-integration"
 
   tfvars = {
-    internal_zone_name      = "integration.govuk-internal.digital"
-    internal_domain_name    = "blue.integration.govuk-internal.digital"
     backup_retention_period = 0
     skip_final_snapshot     = true
     multi_az                = false
@@ -85,7 +83,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -107,7 +104,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -128,7 +124,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -146,7 +141,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -164,7 +158,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -185,7 +178,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -211,7 +203,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 536870912000
       }
 
@@ -232,7 +223,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -253,7 +243,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -274,7 +263,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -295,7 +283,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -316,7 +303,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -338,7 +324,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -359,7 +344,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -380,7 +364,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -401,7 +384,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -425,7 +407,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -443,7 +424,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -461,7 +441,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -482,7 +461,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -500,7 +478,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -521,7 +498,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -539,7 +515,6 @@ module "variable-set-rds-integration" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
     }

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -75,15 +75,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "account-api"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "account-api"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       authenticating_proxy = {
@@ -96,15 +93,12 @@ module "variable-set-rds-integration" {
           log_lock_waits             = { value = 1 }
           password_encryption        = { value = "md5" }
         }
-        engine_params_family = "postgres14"
-
-        name              = "authenticating-proxy"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "postgres14"
+        name                         = "authenticating-proxy"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       ckan = {
@@ -116,15 +110,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "ckan"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "ckan"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       collections_publisher = {
@@ -133,15 +124,12 @@ module "variable-set-rds-integration" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "collections-publisher"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "collections-publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       contacts_admin = {
@@ -150,15 +138,12 @@ module "variable-set-rds-integration" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "contacts-admin"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "contacts-admin"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_data_admin = {
@@ -170,15 +155,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "content-data-admin"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "postgres13"
+        name                         = "content-data-admin"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_data_api = {
@@ -195,15 +177,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout                     = { value = 2500 }
           log_lock_waits                       = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "blue-content-data-api-postgresql-primary"
-        allocated_storage = 400
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "blue-content-data-api-postgresql-primary"
+        allocated_storage            = 400
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 536870912000
+        freestoragespace_threshold   = 536870912000
       }
 
       content_publisher = {
@@ -215,15 +194,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "content-publisher"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "postgres13"
+        name                         = "content-publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_store = {
@@ -235,15 +211,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres14"
-
-        name              = "content-store"
-        allocated_storage = 500
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres14"
+        name                         = "content-store"
+        allocated_storage            = 500
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_tagger = {
@@ -255,15 +228,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "content-tagger"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "postgres13"
+        name                         = "content-tagger"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       draft_content_store = {
@@ -275,15 +245,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres14"
-
-        name              = "draft-content-store"
-        allocated_storage = 500
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres14"
+        name                         = "draft-content-store"
+        allocated_storage            = 500
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       email_alert_api = {
@@ -295,15 +262,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "email-alert-api"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "email-alert-api"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       imminence = {
@@ -316,15 +280,12 @@ module "variable-set-rds-integration" {
           log_lock_waits             = { value = 1 }
           password_encryption        = { value = "md5" }
         }
-        engine_params_family = "postgres14"
-
-        name              = "imminence"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres14"
+        name                         = "imminence"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       link_checker_api = {
@@ -336,15 +297,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "link-checker-api"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "link-checker-api"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       local_links_manager = {
@@ -356,15 +314,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "local-links-manager"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "postgres13"
+        name                         = "local-links-manager"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       locations_api = {
@@ -376,15 +331,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "locations-api"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "locations-api"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       publishing_api = {
@@ -399,15 +351,12 @@ module "variable-set-rds-integration" {
           max_wal_size               = { value = 4096 }
           synchronous_commit         = { value = "off" }
         }
-        engine_params_family = "postgres13"
-
-        name              = "publishing-api"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "publishing-api"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       release = {
@@ -416,15 +365,12 @@ module "variable-set-rds-integration" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "release"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "release"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       search_admin = {
@@ -433,15 +379,12 @@ module "variable-set-rds-integration" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "search-admin"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "search-admin"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       service_manual_publisher = {
@@ -453,15 +396,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "service-manual-publisher"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "postgres13"
+        name                         = "service-manual-publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       signon = {
@@ -470,15 +410,12 @@ module "variable-set-rds-integration" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "signon"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "signon"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       support_api = {
@@ -490,15 +427,12 @@ module "variable-set-rds-integration" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "support-api"
-        allocated_storage = 200
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "support-api"
+        allocated_storage            = 200
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       whitehall = {
@@ -507,15 +441,12 @@ module "variable-set-rds-integration" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "whitehall"
-        allocated_storage = 400
-        instance_class    = "db.t4g.large"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "whitehall"
+        allocated_storage            = 400
+        instance_class               = "db.t4g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
     }
   }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -114,15 +114,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "account-api"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "account-api"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       authenticating_proxy = {
@@ -135,15 +132,12 @@ module "variable-set-rds-production" {
           log_lock_waits             = { value = 1 }
           password_encryption        = { value = "md5" }
         }
-        engine_params_family = "postgres14"
-
-        name              = "authenticating-proxy"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "postgres14"
+        name                         = "authenticating-proxy"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       ckan = {
@@ -155,15 +149,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "ckan"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.2xlarge"
-
+        engine_params_family         = "postgres13"
+        name                         = "ckan"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.2xlarge"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       collections_publisher = {
@@ -172,15 +163,12 @@ module "variable-set-rds-production" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "collections-publisher"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "collections-publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       contacts_admin = {
@@ -189,15 +177,12 @@ module "variable-set-rds-production" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "contacts-admin"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "contacts-admin"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_data_admin = {
@@ -209,15 +194,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "content-data-admin"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "content-data-admin"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_data_api = {
@@ -234,15 +216,12 @@ module "variable-set-rds-production" {
           deadlock_timeout                     = { value = 2500 }
           log_lock_waits                       = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "blue-content-data-api-postgresql-primary"
-        allocated_storage = 1024
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "blue-content-data-api-postgresql-primary"
+        allocated_storage            = 1024
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 536870912000
+        freestoragespace_threshold   = 536870912000
       }
 
       content_publisher = {
@@ -254,15 +233,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "content-publisher"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "content-publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_store = {
@@ -274,15 +250,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres14"
-
-        name              = "content-store"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.2xlarge"
-
+        engine_params_family         = "postgres14"
+        name                         = "content-store"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.2xlarge"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_tagger = {
@@ -294,15 +267,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "content-tagger"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "content-tagger"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       draft_content_store = {
@@ -314,15 +284,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres14"
-
-        name              = "draft-content-store"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.2xlarge"
-
+        engine_params_family         = "postgres14"
+        name                         = "draft-content-store"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.2xlarge"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       email_alert_api = {
@@ -334,15 +301,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "email-alert-api"
-        allocated_storage = 4500
-        instance_class    = "db.m7g.2xlarge"
-
+        engine_params_family         = "postgres13"
+        name                         = "email-alert-api"
+        allocated_storage            = 4500
+        instance_class               = "db.m7g.2xlarge"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       imminence = {
@@ -355,15 +319,12 @@ module "variable-set-rds-production" {
           log_lock_waits             = { value = 1 }
           password_encryption        = { value = "md5" }
         }
-        engine_params_family = "postgres14"
-
-        name              = "imminence"
-        allocated_storage = 100
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres14"
+        name                         = "imminence"
+        allocated_storage            = 100
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       link_checker_api = {
@@ -375,15 +336,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "link-checker-api"
-        allocated_storage = 100
-        instance_class    = "db.t4g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "link-checker-api"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       local_links_manager = {
@@ -395,15 +353,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "local-links-manager"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "local-links-manager"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       locations_api = {
@@ -415,15 +370,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "locations-api"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "locations-api"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       publishing_api = {
@@ -435,15 +387,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "publishing-api"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.4xlarge"
-
+        engine_params_family         = "postgres13"
+        name                         = "publishing-api"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.4xlarge"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       release = {
@@ -452,15 +401,12 @@ module "variable-set-rds-production" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "release"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "release"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       search_admin = {
@@ -469,15 +415,12 @@ module "variable-set-rds-production" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "search-admin"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "search-admin"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       service_manual_publisher = {
@@ -489,15 +432,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "service-manual-publisher"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "service-manual-publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       signon = {
@@ -506,15 +446,12 @@ module "variable-set-rds-production" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "signon"
-        allocated_storage = 100
-        instance_class    = "db.t4g.large"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "signon"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       support_api = {
@@ -526,15 +463,12 @@ module "variable-set-rds-production" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "support-api"
-        allocated_storage = 200
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "support-api"
+        allocated_storage            = 200
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       whitehall = {
@@ -543,15 +477,12 @@ module "variable-set-rds-production" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "whitehall"
-        allocated_storage = 300
-        instance_class    = "db.m7g.xlarge"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "whitehall"
+        allocated_storage            = 300
+        instance_class               = "db.m7g.xlarge"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
     }
   }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -100,8 +100,6 @@ module "variable-set-rds-production" {
 
   name = "rds-production"
   tfvars = {
-    internal_zone_name      = "production.govuk-internal.digital"
-    internal_domain_name    = "blue.production.govuk-internal.digital"
     backup_retention_period = 7
     skip_final_snapshot     = false
     multi_az                = true
@@ -124,7 +122,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -146,7 +143,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -167,7 +163,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -185,7 +180,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -203,7 +197,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -224,7 +217,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -250,7 +242,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 536870912000
       }
 
@@ -271,7 +262,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -292,7 +282,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -313,7 +302,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -334,7 +322,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -355,7 +342,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -377,7 +363,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -398,7 +383,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -419,7 +403,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -440,7 +423,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -461,7 +443,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -479,7 +460,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -497,7 +477,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -518,7 +497,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -536,7 +514,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -557,7 +534,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -575,7 +551,6 @@ module "variable-set-rds-production" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
     }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -87,15 +87,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "account-api"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "account-api"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       authenticating_proxy = {
@@ -108,15 +105,12 @@ module "variable-set-rds-staging" {
           log_lock_waits             = { value = 1 }
           password_encryption        = { value = "md5" }
         }
-        engine_params_family = "postgres14"
-
-        name              = "authenticating-proxy"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "postgres14"
+        name                         = "authenticating-proxy"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       ckan = {
@@ -128,15 +122,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "ckan"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "ckan"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       collections_publisher = {
@@ -145,15 +136,12 @@ module "variable-set-rds-staging" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "collections-publisher"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "collections-publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       contacts_admin = {
@@ -162,15 +150,12 @@ module "variable-set-rds-staging" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "contacts-admin"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "contacts-admin"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_data_admin = {
@@ -182,15 +167,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "content-data-admin"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "postgres13"
+        name                         = "content-data-admin"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_data_api = {
@@ -207,15 +189,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout                     = { value = 2500 }
           log_lock_waits                       = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "blue-content-data-api-postgresql-primary"
-        allocated_storage = 1024
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "blue-content-data-api-postgresql-primary"
+        allocated_storage            = 1024
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 536870912000
+        freestoragespace_threshold   = 536870912000
       }
 
       content_publisher = {
@@ -227,15 +206,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "content-publisher"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "postgres13"
+        name                         = "content-publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_store = {
@@ -247,15 +223,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres14"
-
-        name              = "content-store"
-        allocated_storage = 500
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres14"
+        name                         = "content-store"
+        allocated_storage            = 500
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       content_tagger = {
@@ -267,15 +240,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "content-tagger"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "postgres13"
+        name                         = "content-tagger"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       draft_content_store = {
@@ -287,15 +257,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres14"
-
-        name              = "draft-content-store"
-        allocated_storage = 500
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres14"
+        name                         = "draft-content-store"
+        allocated_storage            = 500
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       email_alert_api = {
@@ -307,15 +274,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "email-alert-api"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.xlarge"
-
+        engine_params_family         = "postgres13"
+        name                         = "email-alert-api"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.xlarge"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       imminence = {
@@ -328,15 +292,12 @@ module "variable-set-rds-staging" {
           log_lock_waits             = { value = 1 }
           password_encryption        = { value = "md5" }
         }
-        engine_params_family = "postgres14"
-
-        name              = "imminence"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres14"
+        name                         = "imminence"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       link_checker_api = {
@@ -348,15 +309,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "link-checker-api"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "link-checker-api"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       local_links_manager = {
@@ -368,15 +326,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "local-links-manager"
-        allocated_storage = 100
-        instance_class    = "db.t4g.small"
-
+        engine_params_family         = "postgres13"
+        name                         = "local-links-manager"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       locations_api = {
@@ -388,15 +343,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "locations-api"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "locations-api"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       publishing_api = {
@@ -411,15 +363,12 @@ module "variable-set-rds-staging" {
           max_wal_size               = { value = 4096 }
           synchronous_commit         = { value = "off" }
         }
-        engine_params_family = "postgres13"
-
-        name              = "publishing-api"
-        allocated_storage = 1000
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "postgres13"
+        name                         = "publishing-api"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       release = {
@@ -428,15 +377,12 @@ module "variable-set-rds-staging" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "release"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "release"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       search_admin = {
@@ -445,15 +391,12 @@ module "variable-set-rds-staging" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "search-admin"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "search-admin"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       service_manual_publisher = {
@@ -465,15 +408,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "service-manual-publisher"
-        allocated_storage = 100
-        instance_class    = "db.t4g.micro"
-
+        engine_params_family         = "postgres13"
+        name                         = "service-manual-publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       signon = {
@@ -482,15 +422,12 @@ module "variable-set-rds-staging" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "signon"
-        allocated_storage = 100
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "signon"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       support_api = {
@@ -502,15 +439,12 @@ module "variable-set-rds-staging" {
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family = "postgres13"
-
-        name              = "support-api"
-        allocated_storage = 200
-        instance_class    = "db.t4g.medium"
-
+        engine_params_family         = "postgres13"
+        name                         = "support-api"
+        allocated_storage            = 200
+        instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
 
       whitehall = {
@@ -519,15 +453,12 @@ module "variable-set-rds-staging" {
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
-        engine_params_family = "mysql8.0"
-
-        name              = "whitehall"
-        allocated_storage = 400
-        instance_class    = "db.m6g.large"
-
+        engine_params_family         = "mysql8.0"
+        name                         = "whitehall"
+        allocated_storage            = 400
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-
-        freestoragespace_threshold = 10737418240
+        freestoragespace_threshold   = 10737418240
       }
     }
   }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -73,8 +73,6 @@ module "variable-set-rds-staging" {
 
   name = "rds-staging"
   tfvars = {
-    internal_zone_name      = "staging.govuk-internal.digital"
-    internal_domain_name    = "blue.staging.govuk-internal.digital"
     backup_retention_period = 0
     skip_final_snapshot     = true
     multi_az                = false
@@ -97,7 +95,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -119,7 +116,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -140,7 +136,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -158,7 +153,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -176,7 +170,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -197,7 +190,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -223,7 +215,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 536870912000
       }
 
@@ -244,7 +235,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -265,7 +255,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -286,7 +275,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -307,7 +295,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -328,7 +315,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -350,7 +336,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -371,7 +356,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -392,7 +376,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -413,7 +396,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -437,7 +419,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -455,7 +436,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -473,7 +453,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -494,7 +473,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = false
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -512,7 +490,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -533,7 +510,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
 
@@ -551,7 +527,6 @@ module "variable-set-rds-staging" {
 
         performance_insights_enabled = true
 
-        cpuutilization_threshold   = 80
         freestoragespace_threshold = 10737418240
       }
     }


### PR DESCRIPTION
Since #1182 and #1188 there are no longer any references to these. Remove them and tidy up the formatting (separate commits for ease of review).