### PR TITLE
Create custom domain endpoint for Opensearch cluster `chat-engine` and corresponding DNS entry in Route53

### DIFF
--- a/terraform/deployments/opensearch/data.tf
+++ b/terraform/deployments/opensearch/data.tf
@@ -39,3 +39,8 @@ data "terraform_remote_state" "infra_networking" {
     region = var.aws_region
   }
 }
+
+data "aws_acm_certificate" "govuk_internal" {
+  domain   = "*.${var.govuk_environment}.govuk-internal.digital"
+  statuses = ["ISSUED"]
+}

--- a/terraform/deployments/opensearch/main.tf
+++ b/terraform/deployments/opensearch/main.tf
@@ -114,8 +114,11 @@ resource "aws_opensearch_domain" "opensearch" {
   }
 
   domain_endpoint_options {
-    enforce_https       = true
-    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+    enforce_https                   = true
+    tls_security_policy             = "Policy-Min-TLS-1-2-2019-07"
+    custom_endpoint_enabled         = true
+    custom_endpoint                 = "chat-opensearch.${var.govuk_environment}.govuk-internal.digital"
+    custom_endpoint_certificate_arn = data.aws_acm_certificate.govuk_internal.arn
   }
 
   ebs_options {
@@ -176,3 +179,10 @@ resource "aws_secretsmanager_secret_version" "opensearch_passwords" {
   })
 }
 
+resource "aws_route53_record" "service_record" {
+  zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
+  name    = "chat-opensearch.${var.govuk_environment}.govuk-internal.digital"
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_opensearch_domain.opensearch.endpoint]
+}


### PR DESCRIPTION
This is to add a custom domain endpoint to the `chat-engine` opensearch clusters, attach existing ACM certificate for the domain, and create a DNS CNAME entry from the custom endpoint to the generated opensearch endpoint. All this is so that when it comes to doing the backups, the script can access the regular known url rather than try to look up the correct automatically generated one.

## Trello Card
https://trello.com/c/zIiHKPHx/1348-configure-daily-data-sync-of-opensearch-data-from-production-to-staging-and-integration