### PR TITLE
Increase chat Opensearch data nodes type to m6g.2xlarge

### DIFF
--- a/terraform/deployments/tfc-configuration/opensearch.tf
+++ b/terraform/deployments/tfc-configuration/opensearch.tf
@@ -38,7 +38,7 @@ module "opensearch-integration" {
     ebs_enabled              = true
     ebs_volume_size          = 45
     service                  = "chat"
-    instance_type            = "m6g.large.search"
+    instance_type            = "m6g.2xlarge.search"
     instance_count           = 3
     dedicated_master_enabled = true
     dedicated_master_count   = 3


### PR DESCRIPTION
We're experiencing bad performance with a populated search index. Moving to m6g.2xlarge for data nodes will increase memory per node from 8G to 32G. Which should improve performance.