### PR TITLE
Clean up remote state references in govuk-pub-infra module.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/frontend_memcache.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/frontend_memcache.tf
@@ -9,7 +9,7 @@ resource "aws_elasticache_subnet_group" "frontend_memcached" {
 
 resource "aws_security_group" "frontend_memcached" {
   name        = local.frontend_memcached_name
-  vpc_id      = local.vpc_id
+  vpc_id      = data.tfe_outputs.vpc.nonsensitive_values.id
   description = "${local.frontend_memcached_name} memcached instance"
   tags = {
     System = "Frontend Memcached"

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -31,7 +31,6 @@ terraform {
 
 locals {
   cluster_name         = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id
-  vpc_id               = data.terraform_remote_state.infra_networking.outputs.vpc_id
   internal_dns_zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
   external_dns_zone_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.external_dns_zone_id
   elasticache_subnets  = data.terraform_remote_state.infra_networking.outputs.private_subnet_elasticache_ids

--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -20,24 +20,6 @@ data "tfe_outputs" "vpc" {
   workspace    = "vpc-${var.govuk_environment}"
 }
 
-data "terraform_remote_state" "infra_assets" {
-  backend = "s3"
-  config = {
-    bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-assets.tfstate"
-    region = data.aws_region.current.name
-  }
-}
-
-data "terraform_remote_state" "infra_content_publisher" {
-  backend = "s3"
-  config = {
-    bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-content-publisher.tfstate"
-    region = data.aws_region.current.name
-  }
-}
-
 data "terraform_remote_state" "infra_networking" {
   backend = "s3"
   config = {
@@ -72,12 +54,6 @@ data "terraform_remote_state" "app_govuk_rds" {
     bucket = var.govuk_aws_state_bucket
     key    = "blue/app-govuk-rds.tfstate"
     region = data.aws_region.current.name
-  }
-
-  # TODO: hack because govuk-aws/app-govuk-rds is not terraformed in `test`.
-  # `test` still uses a single postgres instance for many apps.
-  defaults = {
-    sg_rds = {}
   }
 }
 

--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -65,15 +65,6 @@ data "terraform_remote_state" "infra_security_groups" {
   }
 }
 
-data "terraform_remote_state" "infra_vpc" {
-  backend = "s3"
-  config = {
-    bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-vpc.tfstate"
-    region = data.aws_region.current.name
-  }
-}
-
 data "terraform_remote_state" "app_govuk_rds" {
   backend = "s3"
 

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -146,7 +146,7 @@ resource "aws_security_group_rule" "efs_from_eks_workers" {
 
 resource "aws_security_group" "eks_ingress_www_origin" {
   name        = "eks_ingress_www_origin"
-  vpc_id      = data.terraform_remote_state.infra_vpc.outputs.vpc_id
+  vpc_id      = data.tfe_outputs.vpc.nonsensitive_values.id
   description = "ALBs serving EKS www-origin ingress (and signon ALBs in non-prod environments)."
   tags = {
     System = "Frontend"

--- a/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/shared_redis.tf
@@ -9,7 +9,7 @@ resource "aws_elasticache_subnet_group" "shared_redis_cluster" {
 
 resource "aws_security_group" "shared_redis_cluster" {
   name        = local.shared_redis_name
-  vpc_id      = local.vpc_id
+  vpc_id      = data.tfe_outputs.vpc.nonsensitive_values.id
   description = "${local.shared_redis_name} Redis cluster"
   tags = {
     Name   = local.shared_redis_name


### PR DESCRIPTION
- Consistently use the new vpc module for the VPC ID.
- Remove some disused remote state data resources.

Should be no diff.