### PR TITLE
Turns out Filebeat 8.13.4 isn't tagged yet :/

### DIFF
--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -24,7 +24,7 @@ resource "helm_release" "filebeat" {
     filebeatConfig = {
       "filebeat.yml" = yamlencode(yamldecode(file("${path.module}/filebeat.yml")))
     }
-    imageTag = "8.13.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
+    imageTag = "8.13.3" # TODO: Dependabot or equivalent so this doesn't get neglected.
     clusterRoleRules = [
       {
         apiGroups = [""]


### PR DESCRIPTION
My bad, I shoulda checked before merging 29c3895.

[8.13.3](https://www.docker.elastic.co/r/beats/filebeat:8.13.3) is definitely there.