### PR TITLE
Add Taint restriction to ARM Nodes

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -70,6 +70,13 @@ locals {
       instance_types        = var.arm_workers_instance_types
       update_config         = { max_unavailable = 1 }
       block_device_mappings = local.main_managed_node_group.main.block_device_mappings
+
+      taint = {
+        key    = "kubernetes.io/arch"
+        value  = "arm64"
+        effect = "NO_SCHEDULE"
+      }
+
       additional_tags = {
         "k8s.io/cluster-autoscaler/enabled"             = "true"
         "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"


### PR DESCRIPTION
## What?
This adds a Taint restriction to the ARM Nodes so Kubernetes will only schedule pods that are explicitly marked to "tolerate" ARM64.

## TF Output
At the time of opening the PR:
```No changes Your infrastructure matches the configuration```

This is probably because we have already snowflake'd the taint configuration, so this change is just bringing the Terraform into spec.