### PR TITLE
Increase EBS volume size and change from m6g to r6g instance type

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -81,14 +81,14 @@ module "variable-set-opensearch-integration" {
 
   tfvars = {
     hosted_zone_name         = "chat"
-    engine_version           = "2.11"
+    engine_version           = "2.13"
     security_options_enabled = true
     volume_type              = "gp3"
     throughput               = 250
     ebs_enabled              = true
-    ebs_volume_size          = 45
+    ebs_volume_size          = 90
     service                  = "chat"
-    instance_type            = "m6g.2xlarge.search"
+    instance_type            = "r6g.2xlarge.search"
     instance_count           = 3
     dedicated_master_enabled = true
     dedicated_master_count   = 3


### PR DESCRIPTION
### What
Increase EBS volume size from 45Gb to 90Gb, change instance type from `m6g.2xlarge.search` to `r6g.2xlarge.search` for the nodes, and update the engine version from `2.11` to `2.13`.

### Why
The Chat Opensearch cluster has run out of disk space, so we need to increase that to get it working again. We are also taking the opportunity to update the nodes to give more RAM, and put the cluster on the latest supported version of Opensearch.