### PR TITLE
Revert #1399

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -29,7 +29,7 @@ locals {
 
   main_managed_node_group = {
     main = {
-      name = "${var.cluster_name}-k8s-node"
+      name_prefix = var.cluster_name
       # TODO: set iam_role_permissions_boundary
       # TODO: apply provider default_tags to instances; might need to set launch_template_tags.
       desired_size   = var.workers_size_desired
@@ -58,7 +58,7 @@ locals {
   arm_managed_node_group = {
     arm = {
       ami_type              = "AL2023_ARM_64_STANDARD"
-      name                  = "${var.cluster_name}-k8s-node-arm"
+      name_prefix           = var.cluster_name
       desired_size          = var.arm_workers_size_desired
       max_size              = var.arm_workers_size_max
       min_size              = var.arm_workers_size_min

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -58,7 +58,7 @@ locals {
   arm_managed_node_group = {
     arm = {
       ami_type              = "AL2023_ARM_64_STANDARD"
-      name                  = "${var.cluster_name}-k8s-node"
+      name                  = "${var.cluster_name}-k8s-node-arm"
       desired_size          = var.arm_workers_size_desired
       max_size              = var.arm_workers_size_max
       min_size              = var.arm_workers_size_min


### PR DESCRIPTION
We're not confident this will deploy cleanly - there was some interruption of service in integration.

We're going to revert and do this in a more controlled fashion.