### PR TITLE
Add GCP OIDC connection resources and import a GCP bucket

### DIFF
--- a/terraform/deployments/tfc-aws-config/README.md
+++ b/terraform/deployments/tfc-aws-config/README.md
@@ -10,10 +10,13 @@ You must apply this module locally. It cannot be applied from within Terraform
 Cloud.
 
 ```sh
+# Log in to GCP (only needs to be done once)
+gcloud auth application-default login
+# Run Terraform
 terraform init
 for account in tools test integration staging production; do
   terraform workspace select tfc-aws-config-$account
   gds aws govuk-$account-admin -- \
-    terraform apply -var=aws_environment=$account
+    terraform apply -var=govuk_environment=$account
 done
 ```

--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -139,7 +139,7 @@ resource "aws_iam_policy" "tfc_policy" {
 }
 
 resource "tfe_variable_set" "variable_set" {
-  name = "aws-credentials-${var.aws_environment}"
+  name = "aws-credentials-${var.govuk_environment}"
 }
 
 resource "tfe_variable" "tfc_var_aws_provider_auth" {

--- a/terraform/deployments/tfc-aws-config/gcp_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/gcp_oidc.tf
@@ -1,0 +1,63 @@
+data "google_project" "project" {}
+
+resource "google_iam_workload_identity_pool" "tfc" {
+  workload_identity_pool_id = "terraform-cloud-${var.govuk_environment}"
+  display_name              = "Terraform Cloud (${var.govuk_environment})"
+  description               = "Identity pool for Terraform Cloud connection to GCP (${var.govuk_environment})"
+}
+
+resource "google_iam_workload_identity_pool_provider" "tfc" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.tfc.workload_identity_pool_id
+  workload_identity_pool_provider_id = "terraform-cloud-${var.govuk_environment}"
+  attribute_condition                = "assertion.sub.startsWith(\"organization:govuk:\")"
+  attribute_mapping = {
+    "google.subject" = "assertion.terraform_organization_name"
+  }
+  oidc {
+    issuer_uri = "https://app.terraform.io"
+  }
+}
+
+resource "google_service_account" "tfc" {
+  account_id = "terraform-cloud-${var.govuk_environment}"
+}
+
+resource "google_project_iam_binding" "tfc" {
+  project = "govuk-${var.govuk_environment}"
+  role    = "roles/editor"
+  members = ["serviceAccount:${google_service_account.tfc.email}"]
+}
+
+data "google_iam_policy" "tfc" {
+  binding {
+    role = "roles/iam.workloadIdentityUser"
+    members = [
+      "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/terraform-cloud-${var.govuk_environment}/subject/govuk"
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "tfc" {
+  service_account_id = google_service_account.tfc.id
+  policy_data        = data.google_iam_policy.tfc.policy_data
+}
+
+resource "tfe_variable_set" "gcp_variable_set" {
+  name = "gcp-credentials-${var.govuk_environment}"
+}
+
+resource "tfe_variable" "tfc_var_gcp_provider_auth" {
+  key             = "TFC_GCP_PROVIDER_AUTH"
+  value           = "true"
+  category        = "env"
+  description     = "Configures Terraform Cloud to authenticate with GCP using dynamic credentials"
+  variable_set_id = tfe_variable_set.gcp_variable_set.id
+}
+
+resource "tfe_variable" "tfc_var_gcp_run_service_account_email" {
+  key             = "TFC_GCP_RUN_SERVICE_ACCOUNT_EMAIL"
+  value           = google_service_account.tfc.email
+  category        = "env"
+  description     = "The service account email TFC will use with authenticating with GCP"
+  variable_set_id = tfe_variable_set.gcp_variable_set.id
+}

--- a/terraform/deployments/tfc-aws-config/provider.tf
+++ b/terraform/deployments/tfc-aws-config/provider.tf
@@ -21,6 +21,10 @@ terraform {
       source  = "hashicorp/tls"
       version = "~> 4.0"
     }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.26"
+    }
   }
 }
 
@@ -30,11 +34,23 @@ provider "aws" {
     tags = {
       Product              = "GOV.UK"
       System               = "Terraform Cloud"
-      Environment          = var.aws_environment
+      Environment          = var.govuk_environment
       Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
       repository           = "govuk-infrastructure"
       terraform_deployment = basename(abspath(path.root))
     }
+  }
+}
+
+provider "google" {
+  project = "govuk-${var.govuk_environment}"
+  default_labels = {
+    Product              = "GOV.UK"
+    System               = "Terraform Cloud"
+    Environment          = var.govuk_environment
+    Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+    repository           = "govuk-infrastructure"
+    terraform_deployment = basename(abspath(path.root))
   }
 }
 

--- a/terraform/deployments/tfc-aws-config/variables.tf
+++ b/terraform/deployments/tfc-aws-config/variables.tf
@@ -1,4 +1,4 @@
-variable "aws_environment" {
+variable "govuk_environment" {
   type        = string
   description = "The name of the AWS environment"
 }

--- a/terraform/deployments/tfc-configuration/vpc.tf
+++ b/terraform/deployments/tfc-configuration/vpc.tf
@@ -26,6 +26,7 @@ module "vpc-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
+    "gcp-credentials-integration",
     "common",
     "common-integration"
   ]

--- a/terraform/deployments/vpc/google_logging_bucket.tf
+++ b/terraform/deployments/vpc/google_logging_bucket.tf
@@ -1,0 +1,35 @@
+data "google_project" "project" {}
+
+resource "google_storage_bucket" "google_logging" {
+  name          = "govuk-${var.govuk_environment}-gcp-logging"
+  location      = "eu"
+  storage_class = "multi_regional"
+  project       = data.google_project.project.id
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age = 30
+    }
+  }
+}
+
+resource "google_storage_bucket_acl" "google_logging" {
+  bucket = google_storage_bucket.google_logging.name
+
+  role_entity = [
+    "WRITER:group-cloud-storage-analytics@google.com",
+  ]
+}
+
+import {
+  to = google_storage_bucket.google_logging
+  id = "${data.google_project.project.id}/govuk-${var.govuk_environment}-gcp-logging"
+}

--- a/terraform/deployments/vpc/main.tf
+++ b/terraform/deployments/vpc/main.tf
@@ -27,3 +27,15 @@ provider "aws" {
     }
   }
 }
+
+provider "google" {
+  project = "govuk-${var.govuk_environment}"
+  default_labels = {
+    Product              = "GOV.UK"
+    System               = "Terraform Cloud"
+    Environment          = var.govuk_environment
+    Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+    repository           = "govuk-infrastructure"
+    terraform_deployment = basename(abspath(path.root))
+  }
+}


### PR DESCRIPTION
This adds the initial config for a TFC -> GCP OIDC connection. It has already been applied in integration, but not tested yet.

It also imports a GCP bucket from govuk-aws as a test

TODO: rename the vpc deployment to something more appropriate

#1127 