### PR TITLE
Try and tag builds on main as "latest".

### DIFF
--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -187,6 +187,7 @@ jobs:
           labels: |
             org.opencontainers.image.vendor=GDS
           tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,priority=500,value=${{ inputs.gitRef }},enable=${{ startsWith(inputs.gitRef, 'v') }}
             type=raw,priority=400,value=${{ needs.build-and-push-image.outputs.localSha }},enable=${{ !startsWith(inputs.gitRef, 'v') }}
 


### PR DESCRIPTION
## What?
Some of our helper/sidecar images don't have explicit version tags and instead rely on pulling "latest" which is causing us some issues with our multi-arch images. Also we aren't getting the latest image, which is concerning.

Let's tag all images that are built from the `main` branch of a repo, to make this a more consistent experience.