### PR TITLE
Output SARIF or JSON depending on repo visibility

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -20,14 +20,15 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Run Brakeman
+      - name: Run Brakeman SARIF
         continue-on-error: true
-        run: |
-          if [ "${{ github.repository_visibility }}" == 'public' ]; then
-            bundle exec brakeman . --except CheckRenderInline --quiet -f sarif >> brakeman.sarif
-          else
-            bundle exec brakeman . --except CheckRenderInline --quiet -f json >> brakeman.json
-          fi
+        if: ${{ github.repository_visibility == 'public' }}
+        run: bundle exec brakeman . --except CheckRenderInline --quiet -f sarif >> brakeman.sarif
+
+      - name: Run Brakeman JSON
+        continue-on-error: true
+        if: ${{ github.repository_visibility == 'private' }}
+        run: bundle exec brakeman . --except CheckRenderInline --quiet -f json >> brakeman.json
 
       - name: Check if SARIF file exists
         id: sarif_check

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run Brakeman JSON
         continue-on-error: true
-        if: ${{ github.repository_visibility == 'private' }}
+        if: ${{ github.repository_visibility == 'private' || github.repository_visibility == 'internal' }}
         run: bundle exec brakeman . --except CheckRenderInline --quiet -f json >> brakeman.json
 
       - name: Check if SARIF file exists

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -22,10 +22,31 @@ jobs:
 
       - name: Run Brakeman
         continue-on-error: true
-        run: bundle exec brakeman . --except CheckRenderInline --quiet -f sarif >> brakeman.sarif
+        run: |
+          if [ "${{ github.repository_visibility }}" == 'public' ]; then
+            bundle exec brakeman . --except CheckRenderInline --quiet -f sarif >> brakeman.sarif
+          else
+            bundle exec brakeman . --except CheckRenderInline --quiet -f json >> brakeman.json
+          fi
 
-      - name: Upload result to Github Code Scanning
-        if: always()
+      - name: Check if SARIF file exists
+        id: sarif_check
+        run: |
+          if [ -f brakeman.sarif ]; then
+            echo "sarif_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "sarif_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload SARIF to Github Code Scanning
+        if: steps.sarif_check.outputs.sarif_exists == 'true'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: brakeman.sarif
+
+      - name: Upload JSON result as artifact
+        if: steps.sarif_check.outputs.sarif_exists == 'false'
+        uses: actions/upload-artifact@v2
+        with:
+          name: brakeman-json
+          path: brakeman.json


### PR DESCRIPTION
Trello: https://trello.com/c/9K4r5oJk/3501-update-brakeman-workflow-to-work-with-private-repos-5

This PR checks whether the repository is `public` or `private`. If the repo is public then the output is `SARIF` so that it is uploaded to code scanning, if the repo is `private` then the output is `JSON` and it is uploaded as an artifact. This work is needed because the repos that are `private` do not have GitHub Advanced Security enabled, therefore, we cannot upload to code scanning. 

The steps in the workflow are illustrated below:

Public repo `support`:
![Screenshot 2024-05-15 at 15 31 04](https://github.com/alphagov/govuk-infrastructure/assets/6651749/f474364e-06b1-4b29-8ce5-044b33a8521a)


Private repo `govuk-chat`:
![Screenshot 2024-05-15 at 15 38 53](https://github.com/alphagov/govuk-infrastructure/assets/6651749/a900c0a1-3e98-48fb-a94b-682fc25616ea)

The condition cannot be simplified further to combine the file checks, this is because Github will deprecate the [set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) command, this is why `$GITHUB_OUTPUT` needs to be used. If the output isn't set to true or false, then **ALL** steps are run even when they should not. This is why I've had to do the following:

```
     - name: Check if SARIF file exists
        id: sarif_check
        run: |
          if [ -f brakeman.sarif ]; then
            echo "sarif_exists=true" >> $GITHUB_OUTPUT
          else
            echo "sarif_exists=false" >> $GITHUB_OUTPUT
          fi
```