### PR TITLE
Use preinstalled Docker from the runner image.

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,3 +1,6 @@
+# TODO: remove self-hosted-runner name validation workaround once we're able to
+# use standard names provided by GitHub (likely once the GitHub-hosted ARM
+# runners feature exits beta and becomes GA).
 self-hosted-runner:
   labels:
-    - arm64-runner  # Not actually self-hosted.
+    - ubuntu-24.04-arm  # Not actually self-hosted.

--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -35,7 +35,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: arm64-runner
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     outputs:
       imageTag: ${{ steps.meta.outputs.version }}
@@ -44,26 +44,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      # TODO: remove this step once GitHub's ARM runner image comes with Docker.
-      - name: Install Docker (GitHub ARM Only)
-        if: matrix.runner == 'arm64-runner'
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq --no-install-recommends acl ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
-            | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update -qq
-          sudo apt-get install -qq --no-install-recommends docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-          sudo usermod -aG docker "$USER"
-          sudo setfacl --modify "user:$USER:rw" /var/run/docker.sock
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitRef }}
@@ -138,26 +118,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      # TODO: remove this step once GitHub's ARM runner image comes with Docker.
-      - name: Install Docker (GitHub ARM Only)
-        if: matrix.runner == 'arm64-runner'
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq --no-install-recommends acl ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
-            | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update -qq
-          sudo apt-get install -qq --no-install-recommends docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-          sudo usermod -aG docker "$USER"
-          sudo setfacl --modify "user:$USER:rw" /var/run/docker.sock
-
       - name: Download Digests
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
We no longer need to install Docker ourselves now that https://github.com/actions/partner-runner-images/tree/main/images are available.

Tested: https://github.com/alphagov/release/actions/runs/9697881909