### PR TITLE
Enable ARM builds for "sidecar" images.

### DIFF
--- a/.github/workflows/build-clamav-image.yml
+++ b/.github/workflows/build-clamav-image.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build-and-push-image:
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
       ecrRepositoryName: clamav

--- a/.github/workflows/build-mongodb-image.yml
+++ b/.github/workflows/build-mongodb-image.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build-and-push-image:
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
       ecrRepositoryName: mongodb

--- a/.github/workflows/build-toolbox-image.yml
+++ b/.github/workflows/build-toolbox-image.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build-and-push-image:
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
       ecrRepositoryName: toolbox

--- a/images/clamav/Dockerfile
+++ b/images/clamav/Dockerfile
@@ -1,4 +1,4 @@
-FROM clamav/clamav-debian:1.2
+FROM --platform=$TARGETPLATFORM clamav/clamav-debian:1.2
 
 COPY "./images/clamav/scripts/unprivileged-entrypoint.sh" "/unpriv-init"
 

--- a/images/mongodb/Dockerfile
+++ b/images/mongodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lts/ubuntu:22.04
+FROM --platform=$TARGETPLATFORM public.ecr.aws/lts/ubuntu:22.04
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ENV MONGO_VERSION 2.6.12

--- a/images/toolbox/Dockerfile
+++ b/images/toolbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lts/ubuntu:22.04
+FROM --platform=$TARGETPLATFORM public.ecr.aws/lts/ubuntu:22.04
 ARG TARGETARCH
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 


### PR DESCRIPTION
## What?
This enables ARM builds for the following images:

* ClamAV
* MongoDB
* Toolbox (AKA Glthub-CLI)