### PR TITLE
Add workflow for running erb lint

### DIFF
--- a/.github/workflows/erblint.yml
+++ b/.github/workflows/erblint.yml
@@ -1,0 +1,21 @@
+name: Run Erb Lint
+
+on:
+  workflow_call:
+
+jobs:
+  run-erblint:
+    name: Run ErbLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run ErbLint
+        run: bundle exec erblint --lint-all


### PR DESCRIPTION
Currently in most(may be all) of our app there is no linting mechanism for erb files. We want some way of linting erb files and hence we have tested [erb_lint](https://rubygems.org/gems/erb_lint/versions/0.5.0?locale=en) gem for the same.

The changes in this PR allows us to have a workflow to run erb lint.

When we run the command 'erblint --lint-all' it uses the default '.erb_lint.yml' file inside the project to apply any custom rules.