### PR TITLE
Restrict pact broker secrets to pact publishers only

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -144,10 +144,10 @@ resource "github_actions_organization_secret_repositories" "argo_events_webhook_
 
 resource "github_actions_organization_secret_repositories" "pact_broker_password" {
   secret_name             = "GOVUK_PACT_BROKER_PASSWORD"
-  selected_repository_ids = [for repo in concat(local.deployable_repos, local.pact_publishers) : repo.repo_id]
+  selected_repository_ids = [for repo in local.pact_publishers : repo.repo_id]
 }
 
 resource "github_actions_organization_secret_repositories" "pact_broker_username" {
   secret_name             = "GOVUK_PACT_BROKER_USERNAME"
-  selected_repository_ids = [for repo in concat(local.deployable_repos, local.pact_publishers) : repo.repo_id]
+  selected_repository_ids = [for repo in local.pact_publishers : repo.repo_id]
 }


### PR DESCRIPTION
In https://github.com/alphagov/govuk-infrastructure/pull/1325, we incorrectly added the secret to all deployable repos.

This change limits the secret to only pact publishers.

[Trello card](https://trello.com/c/MHnkSggV)