### PR TITLE
Allow TFC to configure AWS Glue and EKS nodegroups + spring cleaning.

### DIFF
--- a/terraform/deployments/tfc-configuration/aws/main.tf
+++ b/terraform/deployments/tfc-configuration/aws/main.tf
@@ -10,21 +10,16 @@ resource "aws_iam_openid_connect_provider" "tfc_provider" {
 
 data "aws_iam_policy_document" "tfc_role" {
   statement {
-    effect = "Allow"
-
     principals {
       identifiers = [aws_iam_openid_connect_provider.tfc_provider.arn]
       type        = "Federated"
     }
-
     actions = ["sts:AssumeRoleWithWebIdentity"]
-
     condition {
       test     = "StringEquals"
       variable = "${var.tfc_hostname}:aud"
       values   = [one(aws_iam_openid_connect_provider.tfc_provider.client_id_list)]
     }
-
     condition {
       test     = "StringLike"
       variable = "${var.tfc_hostname}:sub"
@@ -34,18 +29,14 @@ data "aws_iam_policy_document" "tfc_role" {
 }
 
 resource "aws_iam_role" "tfc_role" {
-  name = "terraform-cloud"
-
+  name                = "terraform-cloud"
   assume_role_policy  = data.aws_iam_policy_document.tfc_role.json
   managed_policy_arns = [aws_iam_policy.tfc_policy.arn]
 }
 
 data "aws_iam_policy_document" "tfc_policy" {
   statement {
-    effect = "Allow"
-
     resources = ["*"]
-
     actions = [
       "acm:*",
       "apigateway:*",
@@ -136,8 +127,7 @@ data "aws_iam_policy_document" "tfc_policy" {
 resource "aws_iam_policy" "tfc_policy" {
   name        = "terraform-cloud-run"
   description = "Permissions to allow Terraform Cloud to plan and apply"
-
-  policy = data.aws_iam_policy_document.tfc_policy.json
+  policy      = data.aws_iam_policy_document.tfc_policy.json
 }
 
 resource "tfe_variable_set" "variable_set" {

--- a/terraform/deployments/tfc-configuration/aws/main.tf
+++ b/terraform/deployments/tfc-configuration/aws/main.tf
@@ -60,7 +60,24 @@ data "aws_iam_policy_document" "tfc_policy" {
       "elasticfilesystem:*",
       "es:*",
       "events:*",
-      "iam:*",
+      "iam:*InstanceProfile*",
+      "iam:*CloudFrontPublicKey*",
+      "iam:*OpenIDConnectProvider*",
+      "iam:*Policy",
+      "iam:*PolicyVersion",
+      "iam:*RolePolicies",
+      "iam:*RoleTags",
+      "iam:*Roles",
+      "iam:*ServerCertificate*",
+      "iam:*ServiceLinkedRole*",
+      "iam:*SigningCertificate*",
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:GetRole",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateRole",
+      "iam:SetDefaultPolicyVersion",
       "kms:*",
       "lambda:*",
       "logs:*",
@@ -74,12 +91,30 @@ data "aws_iam_policy_document" "tfc_policy" {
       "wafv2:*"
     ]
   }
-
   statement {
-    effect = "Deny"
-
+    actions   = ["iam:PassRole"]
     resources = ["*"]
-
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["eks.amazonaws.com"]
+    }
+  }
+  statement {
+    actions = ["iam:PassRole"]
+    resources = [
+      "arn:aws:iam::*:role/service-role/AWSGlueServiceRole*",
+      "arn:aws:iam::*:role/AWSGlueServiceRole*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["glue.amazonaws.com"]
+    }
+  }
+  statement {
+    effect    = "Deny"
+    resources = ["*"]
     actions = [
       "aws-marketplace:*",
       "aws-marketplace-management:*",
@@ -93,7 +128,7 @@ data "aws_iam_policy_document" "tfc_policy" {
       "iam:*Group*",
       "iam:*PermissionsBoundary*",
       "iam:*User*",
-      "iam:CreateServiceLinkedRole"
+      "iam:CreateServiceLinkedRole",
     ]
   }
 }

--- a/terraform/deployments/tfc-configuration/aws/provider.tf
+++ b/terraform/deployments/tfc-configuration/aws/provider.tf
@@ -28,4 +28,3 @@ provider "tfe" {
   hostname     = var.tfc_hostname
   organization = var.tfc_organization_name
 }
-

--- a/terraform/deployments/tfc-configuration/aws/provider.tf
+++ b/terraform/deployments/tfc-configuration/aws/provider.tf
@@ -13,9 +13,13 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.5"
     }
-
     tfe = {
+      source  = "hashicorp/tfe"
       version = "~> 0.53.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
     }
   }
 }

--- a/terraform/deployments/tfc-configuration/aws/provider.tf
+++ b/terraform/deployments/tfc-configuration/aws/provider.tf
@@ -22,6 +22,16 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
+  default_tags {
+    tags = {
+      Product              = "GOV.UK"
+      System               = "Terraform Cloud"
+      Environment          = var.aws_environment
+      Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      repository           = "govuk-infrastructure"
+      terraform_deployment = basename(abspath(path.root))
+    }
+  }
 }
 
 provider "tfe" {

--- a/terraform/deployments/tfc-configuration/provider.tf
+++ b/terraform/deployments/tfc-configuration/provider.tf
@@ -21,4 +21,3 @@ provider "tfe" {
   organization = var.organization
   token        = var.token
 }
-

--- a/terraform/deployments/tfc-configuration/variables.tf
+++ b/terraform/deployments/tfc-configuration/variables.tf
@@ -16,6 +16,7 @@ variable "organization" {
 variable "token" {
   type        = string
   description = "Account token"
+  sensitive   = true
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
- Give Terraform Cloud permissions to:
  - create EKS managed node groups
  - manage AWS Glue catalogs/schemas (we'll need it when we port the CDN log ingestion stuff over from alphagov/govuk-aws)
- Add AWS tags for the couple of resources that the tfc-configuration module manages.

Plus some minor syntactic cleanup while we're there. See commits for detail.