### PR TITLE
Pin last 2.6-compatible versions of MongoDB tools.

### DIFF
--- a/images/toolbox/Dockerfile
+++ b/images/toolbox/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update -qq ; \
     apt-get update -qq ; \
     apt-get install -qy --no-install-recommends \
         curl file gh git jq libarchive-tools mysql-client netcat-openbsd \
-        postgresql-client pv wget2 gettext mongodb-mongosh \
-        mongodb-database-tools redis-tools ; \
+        postgresql-client pv wget2 gettext mongodb-mongosh=2.2.10 \
+        mongodb-database-tools=100.9.4 redis-tools ; \
     rm -fr /var/lib/apt/lists/*
 
 ARG yq_package_url=https://github.com/mikefarah/yq/releases/latest/download


### PR DESCRIPTION
mongodb-database-tools 100.9.5 links with a version of the Go mongodb client that no longer supports server 2.6.

This should see us out until we get rid of the Router database (either by having Router read from content-store or by getting rid of Router entirely).

Tested: built+pushed new image and successfully ran the cronjob with it.

```
k create job --from cronjob/db-backup-router-mongo sengi-test-db-backup-router-mongo
k logs job/sengi-test-db-backup-router-mongo
...
2024-07-09T11:58:38.700+0000	writing draft_router.users to archive on stdout
2024-07-09T11:58:38.701+0000	writing draft_router.data_migrations to archive on stdout
2024-07-09T11:58:38.702+0000	writing draft_router.backends to archive on stdout
2024-07-09T11:58:38.702+0000	writing draft_router.routes to archive on stdout
2024-07-09T11:58:38.704+0000	done dumping draft_router.users (1 document)
2024-07-09T11:58:38.705+0000	done dumping draft_router.backends (40 documents)
2024-07-09T11:58:38.707+0000	done dumping draft_router.data_migrations (7 documents)
2024-07-09T11:58:41.690+0000	[###############.........]  draft_router.routes  701514/1088911  (64.4%)
2024-07-09T11:58:43.446+0000	[########################]  draft_router.routes  1088912/1088911  (100.0%)
2024-07-09T11:58:43.578+0000	done dumping draft_router.routes (1088912 documents)
0:00:05 [56.4MiB/s]  287MiB
pipe s3://govuk-production-database-backups/router-mongo/2024-07-09T115838Z-draft_router.gz
done
```