### PR TITLE
Add new variables for the Chat terraform project

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -104,6 +104,13 @@ module "variable-set-chat-production" {
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "2"
     chat_redis_cluster_parameter_group_name       = "default.redis7"
+    cloudfront_create                             = "1"
+    cloudfront_enable                             = true
+    service_disabled                              = false
+    origin_chat_domain                            = "chat.eks.production.govuk.digital"
+    origin_chat_id                                = "Chat origin"
+    cloudfront_chat_distribution_aliases          = ["chat.publishing.service.gov.uk"]
+    chat_certificate_arn                          = "arn:aws:acm:us-east-1:172025368201:certificate/ea27535c-f48a-4755-b6ca-c048c880e02d"
   }
 }
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -85,6 +85,13 @@ module "variable-set-chat-staging" {
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"
     chat_redis_cluster_parameter_group_name       = "default.redis7"
+    cloudfront_create                             = "1"
+    cloudfront_enable                             = true
+    service_disabled                              = false
+    origin_chat_domain                            = "chat.eks.staging.govuk.digital"
+    origin_chat_id                                = "Chat origin"
+    cloudfront_chat_distribution_aliases          = ["chat.staging.publishing.service.gov.uk"]
+    chat_certificate_arn                          = "arn:aws:acm:us-east-1:696911096973:certificate/642e34ef-71e2-439d-99f7-e79baf9ed482"
   }
 }
 


### PR DESCRIPTION
We add new resources in the form of a Cloudfront instance that sit in fron of the Chat app.