### PR TITLE
Remove use of pact broker secrets for gds-api-adapters

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -76,11 +76,6 @@ locals {
     for r in data.github_repository.govuk : r
     if !r.fork && contains(r.topics, "gem")
   ]
-
-  pact_publishers = [
-    for r in data.github_repository.govuk : r
-    if !r.fork && contains(r.topics, "pact-publisher")
-  ]
 }
 
 resource "github_team" "govuk_ci_bots" {
@@ -140,14 +135,4 @@ resource "github_actions_organization_secret_repositories" "argo_events_webhook_
 resource "github_actions_organization_secret_repositories" "argo_events_webhook_url" {
   secret_name             = "GOVUK_ARGO_EVENTS_WEBHOOK_URL"
   selected_repository_ids = [for repo in local.deployable_repos : repo.repo_id]
-}
-
-resource "github_actions_organization_secret_repositories" "pact_broker_password" {
-  secret_name             = "GOVUK_PACT_BROKER_PASSWORD"
-  selected_repository_ids = [for repo in local.pact_publishers : repo.repo_id]
-}
-
-resource "github_actions_organization_secret_repositories" "pact_broker_username" {
-  secret_name             = "GOVUK_PACT_BROKER_USERNAME"
-  selected_repository_ids = [for repo in local.pact_publishers : repo.repo_id]
 }


### PR DESCRIPTION
Access to these organisation level secrets was added to enable dependabot PRs raised by gds-api-adapters to have their pact tests published.

However dependabot [does not have access to these secrets](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets), only those specifically set up for dependabot. This means the change didn't work as intended.

There is no purpose in publishing these pact tests anyway when dependabot raises a PR, so removing this change and removing the need for the pact tests to be published (in another PR).

This reverts commits fe4c7be508e1c95e1282ef2e7ad0d8dfbb014765 and 81ede2a2321d139b990a048a313aae52d7b85727.

[Trello card](https://trello.com/c/MHnkSggV)