### PR TITLE
Extend Renovate coverage to TF-managed Helm charts and tfe_workspace TF versions.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     ],
     "packageRules": [
       {
-        "matchDepTypes": ["provider"]
+        "matchDepTypes": ["provider", "helm_release"]
       }
     ]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     ],
     "packageRules": [
       {
-        "matchDepTypes": ["provider", "helm_release"]
+        "matchDepTypes": ["helm_release", "provider", "tfe_workspace"]
       }
     ]
   }


### PR DESCRIPTION
Should help keep e.g. the Argo charts up to date.

These aren't automerged yet btw, this just has Renovate raise PRs for more things so there's less chance of updates being neglected.