### PR TITLE
Push to images to ghcr.io

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -32,6 +32,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,6 +52,13 @@ jobs:
         with:
           mask-password: 'true'
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -63,6 +71,7 @@ jobs:
         with:
           images: |
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }}
+            ghcr.io/${{ github.repository_owner }}/${{ inputs.ecrRepositoryName }}
           tags: |
             type=raw,priority=500,value=${{ inputs.gitRef }},enable=${{ startsWith(inputs.gitRef, 'v') }}
             type=raw,priority=400,value=${{ steps.local-head.outputs.sha }},enable=${{ !startsWith(inputs.gitRef, 'v') }}

--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -43,6 +43,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,6 +63,13 @@ jobs:
         with:
           mask-password: 'true'
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: docker/setup-buildx-action@v3
 
       - run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -73,6 +81,7 @@ jobs:
         with:
           images: |
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }}
+            ghcr.io/${{ github.repository_owner }}/${{ inputs.ecrRepositoryName }}
           labels: |
             org.opencontainers.image.vendor=GDS
           tags: |
@@ -117,6 +126,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     steps:
       - name: Download Digests
         uses: actions/download-artifact@v4
@@ -143,12 +153,20 @@ jobs:
         with:
           mask-password: 'true'
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate Image Metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }}
+            ghcr.io/${{ github.repository_owner }}/${{ inputs.ecrRepositoryName }}
           labels: |
             org.opencontainers.image.vendor=GDS
           tags: |


### PR DESCRIPTION
This enables the image build and push workflows to also push images to ghcr.io (whilst continuing to push to ECR). This allows us to configure pull through cache for ECR, instead having to push directly to ECR.

Future work should rename the inputs to remove references to "ecr".

Calling workflows need to be updated to pass the `packages: write` permission, before this can be merged.

Tested on [Release](https://github.com/alphagov/release/pkgs/container/release).