### PR TITLE
Shared multiarch workflow will now use Github ARM

### DIFF
--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -26,18 +26,41 @@ on:
 jobs:
   build-and-push-image:
     name: Build and push image for ${{ inputs.ecrRepositoryName }}
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         arch:
           - amd64
           - arm64
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: arm64-runner
+    runs-on: ${{ matrix.runner }}
     outputs:
       imageTag: ${{ steps.meta.outputs.version }}
     permissions:
       id-token: write
       contents: read
     steps:
+      - name: Install Docker (Github ARM Only)
+        if: ${{ matrix.runner == 'arm64-runner' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          sudo usermod -a -G docker $USER
+          sudo apt-get install acl
+          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitRef }}
@@ -55,12 +78,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
-
-      - name: Set up QEMU for ${{ matrix.arch }} build
-        if: ${{ matrix.arch != 'amd64' }}
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: ${{ matrix.arch }}
 
       - uses: docker/setup-buildx-action@v3
 
@@ -97,8 +114,8 @@ jobs:
           build-args: ${{ inputs.buildArgs }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=build-${{ matrix.arch}}
-          cache-to: type=gha,scope=build-${{ matrix.arch}},mode=max
+          cache-from: type=gha,scope=build-${{ matrix.arch }}
+          cache-to: type=gha,scope=build-${{ matrix.arch }},mode=max
 
       - id: export-digests
         run: |
@@ -124,6 +141,24 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Install Docker (Github ARM Only)
+        if: ${{ matrix.runner == 'arm64-runner' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          sudo usermod -a -G docker $USER
+          sudo apt-get install acl
+          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
+
       - name: Download Digests
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## What?
So we updated the workflow on the Ruby Images, but did not update the shared workflow here. Let's fix that.

This change now flips the `runs-on` setting to use the relevant Github runner for the relevant build.