### PR TITLE
Change how Taints are configured

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -70,11 +70,13 @@ locals {
       update_config         = { max_unavailable = 1 }
       block_device_mappings = local.main_managed_node_group.main.block_device_mappings
 
-      taint = {
-        key    = "kubernetes.io/arch"
-        value  = "arm64"
-        effect = "NO_SCHEDULE"
-      }
+      taints = [
+        {
+          key    = "kubernetes.io/arch"
+          value  = "arm64"
+          effect = "NO_SCHEDULE"
+        }
+      ]
 
       additional_tags = {
         "k8s.io/cluster-autoscaler/enabled"             = "true"


### PR DESCRIPTION
## What?
So it looked like our previous attempt to define a taint didn't work. What we were using before was how the AWS Provider expects taints to be defined without using the EKS Module. The EKS module instead seems to take an array in `var.taints` and uses a dynamic{} block to generate the final Terraform config for you.