### PR TITLE
Add dedicated Redis for GOV.UK chat in integration/staging/prod

### DIFF
--- a/terraform/deployments/chat/data.tf
+++ b/terraform/deployments/chat/data.tf
@@ -1,0 +1,34 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {
+  name = var.aws_region
+}
+
+data "tfe_outputs" "cluster_infrastructure" {
+  organization = "govuk"
+  workspace    = "cluster-infrastructure-${var.govuk_environment}"
+}
+
+data "tfe_outputs" "vpc" {
+  organization = "govuk"
+  workspace    = "vpc-${var.govuk_environment}"
+}
+
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-networking.tfstate"
+    region = var.aws_region
+  }
+}
+
+data "terraform_remote_state" "infra_root_dns_zones" {
+  backend = "s3"
+  config = {
+    bucket = var.govuk_aws_state_bucket
+    key    = "govuk/infra-root-dns-zones.tfstate"
+    region = var.aws_region
+  }
+}
+

--- a/terraform/deployments/chat/main.tf
+++ b/terraform/deployments/chat/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  cloud {
+    organization = "govuk"
+    workspaces {
+      tags = ["opensearch", "eks", "aws"]
+    }
+  }
+  required_version = "~> 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  internal_dns_zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
+}

--- a/terraform/deployments/chat/outputs.tf
+++ b/terraform/deployments/chat/outputs.tf
@@ -1,0 +1,3 @@
+output "chat_redis_cluster_host" {
+  value = aws_route53_record.chat_redis_cluster.fqdn
+}

--- a/terraform/deployments/chat/redis.tf
+++ b/terraform/deployments/chat/redis.tf
@@ -1,0 +1,46 @@
+locals {
+  chat_redis_name     = "chat-redis"
+  elasticache_subnets = data.terraform_remote_state.infra_networking.outputs.private_subnet_elasticache_ids
+}
+
+resource "aws_elasticache_subnet_group" "chat_redis_cluster" {
+  name       = local.chat_redis_name
+  subnet_ids = local.elasticache_subnets
+}
+
+resource "aws_security_group" "chat_redis_cluster" {
+  name        = local.chat_redis_name
+  vpc_id      = data.tfe_outputs.vpc.nonsensitive_values.id
+  description = "GOV.UK Chat Redis cluster"
+  tags = {
+    Name   = local.chat_redis_name
+    System = "Sidekiq"
+  }
+}
+
+resource "aws_elasticache_replication_group" "chat_redis_cluster" {
+  apply_immediately          = var.chat_redis_cluster_apply_immediately
+  replication_group_id       = local.chat_redis_name
+  description                = "Redis for Sidekiq queues"
+  node_type                  = var.chat_redis_cluster_node_type
+  num_cache_clusters         = var.chat_redis_cluster_num_cache_clusters
+  automatic_failover_enabled = var.chat_redis_cluster_automatic_failover_enabled
+  multi_az_enabled           = var.chat_redis_cluster_multi_az_enabled
+  parameter_group_name       = var.chat_redis_cluster_parameter_group_name
+  engine_version             = var.chat_redis_cluster_engine_version
+  subnet_group_name          = aws_elasticache_subnet_group.chat_redis_cluster.name
+  security_group_ids         = [aws_security_group.chat_redis_cluster.id]
+  tags = {
+    Name   = local.chat_redis_name
+    System = "Sidekiq"
+  }
+}
+
+resource "aws_route53_record" "chat_redis_cluster" {
+  zone_id = local.internal_dns_zone_id
+  # TODO: consider removing EKS suffix once the old EC2 environments are gone.
+  name    = "${local.chat_redis_name}.eks"
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_elasticache_replication_group.chat_redis_cluster.primary_endpoint_address]
+}

--- a/terraform/deployments/chat/redis.tf
+++ b/terraform/deployments/chat/redis.tf
@@ -13,7 +13,7 @@ resource "aws_security_group" "chat_redis_cluster" {
   vpc_id      = data.tfe_outputs.vpc.nonsensitive_values.id
   description = "GOV.UK Chat Redis cluster"
   tags = {
-    Name   = local.chat_redis_name
+    Name = local.chat_redis_name
   }
 }
 
@@ -30,7 +30,7 @@ resource "aws_elasticache_replication_group" "chat_redis_cluster" {
   subnet_group_name          = aws_elasticache_subnet_group.chat_redis_cluster.name
   security_group_ids         = [aws_security_group.chat_redis_cluster.id]
   tags = {
-    Name   = local.chat_redis_name
+    Name = local.chat_redis_name
   }
 }
 

--- a/terraform/deployments/chat/redis.tf
+++ b/terraform/deployments/chat/redis.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "chat_redis_cluster" {
 resource "aws_elasticache_replication_group" "chat_redis_cluster" {
   apply_immediately          = var.chat_redis_cluster_apply_immediately
   replication_group_id       = local.chat_redis_name
-  description                = "Redis for Sidekiq queues"
+  description                = "Redis for GOV.UK Chat"
   node_type                  = var.chat_redis_cluster_node_type
   num_cache_clusters         = var.chat_redis_cluster_num_cache_clusters
   automatic_failover_enabled = var.chat_redis_cluster_automatic_failover_enabled

--- a/terraform/deployments/chat/redis.tf
+++ b/terraform/deployments/chat/redis.tf
@@ -14,7 +14,6 @@ resource "aws_security_group" "chat_redis_cluster" {
   description = "GOV.UK Chat Redis cluster"
   tags = {
     Name   = local.chat_redis_name
-    System = "Sidekiq"
   }
 }
 
@@ -32,7 +31,6 @@ resource "aws_elasticache_replication_group" "chat_redis_cluster" {
   security_group_ids         = [aws_security_group.chat_redis_cluster.id]
   tags = {
     Name   = local.chat_redis_name
-    System = "Sidekiq"
   }
 }
 

--- a/terraform/deployments/chat/security.tf
+++ b/terraform/deployments/chat/security.tf
@@ -1,0 +1,38 @@
+# Security group rules
+#
+# Naming: please use the following conventions where appropriate:
+# For ingress rules:
+#   Name: {destination}_from_{source}_{port_name}
+#   Description: {destination} accepts requests from {source} on {port_name}
+# For egress rules:
+#   Name: {source}_to_{destination}_{port_name}
+#   Description: {source} sends requests to {destination} on {port_name}
+# Omit the port name if it's obvious from the context.
+
+data "aws_ec2_managed_prefix_list" "cloudfront" {
+  name = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
+#
+# Redis
+#
+
+resource "aws_security_group_rule" "chat_redis_cluster_to_any_any" {
+  description       = "Redis cluster sends requests to anywhere over any protocol"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.chat_redis_cluster.id
+}
+
+resource "aws_security_group_rule" "chat_redis_cluster_from_any" {
+  description              = "Redis cluster accepts requests from EKS nodes"
+  type                     = "ingress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.chat_redis_cluster.id
+  source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
+}

--- a/terraform/deployments/chat/variables.tf
+++ b/terraform/deployments/chat/variables.tf
@@ -1,0 +1,45 @@
+variable "engine_version" {
+  type = string
+}
+variable "aws_region" {
+  type        = string
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+variable "govuk_aws_state_bucket" {
+  type        = string
+  description = "Bucket where govuk-aws state is stored"
+}
+variable "govuk_environment" {
+  type        = string
+  description = "Acceptable values are test, integration, staging, production"
+}
+
+variable "chat_redis_cluster_apply_immediately" {
+  type        = bool
+  description = "Specifies whether any modifications are applied immediately, or during the next maintenance window."
+}
+variable "chat_redis_cluster_node_type" {
+  type        = string
+  description = "Instance class to be used."
+}
+variable "chat_redis_cluster_num_cache_clusters" {
+  type        = string
+  description = "Number of cache clusters (primary and replicas) this replication group will have."
+}
+variable "chat_redis_cluster_automatic_failover_enabled" {
+  type        = bool
+  description = "Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails."
+}
+variable "chat_redis_cluster_multi_az_enabled" {
+  type        = bool
+  description = "Specifies whether to enable Multi-AZ Support for the replication group."
+}
+variable "chat_redis_cluster_parameter_group_name" {
+  type        = string
+  description = "Name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used."
+}
+variable "chat_redis_cluster_engine_version" {
+  type        = string
+  description = "Version number of the cache engine to be used for the cache clusters in this replication group."
+}

--- a/terraform/deployments/tfc-configuration/chat.tf
+++ b/terraform/deployments/tfc-configuration/chat.tf
@@ -1,0 +1,98 @@
+module "chat-integration" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.10.0"
+
+  organization        = var.organization
+  workspace_name      = "chat-integration"
+  workspace_desc      = "This module manages the resources needed to run GOV.UK chat"
+  workspace_tags      = ["integration", "chat", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/chat/"
+  trigger_patterns    = ["/terraform/deployments/chat/**/*"]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production" = "write"
+    "GOV.UK Production"     = "write"
+  }
+
+  variable_set_names = [
+    "aws-credentials-integration",
+    "common",
+    "common-integration",
+    "chat-integration"
+  ]
+}
+
+module "chat-staging" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.10.0"
+
+  organization        = var.organization
+  workspace_name      = "chat-staging"
+  workspace_desc      = "This module manages the resources needed to run GOV.UK chat"
+  workspace_tags      = ["staging", "chat", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/chat/"
+  trigger_patterns    = ["/terraform/deployments/chat/**/*"]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Production" = "write"
+  }
+
+  variable_set_names = [
+    "aws-credentials-staging",
+    "common",
+    "common-staging",
+    "chat-staging"
+  ]
+}
+
+module "chat-production" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.10.0"
+
+  organization        = var.organization
+  workspace_name      = "chat-production"
+  workspace_desc      = "This module manages the resources needed to run GOV.UK chat"
+  workspace_tags      = ["production", "chat", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/chat/"
+  trigger_patterns    = ["/terraform/deployments/chat/**/*"]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+  team_access = { "GOV.UK Production" = "write" }
+
+  variable_set_names = [
+    "aws-credentials-production",
+    "common",
+    "common-production",
+    "chat-production"
+  ]
+}

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -55,6 +55,22 @@ module "variable-set-integration" {
   }
 }
 
+module "variable-set-chat-integration" {
+  source = "./variable-set"
+
+  name = "chat-integration"
+
+  tfvars = {
+    chat_redis_cluster_apply_immediately          = true
+    chat_redis_cluster_automatic_failover_enabled = false
+    chat_redis_cluster_engine_version             = "6.x"
+    chat_redis_cluster_multi_az_enabled           = false
+    chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
+    chat_redis_cluster_num_cache_clusters         = "1"
+    chat_redis_cluster_parameter_group_name       = "default.redis6.x"
+  }
+}
+
 module "variable-set-rds-integration" {
   source = "./variable-set"
 

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -63,7 +63,7 @@ module "variable-set-chat-integration" {
   tfvars = {
     chat_redis_cluster_apply_immediately          = true
     chat_redis_cluster_automatic_failover_enabled = false
-    chat_redis_cluster_engine_version             = "6.x"
+    chat_redis_cluster_engine_version             = "7.1"
     chat_redis_cluster_multi_az_enabled           = false
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -99,7 +99,7 @@ module "variable-set-chat-production" {
   tfvars = {
     chat_redis_cluster_apply_immediately          = false
     chat_redis_cluster_automatic_failover_enabled = true
-    chat_redis_cluster_engine_version             = "6.x"
+    chat_redis_cluster_engine_version             = "7.1"
     chat_redis_cluster_multi_az_enabled           = true
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "2"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -91,6 +91,22 @@ resource "tfe_variable" "ecr-puller-arns" {
   hcl = true
 }
 
+module "variable-set-chat-production" {
+  source = "./variable-set"
+
+  name = "chat-production"
+
+  tfvars = {
+    chat_redis_cluster_apply_immediately          = false
+    chat_redis_cluster_automatic_failover_enabled = true
+    chat_redis_cluster_engine_version             = "6.x"
+    chat_redis_cluster_multi_az_enabled           = true
+    chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
+    chat_redis_cluster_num_cache_clusters         = "2"
+    chat_redis_cluster_parameter_group_name       = "default.redis6.x"
+  }
+}
+
 module "variable-set-rds-production" {
   source = "./variable-set"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -68,6 +68,22 @@ module "variable-set-cloudfront-staging" {
   }
 }
 
+module "variable-set-chat-staging" {
+  source = "./variable-set"
+
+  name = "chat-staging"
+
+  tfvars = {
+    chat_redis_cluster_apply_immediately          = true
+    chat_redis_cluster_automatic_failover_enabled = false
+    chat_redis_cluster_engine_version             = "6.x"
+    chat_redis_cluster_multi_az_enabled           = false
+    chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
+    chat_redis_cluster_num_cache_clusters         = "1"
+    chat_redis_cluster_parameter_group_name       = "default.redis6.x"
+  }
+}
+
 module "variable-set-rds-staging" {
   source = "./variable-set"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -76,7 +76,7 @@ module "variable-set-chat-staging" {
   tfvars = {
     chat_redis_cluster_apply_immediately          = true
     chat_redis_cluster_automatic_failover_enabled = false
-    chat_redis_cluster_engine_version             = "6.x"
+    chat_redis_cluster_engine_version             = "7.1"
     chat_redis_cluster_multi_az_enabled           = false
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"


### PR DESCRIPTION
To reduce the blast radius of GOV.UK chat we use a separated Redis cluster for it.