### PR TITLE
Set GCP access credentials on govuk-publishing-infrastructure workspaces

### DIFF
--- a/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
@@ -25,6 +25,7 @@ module "govuk-publishing-infrastructure-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
+    "gcp-credentials-integration",
     "common",
     "common-integration"
   ]
@@ -56,6 +57,7 @@ module "govuk-publishing-infrastructure-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
+    "gcp-credentials-staging",
     "common",
     "common-staging"
   ]
@@ -87,6 +89,7 @@ module "govuk-publishing-infrastructure-production" {
 
   variable_set_names = [
     "aws-credentials-production",
+    "gcp-credentials-production",
     "common",
     "common-production"
   ]


### PR DESCRIPTION
This is in preparation of importing the mirror bucket in GCP from infra-google-mirror-bucket in govuk-aws

#1127 