### PR TITLE
Create tfc workspace for GOV.UK App backend

### DIFF
--- a/terraform/deployments/tfc-configuration/govuk-app.tf
+++ b/terraform/deployments/tfc-configuration/govuk-app.tf
@@ -1,0 +1,33 @@
+module "govuk-app-integration" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.10.0"
+
+  project_name = "govuk-mobile-backend"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-mobile-backend"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  organization        = var.organization
+  workspace_name      = "govuk-app-integration"
+  workspace_desc      = "This module manages provisioning of resources for the GOV.UK App mobile backend"
+  workspace_tags      = ["integration", "govuk-app", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/"
+  trigger_patterns    = ["/terraform/**/*"]
+  global_remote_state = true
+
+  team_access = {
+    "GOV.UK Non-Production" = "write"
+    "GOV.UK Production"     = "write"
+  }
+
+  variable_set_names = [
+    "aws-credentials-integration",
+    "common",
+    "common-integration"
+    // currently there are no tfvars needed for the app backend but can add a reference to them here when needed
+  ]
+}


### PR DESCRIPTION
We would like a Terraform Cloud workspace to deploy resources into the Integration account while we carry out some spikes and investigations. I _think_ all that is needed is a new file in `tfc-configuration`, but any further input would be appreciated.

Currently this file makes reference to a separate repo ([govuk-mobile-backend](https://github.com/alphagov/govuk-mobile-backend)) where we are putting resources (for a few reasons, predominantly that we don't want to 'pollute' main production GOV.UK infra with what we're doing, and also that repo is going to contain a mix of tech approaches that are still being investigated). So I am assuming this will work but again happy to be corrected.
