### PR TITLE
Revert suspected-broken attempt to fix GitHub->ECR IAM authz.

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -39,11 +39,11 @@ jobs:
           show-progress: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
-          role-to-assume: arn:aws:iam::172025368201:role/github_action_ecr_push_${{ github.event.repository.name }}
+          role-to-assume: "arn:aws:iam::172025368201:role/github_action_ecr_push"
           aws-region: eu-west-1
-          role-session-name: ecr-push-${{ github.event.repository.name }}
+          role-session-name: ecr-push
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::172025368201:role/github_action_ecr_push_${{ github.event.repository.name }}
+          role-to-assume: "arn:aws:iam::172025368201:role/github_action_ecr_push"
           aws-region: eu-west-1
-          role-session-name: ecr-push-${{ github.event.repository.name }}
+          role-session-name: ecr-push
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -1,13 +1,20 @@
 terraform {
-  required_version = "~> 1.5"
   cloud {
     organization = "govuk"
-    workspaces { tags = ["ecr", "eks", "aws"] }
+    workspaces {
+      tags = ["ecr", "eks", "aws"]
+    }
   }
+
+  required_version = "~> 1.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
     }
   }
 }
@@ -26,78 +33,39 @@ provider "aws" {
   }
 }
 
+data "aws_secretsmanager_secret" "github-token" {
+  name = "govuk/terraform-cloud/github-token"
+}
+
+data "aws_secretsmanager_secret_version" "github-token" {
+  secret_id = data.aws_secretsmanager_secret.github-token.id
+}
+
+provider "github" {
+  owner = "alphagov"
+  token = data.aws_secretsmanager_secret_version.github-token.secret_string
+}
+
+data "github_repositories" "govuk" {
+  query = "org:alphagov topic:container topic:govuk fork:false archived:false"
+}
+
 locals {
-  # ecr_repos_by_github_repo is a map of GitHub repo name to a list of ECR
-  # repos where the GitHub repo has permission to push images.
-  #
-  # TODO: rename the oddball images like "licensify-frontend" so that they are
-  # prefixed with their Git repo name, for example "licensify/frontend", then
-  # turn this back into a simple list. Or, even better, stop pushing images to
-  # ECR from GitHub Actions altogether and just configure ECR to be a
-  # pull-through cache for ghcr.io.
-  ecr_repos_by_github_repo = {
-    "account-api" : ["account-api"]
-    "asset-manager" : ["asset-manager"]
-    "authenticating-proxy" : ["authenticating-proxy"]
-    "bouncer" : ["bouncer"]
-    "collections" : ["collections"]
-    "collections-publisher" : ["collections-publisher"]
-    "contacts-admin" : ["contacts-admin"]
-    "content-data-admin" : ["content-data-admin"]
-    "content-data-api" : ["content-data-api"]
-    "content-publisher" : ["content-publisher"]
-    "content-store" : ["content-store"]
-    "content-tagger" : ["content-tagger"]
-    "email-alert-api" : ["email-alert-api"]
-    "email-alert-frontend" : ["email-alert-frontend"]
-    "email-alert-service" : ["email-alert-service"]
-    "feedback" : ["feedback"]
-    "finder-frontend" : ["finder-frontend"]
-    "frontend" : ["frontend"]
-    "government-frontend" : ["government-frontend"]
-    "govuk-chat" : ["govuk-chat"]
-    "govuk-dependency-checker" : ["govuk-dependency-checker"]
-    "govuk-developer-docs" : ["govuk-developer-docs"]
-    "govuk-exporter" : ["govuk-exporter"]
-    "govuk-fastly" : ["govuk-fastly"]
-    "govuk-infrastructure" : ["govuk-infrastructure", "clamav", "mongodb", "toolbox"]
-    "govuk-mirror" : ["govuk-mirror"]
-    "govuk-replatform-test-app" : ["govuk-replatform-test-app"]
-    "govuk-ruby-images" : ["govuk-ruby-images"]
-    "govuk-sli-collector" : ["govuk-sli-collector"]
-    "hmrc-manuals-api" : ["hmrc-manuals-api"]
-    "licensify" : ["licensify", "licensify-backend", "licensify-feed", "licensify-frontend"]
-    "link-checker-api" : ["link-checker-api"]
-    "local-links-manager" : ["local-links-manager"]
-    "locations-api" : ["locations-api"]
-    "manuals-publisher" : ["manuals-publisher"]
-    "maslow" : ["maslow"]
-    "places-manager" : ["places-manager"]
-    "publisher" : ["publisher"]
-    "publishing-api" : ["publishing-api"]
-    "release" : ["release"]
-    "router" : ["router"]
-    "router-api" : ["router-api"]
-    "search-admin" : ["search-admin"]
-    "search-api" : ["search-api"]
-    "search-api-learn-to-rank" : ["search-api-learn-to-rank"]
-    "search-api-v2" : ["search-api-v2"]
-    "search-v2-evaluator" : ["search-v2-evaluator"]
-    "service-manual-publisher" : ["service-manual-publisher"]
-    "short-url-manager" : ["short-url-manager"]
-    "signon" : ["signon"]
-    "smart-answers" : ["smart-answers"]
-    "smokey" : ["smokey"]
-    "special-route-publisher" : ["special-route-publisher"]
-    "specialist-publisher" : ["specialist-publisher"]
-    "static" : ["static"]
-    "support" : ["support"]
-    "support-api" : ["support-api"]
-    "transition" : ["transition"]
-    "travel-advice-publisher" : ["travel-advice-publisher"]
-    "whitehall" : ["whitehall"]
-  }
-  repositories = keys(local.ecr_repos_by_github_repo)
+  repositories = concat(
+    local.extra_repositories,
+    data.github_repositories.govuk.names
+  )
+
+  extra_repositories = [
+    "mongodb",
+    "imminence",
+    "toolbox",
+    "clamav",
+    "search-api-learn-to-rank",
+    "licensify-backend",
+    "licensify-feed",
+    "licensify-frontend",
+  ]
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -97,14 +97,14 @@ locals {
     "travel-advice-publisher" : ["travel-advice-publisher"]
     "whitehall" : ["whitehall"]
   }
-  repositories = toset(flatten(concat(values(local.ecr_repos_by_github_repo))))
+  repositories = keys(local.ecr_repos_by_github_repo)
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_ecr_repository" "repositories" {
-  for_each             = local.repositories
+  for_each             = toset(local.repositories)
   name                 = each.key
   image_tag_mutability = "MUTABLE" # To support a movable `latest` for developer convenience.
   image_scanning_configuration { scan_on_push = true }


### PR DESCRIPTION
Reverts #1350, #1351, #1353.

Suspect those changes are why GitHub `deploy.yml` actions started failing like this:

```
Run aws-actions/configure-aws-credentials@v4
  with:
    role-to-assume: arn:aws:iam::17[2](https://github.com/alphagov/maslow/actions/runs/9601582713/job/26480461933#step:4:2)025368201:role/github_action_ecr_push
    aws-region: eu-west-1
    role-session-name: ecr-push
    audience: sts.amazonaws.com
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Assuming role with OIDC
Error: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
```