### PR TITLE
Rename ecr_push role

### DIFF
--- a/terraform/deployments/ecr/gha-iam-role.tf
+++ b/terraform/deployments/ecr/gha-iam-role.tf
@@ -6,21 +6,7 @@ data "aws_iam_openid_connect_provider" "github_oidc" {
   arn = local.github_oidc_arn
 }
 
-data "aws_iam_policy_document" "ecr_role_permissions" {
-  statement {
-    actions = [
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:DescribeImages",
-      "ecr:PutImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:GetAuthorizationToken",
-      "ecr:CompleteLayerUpload"
-    ]
-    resources = ["*"]
-  }
+data "aws_iam_policy_document" "gha_image_attestation_role_permissions" {
   statement {
     actions = [
       "kms:DescribeKey",
@@ -31,7 +17,7 @@ data "aws_iam_policy_document" "ecr_role_permissions" {
   }
 }
 
-data "aws_iam_policy_document" "ecr_role_trust" {
+data "aws_iam_policy_document" "gha_image_attestation_trust" {
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]
     principals {
@@ -46,19 +32,19 @@ data "aws_iam_policy_document" "ecr_role_trust" {
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:alphagov/*"]
+      values   = ["repo:alphagov/govuk-ruby-images"]
     }
   }
 }
 
-resource "aws_iam_role" "ecr_role" {
-  name                 = "github_action_ecr_push"
+resource "aws_iam_role" "gha_image_attestation" {
+  name                 = "github_action_image_attestation"
   max_session_duration = 10800
-  assume_role_policy   = data.aws_iam_policy_document.ecr_role_trust.json
+  assume_role_policy   = data.aws_iam_policy_document.gha_image_attestation_trust.json
 }
 
-resource "aws_iam_role_policy" "ecr_role" {
-  name   = "github_action_ecr_push_policy"
-  role   = aws_iam_role.ecr_role.id
-  policy = data.aws_iam_policy_document.ecr_role_permissions.json
+resource "aws_iam_role_policy" "gha_image_attestation" {
+  name   = "github_action_image_attestation_policy"
+  role   = aws_iam_role.gha_image_attestation.id
+  policy = data.aws_iam_policy_document.gha_image_attestation_role_permissions.json
 }


### PR DESCRIPTION
This role is purely used for image attestations by govuk-ruby-images.

https://github.com/alphagov/govuk-ruby-images/pull/105