### PR TITLE
Update Argo CD and Workflows to latest patch releases.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -47,7 +47,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "6.7.11" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "6.7.17" # TODO: Dependabot or equivalent so this doesn't get neglected.
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     global = {

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -184,7 +184,7 @@ resource "helm_release" "argo_workflows" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "0.41.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.41.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     controller = {


### PR DESCRIPTION
Argo CD 2.10.6 -> [2.10.8](https://github.com/argoproj/argo-cd/blob/-/CHANGELOG.md#v248-2022-07-29)

Argo Workflows 3.5.5 -> [3.5.6](https://github.com/argoproj/argo-workflows/blob/-/CHANGELOG.md#v356-2024-04-19)