### PR TITLE
Add workflow to enforce gem version bumps

### DIFF
--- a/.github/workflows/gem-bump-checker.yml
+++ b/.github/workflows/gem-bump-checker.yml
@@ -1,0 +1,38 @@
+name: Gem Bump Checker
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
+
+jobs:
+  check-files:
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        show-progress: false
+        token: ${{ secrets.GH_TOKEN }}
+
+    - name: Check for version and changelog updates
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      run: |
+        BASE_REF=$(git ls-remote origin HEAD | cut -f 1)
+        HEAD_REF=$(git rev-parse HEAD)
+        MODIFIED_FILES=$(git diff --name-only "$BASE_REF".."$HEAD_REF")
+
+        if ! echo "$MODIFIED_FILES" | grep 'version.rb' && \
+           ! echo "$MODIFIED_FILES" | grep '\.gemspec$'; then
+          echo "Error: Either version.rb or a .gemspec file must be modified with each pull request to bump the gem version."
+          exit 1
+        fi
+
+        if ! echo "$MODIFIED_FILES" | grep 'CHANGELOG.md'; then
+          echo "Error: CHANGELOG.md must be updated with each pull request."
+          exit 1
+        fi


### PR DESCRIPTION
This workflow will run when opening a pull request on gem repositories. It checks if there are changes to the CHANGELOG.md and version.rb or *.gemspec files. If those files have not been changed the workflow will fail.

Code changes are often merged into gems without the gem version being bumped. This leads to changes not being released quickly and sometimes piling up.

https://trello.com/c/R1kkdVjt/3560-re-evaluate-effectiveness-of-gem-auto-release-workflow-3