### PR TITLE
Remove empty + disused repos from ECR.

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -57,12 +57,9 @@ locals {
   )
 
   extra_repositories = [
-    "github-cli",
     "mongodb",
     "toolbox",
     "clamav",
-    "statsd",
-    "govuk-terraform",
     "search-api-learn-to-rank",
     "licensify-backend",
     "licensify-feed",


### PR DESCRIPTION
`github-cli` is now `toolbox` and the last remaining imagerefs are updated.

`statsd` and `govuk-terraform` date back to the old ECS project and are already empty.