### PR TITLE
Remove deprecated ecrRepositoryName input

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -3,10 +3,6 @@ name: Build and push image
 on:
   workflow_call:
     inputs:
-      ecrRepositoryName:
-        required: false
-        type: string
-        default: ${{ github.event.repository.name }}
       imageName:
         required: false
         type: string
@@ -61,7 +57,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName || inputs.imageName }}
+            ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}
           tags: |
             type=raw,priority=500,value=${{ inputs.gitRef }},enable=${{ startsWith(inputs.gitRef, 'v') }}
             type=raw,priority=400,value=${{ steps.local-head.outputs.sha }},enable=${{ !startsWith(inputs.gitRef, 'v') }}

--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -3,10 +3,6 @@ name: Build and push multi-arch image
 on:
   workflow_call:
     inputs:
-      ecrRepositoryName:
-        required: false
-        type: string
-        default: ${{ github.event.repository.name }}
       imageName:
         required: false
         type: string
@@ -33,7 +29,7 @@ on:
 
 jobs:
   build-and-push-image:
-    name: Build and push image for ${{ inputs.ecrRepositoryName || inputs.imageName }}
+    name: Build and push image for ${{ inputs.imageName }}
     strategy:
       matrix:
         arch:
@@ -75,7 +71,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName || inputs.imageName }}
+            ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}
           labels: |
             org.opencontainers.image.vendor=GDS
           tags: |
@@ -92,9 +88,9 @@ jobs:
           provenance: false
           build-args: ${{ inputs.buildArgs }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName || inputs.imageName }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=build-${{ inputs.ecrRepositoryName || inputs.imageName }}-${{ matrix.arch }}
-          cache-to: type=gha,scope=build-${{ inputs.ecrRepositoryName || inputs.imageName }}-${{ matrix.arch }},mode=max
+          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ inputs.imageName }}-${{ matrix.arch }}
+          cache-to: type=gha,scope=build-${{ inputs.imageName }}-${{ matrix.arch }},mode=max
 
       - id: export-digests
         env:
@@ -106,7 +102,7 @@ jobs:
       - id: upload-digests
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ inputs.ecrRepositoryName || inputs.imageName }}-${{ matrix.arch }}
+          name: digests-${{ inputs.imageName }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -126,7 +122,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ inputs.ecrRepositoryName || inputs.imageName }}-*
+          pattern: digests-${{ inputs.imageName }}-*
           merge-multiple: true
 
       - uses: docker/setup-buildx-action@v3
@@ -146,7 +142,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName || inputs.imageName }}
+            ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}
           labels: |
             org.opencontainers.image.vendor=GDS
           tags: |
@@ -156,7 +152,7 @@ jobs:
 
       - name: Create Manifest Lists
         env:
-          IMAGEREF_PREFIX: 'ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName || inputs.imageName }}'
+          IMAGEREF_PREFIX: 'ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}'
         working-directory: /tmp/digests
         run: |
           tag_args=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
@@ -166,6 +162,6 @@ jobs:
 
       - name: Inspect Images
         env:
-          IMAGEREF: 'ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.ecrRepositoryName || inputs.imageName }}:${{ steps.meta.outputs.version }}'
+          IMAGEREF: 'ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}:${{ steps.meta.outputs.version }}'
         run: |
           docker buildx imagetools inspect "$IMAGEREF"

--- a/.github/workflows/build-clamav-image.yml
+++ b/.github/workflows/build-clamav-image.yml
@@ -23,7 +23,7 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
-      ecrRepositoryName: clamav
+      imageName: clamav
       dockerfilePath: images/clamav/Dockerfile
     permissions:
       id-token: write

--- a/.github/workflows/build-mongodb-image.yml
+++ b/.github/workflows/build-mongodb-image.yml
@@ -23,7 +23,7 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
-      ecrRepositoryName: mongodb
+      imageName: mongodb
       dockerfilePath: images/mongodb/Dockerfile
     permissions:
       id-token: write

--- a/.github/workflows/build-toolbox-image.yml
+++ b/.github/workflows/build-toolbox-image.yml
@@ -23,7 +23,7 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
-      ecrRepositoryName: toolbox
+      imageName: toolbox
       dockerfilePath: images/toolbox/Dockerfile
     permissions:
       id-token: write


### PR DESCRIPTION
This should no longer be referenced by dependent workflows, in favor of imageName.