### PR TITLE
Update TFE provider version constraints + fix playbook for tfc-aws-config rollouts.

### DIFF
--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -26,7 +26,7 @@ terraform {
     }
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.53.0"
+      version = "~> 0.55.0"
     }
     # The AWS provider is only used here for remote state in remote.tf. Please
     # do not add AWS resources to this module.

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -22,7 +22,7 @@ terraform {
     }
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.53.0"
+      version = "0.55.0"
     }
   }
 }

--- a/terraform/deployments/tfc-aws-config/README.md
+++ b/terraform/deployments/tfc-aws-config/README.md
@@ -9,14 +9,30 @@ the GOV.UK AWS accounts.
 You must apply this module locally. It cannot be applied from within Terraform
 Cloud.
 
-```sh
-# Log in to GCP (only needs to be done once)
-gcloud auth application-default login
-# Run Terraform
-terraform init
-for account in tools test integration staging production; do
-  terraform workspace select tfc-aws-config-$account
-  gds aws govuk-$account-admin -- \
-    terraform apply -var=govuk_environment=$account
-done
-```
+1. Log into GCP.
+
+    ```sh
+    gcloud auth application-default login
+    ```
+
+1. Log into Terraform Cloud.
+
+    ```sh
+    terraform login
+    ```
+
+1. Fetch remote modules etc.
+
+    ```sh
+    terraform init -upgrade
+    ```
+
+1. Run `terraform apply` for each workspace.
+
+    ```sh
+    for account in tools test integration staging production; do
+      terraform workspace select tfc-aws-config-$account
+      gds aws govuk-$account-admin -- \
+        terraform apply -var=govuk_environment=$account
+    done
+    ```

--- a/terraform/deployments/tfc-aws-config/provider.tf
+++ b/terraform/deployments/tfc-aws-config/provider.tf
@@ -15,7 +15,7 @@ terraform {
     }
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.53.0"
+      version = "~> 0.55.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/terraform/deployments/tfc-bootstrap/provider.tf
+++ b/terraform/deployments/tfc-bootstrap/provider.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.53.0"
+      version = "~> 0.55.0"
     }
   }
 }

--- a/terraform/deployments/tfc-configuration/provider.tf
+++ b/terraform/deployments/tfc-configuration/provider.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.53.0"
+      version = "0.55.0"
     }
   }
 }


### PR DESCRIPTION
- Update a couple of old version constraints for the TFE (Terraform Cloud/Enterprise) provider.
- Add a missing step to the playbook for rolling out the tfc-aws-config root module.