### PR TITLE
Tag RDS instances with their project

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -67,7 +67,7 @@ resource "aws_db_instance" "instance" {
   final_snapshot_identifier = "${each.value.name}-final-snapshot"
   skip_final_snapshot       = var.skip_final_snapshot
 
-  tags = { Name = "govuk-rds-${each.value.name}-${each.value.engine}" }
+  tags = { Name = "govuk-rds-${each.value.name}-${each.value.engine}", project = lookup(each.value, "project", "GOV.UK - Other") }
 }
 
 resource "aws_db_event_subscription" "subscription" {

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -120,6 +120,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       authenticating_proxy = {
@@ -138,6 +139,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       chat = {
@@ -155,6 +157,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - AI"
       }
       ckan = {
         engine         = "postgres"
@@ -171,6 +174,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - DGU"
       }
 
       collections_publisher = {
@@ -185,6 +189,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       contacts_admin = {
@@ -199,6 +204,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_data_admin = {
@@ -216,6 +222,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_data_api = {
@@ -238,6 +245,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
         freestoragespace_threshold   = 536870912000
+        project                      = "GOV.UK - Publishing"
       }
 
       content_publisher = {
@@ -255,6 +263,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_store = {
@@ -272,6 +281,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_tagger = {
@@ -289,6 +299,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       draft_content_store = {
@@ -306,6 +317,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       email_alert_api = {
@@ -323,6 +335,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       imminence = {
@@ -341,6 +354,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       link_checker_api = {
@@ -358,6 +372,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       local_links_manager = {
@@ -375,6 +390,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       locations_api = {
@@ -392,6 +408,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       publishing_api = {
@@ -412,6 +429,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       release = {
@@ -426,6 +444,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Infrastructure"
       }
 
       search_admin = {
@@ -440,6 +459,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Search"
       }
 
       service_manual_publisher = {
@@ -457,6 +477,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       signon = {
@@ -471,6 +492,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       support_api = {
@@ -488,6 +510,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       transition = {
@@ -505,6 +528,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large" # TODO: downsize this after migration if required
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       whitehall = {
@@ -519,6 +543,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
     }
   }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -155,6 +155,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       authenticating_proxy = {
@@ -173,6 +174,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       chat = {
@@ -190,6 +192,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - AI"
       }
 
       ckan = {
@@ -207,6 +210,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.m6g.2xlarge"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - DGU"
       }
 
       collections_publisher = {
@@ -221,6 +225,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       contacts_admin = {
@@ -235,6 +240,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_data_admin = {
@@ -252,6 +258,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_data_api = {
@@ -274,6 +281,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
         freestoragespace_threshold   = 536870912000
+        project                      = "GOV.UK - Publishing"
       }
 
       content_publisher = {
@@ -291,6 +299,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_store = {
@@ -308,6 +317,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.m6g.2xlarge"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_tagger = {
@@ -325,6 +335,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       draft_content_store = {
@@ -342,6 +353,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.m6g.2xlarge"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       email_alert_api = {
@@ -359,6 +371,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.m7g.2xlarge"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       imminence = {
@@ -377,6 +390,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       link_checker_api = {
@@ -394,6 +408,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       local_links_manager = {
@@ -411,6 +426,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       locations_api = {
@@ -428,6 +444,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       publishing_api = {
@@ -445,6 +462,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.m6g.4xlarge"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       release = {
@@ -459,6 +477,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Infrastructure"
       }
 
       search_admin = {
@@ -473,6 +492,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Search"
       }
 
       service_manual_publisher = {
@@ -490,6 +510,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       signon = {
@@ -504,6 +525,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       support_api = {
@@ -521,6 +543,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       transition = {
@@ -538,6 +561,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.m6g.large" # TODO: downsize this after migration if required
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       whitehall = {
@@ -552,6 +576,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.m7g.xlarge"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
     }
   }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -132,6 +132,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       authenticating_proxy = {
@@ -150,6 +151,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       chat = {
@@ -167,6 +169,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - AI"
       }
 
       ckan = {
@@ -184,6 +187,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - DGU"
       }
 
       collections_publisher = {
@@ -198,6 +202,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       contacts_admin = {
@@ -212,6 +217,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_data_admin = {
@@ -229,6 +235,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_data_api = {
@@ -251,6 +258,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
         freestoragespace_threshold   = 536870912000
+        project                      = "GOV.UK - Publishing"
       }
 
       content_publisher = {
@@ -268,6 +276,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_store = {
@@ -285,6 +294,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       content_tagger = {
@@ -302,6 +312,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       draft_content_store = {
@@ -319,6 +330,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       email_alert_api = {
@@ -336,6 +348,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m6g.xlarge"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       imminence = {
@@ -354,6 +367,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       link_checker_api = {
@@ -371,6 +385,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       local_links_manager = {
@@ -388,6 +403,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       locations_api = {
@@ -405,6 +421,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Web"
       }
 
       publishing_api = {
@@ -425,6 +442,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       release = {
@@ -439,6 +457,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Infrastructure"
       }
 
       search_admin = {
@@ -453,6 +472,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Search"
       }
 
       service_manual_publisher = {
@@ -470,6 +490,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       signon = {
@@ -484,6 +505,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       support_api = {
@@ -501,6 +523,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       transition = {
@@ -518,6 +541,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m6g.large" # TODO: downsize this after migration if required
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
 
       whitehall = {
@@ -532,6 +556,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
       }
     }
   }


### PR DESCRIPTION
This will be used to differentiate publishing databases from web / ai / app etc. in cost explorer.

project feels like the most appropriate of the 8 cost allocation tags we currently have in the organisation (aws:createdBy, Customer, Environment, Name, Service, Source, chargeable_entity, project)

These will have to be set in the `databases` variable in Terraform Cloud in each environment.

We should prefix tag values with "GOV.UK - " so that they're easily distinguishable from values elsewhere in the AWS Organisation when looking at cross account bills.