### PR TITLE
Remove unnecessary tfvars for "stackname".

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -6,10 +6,10 @@ resource "random_string" "database_password" {
 }
 
 resource "aws_db_subnet_group" "subnet_group" {
-  name       = "${var.stackname}-govuk-rds-subnet"
+  name       = "blue-govuk-rds-subnet"
   subnet_ids = data.terraform_remote_state.infra_networking.outputs.private_subnet_rds_ids
 
-  tags = { Name = "${var.stackname}-govuk-rds-subnet" }
+  tags = { Name = "blue-govuk-rds-subnet" }
 }
 
 resource "aws_db_parameter_group" "engine_params" {
@@ -66,7 +66,7 @@ resource "aws_db_instance" "instance" {
   final_snapshot_identifier = "${each.value.name}-final-snapshot"
   skip_final_snapshot       = var.skip_final_snapshot
 
-  tags = { Name = "${var.stackname}-govuk-rds-${each.value.name}-${each.value.engine}" }
+  tags = { Name = "blue-govuk-rds-${each.value.name}-${each.value.engine}" }
 }
 
 resource "aws_db_event_subscription" "subscription" {

--- a/terraform/deployments/rds/remote_state.tf
+++ b/terraform/deployments/rds/remote_state.tf
@@ -1,39 +1,35 @@
 data "terraform_remote_state" "infra_monitoring" {
   backend = "s3"
-
   config = {
     bucket = var.govuk_aws_state_bucket
-    key    = "${coalesce(var.remote_state_infra_monitoring_key_stack, var.stackname)}/infra-monitoring.tfstate"
+    key    = "govuk/infra-monitoring.tfstate"
     region = var.aws_region
   }
 }
 
 data "terraform_remote_state" "infra_networking" {
   backend = "s3"
-
   config = {
     bucket = var.govuk_aws_state_bucket
-    key    = "${coalesce(var.remote_state_infra_networking_key_stack, var.stackname)}/infra-networking.tfstate"
+    key    = "govuk/infra-networking.tfstate"
     region = var.aws_region
   }
 }
 
 data "terraform_remote_state" "infra_root_dns_zones" {
   backend = "s3"
-
   config = {
     bucket = var.govuk_aws_state_bucket
-    key    = "${coalesce(var.remote_state_infra_root_dns_zones_key_stack, var.stackname)}/infra-root-dns-zones.tfstate"
+    key    = "govuk/infra-root-dns-zones.tfstate"
     region = var.aws_region
   }
 }
 
 data "terraform_remote_state" "infra_vpc" {
   backend = "s3"
-
   config = {
     bucket = var.govuk_aws_state_bucket
-    key    = "${coalesce(var.remote_state_infra_vpc_key_stack, var.stackname)}/infra-vpc.tfstate"
+    key    = "govuk/infra-vpc.tfstate"
     region = var.aws_region
   }
 }

--- a/terraform/deployments/rds/security_groups.tf
+++ b/terraform/deployments/rds/security_groups.tf
@@ -1,8 +1,8 @@
 resource "aws_security_group" "rds" {
   for_each = var.databases
 
-  name        = "${var.stackname}_${each.value.name}_rds_access"
+  name        = "blue_${each.value.name}_rds_access"
   vpc_id      = data.terraform_remote_state.infra_vpc.outputs.vpc_id
   description = "Access to ${each.value.name} RDS"
-  tags        = { Name = "${var.stackname}_${each.value.name}_rds_access" }
+  tags        = { Name = "blue_${each.value.name}_rds_access" }
 }

--- a/terraform/deployments/rds/variables.tf
+++ b/terraform/deployments/rds/variables.tf
@@ -9,39 +9,9 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "stackname" {
-  type        = string
-  description = "Stackname"
-  default     = "blue"
-}
-
 variable "govuk_aws_state_bucket" {
   type        = string
   description = "Bucket where govuk-aws state is stored"
-}
-
-variable "remote_state_infra_monitoring_key_stack" {
-  type        = string
-  description = "Override path to infra_monitoring remote state"
-  default     = "govuk"
-}
-
-variable "remote_state_infra_networking_key_stack" {
-  type        = string
-  description = "Override path to infra_networking remote state"
-  default     = "govuk"
-}
-
-variable "remote_state_infra_root_dns_zones_key_stack" {
-  type        = string
-  description = "Override path to infra_root_dns_zones remote state"
-  default     = "govuk"
-}
-
-variable "remote_state_infra_vpc_key_stack" {
-  type        = string
-  description = "Override path to infra_vpc remote state"
-  default     = "govuk"
 }
 
 variable "databases" {


### PR DESCRIPTION
The "stack" concept dates from an abandoned attempt at blue-green deployments nearly a decade ago. There's only ever been one "stack" for any given resource and that's not going to change, so we can get rid of this complexity in constructing resource names.

For now, keep all the (API) resource names the same, i.e. just hardcode the "blue" / "govuk" part. I'll rename things in a later PR.

This should be zero-diff in all three workspaces.