### PR TITLE
Adds govuk-chat as a sentry project

### DIFF
--- a/terraform/deployments/sentry/locals.tf
+++ b/terraform/deployments/sentry/locals.tf
@@ -18,6 +18,7 @@ locals {
     "content-tagger"           = [],
     "datagovuk_find"           = ["govuk-datagovuk"],
     "datagovuk_publish"        = ["govuk-datagovuk"],
+    "govuk-chat"               = [],
     "email-alert-api"          = ["govuk-content-interactions-on-platform", "govuk-find-and-view"],
     "email-alert-frontend"     = ["govuk-content-interactions-on-platform", "govuk-find-and-view"],
     "email-alert-service"      = ["govuk-content-interactions-on-platform", "govuk-find-and-view"],


### PR DESCRIPTION
- Followed instructions from here: https://docs.publishing.service.gov.uk/manual/sentry.html#how-gov-uk-projects-are-added-to-sentry
- I haven't added any additional groups other than the default `govuk-developers` for now. All users that are part of `govuk-find-and-view` are also part of `govuk-developers`, so just kept the default one. Group info: https://github.com/alphagov/govuk-user-reviewer/blob/18188621f1f05ab561df72d82e5d3bc99d28a080/config/govuk_tech.yml

Trello card: https://trello.com/c/ewV5ilJ6/1229-initial-terraform-for-integration-environment