### PR TITLE
Add variable in Integration for Test Opensearch Cluster Endpoint

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -96,6 +96,7 @@ module "variable-set-opensearch-integration" {
     dedicated_master_count   = 3
     dedicated_master_type    = "m6g.large.search"
     zone_awareness_enabled   = true
+    test_opensearch_url      = "search-chat-engine-test-dofkxncldpkjd7huoyakdenpbi.eu-west-1.es.amazonaws.com"
   }
 }
 


### PR DESCRIPTION
### What
Add variable `test_opensearch_url` in Integration TFC Configuration

### Why
The Test Opensearch Cluster endpoint will be required for the Route53 record to be created, which is needed by the snapshot cronjob to import indices on a daily basis