### PR TITLE
Turn off Argo CD chart's "redis-ha" option.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -138,7 +138,6 @@ resource "helm_release" "argo_cd" {
 
     applicationSet = { replicas = var.desired_ha_replicas }
     dex            = { enabled = false }
-    redis-ha       = { enabled = var.argo_redis_ha }
 
     notifications = {
       argocdUrl = "https://${local.argo_host}"

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -10,12 +10,6 @@ variable "argo_workflows_namespaces" {
   default     = ["apps"]
 }
 
-variable "argo_redis_ha" {
-  type        = bool
-  description = "Whether to run high-availability (3 replicas) Redis for ArgoCD, instead of 1 replica."
-  default     = true
-}
-
 variable "github_read_write_team" {
   type        = string
   description = "Name of the GitHub team that should have read-write access to Dex SSO-enabled applications"

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -49,7 +49,6 @@ module "variable-set-integration" {
 
     secrets_recovery_window_in_days = 0
 
-    argo_redis_ha       = false
     desired_ha_replicas = 1
 
     ckan_s3_organogram_bucket = "datagovuk-integration-ckan-organogram"


### PR DESCRIPTION
This option sounds great, but turns out to be [pretty gross](https://www.github.com/argoproj/argo-cd/blob/4f6a8dc/manifests/ha/namespace-install.yaml#L862) under the hood and is almost certainly a net loss for reliability.

Proximate reason for getting rid of it is that it doesn't play nice with the AL2023 node image. This bug is just the tip of the iceberg: https://www.github.com/argoproj/argo-helm/issues/1958

Redis isn't really critical for Argo CD anyway; it's fine if it's momentarily unavailable, whereas running a bunch of HAProxy in front of a replicated, leader-elected, Redis statefulset is a recipe for pain.

Tested in staging; solves the immediate problem and results in a way simpler setup.

#1201