### PR TITLE
Add www.data.gov.uk to allowed origins for DGU organogram bucket

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/organogram_bucket.tf
+++ b/terraform/deployments/datagovuk-infrastructure/organogram_bucket.tf
@@ -40,6 +40,7 @@ resource "aws_s3_bucket_cors_configuration" "datagovuk_organogram" {
     allowed_methods = ["GET"]
     allowed_origins = [
       "https://data.gov.uk",
+      "https://www.data.gov.uk",
       "https://staging.data.gov.uk",
       "https://www.staging.data.gov.uk",
       "https://integration.data.gov.uk",


### PR DESCRIPTION
This origin was missed during the migration, and is causing CORS issues in production