### PR TITLE
Add optional ARM Node Group Config

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -28,6 +28,45 @@ locals {
   secrets_prefix             = "govuk"
   monitoring_namespace       = "monitoring"
   node_security_group_id     = module.eks.cluster_primary_security_group_id
+
+  main_managed_node_group = {
+    main = {
+      name_prefix = var.cluster_name
+      # TODO: set iam_role_permissions_boundary
+      # TODO: apply provider default_tags to instances; might need to set launch_template_tags.
+      desired_size               = var.workers_size_desired
+      max_size                   = var.workers_size_max
+      min_size                   = var.workers_size_min
+      instance_types             = var.workers_instance_types
+      disk_size                  = var.node_disk_size
+      use_custom_launch_template = false
+      update_config              = { max_unavailable = 1 }
+      additional_tags = {
+        "k8s.io/cluster-autoscaler/enabled"             = "true"
+        "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"
+      }
+    }
+  }
+
+  arm_managed_node_group = {
+    arm = {
+      ami_type                   = "AL2_ARM_64"
+      name_prefix                = var.cluster_name
+      desired_size               = var.arm_workers_size_desired
+      max_size                   = var.arm_workers_size_max
+      min_size                   = var.arm_workers_size_min
+      instance_types             = var.arm_workers_instance_types
+      disk_size                  = var.node_disk_size
+      use_custom_launch_template = false
+      update_config              = { max_unavailable = 1 }
+      additional_tags = {
+        "k8s.io/cluster-autoscaler/enabled"             = "true"
+        "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"
+      }
+    }
+  }
+
+  eks_managed_node_groups = merge(local.main_managed_node_group, var.enable_arm_workers ? local.arm_managed_node_group : {})
 }
 
 provider "aws" {
@@ -83,24 +122,8 @@ module "eks" {
     create_security_group = false
   }
 
-  eks_managed_node_groups = {
-    main = {
-      name_prefix = var.cluster_name
-      # TODO: set iam_role_permissions_boundary
-      # TODO: apply provider default_tags to instances; might need to set launch_template_tags.
-      desired_size               = var.workers_size_desired
-      max_size                   = var.workers_size_max
-      min_size                   = var.workers_size_min
-      instance_types             = var.workers_instance_types
-      disk_size                  = var.node_disk_size
-      use_custom_launch_template = false
-      update_config              = { max_unavailable = 1 }
-      additional_tags = {
-        "k8s.io/cluster-autoscaler/enabled"             = "true"
-        "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"
-      }
-    }
-  }
+  # Moved Node Groups Config to Locals section to add conditional node groups.
+  eks_managed_node_groups = local.eks_managed_node_groups
 }
 
 # Allow us to connect to nodes using AWS Systems Manager Session Manager.

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -51,6 +51,42 @@ variable "force_destroy" {
   default     = false
 }
 
+variable "enable_arm_workers" {
+  type        = bool
+  description = "Whether to enable the ARM/Graviton-based Managed Node Group"
+  default     = false
+}
+
+variable "arm_workers_instance_types" {
+  type        = list(string)
+  description = "List of ARM-based instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
+  default     = ["m7g.4xlarge", "m6g.4xlarge", "m7g.2xlarge", "m6g.2xlarge"]
+}
+
+variable "arm_workers_default_capacity_type" {
+  type        = string
+  description = "Default capacity type for ARM-based managed node groups: SPOT or ON_DEMAND."
+  default     = "ON_DEMAND"
+}
+
+variable "arm_workers_size_desired" {
+  type        = number
+  description = "Desired capacity of ARM-based managed node autoscale group."
+  default     = 1
+}
+
+variable "arm_workers_size_min" {
+  type        = number
+  description = "Min capacity of ARM-based managed node autoscale group."
+  default     = 1
+}
+
+variable "arm_workers_size_max" {
+  type        = number
+  description = "Max capacity of ARM-based managed node autoscale group."
+  default     = 3
+}
+
 variable "workers_instance_types" {
   type        = list(string)
   description = "List of instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -29,8 +29,9 @@ module "variable-set-integration" {
       c = { az = "eu-west-1c", cidr = "10.1.32.0/22" }
     }
 
-    govuk_environment = "integration"
-    force_destroy     = true
+    govuk_environment  = "integration"
+    force_destroy      = true
+    enable_arm_workers = true
 
     publishing_service_domain = "integration.publishing.service.gov.uk"
 


### PR DESCRIPTION
## What?
This is an attempt to start to configure secondary Node Groups for our Cluster, allowing us to start to configure an availability of Graviton-powered nodes in Integration for testing. This could also theoretically be used in the future if we wanted something like GPU-backed instances.

## TF Output
Few things to note - firstly, the AMI Type seems to be causing a forced replacement (even though it hasn't changed):
```
  # module.eks.module.eks_managed_node_group["main"].aws_eks_node_group.this[0] must be replaced
+/- resource "aws_eks_node_group" "this" {
      ~ ami_type               = "AL2023_x86_64_STANDARD" -> "AL2_x86_64" # forces replacement
      ~ arn                    = "arn:aws:eks:eu-west-1:210287912431:nodegroup/govuk/main-20240408160437667800000001/8ac75f3a-28c8-cda0-3b09-ebc0d06bfa57" -> (known after apply)
      ~ id                     = "govuk:main-20240408160437667800000001" -> (known after apply)
      - labels                 = {} -> null
      ~ node_group_name        = "main-20240408160437667800000001" -> (known after apply)
      ~ release_version        = "1.29.0-20240329" -> (known after apply)
      ~ resources              = [
          - {
              - autoscaling_groups              = [
                  - {
                      - name = "eks-main-20240408160437667800000001-8ac75f3a-28c8-cda0-3b09-ebc0d06bfa57"
                    },
                ]
              - remote_access_security_group_id = ""
            },
        ] -> (known after apply)
      ~ status                 = "ACTIVE" -> (known after apply)
        tags                   = {
            "Name" = "main"
        }
        # (9 unchanged attributes hidden)

      ~ scaling_config {
          ~ desired_size = 6 -> 5
            # (2 unchanged attributes hidden)
        }

      ~ update_config {
          - max_unavailable_percentage = 0 -> null
            # (1 unchanged attribute hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

Also, some deprecation warnings are popping up:
```
│ Warning: Argument is deprecated
│
│   with module.eks.aws_eks_addon.this["kube-proxy"],
│   on .terraform/modules/eks/main.tf line 400, in resource "aws_eks_addon" "this":
│  400:   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
│
│ The "resolve_conflicts" attribute can't be set to "PRESERVE" on initial
│ resource creation. Use "resolve_conflicts_on_create" and/or
│ "resolve_conflicts_on_update" instead
╵
╷
│ Warning: Argument is deprecated
│
│   with module.eks.aws_eks_addon.this["coredns"],
│   on .terraform/modules/eks/main.tf line 400, in resource "aws_eks_addon" "this":
│  400:   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
│
│ The "resolve_conflicts" attribute can't be set to "PRESERVE" on initial
│ resource creation. Use "resolve_conflicts_on_create" and/or
│ "resolve_conflicts_on_update" instead
╵
╷
│ Warning: Argument is deprecated
│
│   with module.eks.aws_eks_addon.this["vpc-cni"],
│   on .terraform/modules/eks/main.tf line 400, in resource "aws_eks_addon" "this":
│  400:   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
│
│ The "resolve_conflicts" attribute can't be set to "PRESERVE" on initial
│ resource creation. Use "resolve_conflicts_on_create" and/or
│ "resolve_conflicts_on_update" instead
╵
```