### PR TITLE
Revert "Remove use of pact broker secrets for gds-api-adapters"

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -76,6 +76,11 @@ locals {
     for r in data.github_repository.govuk : r
     if !r.fork && contains(r.topics, "gem")
   ]
+
+  pact_publishers = [
+    for r in data.github_repository.govuk : r
+    if !r.fork && contains(r.topics, "pact-publisher")
+  ]
 }
 
 resource "github_team" "govuk_ci_bots" {
@@ -135,4 +140,14 @@ resource "github_actions_organization_secret_repositories" "argo_events_webhook_
 resource "github_actions_organization_secret_repositories" "argo_events_webhook_url" {
   secret_name             = "GOVUK_ARGO_EVENTS_WEBHOOK_URL"
   selected_repository_ids = [for repo in local.deployable_repos : repo.repo_id]
+}
+
+resource "github_actions_organization_secret_repositories" "pact_broker_password" {
+  secret_name             = "GOVUK_PACT_BROKER_PASSWORD"
+  selected_repository_ids = [for repo in local.pact_publishers : repo.repo_id]
+}
+
+resource "github_actions_organization_secret_repositories" "pact_broker_username" {
+  secret_name             = "GOVUK_PACT_BROKER_USERNAME"
+  selected_repository_ids = [for repo in local.pact_publishers : repo.repo_id]
 }


### PR DESCRIPTION
It turns out these organisation level secrets are required and were previously set in the UI.  Therefore we need to retain access to them in the relevant repos.

Reverts alphagov/govuk-infrastructure#1327