### PR TITLE
Switch the ARM Worker ASG default amounts.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -72,19 +72,19 @@ variable "arm_workers_default_capacity_type" {
 variable "arm_workers_size_desired" {
   type        = number
   description = "Desired capacity of ARM-based managed node autoscale group."
-  default     = 1
+  default     = 6
 }
 
 variable "arm_workers_size_min" {
   type        = number
   description = "Min capacity of ARM-based managed node autoscale group."
-  default     = 1
+  default     = 3
 }
 
 variable "arm_workers_size_max" {
   type        = number
   description = "Max capacity of ARM-based managed node autoscale group."
-  default     = 3
+  default     = 12
 }
 
 variable "workers_instance_types" {

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -33,10 +33,6 @@ module "variable-set-integration" {
     force_destroy      = true
     enable_arm_workers = true
 
-    workers_size_min     = 3
-    workers_size_desired = 3
-    workers_size_max     = 5
-
     publishing_service_domain = "integration.publishing.service.gov.uk"
 
     frontend_memcached_node_type   = "cache.t4g.micro"


### PR DESCRIPTION
## What?
This changes (increases) the ARM Worker default ASG amounts from 1-1-3 to 3-6-12, in line with what we have for the existing AMD64 defaults.

## Related
This succeeds the previous ASG change, which would have changed the wrong scaling values (and was not applied).

* https://github.com/alphagov/govuk-infrastructure/pull/1284