### PR TITLE
Update permission for Integration to read Production Chat Snapshot S3 bucket

### DIFF
--- a/terraform/deployments/opensearch/iam.tf
+++ b/terraform/deployments/opensearch/iam.tf
@@ -7,7 +7,7 @@ locals {
       "arn:aws:s3:::govuk-staging-chat-opensearch-snapshots",
     ]
     integration = [
-      "arn:aws:s3:::govuk-staging-chat-opensearch-snapshots",
+      "arn:aws:s3:::govuk-production-chat-opensearch-snapshots",
       "arn:aws:s3:::govuk-integration-chat-opensearch-snapshots",
     ]
   }[var.govuk_environment]

--- a/terraform/deployments/opensearch/register-snapshot-repository.py
+++ b/terraform/deployments/opensearch/register-snapshot-repository.py
@@ -66,7 +66,7 @@ if sys.argv[1] == 'test':
 elif sys.argv[1] == 'integration':
     role_arn = 'arn:aws:iam::210287912431:role/govuk-integration-chat-opensearch-snapshot-role'
     register_repository('govuk-integration', role_arn, delete_first=delete_first)
-    register_repository('govuk-staging', role_arn, delete_first=delete_first, read_only=True)
+    register_repository('govuk-production', role_arn, delete_first=delete_first, read_only=True)
 elif sys.argv[1] == 'staging':
     role_arn = 'arn:aws:iam::696911096973:role/govuk-staging-chat-opensearch-snapshot-role'
     register_repository('govuk-staging', role_arn, delete_first=delete_first)


### PR DESCRIPTION
### What
This change is to update permission for Chat Opensearch in Integration to read from the Production snapshot bucket

### Why
There have been a number of times when the snapshot imported from Staging into Integration has been corrupted somehow, resulting in the Integration Chat Opensearch Cluster Health going Red and the Integration Chat Service experiencing an outage. When the Test and Staging environments import snapshots from Production, this issue has not occurred.