### PR TITLE
Migrate GitHub repo config

### DIFF
--- a/terraform/deployments/github/imports.tf
+++ b/terraform/deployments/github/imports.tf
@@ -1226,3 +1226,8 @@ import {
   to = github_branch_protection.govuk_repos["whitehall"]
   id = "whitehall:main"
 }
+
+import {
+  to = github_repository.govuk_repos["govuk-crd-library"]
+  id = "govuk-crd-library"
+}

--- a/terraform/deployments/github/imports.tf
+++ b/terraform/deployments/github/imports.tf
@@ -430,16 +430,6 @@ import {
 }
 
 import {
-  to = github_repository.govuk_repos["govuk-display-screen"]
-  id = "govuk-display-screen"
-}
-
-import {
-  to = github_branch_protection.govuk_repos["govuk-display-screen"]
-  id = "govuk-display-screen:main"
-}
-
-import {
   to = github_repository.govuk_repos["govuk-dns-tf"]
   id = "govuk-dns-tf"
 }
@@ -545,39 +535,22 @@ import {
 }
 
 import {
-  to = github_branch_protection.govuk_repos["govuk-mobile-android-app"]
-  id = "govuk-mobile-android-app:main"
-}
-
-import {
   to = github_repository.govuk_repos["govuk-mobile-android-homepage"]
   id = "govuk-mobile-android-homepage"
 }
 
-import {
-  to = github_branch_protection.govuk_repos["govuk-mobile-android-homepage"]
-  id = "govuk-mobile-android-homepage:main"
-}
 
 import {
   to = github_repository.govuk_repos["govuk-mobile-android-onboarding"]
   id = "govuk-mobile-android-onboarding"
 }
 
-import {
-  to = github_branch_protection.govuk_repos["govuk-mobile-android-onboarding"]
-  id = "govuk-mobile-android-onboarding:main"
-}
 
 import {
   to = github_repository.govuk_repos["govuk-mobile-android-services"]
   id = "govuk-mobile-android-services"
 }
 
-import {
-  to = github_branch_protection.govuk_repos["govuk-mobile-android-services"]
-  id = "govuk-mobile-android-services:main"
-}
 
 import {
   to = github_repository.govuk_repos["govuk-mobile-backend"]
@@ -604,59 +577,34 @@ import {
   id = "govuk-mobile-ios-app"
 }
 
-import {
-  to = github_branch_protection.govuk_repos["govuk-mobile-ios-app"]
-  id = "govuk-mobile-ios-app:main"
-}
 
 import {
   to = github_repository.govuk_repos["govuk-mobile-ios-homepage"]
   id = "govuk-mobile-ios-homepage"
 }
 
-import {
-  to = github_branch_protection.govuk_repos["govuk-mobile-ios-homepage"]
-  id = "govuk-mobile-ios-homepage:main"
-}
 
 import {
   to = github_repository.govuk_repos["govuk-mobile-ios-onboarding"]
   id = "govuk-mobile-ios-onboarding"
 }
 
-import {
-  to = github_branch_protection.govuk_repos["govuk-mobile-ios-onboarding"]
-  id = "govuk-mobile-ios-onboarding:main"
-}
 
 import {
   to = github_repository.govuk_repos["govuk-mobile-ios-services"]
   id = "govuk-mobile-ios-services"
 }
 
-import {
-  to = github_branch_protection.govuk_repos["govuk-mobile-ios-services"]
-  id = "govuk-mobile-ios-services:main"
-}
 
 import {
   to = github_repository.govuk_repos["govuk-mobile-ios-ui-components"]
   id = "govuk-mobile-ios-ui-components"
 }
 
-import {
-  to = github_branch_protection.govuk_repos["govuk-mobile-ios-ui-components"]
-  id = "govuk-mobile-ios-ui-components:main"
-}
 
 import {
   to = github_repository.govuk_repos["govuk-mobile-remote-config"]
   id = "govuk-mobile-remote-config"
-}
-
-import {
-  to = github_branch_protection.govuk_repos["govuk-mobile-remote-config"]
-  id = "govuk-mobile-remote-config:main"
 }
 
 import {

--- a/terraform/deployments/github/imports.tf
+++ b/terraform/deployments/github/imports.tf
@@ -1259,11 +1259,6 @@ import {
 }
 
 import {
-  to = github_repository.govuk_repos["govuk-mobile-service-registry"]
-  id = "govuk-mobile-service-registry"
-}
-
-import {
   to = github_repository.govuk_repos["markdown-toolbar-element"]
   id = "markdown-toolbar-element"
 }

--- a/terraform/deployments/github/imports.tf
+++ b/terraform/deployments/github/imports.tf
@@ -1,0 +1,1280 @@
+
+import {
+  to = github_repository.govuk_repos["accessible-autocomplete-multiselect"]
+  id = "accessible-autocomplete-multiselect"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["accessible-autocomplete-multiselect"]
+  id = "accessible-autocomplete-multiselect:main"
+}
+
+import {
+  to = github_repository.govuk_repos["account-api"]
+  id = "account-api"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["account-api"]
+  id = "account-api:main"
+}
+
+import {
+  to = github_repository.govuk_repos["asset-manager"]
+  id = "asset-manager"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["asset-manager"]
+  id = "asset-manager:main"
+}
+
+import {
+  to = github_repository.govuk_repos["authenticating-proxy"]
+  id = "authenticating-proxy"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["authenticating-proxy"]
+  id = "authenticating-proxy:main"
+}
+
+import {
+  to = github_repository.govuk_repos["bouncer"]
+  id = "bouncer"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["bouncer"]
+  id = "bouncer:main"
+}
+
+import {
+  to = github_repository.govuk_repos["bulk-changer"]
+  id = "bulk-changer"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["bulk-changer"]
+  id = "bulk-changer:main"
+}
+
+import {
+  to = github_repository.govuk_repos["bulk-merger"]
+  id = "bulk-merger"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["bulk-merger"]
+  id = "bulk-merger:main"
+}
+
+import {
+  to = github_repository.govuk_repos["ckan-mock-harvest-sources"]
+  id = "ckan-mock-harvest-sources"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["ckan-mock-harvest-sources"]
+  id = "ckan-mock-harvest-sources:main"
+}
+
+import {
+  to = github_repository.govuk_repos["ckanext-datagovuk"]
+  id = "ckanext-datagovuk"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["ckanext-datagovuk"]
+  id = "ckanext-datagovuk:main"
+}
+
+import {
+  to = github_repository.govuk_repos["collections"]
+  id = "collections"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["collections"]
+  id = "collections:main"
+}
+
+import {
+  to = github_repository.govuk_repos["collections-publisher"]
+  id = "collections-publisher"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["collections-publisher"]
+  id = "collections-publisher:main"
+}
+
+import {
+  to = github_repository.govuk_repos["contacts-admin"]
+  id = "contacts-admin"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["contacts-admin"]
+  id = "contacts-admin:main"
+}
+
+import {
+  to = github_repository.govuk_repos["content-data-admin"]
+  id = "content-data-admin"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["content-data-admin"]
+  id = "content-data-admin:main"
+}
+
+import {
+  to = github_repository.govuk_repos["content-data-api"]
+  id = "content-data-api"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["content-data-api"]
+  id = "content-data-api:main"
+}
+
+import {
+  to = github_repository.govuk_repos["content-publisher"]
+  id = "content-publisher"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["content-publisher"]
+  id = "content-publisher:main"
+}
+
+import {
+  to = github_repository.govuk_repos["content-store"]
+  id = "content-store"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["content-store"]
+  id = "content-store:main"
+}
+
+import {
+  to = github_repository.govuk_repos["content-tagger"]
+  id = "content-tagger"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["content-tagger"]
+  id = "content-tagger:main"
+}
+
+import {
+  to = github_repository.govuk_repos["data-community-tech-docs"]
+  id = "data-community-tech-docs"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["data-community-tech-docs"]
+  id = "data-community-tech-docs:main"
+}
+
+import {
+  to = github_repository.govuk_repos["datagovuk-tech-docs"]
+  id = "datagovuk-tech-docs"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["datagovuk-tech-docs"]
+  id = "datagovuk-tech-docs:main"
+}
+
+import {
+  to = github_repository.govuk_repos["datagovuk_find"]
+  id = "datagovuk_find"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["datagovuk_find"]
+  id = "datagovuk_find:main"
+}
+
+import {
+  to = github_repository.govuk_repos["datagovuk_publish"]
+  id = "datagovuk_publish"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["datagovuk_publish"]
+  id = "datagovuk_publish:main"
+}
+
+import {
+  to = github_repository.govuk_repos["email-alert-api"]
+  id = "email-alert-api"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["email-alert-api"]
+  id = "email-alert-api:main"
+}
+
+import {
+  to = github_repository.govuk_repos["email-alert-frontend"]
+  id = "email-alert-frontend"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["email-alert-frontend"]
+  id = "email-alert-frontend:main"
+}
+
+import {
+  to = github_repository.govuk_repos["email-alert-service"]
+  id = "email-alert-service"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["email-alert-service"]
+  id = "email-alert-service:main"
+}
+
+import {
+  to = github_repository.govuk_repos["feedback"]
+  id = "feedback"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["feedback"]
+  id = "feedback:main"
+}
+
+import {
+  to = github_repository.govuk_repos["finder-frontend"]
+  id = "finder-frontend"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["finder-frontend"]
+  id = "finder-frontend:main"
+}
+
+import {
+  to = github_repository.govuk_repos["frontend"]
+  id = "frontend"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["frontend"]
+  id = "frontend:main"
+}
+
+import {
+  to = github_repository.govuk_repos["gds-api-adapters"]
+  id = "gds-api-adapters"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["gds-api-adapters"]
+  id = "gds-api-adapters:main"
+}
+
+import {
+  to = github_repository.govuk_repos["gds-sso"]
+  id = "gds-sso"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["gds-sso"]
+  id = "gds-sso:main"
+}
+
+import {
+  to = github_repository.govuk_repos["gds_zendesk"]
+  id = "gds_zendesk"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["gds_zendesk"]
+  id = "gds_zendesk:main"
+}
+
+import {
+  to = github_repository.govuk_repos["government-frontend"]
+  id = "government-frontend"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["government-frontend"]
+  id = "government-frontend:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govspeak"]
+  id = "govspeak"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govspeak"]
+  id = "govspeak:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govspeak-preview"]
+  id = "govspeak-preview"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govspeak-preview"]
+  id = "govspeak-preview:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govspeak-visual-editor"]
+  id = "govspeak-visual-editor"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govspeak-visual-editor"]
+  id = "govspeak-visual-editor:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-analytics-engineering"]
+  id = "govuk-analytics-engineering"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-analytics-engineering"]
+  id = "govuk-analytics-engineering:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-aws"]
+  id = "govuk-aws"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-aws"]
+  id = "govuk-aws:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-aws-data"]
+  id = "govuk-aws-data"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-aws-data"]
+  id = "govuk-aws-data:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-browser-extension"]
+  id = "govuk-browser-extension"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-browser-extension"]
+  id = "govuk-browser-extension:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-chat"]
+  id = "govuk-chat"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-chat"]
+  id = "govuk-chat:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-content-api-docs"]
+  id = "govuk-content-api-docs"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-content-api-docs"]
+  id = "govuk-content-api-docs:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-data-science-workshop"]
+  id = "govuk-data-science-workshop"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-data-science-workshop"]
+  id = "govuk-data-science-workshop:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-dependency-checker"]
+  id = "govuk-dependency-checker"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-dependency-checker"]
+  id = "govuk-dependency-checker:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-developer-docs"]
+  id = "govuk-developer-docs"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-developer-docs"]
+  id = "govuk-developer-docs:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-display-screen"]
+  id = "govuk-display-screen"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-display-screen"]
+  id = "govuk-display-screen:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-dns-tf"]
+  id = "govuk-dns-tf"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-dns-tf"]
+  id = "govuk-dns-tf:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-dns-ui"]
+  id = "govuk-dns-ui"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-dns-ui"]
+  id = "govuk-dns-ui:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-docker"]
+  id = "govuk-docker"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-docker"]
+  id = "govuk-docker:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-exporter"]
+  id = "govuk-exporter"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-exporter"]
+  id = "govuk-exporter:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-fastly"]
+  id = "govuk-fastly"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-fastly"]
+  id = "govuk-fastly:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-fastly-secrets"]
+  id = "govuk-fastly-secrets"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-fastly-secrets"]
+  id = "govuk-fastly-secrets:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-helm-charts"]
+  id = "govuk-helm-charts"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-helm-charts"]
+  id = "govuk-helm-charts:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-infrastructure"]
+  id = "govuk-infrastructure"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-infrastructure"]
+  id = "govuk-infrastructure:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-knowledge-graph-search"]
+  id = "govuk-knowledge-graph-search"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-knowledge-graph-search"]
+  id = "govuk-knowledge-graph-search:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mirror"]
+  id = "govuk-mirror"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mirror"]
+  id = "govuk-mirror:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-android-app"]
+  id = "govuk-mobile-android-app"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-android-app"]
+  id = "govuk-mobile-android-app:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-android-homepage"]
+  id = "govuk-mobile-android-homepage"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-android-homepage"]
+  id = "govuk-mobile-android-homepage:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-android-onboarding"]
+  id = "govuk-mobile-android-onboarding"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-android-onboarding"]
+  id = "govuk-mobile-android-onboarding:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-android-services"]
+  id = "govuk-mobile-android-services"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-android-services"]
+  id = "govuk-mobile-android-services:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-backend"]
+  id = "govuk-mobile-backend"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-backend"]
+  id = "govuk-mobile-backend:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-backend-config"]
+  id = "govuk-mobile-backend-config"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-backend-config"]
+  id = "govuk-mobile-backend-config:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-ios-app"]
+  id = "govuk-mobile-ios-app"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-ios-app"]
+  id = "govuk-mobile-ios-app:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-ios-homepage"]
+  id = "govuk-mobile-ios-homepage"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-ios-homepage"]
+  id = "govuk-mobile-ios-homepage:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-ios-onboarding"]
+  id = "govuk-mobile-ios-onboarding"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-ios-onboarding"]
+  id = "govuk-mobile-ios-onboarding:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-ios-services"]
+  id = "govuk-mobile-ios-services"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-ios-services"]
+  id = "govuk-mobile-ios-services:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-ios-ui-components"]
+  id = "govuk-mobile-ios-ui-components"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-ios-ui-components"]
+  id = "govuk-mobile-ios-ui-components:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-remote-config"]
+  id = "govuk-mobile-remote-config"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-mobile-remote-config"]
+  id = "govuk-mobile-remote-config:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-pact-broker"]
+  id = "govuk-pact-broker"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-pact-broker"]
+  id = "govuk-pact-broker:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-replatform-test-app"]
+  id = "govuk-replatform-test-app"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-replatform-test-app"]
+  id = "govuk-replatform-test-app:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-rfcs"]
+  id = "govuk-rfcs"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-rfcs"]
+  id = "govuk-rfcs:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-rota-announcer"]
+  id = "govuk-rota-announcer"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-rota-announcer"]
+  id = "govuk-rota-announcer:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-rota-generator"]
+  id = "govuk-rota-generator"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-rota-generator"]
+  id = "govuk-rota-generator:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-ruby-images"]
+  id = "govuk-ruby-images"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-ruby-images"]
+  id = "govuk-ruby-images:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-s3-mirror"]
+  id = "govuk-s3-mirror"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-s3-mirror"]
+  id = "govuk-s3-mirror:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-saas-config"]
+  id = "govuk-saas-config"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-saas-config"]
+  id = "govuk-saas-config:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-sli-collector"]
+  id = "govuk-sli-collector"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-sli-collector"]
+  id = "govuk-sli-collector:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-user-reviewer"]
+  id = "govuk-user-reviewer"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-user-reviewer"]
+  id = "govuk-user-reviewer:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk_ab_testing"]
+  id = "govuk_ab_testing"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk_ab_testing"]
+  id = "govuk_ab_testing:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk_admin_template"]
+  id = "govuk_admin_template"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk_admin_template"]
+  id = "govuk_admin_template:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk_app_config"]
+  id = "govuk_app_config"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk_app_config"]
+  id = "govuk_app_config:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk_document_types"]
+  id = "govuk_document_types"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk_document_types"]
+  id = "govuk_document_types:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk_message_queue_consumer"]
+  id = "govuk_message_queue_consumer"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk_message_queue_consumer"]
+  id = "govuk_message_queue_consumer:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk_personalisation"]
+  id = "govuk_personalisation"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk_personalisation"]
+  id = "govuk_personalisation:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk_publishing_components"]
+  id = "govuk_publishing_components"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk_publishing_components"]
+  id = "govuk_publishing_components:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk_schemas"]
+  id = "govuk_schemas"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk_schemas"]
+  id = "govuk_schemas:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk_sidekiq"]
+  id = "govuk_sidekiq"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk_sidekiq"]
+  id = "govuk_sidekiq:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk_test"]
+  id = "govuk_test"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk_test"]
+  id = "govuk_test:main"
+}
+
+import {
+  to = github_repository.govuk_repos["hmrc-manuals-api"]
+  id = "hmrc-manuals-api"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["hmrc-manuals-api"]
+  id = "hmrc-manuals-api:main"
+}
+
+import {
+  to = github_repository.govuk_repos["licensify"]
+  id = "licensify"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["licensify"]
+  id = "licensify:main"
+}
+
+import {
+  to = github_repository.govuk_repos["link-checker-api"]
+  id = "link-checker-api"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["link-checker-api"]
+  id = "link-checker-api:main"
+}
+
+import {
+  to = github_repository.govuk_repos["local-links-manager"]
+  id = "local-links-manager"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["local-links-manager"]
+  id = "local-links-manager:main"
+}
+
+import {
+  to = github_repository.govuk_repos["locations-api"]
+  id = "locations-api"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["locations-api"]
+  id = "locations-api:main"
+}
+
+import {
+  to = github_repository.govuk_repos["manuals-publisher"]
+  id = "manuals-publisher"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["manuals-publisher"]
+  id = "manuals-publisher:main"
+}
+
+import {
+  to = github_repository.govuk_repos["maslow"]
+  id = "maslow"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["maslow"]
+  id = "maslow:main"
+}
+
+import {
+  to = github_repository.govuk_repos["miller-columns-element"]
+  id = "miller-columns-element"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["miller-columns-element"]
+  id = "miller-columns-element:main"
+}
+
+import {
+  to = github_repository.govuk_repos["optic14n"]
+  id = "optic14n"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["optic14n"]
+  id = "optic14n:main"
+}
+
+import {
+  to = github_repository.govuk_repos["paste-html-to-govspeak"]
+  id = "paste-html-to-govspeak"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["paste-html-to-govspeak"]
+  id = "paste-html-to-govspeak:main"
+}
+
+import {
+  to = github_repository.govuk_repos["places-manager"]
+  id = "places-manager"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["places-manager"]
+  id = "places-manager:main"
+}
+
+import {
+  to = github_repository.govuk_repos["plek"]
+  id = "plek"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["plek"]
+  id = "plek:main"
+}
+
+import {
+  to = github_repository.govuk_repos["public-asset-checker"]
+  id = "public-asset-checker"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["public-asset-checker"]
+  id = "public-asset-checker:main"
+}
+
+import {
+  to = github_repository.govuk_repos["publisher"]
+  id = "publisher"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["publisher"]
+  id = "publisher:main"
+}
+
+import {
+  to = github_repository.govuk_repos["publishing-api"]
+  id = "publishing-api"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["publishing-api"]
+  id = "publishing-api:main"
+}
+
+import {
+  to = github_repository.govuk_repos["rack-logstasher"]
+  id = "rack-logstasher"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["rack-logstasher"]
+  id = "rack-logstasher:main"
+}
+
+import {
+  to = github_repository.govuk_repos["rails_translation_manager"]
+  id = "rails_translation_manager"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["rails_translation_manager"]
+  id = "rails_translation_manager:main"
+}
+
+import {
+  to = github_repository.govuk_repos["release"]
+  id = "release"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["release"]
+  id = "release:main"
+}
+
+import {
+  to = github_repository.govuk_repos["router"]
+  id = "router"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["router"]
+  id = "router:main"
+}
+
+import {
+  to = github_repository.govuk_repos["router-api"]
+  id = "router-api"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["router-api"]
+  id = "router-api:main"
+}
+
+import {
+  to = github_repository.govuk_repos["rubocop-govuk"]
+  id = "rubocop-govuk"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["rubocop-govuk"]
+  id = "rubocop-govuk:main"
+}
+
+import {
+  to = github_repository.govuk_repos["seal"]
+  id = "seal"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["seal"]
+  id = "seal:main"
+}
+
+import {
+  to = github_repository.govuk_repos["search-admin"]
+  id = "search-admin"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["search-admin"]
+  id = "search-admin:main"
+}
+
+import {
+  to = github_repository.govuk_repos["search-api"]
+  id = "search-api"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["search-api"]
+  id = "search-api:main"
+}
+
+import {
+  to = github_repository.govuk_repos["search-api-v2"]
+  id = "search-api-v2"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["search-api-v2"]
+  id = "search-api-v2:main"
+}
+
+import {
+  to = github_repository.govuk_repos["search-v2-evaluator"]
+  id = "search-v2-evaluator"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["search-v2-evaluator"]
+  id = "search-v2-evaluator:main"
+}
+
+import {
+  to = github_repository.govuk_repos["search-v2-infrastructure"]
+  id = "search-v2-infrastructure"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["search-v2-infrastructure"]
+  id = "search-v2-infrastructure:main"
+}
+
+import {
+  to = github_repository.govuk_repos["service-manual-publisher"]
+  id = "service-manual-publisher"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["service-manual-publisher"]
+  id = "service-manual-publisher:main"
+}
+
+import {
+  to = github_repository.govuk_repos["short-url-manager"]
+  id = "short-url-manager"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["short-url-manager"]
+  id = "short-url-manager:main"
+}
+
+import {
+  to = github_repository.govuk_repos["signon"]
+  id = "signon"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["signon"]
+  id = "signon:main"
+}
+
+import {
+  to = github_repository.govuk_repos["siteimprove_api_client"]
+  id = "siteimprove_api_client"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["siteimprove_api_client"]
+  id = "siteimprove_api_client:main"
+}
+
+import {
+  to = github_repository.govuk_repos["slimmer"]
+  id = "slimmer"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["slimmer"]
+  id = "slimmer:main"
+}
+
+import {
+  to = github_repository.govuk_repos["smart-answers"]
+  id = "smart-answers"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["smart-answers"]
+  id = "smart-answers:main"
+}
+
+import {
+  to = github_repository.govuk_repos["smokey"]
+  id = "smokey"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["smokey"]
+  id = "smokey:main"
+}
+
+import {
+  to = github_repository.govuk_repos["special-route-publisher"]
+  id = "special-route-publisher"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["special-route-publisher"]
+  id = "special-route-publisher:main"
+}
+
+import {
+  to = github_repository.govuk_repos["specialist-publisher"]
+  id = "specialist-publisher"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["specialist-publisher"]
+  id = "specialist-publisher:main"
+}
+
+import {
+  to = github_repository.govuk_repos["static"]
+  id = "static"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["static"]
+  id = "static:main"
+}
+
+import {
+  to = github_repository.govuk_repos["support"]
+  id = "support"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["support"]
+  id = "support:main"
+}
+
+import {
+  to = github_repository.govuk_repos["support-api"]
+  id = "support-api"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["support-api"]
+  id = "support-api:main"
+}
+
+import {
+  to = github_repository.govuk_repos["transition"]
+  id = "transition"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["transition"]
+  id = "transition:main"
+}
+
+import {
+  to = github_repository.govuk_repos["travel-advice-publisher"]
+  id = "travel-advice-publisher"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["travel-advice-publisher"]
+  id = "travel-advice-publisher:main"
+}
+
+import {
+  to = github_repository.govuk_repos["whitehall"]
+  id = "whitehall"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["whitehall"]
+  id = "whitehall:main"
+}

--- a/terraform/deployments/github/imports.tf
+++ b/terraform/deployments/github/imports.tf
@@ -1231,3 +1231,69 @@ import {
   to = github_repository.govuk_repos["govuk-crd-library"]
   id = "govuk-crd-library"
 }
+
+
+import {
+  to = github_repository.govuk_repos["govuk-knowledge-graph-gcp"]
+  id = "govuk-knowledge-graph-gcp"
+}
+
+import {
+  to = github_repository.govuk_repos["github-trello-poster"]
+  id = "github-trello-poster"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["github-trello-poster"]
+  id = "github-trello-poster:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-dependabot-merger"]
+  id = "govuk-dependabot-merger"
+}
+
+import {
+  to = github_branch_protection.govuk_repos["govuk-dependabot-merger"]
+  id = "govuk-dependabot-merger:main"
+}
+
+import {
+  to = github_repository.govuk_repos["govuk-mobile-service-registry"]
+  id = "govuk-mobile-service-registry"
+}
+
+import {
+  to = github_repository.govuk_repos["markdown-toolbar-element"]
+  id = "markdown-toolbar-element"
+}
+
+import {
+  to = github_team_repository.govuk_production_admin_repos["github-trello-poster"]
+  id = "3279244:github-trello-poster"
+}
+
+import {
+  to = github_team_repository.govuk_production_admin_repos["markdown-toolbar-element"]
+  id = "3279244:markdown-toolbar-element"
+}
+
+import {
+  to = github_team_repository.govuk_repos["github-trello-poster"]
+  id = "3279243:github-trello-poster"
+}
+
+import {
+  to = github_team_repository.govuk_repos["govuk-dependabot-merger"]
+  id = "3279243:govuk-dependabot-merger"
+}
+
+import {
+  to = github_team_repository.govuk_production_admin_repos["govuk-dependabot-merger"]
+  id = "3279244:govuk-dependabot-merger"
+}
+
+import {
+  to = github_team_repository.govuk_repos["markdown-toolbar-element"]
+  id = "3279243:markdown-toolbar-element"
+}

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -128,6 +128,31 @@ resource "github_repository" "govuk_repos" {
   delete_branch_on_merge = true
 }
 
+resource "github_branch_protection" "govuk_repos" {
+  for_each = github_repository.govuk_repos
+
+  repository_id    = each.value.name
+  pattern          = "main"
+  enforce_admins   = true
+  allows_deletions = true
+
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    strict = true # This ensures the branch is up to date before merging
+    contexts = [
+      "Lint SCSS / Run Stylelint",
+      "Security Analysis / Run Brakeman",
+      "Lint Ruby / Run RuboCop",
+      "Lint JavaScript / Run Standardx",
+      "Test JavaScript / Run Jasmine",
+      "Test Ruby / Run RSpec"
+    ]
+  }
+}
+
 #
 # Only the list of repositories which will have access to a secret is created/modified
 # here, the secret should have been created in the GitHub UI in advance by a

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -123,6 +123,8 @@ resource "github_repository" "govuk_repos" {
 
   delete_branch_on_merge = true
 
+  homepage_url = try(each.value.homepage_url, null)
+
   lifecycle {
     ignore_changes = [description]
   }
@@ -138,6 +140,8 @@ resource "github_branch_protection" "govuk_repos" {
 
   required_pull_request_reviews {
     required_approving_review_count = 1
+
+    pull_request_bypassers = try(each.value.required_pull_request_reviews.pull_request_bypassers, null)
   }
 
   restrict_pushes {
@@ -150,7 +154,7 @@ resource "github_branch_protection" "govuk_repos" {
   }
 
   required_status_checks {
-    strict = false
+    strict = try(each.value.strict, false)
 
     contexts = concat(
       try(each.value["required_status_checks"]["standard_contexts"], []),

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -114,10 +114,7 @@ resource "github_repository" "govuk_repos" {
 
   allow_squash_merge = true
   allow_merge_commit = false
-  allow_rebase_merge = false
 
-  has_issues           = true
-  has_projects         = true
   has_downloads        = true
   vulnerability_alerts = true
 
@@ -126,7 +123,20 @@ resource "github_repository" "govuk_repos" {
   homepage_url = try(each.value.homepage_url, null)
 
   lifecycle {
-    ignore_changes = [description]
+    ignore_changes = [
+      description,
+      allow_auto_merge,
+      allow_merge_commit,
+      allow_rebase_merge,
+      allow_squash_merge,
+      allow_update_branch,
+      has_issues,
+      has_projects,
+      has_wiki,
+      squash_merge_commit_title,
+      squash_merge_commit_message,
+      pages
+    ]
   }
 }
 
@@ -160,6 +170,12 @@ resource "github_branch_protection" "govuk_repos" {
       try(each.value["required_status_checks"]["standard_contexts"], []),
       try(each.value["required_status_checks"]["additional_contexts"], [])
     )
+  }
+
+  lifecycle {
+    ignore_changes = [
+      require_conversation_resolution
+    ]
   }
 }
 

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -115,6 +115,19 @@ resource "github_team_repository" "govuk_repos" {
   permission = "push"
 }
 
+resource "github_repository" "govuk_repos" {
+  for_each = { for repo in local.auto_configurable_repos : repo.name => repo }
+
+  name        = each.value.name
+  description = each.value.description
+
+  allow_squash_merge = true
+  allow_merge_commit = false
+  allow_rebase_merge = false
+
+  delete_branch_on_merge = true
+}
+
 #
 # Only the list of repositories which will have access to a secret is created/modified
 # here, the secret should have been created in the GitHub UI in advance by a

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1,0 +1,629 @@
+access_levels:
+  standard_security_checks: &standard_security_checks
+    - CodeQL SAST scan / Analyze
+    - Dependency Review scan / dependency-review-pr
+  standard_govuk_rails_checks: &standard_govuk_rails_checks
+    - CodeQL SAST scan / Analyze
+    - Dependency Review scan / dependency-review-pr
+    - Lint Ruby / Run RuboCop
+    - Security Analysis / Run Brakeman
+
+repos:
+  accessible-autocomplete-multiselect: {}
+
+  account-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/account-api/blob/main/.github/workflows/ci.yml):
+        # - Run Pact tests
+
+  asset-manager:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/asset-manager/blob/main/.github/workflows/ci.yml):
+        # - Run Pact tests
+
+  authenticating-proxy:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+
+  bouncer:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint Ruby / Run RuboCop
+
+  bulk-changer:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  bulk-merger:
+  collections:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Integration tests
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+        - Lint ERB / Lint ERB
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/ci.yml):
+        # - Run Pact tests
+
+  collections-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test Ruby / Run RSpec
+
+  contacts-admin:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test Ruby / Run RSpec
+
+  content-data-admin:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+
+  content-data-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby / Run RSpec
+
+  content-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+
+  content-store:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby / Run RSpec
+
+  content-tagger:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test Ruby / Run RSpec
+
+  data-community-tech-docs:
+    need_production_access_to_merge: false
+    allow_squash_merge: true
+
+  datagovuk-tech-docs:
+    need_production_access_to_merge: false
+    allow_squash_merge: true
+
+  email-alert-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-api/blob/main/.github/workflows/ci.yml):
+        # - Run Pact tests
+
+  email-alert-frontend:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+
+  email-alert-service:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Test Ruby / Run RSpec
+
+  feedback:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+
+  finder-frontend:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Integration tests
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+
+  frontend:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml):
+        # - Run Pact tests
+
+  gds-api-adapters:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/gds-api-adapters/blob/main/.github/workflows/ci.yml):
+        # - Many different pact tests
+
+  gds-sso:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  gds_zendesk:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  github-trello-poster:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  government-frontend:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+
+  govspeak:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govspeak-preview:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk-aws:
+    required_status_checks:
+      additional_contexts:
+        - Shellcheck
+        - terraform fmt
+
+  govuk-content-api-docs:
+    need_production_access_to_merge: false
+    allow_squash_merge: true
+
+  govuk-dependabot-merger:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk-dependency-checker:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk-developer-docs:
+    need_production_access_to_merge: false
+    allow_squash_merge: true
+
+  govuk-dns-tf:
+    up_to_date_branches: true
+
+  govuk-fastly:
+    up_to_date_branches: true
+
+  govuk-fastly-secrets:
+    up_to_date_branches: true
+
+  govuk-infrastructure:
+    up_to_date_branches: true
+
+  govuk-mobile-android-app:
+    allow_squash_merge: true
+
+  govuk-mobile-android-homepage:
+    allow_squash_merge: true
+
+  govuk-mobile-android-onboarding:
+    allow_squash_merge: true
+
+  govuk-mobile-android-services:
+    allow_squash_merge: true
+
+  govuk-mobile-ios-app:
+    allow_squash_merge: true
+
+  govuk-mobile-ios-homepage:
+    allow_squash_merge: true
+
+  govuk-mobile-ios-onboarding:
+    allow_squash_merge: true
+
+  govuk-mobile-ios-services:
+    allow_squash_merge: true
+
+  govuk-mobile-ios-ui-components:
+    allow_squash_merge: true
+
+  govuk-rota-generator:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk-saas-config:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk-sli-collector:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk_ab_testing:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk_admin_template:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk_app_config:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk_document_types:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk_message_queue_consumer:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk_personalisation:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk_publishing_components:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk_schemas:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk_sidekiq:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  govuk_test:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  hmrc-manuals-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby / Run RSpec
+
+  link-checker-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/link-checker-api/blob/main/.github/workflows/ci.yml):
+        # - Run Pact tests
+
+  local-links-manager:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Lint Views
+
+  locations-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/locations-api/blob/main/.github/workflows/ci.yml):
+        # - Run Pact tests
+
+  manuals-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Integration tests
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+
+  markdown-toolbar-element:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  maslow:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+
+  miller-columns-element:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  optic14n:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  paste-html-to-govspeak:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  places-manager:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Integration tests
+        - Test Ruby
+        - Lint Views
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/places-manager/blob/main/.github/workflows/ci.yml):
+        # - Run Pact tests
+
+  plek:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+
+  publishing-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Check content schemas are built
+        - Test Ruby
+        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publishing-api/blob/main/.github/workflows/ci.yml):
+        # - Run Content Store Pact tests
+        # - Run GDS API Adapter Pact tests
+
+  rack-logstasher:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  rails_translation_manager:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  release:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+
+  router:
+    required_status_checks:
+      additional_contexts:
+        - Test Go
+
+  router-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+
+  rubocop-govuk:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  seal:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  search-admin:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test Ruby / Run RSpec
+
+  search-api:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Test Ruby / Run RSpec
+
+  search-api-v2:
+    required_status_checks:
+      ignore_jenkins: true
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+
+  search-v2-evaluator:
+
+  search-v2-infrastructure:
+    required_status_checks:
+      ignore_jenkins: true
+      additional_contexts:
+        - lint_and_validate
+
+  service-manual-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+
+  short-url-manager:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby / Run RSpec
+        - Lint SCSS / Run Stylelint
+
+  signon:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+
+  siteimprove_api_client:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  slimmer:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  smart-answers:
+    allow_squash_merge: true
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+
+  smokey:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  special-route-publisher:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+
+  specialist-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+
+  static:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+
+  support:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+
+  support-api:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby
+
+  transition:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Integration tests
+        - Test Ruby
+        - Test JavaScript / Run Jasmine
+
+  travel-advice-publisher:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run RSpec
+
+  whitehall:
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test features / Run Cucumber
+        - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standardx
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+        - Lint ERB / Run ERB lint
+        - Prettier / Run Prettier
+
+  ckan-mock-harvest-sources: {}
+  ckanext-datagovuk: {}
+  datagovuk_find: {}
+  datagovuk_publish: {}
+  govspeak-visual-editor: {}
+  govuk-analytics-engineering: {}
+  govuk-aws-data: {}
+  govuk-browser-extension: {}
+  govuk-chat: {}
+  govuk-data-science-workshop: {}
+  govuk-dns-ui: {}
+  govuk-docker: {}
+  govuk-exporter: {}
+  govuk-helm-charts: {}
+  govuk-knowledge-graph-gcp: {}
+  govuk-knowledge-graph-search: {}
+  govuk-mirror: {}
+  govuk-mobile-backend: {}
+  govuk-mobile-backend-config: {}
+  govuk-mobile-remote-config: {}
+  govuk-pact-broker: {}
+  govuk-replatform-test-app: {}
+  govuk-rfcs: {}
+  govuk-rota-announcer: {}
+  govuk-ruby-images: {}
+  govuk-s3-mirror: {}
+  govuk-user-reviewer: {}
+  licensify: {}
+  public-asset-checker: {}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -245,30 +245,43 @@ repos:
 
   govuk-mobile-android-app:
     allow_squash_merge: true
+    branch_protection: false
 
   govuk-mobile-android-homepage:
     allow_squash_merge: true
+    branch_protection: false
 
   govuk-mobile-android-onboarding:
     allow_squash_merge: true
+    branch_protection: false
 
   govuk-mobile-android-services:
     allow_squash_merge: true
+    branch_protection: false
 
   govuk-mobile-ios-app:
     allow_squash_merge: true
+    branch_protection: false
 
   govuk-mobile-ios-homepage:
     allow_squash_merge: true
+    branch_protection: false
 
   govuk-mobile-ios-onboarding:
     allow_squash_merge: true
+    branch_protection: false
 
   govuk-mobile-ios-services:
     allow_squash_merge: true
+    branch_protection: false
 
   govuk-mobile-ios-ui-components:
     allow_squash_merge: true
+    branch_protection: false
+
+  govuk-mobile-service-registry:
+    allow_squash_merge: true
+    branch_protection: false
 
   govuk-rota-generator:
     required_status_checks:

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -836,13 +836,23 @@ repos:
       pull_request_bypassers:
         - "alphagov/gov-uk"
 
+  govuk-knowledge-graph-gcp:
+    homepage_url: "https://docs.data-community.publishing.service.gov.uk/tools/govgraph/"
+
+  github-trello-poster:
+    required_status_checks:
+      additional_contexts:
+        - "CodeQL SAST scan / Analyze"
+        - "Dependency Review scan / dependency-review-pr"
+        - "test"
+
   accessible-autocomplete-multiselect: {}
   ckan-mock-harvest-sources: {}
   govuk-analytics-engineering: {}
   govuk-aws-data: {}
   govuk-chat: {}
   govuk-data-science-workshop: {}
-  govuk-knowledge-graph-gcp: {}
+
   govuk-mobile-backend: {}
   govuk-mobile-backend-config: {}
   govuk-mobile-remote-config: {}
@@ -850,4 +860,3 @@ repos:
   govuk-rfcs: {}
   govuk-ruby-images: {}
   govuk-s3-mirror: {}
-  github-trello-poster: {}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -9,8 +9,6 @@ access_levels:
     - Security Analysis / Run Brakeman
 
 repos:
-  accessible-autocomplete-multiselect: {}
-
   account-api:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
@@ -834,10 +832,11 @@ repos:
     homepage_url: "https://govuk-public-asset-checker.herokuapp.com"
 
   govspeak-visual-editor:
-  required_pull_request_reviews:
-    pull_request_bypassers:
-      - "/guilhem-fry"
+    required_pull_request_reviews:
+      pull_request_bypassers:
+        - "alphagov/gov-uk"
 
+  accessible-autocomplete-multiselect: {}
   ckan-mock-harvest-sources: {}
   govuk-analytics-engineering: {}
   govuk-aws-data: {}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -16,16 +16,22 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/account-api/blob/main/.github/workflows/ci.yml):
-        # - Run Pact tests
+        - CodeQL SAST scan / Analyze
+        - Dependency Review scan / dependency-review-pr
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Run Pact tests
 
   asset-manager:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/asset-manager/blob/main/.github/workflows/ci.yml):
-        # - Run Pact tests
+        - CodeQL SAST scan / Analyze
+        - Dependency Review scan / dependency-review-pr
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Run Pact tests
 
   authenticating-proxy:
     required_status_checks:
@@ -55,8 +61,11 @@ repos:
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
         - Lint ERB / Lint ERB
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/collections/blob/main/.github/workflows/ci.yml):
-        # - Run Pact tests
+        - CodeQL SAST scan / Analyze
+        - Dependency Review scan / dependency-review-pr
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Run Pact tests
 
   collections-publisher:
     required_status_checks:
@@ -124,8 +133,11 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/email-alert-api/blob/main/.github/workflows/ci.yml):
-        # - Run Pact tests
+        - CodeQL SAST scan / Analyze
+        - Dependency Review scan / dependency-review-pr
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Run Pact tests
 
   email-alert-frontend:
     required_status_checks:
@@ -170,15 +182,22 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run Minitest
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml):
-        # - Run Pact tests
+        - CodeQL SAST scan / Analyze
+        - Dependency Review scan / dependency-review-pr
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Run Pact tests
 
   gds-api-adapters:
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/gds-api-adapters/blob/main/.github/workflows/ci.yml):
-        # - Many different pact tests
+        - Test Ruby
+        - CodeQL SAST scan / Analyze
+        - Dependency Review scan / dependency-review-pr
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Run Pact tests
 
   gds-sso:
     required_status_checks:
@@ -346,8 +365,11 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/link-checker-api/blob/main/.github/workflows/ci.yml):
-        # - Run Pact tests
+        - CodeQL SAST scan / Analyze
+        - Dependency Review scan / dependency-review-pr
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Run Pact tests
 
   local-links-manager:
     required_status_checks:
@@ -363,8 +385,11 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/locations-api/blob/main/.github/workflows/ci.yml):
-        # - Run Pact tests
+        - CodeQL SAST scan / Analyze
+        - Dependency Review scan / dependency-review-pr
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Run Pact tests
 
   manuals-publisher:
     required_status_checks:
@@ -408,8 +433,11 @@ repos:
         - Integration tests
         - Test Ruby
         - Lint Views
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/places-manager/blob/main/.github/workflows/ci.yml):
-        # - Run Pact tests
+        - CodeQL SAST scan / Analyze
+        - Dependency Review scan / dependency-review-pr
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Run Pact tests
 
   plek:
     required_status_checks:
@@ -430,9 +458,11 @@ repos:
       additional_contexts:
         - Check content schemas are built
         - Test Ruby
-        # Status checks missing from here but present in [ci.yml](https://github.com/alphagov/publishing-api/blob/main/.github/workflows/ci.yml):
-        # - Run Content Store Pact tests
-        # - Run GDS API Adapter Pact tests
+        - CodeQL SAST scan / Analyze
+        - Dependency Review scan / dependency-review-pr
+        - Security Analysis / Run Brakeman
+        - Lint Ruby / Run RuboCop
+        - Run Pact tests
 
   rack-logstasher:
     required_status_checks:

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -22,6 +22,7 @@ repos:
         - Lint Ruby / Run RuboCop
 
   asset-manager:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/asset-manager.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -32,12 +33,14 @@ repos:
         - Lint Ruby / Run RuboCop
 
   authenticating-proxy:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/authenticating-proxy.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
 
   bouncer:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/bouncer.html"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
@@ -51,7 +54,9 @@ repos:
         - Test
 
   bulk-merger:
+
   collections:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/collections.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -67,6 +72,7 @@ repos:
         - Lint Ruby / Run RuboCop
 
   collections-publisher:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/collections-publisher.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -75,6 +81,7 @@ repos:
         - Test Ruby / Run RSpec
 
   contacts-admin:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/contacts-admin.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -83,6 +90,7 @@ repos:
         - Test Ruby / Run RSpec
 
   content-data-admin:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/content-data-admin.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -91,12 +99,14 @@ repos:
         - Lint JavaScript / Run Standardx
 
   content-data-api:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/content-performance-manager.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby / Run RSpec
 
   content-publisher:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/content-publisher.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -106,12 +116,14 @@ repos:
         - Test Ruby / Run RSpec
 
   content-store:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/content-store.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby / Run RSpec
 
   content-tagger:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/content-tagger.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -120,16 +132,19 @@ repos:
         - Test Ruby / Run RSpec
 
   data-community-tech-docs:
+    homepage_url: "https://docs.data-community.publishing.service.gov.uk/"
     need_production_access_to_merge: false
     allow_squash_merge: true
     push_allowances: []
 
   datagovuk-tech-docs:
+    homepage_url: "https://guidance.data.gov.uk/"
     need_production_access_to_merge: false
     allow_squash_merge: true
     push_allowances: []
 
   email-alert-api:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/email-alert-api.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -140,6 +155,7 @@ repos:
         - Lint Ruby / Run RuboCop
 
   email-alert-frontend:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/email-alert-frontend.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -149,6 +165,7 @@ repos:
         - Test Ruby / Run RSpec
 
   email-alert-service:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/email-alert-service.html"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
@@ -156,6 +173,7 @@ repos:
         - Test Ruby / Run RSpec
 
   feedback:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/feedback.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -165,6 +183,7 @@ repos:
         - Test Ruby / Run RSpec
 
   finder-frontend:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/finder-frontend.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -175,6 +194,7 @@ repos:
         - Test Ruby / Run RSpec
 
   frontend:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/frontend.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -188,6 +208,7 @@ repos:
         - Lint Ruby / Run RuboCop
 
   gds-api-adapters:
+    homepage_url: "http://www.rubydoc.info/github/alphagov/gds-api-adapters"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
@@ -208,6 +229,7 @@ repos:
         - test
 
   government-frontend:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/government-frontend.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -217,12 +239,14 @@ repos:
         - Test Ruby / Run Minitest
 
   govspeak:
+    homepage_url: "http://govspeak-preview.herokuapp.com/"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
         - test
 
   govspeak-preview:
+    homepage_url: "https://govspeak-preview.publishing.service.gov.uk/"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
@@ -235,6 +259,7 @@ repos:
         - terraform fmt
 
   govuk-content-api-docs:
+    homepage_url: "https://content-api.publishing.service.gov.uk"
     need_production_access_to_merge: false
     allow_squash_merge: true
     push_allowances: []
@@ -250,23 +275,28 @@ repos:
         - Test
 
   govuk-developer-docs:
+    homepage_url: "https://docs.publishing.service.gov.uk"
     need_production_access_to_merge: false
     allow_squash_merge: true
     push_allowances: []
 
   govuk-dns-tf:
+    strict: true
     up_to_date_branches: true
     required_status_checks:
       additional_contexts:
         - test
 
   govuk-fastly:
+    strict: true
     up_to_date_branches: true
 
   govuk-fastly-secrets:
+    strict: true
     up_to_date_branches: true
 
   govuk-infrastructure:
+    strict: true
     up_to_date_branches: true
 
   govuk-mobile-android-app:
@@ -338,12 +368,14 @@ repos:
         - test
 
   govuk_app_config:
+    homepage_url: "https://rubygems.org/gems/govuk_app_config"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
         - test
 
   govuk_document_types:
+    homepage_url: "https://docs.publishing.service.gov.uk/document-types.html"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
@@ -356,18 +388,21 @@ repos:
         - test
 
   govuk_personalisation:
+    homepage_url: "https://github.com/alphagov/govuk_personalisation"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
         - test
 
   govuk_publishing_components:
+    homepage_url: "https://components.publishing.service.gov.uk"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
         - test
 
   govuk_schemas:
+    homepage_url: "http://www.rubydoc.info/github/alphagov/govuk_schemas"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
@@ -386,12 +421,14 @@ repos:
         - test
 
   hmrc-manuals-api:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/hmrc-manuals-api.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby / Run RSpec
 
   link-checker-api:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/link-checker-api.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -402,6 +439,7 @@ repos:
         - Lint Ruby / Run RuboCop
 
   local-links-manager:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/local-links-manager.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -421,6 +459,7 @@ repos:
         - Lint Ruby / Run RuboCop
 
   manuals-publisher:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/manuals-publisher.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -431,10 +470,12 @@ repos:
         - Test Ruby / Run RSpec
 
   markdown-toolbar-element:
+    homepage_url: "https://alphagov.github.io/markdown-toolbar-element"
     required_status_checks:
       standard_contexts: *standard_security_checks
 
   maslow:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/maslow.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -444,6 +485,7 @@ repos:
         - Test JavaScript / Run Jasmine
 
   miller-columns-element:
+    homepage_url: "https://alphagov.github.io/miller-columns-element/"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
@@ -456,12 +498,14 @@ repos:
         - test
 
   paste-html-to-govspeak:
+    homepage_url: "https://alphagov.github.io/paste-html-to-govspeak/"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
         - test
 
   places-manager:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/imminence.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -480,6 +524,7 @@ repos:
         - test
 
   publisher:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/publisher.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -489,6 +534,7 @@ repos:
         - Test Ruby / Run Minitest
 
   publishing-api:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/publishing-api.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -500,6 +546,7 @@ repos:
         - Lint Ruby / Run RuboCop
 
   rack-logstasher:
+    homepage_url: "https://rubygems.org/gems/rack-logstasher"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
@@ -512,6 +559,7 @@ repos:
         - test
 
   release:
+    homepage_url: "https://docs.publishing.service.gov.uk/repos/release.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -520,11 +568,13 @@ repos:
         - Lint SCSS / Run Stylelint
 
   router:
+    homepage_url: "https://docs.publishing.service.gov.uk/repos/router.html"
     required_status_checks:
       additional_contexts:
         - Test Go
 
   router-api:
+    homepage_url: "https://docs.publishing.service.gov.uk/repos/router-api.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -543,6 +593,7 @@ repos:
         - test
 
   search-admin:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/search-admin.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -551,6 +602,7 @@ repos:
         - Test Ruby / Run RSpec
 
   search-api:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/search-api.html"
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
@@ -573,6 +625,7 @@ repos:
         - lint_and_validate
 
   service-manual-publisher:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/service-manual-publisher.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -582,6 +635,7 @@ repos:
         - Test Ruby / Run RSpec
 
   short-url-manager:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/short-url-manager.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -589,6 +643,7 @@ repos:
         - Lint SCSS / Run Stylelint
 
   signon:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/signon.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -610,6 +665,7 @@ repos:
         - test
 
   smart-answers:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/smart-answers.html"
     allow_squash_merge: true
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
@@ -630,6 +686,7 @@ repos:
         - test
 
   specialist-publisher:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/specialist-publisher.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -639,6 +696,7 @@ repos:
         - Test Ruby / Run RSpec
 
   static:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/static.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -648,6 +706,7 @@ repos:
         - Test JavaScript / Run Jasmine
 
   support:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/support.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -656,12 +715,14 @@ repos:
         - Lint SCSS / Run Stylelint
 
   support-api:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/support-api.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby
 
   transition:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/transition.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -670,6 +731,7 @@ repos:
         - Test JavaScript / Run Jasmine
 
   travel-advice-publisher:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/travel-advice-publisher.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -679,6 +741,7 @@ repos:
         - Test Ruby / Run RSpec
 
   whitehall:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/whitehall.html"
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
@@ -701,6 +764,7 @@ repos:
         - test
 
   datagovuk_publish:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/datagovuk_publish.html"
     required_status_checks:
       additional_contexts:
         - test
@@ -736,6 +800,7 @@ repos:
         - test
 
   govuk-user-reviewer:
+    homepage_url: "https://github.com/alphagov/govuk-rfcs/pull/75"
     required_status_checks:
       additional_contexts:
         - test
@@ -745,17 +810,40 @@ repos:
       additional_contexts:
         - test
 
+  govuk-crd-library:
+    homepage_url: "https://alphagov.github.io/govuk-crd-library/"
+
+  govuk-dns-ui:
+    homepage_url: "https://dns.publishing.service.gov.uk"
+
+  govuk-helm-charts:
+    homepage_url: "https://www.gov.uk/"
+    required_pull_request_reviews:
+      pull_request_bypassers:
+        - "/govuk-ci"
+
+  govuk-knowledge-graph-search:
+    homepage_url: "https://docs.data-community.publishing.service.gov.uk/tools/govsearch/"
+    required_pull_request_reviews:
+      pull_request_bypassers:
+        - "/guilhem-fry"
+        - "/nacnudus"
+        - "/somme"
+
+  public-asset-checker:
+    homepage_url: "https://govuk-public-asset-checker.herokuapp.com"
+
+  govspeak-visual-editor:
+  required_pull_request_reviews:
+    pull_request_bypassers:
+      - "/guilhem-fry"
+
   ckan-mock-harvest-sources: {}
-  govspeak-visual-editor: {}
   govuk-analytics-engineering: {}
   govuk-aws-data: {}
   govuk-chat: {}
-  govuk-crd-library: {}
   govuk-data-science-workshop: {}
-  govuk-dns-ui: {}
-  govuk-helm-charts: {}
   govuk-knowledge-graph-gcp: {}
-  govuk-knowledge-graph-search: {}
   govuk-mobile-backend: {}
   govuk-mobile-backend-config: {}
   govuk-mobile-remote-config: {}
@@ -764,4 +852,3 @@ repos:
   govuk-ruby-images: {}
   govuk-s3-mirror: {}
   github-trello-poster: {}
-  public-asset-checker: {}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -333,10 +333,6 @@ repos:
     allow_squash_merge: true
     branch_protection: false
 
-  govuk-mobile-service-registry:
-    allow_squash_merge: true
-    branch_protection: false
-
   govuk-rota-generator:
     required_status_checks:
       standard_contexts: *standard_security_checks

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -20,7 +20,6 @@ repos:
         - Dependency Review scan / dependency-review-pr
         - Security Analysis / Run Brakeman
         - Lint Ruby / Run RuboCop
-        - Run Pact tests
 
   asset-manager:
     required_status_checks:
@@ -31,7 +30,6 @@ repos:
         - Dependency Review scan / dependency-review-pr
         - Security Analysis / Run Brakeman
         - Lint Ruby / Run RuboCop
-        - Run Pact tests
 
   authenticating-proxy:
     required_status_checks:
@@ -49,6 +47,8 @@ repos:
   bulk-changer:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - Test
 
   bulk-merger:
   collections:
@@ -65,7 +65,6 @@ repos:
         - Dependency Review scan / dependency-review-pr
         - Security Analysis / Run Brakeman
         - Lint Ruby / Run RuboCop
-        - Run Pact tests
 
   collections-publisher:
     required_status_checks:
@@ -123,10 +122,12 @@ repos:
   data-community-tech-docs:
     need_production_access_to_merge: false
     allow_squash_merge: true
+    push_allowances: []
 
   datagovuk-tech-docs:
     need_production_access_to_merge: false
     allow_squash_merge: true
+    push_allowances: []
 
   email-alert-api:
     required_status_checks:
@@ -137,7 +138,6 @@ repos:
         - Dependency Review scan / dependency-review-pr
         - Security Analysis / Run Brakeman
         - Lint Ruby / Run RuboCop
-        - Run Pact tests
 
   email-alert-frontend:
     required_status_checks:
@@ -181,35 +181,31 @@ repos:
         - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
-        - Test Ruby / Run Minitest
+        - Test Ruby / Run RSpec
         - CodeQL SAST scan / Analyze
         - Dependency Review scan / dependency-review-pr
         - Security Analysis / Run Brakeman
         - Lint Ruby / Run RuboCop
-        - Run Pact tests
 
   gds-api-adapters:
     required_status_checks:
       standard_contexts: *standard_security_checks
       additional_contexts:
-        - Test Ruby
         - CodeQL SAST scan / Analyze
         - Dependency Review scan / dependency-review-pr
-        - Security Analysis / Run Brakeman
-        - Lint Ruby / Run RuboCop
-        - Run Pact tests
+        - test
 
   gds-sso:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   gds_zendesk:
     required_status_checks:
       standard_contexts: *standard_security_checks
-
-  github-trello-poster:
-    required_status_checks:
-      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   government-frontend:
     required_status_checks:
@@ -223,10 +219,14 @@ repos:
   govspeak:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govspeak-preview:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk-aws:
     required_status_checks:
@@ -237,6 +237,7 @@ repos:
   govuk-content-api-docs:
     need_production_access_to_merge: false
     allow_squash_merge: true
+    push_allowances: []
 
   govuk-dependabot-merger:
     required_status_checks:
@@ -245,13 +246,19 @@ repos:
   govuk-dependency-checker:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - Test
 
   govuk-developer-docs:
     need_production_access_to_merge: false
     allow_squash_merge: true
+    push_allowances: []
 
   govuk-dns-tf:
     up_to_date_branches: true
+    required_status_checks:
+      additional_contexts:
+        - test
 
   govuk-fastly:
     up_to_date_branches: true
@@ -305,10 +312,14 @@ repos:
   govuk-rota-generator:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk-saas-config:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk-sli-collector:
     required_status_checks:
@@ -317,42 +328,62 @@ repos:
   govuk_ab_testing:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk_admin_template:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk_app_config:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk_document_types:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk_message_queue_consumer:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk_personalisation:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk_publishing_components:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk_schemas:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk_sidekiq:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   govuk_test:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   hmrc-manuals-api:
     required_status_checks:
@@ -369,7 +400,6 @@ repos:
         - Dependency Review scan / dependency-review-pr
         - Security Analysis / Run Brakeman
         - Lint Ruby / Run RuboCop
-        - Run Pact tests
 
   local-links-manager:
     required_status_checks:
@@ -389,7 +419,6 @@ repos:
         - Dependency Review scan / dependency-review-pr
         - Security Analysis / Run Brakeman
         - Lint Ruby / Run RuboCop
-        - Run Pact tests
 
   manuals-publisher:
     required_status_checks:
@@ -417,14 +446,20 @@ repos:
   miller-columns-element:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   optic14n:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   paste-html-to-govspeak:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   places-manager:
     required_status_checks:
@@ -437,11 +472,12 @@ repos:
         - Dependency Review scan / dependency-review-pr
         - Security Analysis / Run Brakeman
         - Lint Ruby / Run RuboCop
-        - Run Pact tests
 
   plek:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   publisher:
     required_status_checks:
@@ -462,15 +498,18 @@ repos:
         - Dependency Review scan / dependency-review-pr
         - Security Analysis / Run Brakeman
         - Lint Ruby / Run RuboCop
-        - Run Pact tests
 
   rack-logstasher:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   rails_translation_manager:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   release:
     required_status_checks:
@@ -494,10 +533,14 @@ repos:
   rubocop-govuk:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   seal:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   search-admin:
     required_status_checks:
@@ -557,10 +600,14 @@ repos:
   siteimprove_api_client:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   slimmer:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   smart-answers:
     allow_squash_merge: true
@@ -579,6 +626,8 @@ repos:
   special-route-publisher:
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
 
   specialist-publisher:
     required_status_checks:
@@ -641,33 +690,78 @@ repos:
         - Lint ERB / Run ERB lint
         - Prettier / Run Prettier
 
+  ckanext-datagovuk:
+    required_status_checks:
+      additional_contexts:
+        - test
+
+  datagovuk_find:
+    required_status_checks:
+      additional_contexts:
+        - test
+
+  datagovuk_publish:
+    required_status_checks:
+      additional_contexts:
+        - test
+
+  govuk-browser-extension:
+    required_status_checks:
+      additional_contexts:
+        - Test Extension JS
+
+  govuk-docker:
+    required_status_checks:
+      additional_contexts:
+        - test
+
+  govuk-exporter:
+    required_status_checks:
+      additional_contexts:
+        - Test Go
+
+  govuk-mirror:
+    required_status_checks:
+      additional_contexts:
+        - Test Go
+
+  govuk-replatform-test-app:
+    required_status_checks:
+      additional_contexts:
+        - Test
+
+  govuk-rota-announcer:
+    required_status_checks:
+      additional_contexts:
+        - test
+
+  govuk-user-reviewer:
+    required_status_checks:
+      additional_contexts:
+        - test
+
+  licensify:
+    required_status_checks:
+      additional_contexts:
+        - test
+
   ckan-mock-harvest-sources: {}
-  ckanext-datagovuk: {}
-  datagovuk_find: {}
-  datagovuk_publish: {}
   govspeak-visual-editor: {}
   govuk-analytics-engineering: {}
   govuk-aws-data: {}
-  govuk-browser-extension: {}
   govuk-chat: {}
   govuk-crd-library: {}
   govuk-data-science-workshop: {}
   govuk-dns-ui: {}
-  govuk-docker: {}
-  govuk-exporter: {}
   govuk-helm-charts: {}
   govuk-knowledge-graph-gcp: {}
   govuk-knowledge-graph-search: {}
-  govuk-mirror: {}
   govuk-mobile-backend: {}
   govuk-mobile-backend-config: {}
   govuk-mobile-remote-config: {}
   govuk-pact-broker: {}
-  govuk-replatform-test-app: {}
   govuk-rfcs: {}
-  govuk-rota-announcer: {}
   govuk-ruby-images: {}
   govuk-s3-mirror: {}
-  govuk-user-reviewer: {}
-  licensify: {}
+  github-trello-poster: {}
   public-asset-checker: {}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -620,6 +620,7 @@ repos:
   govuk-aws-data: {}
   govuk-browser-extension: {}
   govuk-chat: {}
+  govuk-crd-library: {}
   govuk-data-science-workshop: {}
   govuk-dns-ui: {}
   govuk-docker: {}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -220,12 +220,6 @@ repos:
       additional_contexts:
         - test
 
-  gds_zendesk:
-    required_status_checks:
-      standard_contexts: *standard_security_checks
-      additional_contexts:
-        - test
-
   government-frontend:
     homepage_url: "https://docs.publishing.service.gov.uk/apps/government-frontend.html"
     required_status_checks:
@@ -848,7 +842,6 @@ repos:
   govuk-aws-data: {}
   govuk-chat: {}
   govuk-data-science-workshop: {}
-
   govuk-mobile-backend: {}
   govuk-mobile-backend-config: {}
   govuk-mobile-remote-config: {}
@@ -856,3 +849,4 @@ repos:
   govuk-rfcs: {}
   govuk-ruby-images: {}
   govuk-s3-mirror: {}
+  gds_zendesk: {}


### PR DESCRIPTION
Migrate Github repo config from Ruby to Infrastructure as Code. 

Adds merge settings and branch protection resource settings.

Trello: https://trello.com/c/zXGouwXs/3575-investigate-migrating-github-repos-config-to-govuk-infrastructure-3-days
Closes https://github.com/alphagov/govuk-infrastructure/issues/1398