### PR TITLE
Send Amazon Inspector image scan results to PlatEng.

### DIFF
--- a/terraform/deployments/ecr/ecr-scan.tf
+++ b/terraform/deployments/ecr/ecr-scan.tf
@@ -44,11 +44,7 @@ resource "aws_cloudwatch_event_rule" "event_rule" {
     "detail-type" : ["ECR Image Scan"],
     "detail" : {
       "finding-severity-counts" : {
-        "HIGH" : [
-          {
-            "numeric" : [">", 0]
-          }
-        ]
+        "CRITICAL" : [{ "numeric" : [">", 0] }]
       }
     }
   })

--- a/terraform/deployments/ecr/variables.tf
+++ b/terraform/deployments/ecr/variables.tf
@@ -5,8 +5,7 @@ variable "puller_arns" {
 
 variable "emails" {
   type    = list(string)
-  default = [] # TODO: Set emails in tfvars.
-
+  default = []
 }
 
 variable "govuk_environment" {

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -70,11 +70,7 @@ module "variable-set-ecr-production" {
 
   name = "ecr-production"
   tfvars = {
-    emails = [
-      # TODO: manage this via a mailing list so as not to introduce toil.
-      "nadeem.sabri@digital.cabinet-office.gov.uk",
-      "chris.banks@digital.cabinet-office.gov.uk",
-    ]
+    emails = ["govuk-platform-engineering+ecr-inspector@digital.cabinet-office.gov.uk"]
   }
 }
 


### PR DESCRIPTION
We're paying for this, so we might as well have a look at the results.

Also set the threshold to crit for now. Remains to be seen if there's value in these scan results, but there's really only one way to find out!

It's also quite likely that the "Enhanced" option overlaps with GitHub's scanning features, but let's see.

https://docs.aws.amazon.com/inspector/latest/user/scanning-ecr.html