### PR TITLE
Update filebeat and make it run on ARM nodes.

### DIFF
--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -12,7 +12,15 @@ resource "helm_release" "filebeat" {
   create_namespace = true
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
-    daemonset = { secretMounts = [] }
+    daemonset = {
+      secretMounts = []
+      tolerations = [{ # TODO: remove once we no longer run amd64 (Intel) nodes.
+        key      = "arch"
+        operator = "Equal"
+        value    = "arm64"
+        effect   = "NoSchedule"
+      }]
+    }
     filebeatConfig = {
       "filebeat.yml" = yamlencode(yamldecode(file("${path.module}/filebeat.yml")))
     }

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -24,7 +24,7 @@ resource "helm_release" "filebeat" {
     filebeatConfig = {
       "filebeat.yml" = yamlencode(yamldecode(file("${path.module}/filebeat.yml")))
     }
-    imageTag = "8.11.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
+    imageTag = "8.13.2" # TODO: Dependabot or equivalent so this doesn't get neglected.
     clusterRoleRules = [
       {
         apiGroups = [""]


### PR DESCRIPTION
- Add the arm64 node toleration for the filebeat daemonset so it runs on all nodes again.
- Update filebeat from 8.11.3 to 8.13.2.