### PR TITLE
Specify cluster version as string instead of number

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -6,7 +6,7 @@ module "variable-set-integration" {
     govuk_aws_state_bucket              = "govuk-terraform-steppingstone-integration"
     cluster_infrastructure_state_bucket = "govuk-terraform-integration"
 
-    cluster_version               = 1.30
+    cluster_version               = "1.30"
     cluster_log_retention_in_days = 7
 
     vpc_cidr = "10.1.0.0/16"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -6,7 +6,7 @@ module "variable-set-production" {
     govuk_aws_state_bucket              = "govuk-terraform-steppingstone-production"
     cluster_infrastructure_state_bucket = "govuk-terraform-production"
 
-    cluster_version               = 1.30
+    cluster_version               = "1.30"
     cluster_log_retention_in_days = 7
 
     vpc_cidr = "10.13.0.0/16"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -6,7 +6,7 @@ module "variable-set-staging" {
     govuk_aws_state_bucket              = "govuk-terraform-steppingstone-staging"
     cluster_infrastructure_state_bucket = "govuk-terraform-staging"
 
-    cluster_version               = 1.30
+    cluster_version               = "1.30"
     cluster_log_retention_in_days = 7
 
     vpc_cidr = "10.12.0.0/16"


### PR DESCRIPTION
TF interpreted this as a number, so set it to "1.3" instead of "1.30"