### PR TITLE
Create a shared action for running a node task

### DIFF
--- a/.github/workflows/node-script.yml
+++ b/.github/workflows/node-script.yml
@@ -1,0 +1,25 @@
+name: Run Node.js Script
+run-name: Run ${{ inputs.script }}
+
+on:
+  workflow_call:
+    inputs:
+      script:
+        description: 'Script to execute (typically `yarn run <script>`)'
+        required: true
+        type: string
+
+jobs:
+  run-script:
+    name: Run Node.js Script
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: Setup Node
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
+
+      - name: Run script
+        run: ${{ inputs.script }}

--- a/.github/workflows/standardx.yml
+++ b/.github/workflows/standardx.yml
@@ -12,14 +12,6 @@ on:
 jobs:
   run-standardx:
     name: Run Standardx
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          show-progress: false
-
-      - name: Setup Node
-        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
-
-      - name: Run Standardx
-        run: yarn run standardx ${{ inputs.files }}
+    uses: alphagov/govuk-infrastructure/.github/workflows/node-script.yml@main
+    with:
+      script: yarn run standardx ${{ inputs.files }}

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -12,14 +12,6 @@ on:
 jobs:
   run-stylelint:
     name: Run Stylelint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          show-progress: false
-
-      - name: Setup Node
-        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
-
-      - name: Run Stylelint
-        run: yarn run stylelint ${{ inputs.files }}
+    uses: alphagov/govuk-infrastructure/.github/workflows/node-script.yml@main
+    with:
+      script: yarn run stylelint ${{ inputs.files }}


### PR DESCRIPTION
This creates a new reusable GitHub workflow that can be used to run a node JS task from a repository. By task I expect it to be something that is defined inside a package.json scripts object (e.g. yarn run lint:js).

It then utilises this workflow on the standardx and stylelint workflows to simplify them.

The motivation for adding this was due to on govuk-chat deviating from standardx to standard and then having to define our own workflow [1]. I looked and saw other repos had also defined their own near identical workflows [2] [3] so felt the govuk-chat need was not unique.

A demo of this working from a branch is available at: https://github.com/alphagov/govuk-chat/pull/236

[1]: https://github.com/alphagov/govuk-chat/pull/235/commits/fbb629e60854fc51808abb8867d84679ca30e1f9
[2]: https://github.com/alphagov/whitehall/blob/main/.github/workflows/lintjs.yml
[3]: https://github.com/alphagov/whitehall/blob/main/.github/workflows/lintprettier.yml