### PR TITLE
Fix default GCP labels to conform with restrictions

### DIFF
--- a/terraform/deployments/vpc/main.tf
+++ b/terraform/deployments/vpc/main.tf
@@ -30,11 +30,11 @@ provider "aws" {
 
 provider "google" {
   default_labels = {
-    product              = "GOV.UK"
-    system               = "Terraform Cloud"
+    product              = "gov-uk"
+    system               = "terraform-cloud"
     environment          = var.govuk_environment
-    owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+    owner                = "govuk-platform-engineering"
     repository           = "govuk-infrastructure"
-    terraform_deployment = basename(abspath(path.root))
+    terraform_deployment = lower(basename(abspath(path.root)))
   }
 }


### PR DESCRIPTION
Turns out labels in GCP are much more restrictive than tags in AWS. Upper-case letters, dots, spaces and @ symbols are not allowed, so our default labels need to be changed to accomodate for these restrictions.

https://cloud.google.com/resource-manager/docs/labels-overview#requirements

#1127 