### PR TITLE
Avoid "special" characters in RDS passwords.

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -1,8 +1,8 @@
 resource "random_string" "database_password" {
   for_each = var.databases
 
-  length = 32
-  lower  = true
+  length  = 32
+  special = false
 }
 
 resource "aws_db_subnet_group" "subnet_group" {


### PR DESCRIPTION
This can make the RDS API fall over with excuses like `The parameter MasterUserPassword is not a valid password. Only printable ASCII characters besides '/', '@', '"', ' ' may be used.`