### PR TITLE
Unpin content-data-api minor versions

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -227,7 +227,7 @@ module "variable-set-rds-integration" {
 
       content_data_api = {
         engine         = "postgres"
-        engine_version = "13.13"
+        engine_version = "13"
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -263,7 +263,7 @@ module "variable-set-rds-production" {
 
       content_data_api = {
         engine         = "postgres"
-        engine_version = "13.13"
+        engine_version = "13"
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -240,7 +240,7 @@ module "variable-set-rds-staging" {
 
       content_data_api = {
         engine         = "postgres"
-        engine_version = "13.13"
+        engine_version = "13"
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }


### PR DESCRIPTION
We have auto minor version upgrade set on these databases, but terraform is trying to pin them to a specific minor version. That means that currently, terraform applies try to "upgrade" from 13.15 to 13.13, which AWS won't allow.

All the other postgres databases just specify the major version, avoiding this issue.