### PR TITLE
Add govuk-e2e-tests ECR repo

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -66,6 +66,7 @@ locals {
     "licensify-feed",
     "licensify-frontend",
     "govuk-fastly-diff-generator",
+    "govuk-e2e-tests"
   ]
 }
 


### PR DESCRIPTION
This is a new GitHub repository for GOV.UK End to End tests.