### PR TITLE
Continue to upload SARIF on Brakeman errors

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -21,6 +21,7 @@ jobs:
           bundler-cache: true
 
       - name: Run Brakeman
+        continue-on-error: true
         run: bundle exec brakeman . --except CheckRenderInline --quiet -f sarif >> brakeman.sarif
 
       - name: Upload result to Github Code Scanning


### PR DESCRIPTION
By default Brakeman returns a non-zero exit code if any security warnings are found or scanning errors are encountered. This ensures the scan output (SARIF file) gets uploaded to GitHub Code scanning.