### PR TITLE
Remove a reference to the legacy "blue" stackname.

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -66,7 +66,7 @@ resource "aws_db_instance" "instance" {
   final_snapshot_identifier = "${each.value.name}-final-snapshot"
   skip_final_snapshot       = var.skip_final_snapshot
 
-  tags = { Name = "blue-govuk-rds-${each.value.name}-${each.value.engine}" }
+  tags = { Name = "govuk-rds-${each.value.name}-${each.value.engine}" }
 }
 
 resource "aws_db_event_subscription" "subscription" {


### PR DESCRIPTION
I think this might be the only "blue" reference we can clean up easily in this module. The others are in names of subnet groups, which I suspect might be more trouble than they're worth.