### PR TITLE
Update Argo CD to 2.11.0.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -47,7 +47,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "6.7.18" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "6.8.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     global = {


### PR DESCRIPTION
Should be able to use [manifest-generate-paths] to [speed up syncs](https://blog.argoproj.io/argo-cd-v2-11-release-candidate-b83ba3008ba5#dccd).

https://github.com/argoproj/argo-cd/compare/v2.10.9...v2.11.0

[manifest-generate-paths]: https://argo-cd.readthedocs.io/en/latest/operator-manual/high_availability/#manifest-paths-annotation

Tested: running on the staging cluster (`helm repo update && helm -n cluster-services upgrade argo-cd argo-helm/argo-cd`)