### PR TITLE
Use an unreserved key for the taint for now.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -71,7 +71,7 @@ locals {
       block_device_mappings = local.main_managed_node_group.main.block_device_mappings
       taints = {
         arch = {
-          key    = "kubernetes.io/arch"
+          key    = "arch"
           value  = "arm64"
           effect = "NO_SCHEDULE"
         }


### PR DESCRIPTION
## What?
So it turns out that EKS have decided that `kubernetes.io/anything` is reserved and should not be set when applying a taint. To get around this we'll just set our own taint for the time being.