### PR TITLE
Update set-automatic-deploys script to use newer version of curl

### DIFF
--- a/.github/workflows/set-automatic-deploys.yml
+++ b/.github/workflows/set-automatic-deploys.yml
@@ -52,9 +52,12 @@ jobs:
           WEBHOOK_TOKEN: ${{ secrets.WEBHOOK_TOKEN }}
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
         run: |
-          # TODO: use --fail-with-body instead of -f once curl 7.76 is in GH's ubuntu-latest.
-          curl -fs \
+          curl --fail-with-body --silent \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
-            -d "{\"environment\": \"${ENVIRONMENT}\", \"repoName\": \"${REPO_NAME}\", \"automaticDeploysEnabled\": \"${AUTOMATIC_DEPLOYS_ENABLED}\"}" \
+            -d "{
+              \"environment\": \"${ENVIRONMENT}\",
+              \"repoName\": \"${REPO_NAME}\",
+              \"automaticDeploysEnabled\": \"${AUTOMATIC_DEPLOYS_ENABLED}\"
+            }" \
             "${WEBHOOK_URL}/set-automatic-deploys-enabled"


### PR DESCRIPTION
Description:
- Ubuntu latest now has a newer version of curl - see https://github.com/alphagov/govuk-infrastructure/pull/825
- Replacing -s with --silent for better legibility