### PR TITLE
Change SSE for S3 bucket from "aws:kms" to "AES256" 

### DIFF
--- a/terraform/deployments/opensearch/s3.tf
+++ b/terraform/deployments/opensearch/s3.tf
@@ -27,7 +27,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "opensearch_snapsh
   bucket = aws_s3_bucket.opensearch_snapshot.id
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      sse_algorithm = "AES256"
     }
   }
 }


### PR DESCRIPTION
Change SSE for S3 bucket from "aws:kms" to "AES256" so that cross account decryption of files can take place.
This is required as snapshots taken from Production need to be imported into Staging, and then from Staging into Integration.