### PR TITLE
Give GitHub Actions access to pact secrets for some repos

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -76,6 +76,11 @@ locals {
     for r in data.github_repository.govuk : r
     if !r.fork && contains(r.topics, "gem")
   ]
+
+  pact_publishers = [
+    for r in data.github_repository.govuk : r
+    if !r.fork && contains(r.topics, "pact-publisher")
+  ]
 }
 
 resource "github_team" "govuk_ci_bots" {
@@ -135,4 +140,14 @@ resource "github_actions_organization_secret_repositories" "argo_events_webhook_
 resource "github_actions_organization_secret_repositories" "argo_events_webhook_url" {
   secret_name             = "GOVUK_ARGO_EVENTS_WEBHOOK_URL"
   selected_repository_ids = [for repo in local.deployable_repos : repo.repo_id]
+}
+
+resource "github_actions_organization_secret_repositories" "pact_broker_password" {
+  secret_name             = "GOVUK_PACT_BROKER_PASSWORD"
+  selected_repository_ids = [for repo in concat(local.deployable_repos, local.pact_publishers) : repo.repo_id]
+}
+
+resource "github_actions_organization_secret_repositories" "pact_broker_username" {
+  secret_name             = "GOVUK_PACT_BROKER_USERNAME"
+  selected_repository_ids = [for repo in concat(local.deployable_repos, local.pact_publishers) : repo.repo_id]
 }


### PR DESCRIPTION
For repos tagged `pact-publisher` (currently only `gds-api-adapters`) we need to give GitHub Actions access to organisation level secrets for accessing the pact broker, in order to publish pact tests.

This was never an issue before as the pact tests was incorrectly set to only publish from a PR being merged into the main branch, so were never run on automatically raised PRs (e.g. dependabot). This was resolved in https://github.com/alphagov/gds-api-adapters/commit/5d27c95d96fb49334b002c3be70993e6b6f1145e.

[Trello card](https://trello.com/c/MHnkSggV)