### PR TITLE
Revert "Set grafana DB backup window to match what was set in AWS"

### DIFF
--- a/terraform/deployments/cluster-infrastructure/grafana.tf
+++ b/terraform/deployments/cluster-infrastructure/grafana.tf
@@ -1,11 +1,6 @@
 locals {
   grafana_db_name         = "grafana-${module.eks.cluster_name}"
   grafana_service_account = "kube-prometheus-stack-grafana"
-  grafana_db_backup_window = {
-    "integration" = "mon:00:35-mon:01:05"
-    "staging"     = "fri:04:03-fri:05:03"
-    "production"  = "wed:22:11-wed:23:11"
-  }
 }
 
 module "grafana_iam_role" {
@@ -123,7 +118,6 @@ module "grafana_db" {
   apply_immediately       = var.rds_apply_immediately
   backup_retention_period = var.rds_backup_retention_period
   skip_final_snapshot     = var.rds_skip_final_snapshot
-  preferred_backup_window = lookup(local.grafana_db_backup_window, var.govuk_environment, "sun:05:00-sun:06:00")
 }
 
 resource "aws_route53_record" "grafana_db" {

--- a/terraform/deployments/cluster-infrastructure/grafana.tf
+++ b/terraform/deployments/cluster-infrastructure/grafana.tf
@@ -115,9 +115,10 @@ module "grafana_db" {
     timeout_action           = "ForceApplyCapacityChange"
   }
 
-  apply_immediately       = var.rds_apply_immediately
-  backup_retention_period = var.rds_backup_retention_period
-  skip_final_snapshot     = var.rds_skip_final_snapshot
+  apply_immediately            = var.rds_apply_immediately
+  backup_retention_period      = var.rds_backup_retention_period
+  skip_final_snapshot          = var.rds_skip_final_snapshot
+  preferred_maintenance_window = "sun:02:00-sun:03:00"
 }
 
 resource "aws_route53_record" "grafana_db" {


### PR DESCRIPTION
Turns out this doesn't apply to serverless aurora instances

This reverts commit 7f8b7206a183830db6c2b29482a44c6d0012c434.