### PR TITLE
Replace custom origin config to S3 origin config

### DIFF
--- a/terraform/deployments/chat/cloudfront.tf
+++ b/terraform/deployments/chat/cloudfront.tf
@@ -31,11 +31,8 @@ resource "aws_cloudfront_distribution" "chat_distribution" {
     domain_name              = aws_s3_bucket.origin_service_disabled.bucket_regional_domain_name
     origin_access_control_id = aws_cloudfront_origin_access_control.govuk-chat.id
     origin_id                = aws_s3_bucket.origin_service_disabled.id
-    custom_origin_config {
-      http_port              = 80
-      https_port             = 443
-      origin_protocol_policy = "https-only"
-      origin_ssl_protocols   = ["TLSv1.2"]
+    s3_origin_config {
+      origin_access_control_id = aws_cloudfront_origin_access_control.govuk-chat.id
     }
   }
 


### PR DESCRIPTION
The S3 origin config block is required when using an S3 bucket as origin.