### PR TITLE
Remove comment about manually creating ECR credentials

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -41,12 +41,6 @@ provider "github" {
   }
 }
 
-#
-# Gives repositories access to push OCI images to GOV.UK Production AWS ECR
-# NOTE: AWS_GOVUK_ECR_ACCESS_KEY_ID and AWS_GOVUK_ECR_SECRET_ACCESS_KEY are
-# manually created.
-#
-
 data "github_repositories" "govuk" {
   query = "topic:govuk org:alphagov archived:false"
 }


### PR DESCRIPTION
We no longer use long lived AWS creds for GitHub Actions.