### PR TITLE
Update EKS module from 19 to 20

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -129,7 +129,7 @@ resource "aws_iam_role_policy_attachment" "node" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.0"
+  version = "~> 20.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version
@@ -152,11 +152,14 @@ module "eks" {
     provider_key_arn = aws_kms_key.eks.arn
     resources        = ["secrets"]
   }
-  create_kms_key = false
+  create_kms_key                = false
+  kms_key_enable_default_policy = false
 
   # We're just using the cluster primary SG as created by EKS.
   create_cluster_security_group = false
   create_node_security_group    = false
+
+  authentication_mode = "CONFIG_MAP"
 
   eks_managed_node_group_defaults = {
     ami_type = (


### PR DESCRIPTION
Description:
- See https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-20.0.md for a list of backward incompatible changes
- The default value for `authentication_mode` is "API_AND_CONFIG_MAP". However we are using "CONFIG_MAP" only.
- Default policy of `kms_key_enable_default_policy` is true whereby if we don't specify the key policy for a new KMS key AWS will create it for us. But since we aren't creating a kms key here we can set it to false
- The creation of the aws_auth ConfigMap is handled by the kubernetes provider in aws_auth_configmap.tf. No need to use the sub-module as we don't want the cluster-infrastructure/main.tf to create the aws_auth ConfigMap as specified in https://docs.publishing.service.gov.uk/repos/govuk-infrastructure/architecture/decisions/0003-split-terraform-state-into-separate-aws-cluster-and-kubernetes-resource-phases.html
- Closes https://github.com/alphagov/govuk-infrastructure/issues/1202