### PR TITLE
Fix caching build issue on multi-image repos

### DIFF
--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -99,8 +99,8 @@ jobs:
           build-args: ${{ inputs.buildArgs }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=build-${{ matrix.arch }}
-          cache-to: type=gha,scope=build-${{ matrix.arch }},mode=max
+          cache-from: type=gha,scope=build-${{ inputs.ecrRepositoryName }}-${{ matrix.arch }}
+          cache-to: type=gha,scope=build-${{ inputs.ecrRepositoryName }}-${{ matrix.arch }},mode=max
 
       - id: export-digests
         env:
@@ -112,7 +112,7 @@ jobs:
       - id: upload-digests
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.arch }}
+          name: digests-${{ inputs.ecrRepositoryName }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -132,7 +132,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ inputs.ecrRepositoryName }}-*
           merge-multiple: true
 
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## What?
On some repos like on Licensify, we build multiple different container images. This has resulted in some "cache clash" and ended up in some builds failing due to artifacts getting mixed up across the different images.

Hopefully by adding an extra label to the cache key we can stop this from happening.