### PR TITLE
Manage govuk-attachments S3 buckets

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/attachments_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/attachments_s3.tf
@@ -1,0 +1,28 @@
+resource "aws_s3_bucket" "attachments" {
+  bucket = "govuk-attachments-${var.govuk_environment}"
+}
+
+resource "aws_s3_bucket_acl" "attachments" {
+  bucket = aws_s3_bucket.attachments.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "attachments" {
+  count  = var.govuk_environment == "production" ? 1 : 0
+  bucket = aws_s3_bucket.attachments.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "attachments" {
+  count  = var.govuk_environment == "integration" ? 1 : 0
+  bucket = aws_s3_bucket.attachments.id
+  rule {
+    id = "Expire-30-Days"
+    expiration {
+      days = 30
+    }
+    status = "Enabled"
+  }
+}


### PR DESCRIPTION
Migrated from app-govuk-attachments in govuk-aws

#1127 