### PR TITLE
Exclude vendor files from automated PR

### DIFF
--- a/.github/workflows/autorelease-rubygem.yml
+++ b/.github/workflows/autorelease-rubygem.yml
@@ -86,6 +86,7 @@ jobs:
 
         git checkout -b $BRANCH
         git add .
+        git reset -- vendor/bundle
         git commit -m "$PR_TITLE"
         git push origin $BRANCH
 


### PR DESCRIPTION
The issue, which can be seen in [this PR](https://github.com/alphagov/rubocop-govuk/pull/368), is that setup-ruby configures bundler to install gems in vendor/bundle, and this workflow just runs git adds everything.

Adding `git reset -- vendor/bundle` should exclude all of those. 

Thanks @robinjam for suggesting this fix.