### PR TITLE
Import SG rules in RDS security groups

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -52,7 +52,7 @@ resource "aws_db_instance" "instance" {
   monitoring_role_arn     = data.terraform_remote_state.infra_monitoring.outputs.rds_enhanced_monitoring_role_arn
   vpc_security_group_ids  = [aws_security_group.rds[each.key].id]
   ca_cert_identifier      = "rds-ca-rsa2048-g1"
-  apply_immediately       = true #var.govuk_environment != "production"
+  apply_immediately       = var.govuk_environment != "production"
 
   performance_insights_enabled          = each.value.performance_insights_enabled
   performance_insights_retention_period = each.value.performance_insights_enabled ? 7 : 0

--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -52,7 +52,7 @@ resource "aws_db_instance" "instance" {
   monitoring_role_arn     = data.terraform_remote_state.infra_monitoring.outputs.rds_enhanced_monitoring_role_arn
   vpc_security_group_ids  = [aws_security_group.rds[each.key].id]
   ca_cert_identifier      = "rds-ca-rsa2048-g1"
-  apply_immediately       = var.govuk_environment != "production"
+  apply_immediately       = true #var.govuk_environment != "production"
 
   performance_insights_enabled          = each.value.performance_insights_enabled
   performance_insights_retention_period = each.value.performance_insights_enabled ? 7 : 0

--- a/terraform/deployments/rds/security_groups.tf
+++ b/terraform/deployments/rds/security_groups.tf
@@ -33,3 +33,15 @@ resource "aws_security_group_rule" "postgres" {
   source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 
 }
+
+import {
+  for_each = { for name, data in var.databases : name => data if data.engine == "mysql" }
+  to       = aws_security_group_rule.mysql[each.key]
+  id       = "${aws_security_group.rds[each.key].id}_ingress_tcp_3306_3306_${data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id}"
+}
+
+import {
+  for_each = { for name, data in var.databases : name => data if data.engine == "postgres" }
+  to       = aws_security_group_rule.postgres[each.key]
+  id       = "${aws_security_group.rds[each.key].id}_ingress_tcp_5432_5432_${data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id}"
+}


### PR DESCRIPTION
Terraform tries to create duplicate rules if the existing ones aren't imported and the AWS API doesn't like that

#1127 