### PR TITLE
Add gem topic and token

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -71,6 +71,11 @@ locals {
     for r in data.github_repository.govuk_repo_names : r
     if !r.fork && !contains(r.topics, "govuk-sensitive-access")
   ]
+
+  gems = [
+    for r in data.github_repository.govuk : r
+    if !r.fork && contains(r.topics, "gem")
+  ]
 }
 
 resource "github_team" "govuk_ci_bots" {
@@ -120,6 +125,11 @@ resource "github_team_repository" "govuk_repos" {
 resource "github_actions_organization_secret_repositories" "ci_user_github_api_token" {
   secret_name             = "GOVUK_CI_GITHUB_API_TOKEN"
   selected_repository_ids = [for repo in local.deployable_repos : repo.repo_id]
+}
+
+resource "github_actions_organization_secret_repositories" "gems_github_api_token" {
+  secret_name             = "GOVUK_CI_GITHUB_API_TOKEN"
+  selected_repository_ids = [for repo in local.gems : repo.repo_id]
 }
 
 resource "github_actions_organization_secret_repositories" "argo_events_webhook_token" {


### PR DESCRIPTION
Filter repos by gem and ensure they have needed token.

This should fix the gem autorelease workflow errors.

https://trello.com/c/Wjv5dUpZ/3498-fix-token-for-autorelease-workflow