### PR TITLE
We have run out of capacity on Integration for ARM

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -33,6 +33,10 @@ module "variable-set-integration" {
     force_destroy      = true
     enable_arm_workers = true
 
+    workers_size_min     = 3
+    workers_size_desired = 3
+    workers_size_max     = 5
+
     publishing_service_domain = "integration.publishing.service.gov.uk"
 
     frontend_memcached_node_type   = "cache.t4g.micro"


### PR DESCRIPTION
## What?
We have started getting scheduling error on Integration when trying to schedule ARM pods. This is because we have auto-scaling set too low and EKS needs to step in more instances!

We'll set our desired to 3 and our max to 5 for now. We can bump these again if needed.

Spotted by @kentsanggds @KludgeKML.