### PR TITLE
Add context input for build image workflow

### DIFF
--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
         default: Dockerfile
+      context:
+        required: false
+        type: string
+        default: .
       buildArgs:
         required: false
         type: string
@@ -78,7 +82,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ${{ inputs.dockerfilepath }}
-          context: .
+          context: ${{ inputs.context }}
           platforms: "linux/${{ matrix.arch }}"
           load: true
           provenance: false


### PR DESCRIPTION
This is so we can use it for govuk-fastly to build the diff-generator image (which has its dockerfile) in a nested folder