### PR TITLE
Use renovate to manage TF provider updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "platformAutomerge": true,
+  "terraform":{
+    "commitMessageTopic": "Terraform {{depName}}",
+    "fileMatch": [
+      "\\.tf$"
+    ],
+    "packageRules": [
+      {
+        "matchDepTypes": ["provider"]
+      }
+    ]
+  }
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/attachments_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/attachments_s3.tf
@@ -26,8 +26,3 @@ resource "aws_s3_bucket_lifecycle_configuration" "attachments" {
     status = "Enabled"
   }
 }
-
-import {
-  to = aws_s3_bucket.attachments
-  id = "govuk-attachments-${var.govuk_environment}"
-}


### PR DESCRIPTION
Now we're using TFC for everything, automated provider updates shouldn't cause too much toil (at least when auto-apply is enabled)