### PR TITLE
Output the VPC ID from the VPC module.

### DIFF
--- a/terraform/deployments/vpc/outputs.tf
+++ b/terraform/deployments/vpc/outputs.tf
@@ -1,0 +1,1 @@
+output "id" { value = aws_vpc.vpc.id }


### PR DESCRIPTION
For use in downstream root modules including `cluster-services` (in #1204).

#1196