### PR TITLE
Fix digest variable name.

### DIFF
--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           mkdir -p /tmp/digests
           digest="${{steps.build-image.outputs.digest }}"
-          touch "/tmp/digests/${baseDigest#sha256:}"
+          touch "/tmp/digests/${digest#sha256:}"
 
       - id: upload-digests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What?
This fixes the variable being used to output/upload the image digest in the multi-arch build workflow - I missed this out when copying the flow over from the ruby image workflows.