### PR TITLE
Create ECR repo for govuk-fastly-diff-generator

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -65,6 +65,7 @@ locals {
     "licensify-backend",
     "licensify-feed",
     "licensify-frontend",
+    "govuk-fastly-diff-generator",
   ]
 }
 


### PR DESCRIPTION
This will be a pull through cache for images in ghcr.io.