### PR TITLE
Use google_project_iam_member instead of google_project_iam_binding for TFC service account config

### DIFF
--- a/terraform/deployments/tfc-aws-config/gcp_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/gcp_oidc.tf
@@ -34,10 +34,10 @@ resource "google_service_account" "tfc" {
   account_id = "terraform-cloud-${var.govuk_environment}"
 }
 
-resource "google_project_iam_binding" "tfc" {
+resource "google_project_iam_member" "tfc" {
   project = local.google_project
   role    = "roles/owner"
-  members = ["serviceAccount:${google_service_account.tfc.email}"]
+  member  = "serviceAccount:${google_service_account.tfc.email}"
 }
 
 data "google_iam_policy" "tfc" {


### PR DESCRIPTION
Using `google_project_iam_binding` causes terraform to remove the role from all other users/groups, including the govuk-gcp-access group so nobody could access these projects. Oops.