### PR TITLE
ECR module no longer uses the GitHub provider.

### DIFF
--- a/terraform/deployments/ecr/gha-iam-role.tf
+++ b/terraform/deployments/ecr/gha-iam-role.tf
@@ -22,11 +22,7 @@ data "aws_iam_policy_document" "ecr_role_permissions" {
     resources = ["*"]
   }
   statement {
-    actions = [
-      "kms:DescribeKey",
-      "kms:GetPublicKey",
-      "kms:Sign"
-    ]
+    actions   = ["kms:DescribeKey", "kms:GetPublicKey", "kms:Sign"]
     resources = [aws_kms_key.container_signing_key.arn]
   }
 }

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -1,20 +1,13 @@
 terraform {
+  required_version = "~> 1.5"
   cloud {
     organization = "govuk"
-    workspaces {
-      tags = ["ecr", "eks", "aws"]
-    }
+    workspaces { tags = ["ecr", "eks", "aws"] }
   }
-
-  required_version = "~> 1.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.0"
-    }
-    github = {
-      source  = "integrations/github"
-      version = "~> 6.0"
     }
   }
 }
@@ -31,23 +24,6 @@ provider "aws" {
       terraform_deployment = basename(abspath(path.root))
     }
   }
-}
-
-data "aws_secretsmanager_secret" "github-token" {
-  name = "govuk/terraform-cloud/github-token"
-}
-
-data "aws_secretsmanager_secret_version" "github-token" {
-  secret_id = data.aws_secretsmanager_secret.github-token.id
-}
-
-provider "github" {
-  owner = "alphagov"
-  token = data.aws_secretsmanager_secret_version.github-token.secret_string
-}
-
-data "github_repositories" "govuk" {
-  query = "org:alphagov topic:container topic:govuk fork:false archived:false"
 }
 
 locals {


### PR DESCRIPTION
Remove disused provider and related gubbins, plus some trivial formatting while we're in there.

Should be functionally a no-op.

Sorry meant to include this as a commit in #1346 but forgot to push 🙃 