### PR TITLE
Pass packages write permissions for image build workflows

### DIFF
--- a/.github/workflows/build-clamav-image.yml
+++ b/.github/workflows/build-clamav-image.yml
@@ -28,3 +28,4 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write

--- a/.github/workflows/build-mongodb-image.yml
+++ b/.github/workflows/build-mongodb-image.yml
@@ -28,3 +28,4 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write

--- a/.github/workflows/build-toolbox-image.yml
+++ b/.github/workflows/build-toolbox-image.yml
@@ -28,3 +28,4 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write


### PR DESCRIPTION
This is needed to push images to ghcr.io.