### PR TITLE
Update Argo CD from 2.11.0 to 2.11.3.

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -47,7 +47,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "6.8.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "7.1.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     global = {


### PR DESCRIPTION
The only breaking change in the chart is for `configs.clusterCredentials`, which we're not using (because each cluster has its own Argo CD).