### PR TITLE
No longer push images directly to ECR

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -39,19 +39,6 @@ jobs:
           ref: ${{ inputs.gitRef }}
           show-progress: false
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.1
-        with:
-          role-to-assume: "arn:aws:iam::172025368201:role/github_action_ecr_push"
-          aws-region: eu-west-1
-          role-session-name: ecr-push
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          mask-password: 'true'
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -70,7 +57,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }}
             ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName }}
           tags: |
             type=raw,priority=500,value=${{ inputs.gitRef }},enable=${{ startsWith(inputs.gitRef, 'v') }}

--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -50,19 +50,6 @@ jobs:
           ref: ${{ inputs.gitRef }}
           show-progress: false
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: "arn:aws:iam::172025368201:role/github_action_ecr_push"
-          aws-region: eu-west-1
-          role-session-name: ecr-push
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          mask-password: 'true'
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -80,7 +67,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }}
             ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName }}
           labels: |
             org.opencontainers.image.vendor=GDS
@@ -98,7 +84,7 @@ jobs:
           provenance: false
           build-args: ${{ inputs.buildArgs }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=build-${{ inputs.ecrRepositoryName }}-${{ matrix.arch }}
           cache-to: type=gha,scope=build-${{ inputs.ecrRepositoryName }}-${{ matrix.arch }},mode=max
 
@@ -140,19 +126,6 @@ jobs:
       - run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         id: local-head
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: "arn:aws:iam::172025368201:role/github_action_ecr_push"
-          aws-region: eu-west-1
-          role-session-name: ecr-push
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          mask-password: 'true'
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -165,7 +138,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }}
             ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName }}
           labels: |
             org.opencontainers.image.vendor=GDS
@@ -176,7 +148,7 @@ jobs:
 
       - name: Create Manifest Lists
         env:
-          IMAGEREF_PREFIX: '${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }}'
+          IMAGEREF_PREFIX: 'ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName }}'
         working-directory: /tmp/digests
         run: |
           tag_args=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
@@ -186,6 +158,6 @@ jobs:
 
       - name: Inspect Images
         env:
-          IMAGEREF: '${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepositoryName }}:${{ steps.meta.outputs.version }}'
+          IMAGEREF: 'ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName }}:${{ steps.meta.outputs.version }}'
         run: |
           docker buildx imagetools inspect "$IMAGEREF"

--- a/terraform/deployments/ecr/ecr-pull.tf
+++ b/terraform/deployments/ecr/ecr-pull.tf
@@ -16,10 +16,7 @@ data "aws_iam_policy_document" "allow_cross_account_pull_from_ecr" {
 }
 
 resource "aws_ecr_repository_policy" "pull_from_ecr" {
-  for_each = toset(concat(
-    [for repo in local.repositories : aws_ecr_repository.repositories[repo].name],
-    [for repo in local.repositories : aws_ecr_repository.github_repositories[repo].name]
-  ))
+  for_each = toset([for repo in local.repositories : aws_ecr_repository.github_repositories[repo].name])
   repository = each.key
   policy     = data.aws_iam_policy_document.allow_cross_account_pull_from_ecr.json
 }

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -71,13 +71,6 @@ locals {
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-resource "aws_ecr_repository" "repositories" {
-  for_each             = toset(local.repositories)
-  name                 = each.key
-  image_tag_mutability = "MUTABLE" # To support a movable `latest` for developer convenience.
-  image_scanning_configuration { scan_on_push = true }
-}
-
 resource "aws_ecr_repository" "github_repositories" {
   for_each             = toset(local.repositories)
   name                 = "github/alphagov/govuk/${each.key}"
@@ -91,16 +84,8 @@ resource "aws_ecr_pull_through_cache_rule" "github" {
   credential_arn        = "arn:aws:secretsmanager:eu-west-1:172025368201:secret:ecr-pullthroughcache/github-packages-udvpiZ"
 }
 
-import {
-  to = aws_ecr_pull_through_cache_rule.github
-  id = "github"
-}
-
 resource "aws_ecr_lifecycle_policy" "ecr_lifecycle_policy" {
-  for_each = toset(concat(
-    [for repo in local.repositories : aws_ecr_repository.repositories[repo].name],
-    [for repo in local.repositories : aws_ecr_repository.github_repositories[repo].name]
-  ))
+  for_each = toset([for repo in local.repositories : aws_ecr_repository.github_repositories[repo].name])
   repository = each.key
 
   policy = jsonencode({


### PR DESCRIPTION
ECR is now configured as ghcr.io pull cache, which our EKS clusters now reference. We no longer need to push images directly to ECR. 

Tested with Release.