### PR TITLE
Fix names of kubernetes nodes

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -58,7 +58,7 @@ locals {
   arm_managed_node_group = {
     arm = {
       ami_type              = "AL2023_ARM_64_STANDARD"
-      name                  = "${var.cluster_name}-k8s-node-arm"
+      name                  = "${var.cluster_name}-k8s-node"
       desired_size          = var.arm_workers_size_desired
       max_size              = var.arm_workers_size_max
       min_size              = var.arm_workers_size_min

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -29,7 +29,7 @@ locals {
 
   main_managed_node_group = {
     main = {
-      name_prefix = var.cluster_name
+      name = "${var.cluster_name}-k8s-node"
       # TODO: set iam_role_permissions_boundary
       # TODO: apply provider default_tags to instances; might need to set launch_template_tags.
       desired_size   = var.workers_size_desired
@@ -58,7 +58,7 @@ locals {
   arm_managed_node_group = {
     arm = {
       ami_type              = "AL2023_ARM_64_STANDARD"
-      name_prefix           = var.cluster_name
+      name                  = "${var.cluster_name}-k8s-node-arm"
       desired_size          = var.arm_workers_size_desired
       max_size              = var.arm_workers_size_max
       min_size              = var.arm_workers_size_min


### PR DESCRIPTION
Currently in AWS each of the arm nodes is just called "arm", and each of the non-arm nodes is called "main".

![image](https://github.com/user-attachments/assets/db25e985-263c-4529-a02b-92500bd71c4a)


It looks like the eks module is pulling these from the key (main / arm) in this map.

We switched from using name to name_prefix in fa08608c, but the [documentation for the eks module](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/modules/eks-managed-node-group#input_name) doesn't mention name_prefix - it only has name and use_name_prefix.

Switching to name should hopefully mean the module will name the instances with something more descriptive than "main". Specifically, this PR will call the nodes `govuk-k8s-node` / `govuk-k8s-node-arm`.