### PR TITLE
Update actionlint and factor out its config into a reusable action.

### DIFF
--- a/.github/actions/actionlint/action.yml
+++ b/.github/actions/actionlint/action.yml
@@ -1,0 +1,27 @@
+# This reusable action exists only to reduce toil by representing GOV.UK's
+# global config for rhysd/actionlint in a single place so we don't have to
+# change it in N repos every time we update.
+name: Run actionlint
+description: Lint GitHub Actions YAML files with rhysd/actionlint.
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      env:
+        VERSION: '1.7.1'
+      run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/4f6274a8e0f4f4d2057aa9ae07660f61aa29c5f3/scripts/download-actionlint.bash) "$VERSION" .
+    - name: Run actionlint
+      shell: bash
+      env:
+        ACTIONLINT: '${{ steps.install.outputs.executable }}'
+      run: |
+        echo "::add-matcher::.github/actionlint-matcher.json"
+        # TODO: move non-global ignores inline or to in-tree actionlint.yml once
+        #       https://www.github.com/rhysd/actionlint/issues/237 and/or
+        #       https://www.github.com/rhysd/actionlint/issues/217 is fixed.
+        # TODO: remove -ignore "property .runner. is not defined" once
+        #       https://www.github.com/rhysd/actionlint/issues/77 is fixed.
+        "$ACTIONLINT" -color \
+          -ignore "property .runner. is not defined" \
+          -ignore "property .repository_visibility. is not defined"

--- a/.github/actions/actionlint/action.yml
+++ b/.github/actions/actionlint/action.yml
@@ -9,8 +9,8 @@ runs:
     - id: install
       shell: bash
       env:
-        VERSION: '1.7.1'
-      run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/4f6274a8e0f4f4d2057aa9ae07660f61aa29c5f3/scripts/download-actionlint.bash) "$VERSION" .
+        ACTIONLINT_SHA: 4f6274a8e0f4f4d2057aa9ae07660f61aa29c5f3  # v1.7.1
+      run: bash <(curl "https://raw.githubusercontent.com/rhysd/actionlint/$ACTIONLINT_SHA/scripts/download-actionlint.bash")
     - name: Run actionlint
       shell: bash
       env:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,8 +11,8 @@ jobs:
         show-progress: false
     - id: install
       env:
-        VERSION: '1.7.0'
-      run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/b6b7a2901eb4fa4bae2e6d8f9b6edd1a37b3cca7/scripts/download-actionlint.bash) "$VERSION" .
+        VERSION: '1.7.1'
+      run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/4f6274a8e0f4f4d2057aa9ae07660f61aa29c5f3/scripts/download-actionlint.bash) "$VERSION" .
     - name: Run actionlint
       env:
         ACTIONLINT: '${{ steps.install.outputs.executable }}'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,23 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        show-progress: false
-    - id: install
-      env:
-        VERSION: '1.7.1'
-      run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/4f6274a8e0f4f4d2057aa9ae07660f61aa29c5f3/scripts/download-actionlint.bash) "$VERSION" .
-    - name: Run actionlint
-      env:
-        ACTIONLINT: '${{ steps.install.outputs.executable }}'
-      run: |
-        echo "::add-matcher::.github/actionlint-matcher.json"
-        # TODO: move -ignores inline or to actionlint.yml once
-        #       https://www.github.com/rhysd/actionlint/issues/237 and/or
-        #       https://www.github.com/rhysd/actionlint/issues/217 is fixed.
-        # TODO: remove -ignore "property .runner. is not defined" once
-        #       https://www.github.com/rhysd/actionlint/issues/77 is fixed.
-        "$ACTIONLINT" -color \
-          -ignore "property .runner. is not defined" \
-          -ignore "property .repository_visibility. is not defined"
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main


### PR DESCRIPTION
So we don't have to update the version pinning etc. across multiple repos, since I'm about to add it to alphagov/govuk-ruby-images.

The actionlint check failure on this PR is expected (because the reusable action won't exist on `main` until this PR is merged).

Tested: check passes when pointing at the PR branch for the reusable action: https://github.com/alphagov/govuk-infrastructure/actions/runs/9716231768/job/26819399056#step:3:31

#1361