### PR TITLE
Enable use_custom_launch_template in aws-eks module.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -39,7 +39,7 @@ locals {
       min_size                   = var.workers_size_min
       instance_types             = var.workers_instance_types
       disk_size                  = var.node_disk_size
-      use_custom_launch_template = false
+      use_custom_launch_template = var.govuk_environment == "integration" # TODO(#1201): remove with AL2023 rollout.
       update_config              = { max_unavailable = 1 }
       additional_tags = {
         "k8s.io/cluster-autoscaler/enabled"             = "true"
@@ -57,7 +57,7 @@ locals {
       min_size                   = var.arm_workers_size_min
       instance_types             = var.arm_workers_instance_types
       disk_size                  = var.node_disk_size
-      use_custom_launch_template = false
+      use_custom_launch_template = var.govuk_environment == "integration" # TODO(#1201): remove with AL2023 rollout.
       update_config              = { max_unavailable = 1 }
       additional_tags = {
         "k8s.io/cluster-autoscaler/enabled"             = "true"


### PR DESCRIPTION
The terraform-aws-eks module's [use_custom_launch_template](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/v19.21.0/modules/eks-managed-node-group#input_use_custom_launch_template) param determines whether the module sets its own (sensible) defaults for the launch template or uses the launch template that the EKS API creates.

It turns out that the EKS API's default launch template doesn't play nice with Amazon Linux 2023 because `MetadataOptions.http-put-response-hop-limit` defaults to `1`, which plays havoc with AWS SDK workloads that use instance profile authentication because they can't talk to IMDS.

I suspect this also affects workloads that use IRSA or Pod Identity but I haven't tested that.

The aws-eks module works around this, but only if you let it use its custom launch template.

Just the integration cluster for now, because AL2023 is only rolled out there so far.

#1201