### PR TITLE
Small import fixes

### DIFF
--- a/terraform/deployments/vpc/aws_logging.tf
+++ b/terraform/deployments/vpc/aws_logging.tf
@@ -130,6 +130,9 @@ resource "aws_s3_bucket_replication_configuration" "aws_logging" {
     filter {
       prefix = "elb/govuk-ckan-public-elb"
     }
+    delete_marker_replication {
+      status = "Enabled"
+    }
   }
 }
 

--- a/terraform/deployments/vpc/main.tf
+++ b/terraform/deployments/vpc/main.tf
@@ -30,10 +30,10 @@ provider "aws" {
 
 provider "google" {
   default_labels = {
-    Product              = "GOV.UK"
-    System               = "Terraform Cloud"
-    Environment          = var.govuk_environment
-    Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+    product              = "GOV.UK"
+    system               = "Terraform Cloud"
+    environment          = var.govuk_environment
+    owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
     repository           = "govuk-infrastructure"
     terraform_deployment = basename(abspath(path.root))
   }


### PR DESCRIPTION
Fixes a couple of issues:

1. GCP doesn't want to set a tag with an upper case name on storage buckets for some reason, so lets just set them in lower case instead
2. AWS API complains if delete marker replication is not specified

#1127 