### PR TITLE
Integration aws-lb-controller 2.4->2.7 + don't depend on IMDS.

### DIFF
--- a/terraform/deployments/cluster-services/aws_lb_controller.tf
+++ b/terraform/deployments/cluster-services/aws_lb_controller.tf
@@ -5,17 +5,42 @@
 # ../cluster-infrastructure/aws_lb_controller_iam.tf. See
 # https://github.com/alphagov/govuk-infrastructure/blob/main/docs/architecture/decisions/0003-split-terraform-state-into-separate-aws-cluster-and-kubernetes-resource-phases.md#decision for rationale.
 
+locals {
+  aws_lb_values_integration = {
+    clusterName        = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id
+    defaultSSLPolicy   = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+    defaultTargetType  = "ip"
+    ingressClass       = "aws-alb"
+    ingressClassConfig = { default = true }
+    ingressClassParams = { spec = { loadBalancerAttributes = {
+      # TODO: factor out ALB attributes that are common to all of our ingresses.
+      # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes
+    } } }
+    podDisruptionBudget = var.desired_ha_replicas > 1 ? { minAvailable = 1 } : {}
+    replicaCount        = var.desired_ha_replicas
+    region              = data.aws_region.current.name
+    serviceMonitor      = { enabled = true }
+    vpcId               = data.tfe_outputs.vpc.nonsensitive_values.id
+    serviceAccount = {
+      name = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.aws_lb_controller_service_account_name
+      annotations = {
+        "eks.amazonaws.com/role-arn" = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.aws_lb_controller_role_arn
+      }
+    }
+  }
+}
+
 resource "helm_release" "aws_lb_controller" {
   name             = "aws-load-balancer-controller"
   repository       = "https://aws.github.io/eks-charts"
   chart            = "aws-load-balancer-controller"
-  version          = "1.4.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = var.govuk_environment == "integration" ? "1.7.2" : "1.4.4"
   namespace        = local.services_ns
   create_namespace = true
   timeout          = var.helm_timeout_seconds
-  values = [yamlencode({
+  values = [var.govuk_environment == "integration" ? yamlencode(local.aws_lb_values_integration) : yamlencode({
     clusterName      = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id
-    defaultSSLPolicy = "ELBSecurityPolicy-TLS13-1-2-2021-06" # TLS 1.3, backward compatible with 1.2
+    defaultSSLPolicy = "ELBSecurityPolicy-TLS13-1-2-2021-06"
     serviceAccount = {
       name = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.aws_lb_controller_service_account_name
       annotations = {
@@ -27,9 +52,14 @@ resource "helm_release" "aws_lb_controller" {
 }
 
 resource "helm_release" "aws_lb_ingress_class" {
+  count      = var.govuk_environment == "integration" ? 0 : 1
   name       = "aws-lb-ingress-class"
   repository = "https://alphagov.github.io/govuk-helm-charts/"
   chart      = "ingress-class"
-  version    = "0.1.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "0.1.1"
   timeout    = var.helm_timeout_seconds
+}
+moved {
+  from = helm_release.aws_lb_ingress_class
+  to   = helm_release.aws_lb_ingress_class[0]
 }

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -26,6 +26,10 @@ terraform {
       source  = "hashicorp/helm"
       version = "~> 2.0"
     }
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.53.0"
+    }
     # The AWS provider is only used here for remote state in remote.tf. Please
     # do not add AWS resources to this module.
     aws = {

--- a/terraform/deployments/cluster-services/remote.tf
+++ b/terraform/deployments/cluster-services/remote.tf
@@ -6,3 +6,8 @@ data "tfe_outputs" "cluster_infrastructure" {
   organization = "govuk"
   workspace    = "cluster-infrastructure-${var.govuk_environment}"
 }
+
+data "tfe_outputs" "vpc" {
+  organization = "govuk"
+  workspace    = "vpc-${var.govuk_environment}"
+}


### PR DESCRIPTION
Starting with just the integration cluster:

- Update aws-load-balancer-controller from 2.4 to 2.7.
- Pass the region and VPC ID to aws-lb-controller directly instead of implicitly depending on EC2 IMDS(v2) at startup.

Part of #1196 surfaced by #1201.

#### Rollout

[Update the aws-lb-controller CRDs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.7/deploy/installation/#summary):

```sh
curl -fs \
    https://raw.githubusercontent.com/aws/eks-charts/master/stable/aws-load-balancer-controller/crds/crds.yaml \
  | kubectl apply -f -
```