### PR TITLE
Add netcat (nc) and redis-cli.

### DIFF
--- a/images/toolbox/Dockerfile
+++ b/images/toolbox/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update -qq ; \
     echo "deb [arch=${TARGETARCH} signed-by=${keyrings_dir}/mongodb.gpg] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" > /etc/apt/sources.list.d/mongodb.list ; \
     apt-get update -qq ; \
     apt-get install -qy --no-install-recommends \
-        curl file gh git jq libarchive-tools mysql-client postgresql-client \
-        pv wget2 gettext mongodb-mongosh mongodb-database-tools ; \
+        curl file gh git jq libarchive-tools mysql-client netcat postgresql-client \
+        pv wget2 gettext mongodb-mongosh mongodb-database-tools redis-tools ; \
     rm -fr /var/lib/apt/lists/*
 
 ARG yq_package_url=https://github.com/mikefarah/yq/releases/latest/download
@@ -53,6 +53,7 @@ RUN aws --version ; \
     mongodump --version ; \
     mysql --version ; \
     psql --version ; \
+    redis-cli --version ; \
     echo -n "s5cmd "; s5cmd version ; \
     yq --version
 


### PR DESCRIPTION
Useful for rare occasions where we need to poke about with Redis.

It's the OpenBSD flavor of netcat, if anyone cares.

Tested: builds locally with `docker build -t toolbox .`