### PR TITLE
Migrate "infra-mirror-bucket" project from govuk-aws

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -65,4 +65,15 @@ provider "fastly" {
 provider "tfe" {
 }
 
+provider "google" {
+  default_labels = {
+    product              = "gov-uk"
+    system               = "terraform-cloud"
+    environment          = var.govuk_environment
+    owner                = "govuk-platform-engineering"
+    repository           = "govuk-infrastructure"
+    terraform_deployment = lower(basename(abspath(path.root)))
+  }
+}
+
 data "aws_caller_identity" "current" {}

--- a/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
@@ -25,6 +25,7 @@ module "govuk-publishing-infrastructure-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
+    "gcp-credentials-integration",
     "common",
     "common-integration"
   ]
@@ -56,6 +57,7 @@ module "govuk-publishing-infrastructure-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
+    "gcp-credentials-staging",
     "common",
     "common-staging"
   ]
@@ -87,6 +89,7 @@ module "govuk-publishing-infrastructure-production" {
 
   variable_set_names = [
     "aws-credentials-production",
+    "gcp-credentials-production",
     "common",
     "common-production"
   ]


### PR DESCRIPTION
This migrates the related terraform to manage the govuk-mirror buckets from https://github.com/alphagov/govuk-aws.

This changes the IAM User used by GCP to a federated IAM Role that can be assume. This helps eliminate the need for long lived credentials.