### PR TITLE
Change the opensearch url secret to include 'https://'

### DIFF
--- a/terraform/deployments/opensearch/main.tf
+++ b/terraform/deployments/opensearch/main.tf
@@ -170,7 +170,7 @@ resource "aws_secretsmanager_secret" "opensearch_passwords" {
 resource "aws_secretsmanager_secret_version" "opensearch_passwords" {
   secret_id = aws_secretsmanager_secret.opensearch_passwords.id
   secret_string = jsonencode({
-    url      = aws_opensearch_domain.opensearch.endpoint
+    url      = "https://${aws_opensearch_domain.opensearch.endpoint}"
     username = local.master_user
     password = random_password.password.result
   })


### PR DESCRIPTION
previously it generated the uri without the scheme: vpc-chat-engine-....eu-west-1.es.amazonaws.com

This PR adds the required scheme(https://)