### PR TITLE
Update `README.md` and `register-snapshot-repository.py` for Opensearch module

### DIFF
--- a/terraform/deployments/opensearch/README.md
+++ b/terraform/deployments/opensearch/README.md
@@ -1,5 +1,5 @@
 ## Chat OpenSearch Snapshots - `register-snapshot-repository.py`
-This document details how the S3 buckets created for the backup process should be registered in each environment. Detailed instructions on how to create index snapshots in Amazon OpenSearch Service can be found [here]. Full instructions on how to access the Amazon OpenSearch Dashboard can be found on this [page].
+This document details how the S3 buckets created for the backup process should be registered in each environment. Detailed instructions on how to create index snapshots in Amazon OpenSearch Service can be found [here]. Full instructions on how to access the Amazon OpenSearch Dashboard, along with how to get the login credentials, can be found on this [page].
 
 Registering the S3 buckets as snapshot repositories is a manual one-off process to be carried out in each environment (Integration, Staging and Production). The first step is to log in to the OpenSearch Dashboard and map the AWS IAM Role of the user who will register the repositories. This is followed by running the `register-snapshot-repository.py` script. The backup jobs are run as cronjobs on the EKS cluster. The Production snapshot is created first, which gets imported by Staging and then Integration.
 

--- a/terraform/deployments/opensearch/register-snapshot-repository.py
+++ b/terraform/deployments/opensearch/register-snapshot-repository.py
@@ -52,7 +52,7 @@ def register_repository(name, role_arn, delete_first=False, read_only=False):
 
     headers = {"Content-Type": "application/json"}
 
-    r = requests.put(url, auth=awsauth, json=payload, headers=headers)
+    r = requests.put(url, auth=awsauth, json=payload, headers=headers, verify=False)
     r.raise_for_status()
     print(r.text)
 


### PR DESCRIPTION
Update `README.md` to specify the page where instructions on how to find the login credentials for the Opensearch Dashboard can be found, and modify `register-snapshot-repository.py` so that it does not verify the certificate for `https://localhost:4443`, allowing the script to work without error.