### PR TITLE
cdn-analytics fixes

### DIFF
--- a/terraform/deployments/cdn-analytics/bigquery.tf
+++ b/terraform/deployments/cdn-analytics/bigquery.tf
@@ -20,7 +20,7 @@ resource "google_bigquery_dataset" "fastly_logs" {
   }
 
   access {
-    role       = "roles/bigquery.dataEditor"
+    role          = "roles/bigquery.dataEditor"
     user_by_email = google_service_account.fastly_writer.email
   }
 }
@@ -34,99 +34,5 @@ resource "google_bigquery_table" "fastly_logs" {
     expiration_ms = 604800000 # 7 days
   }
 
-  schema = jsonencode(
-    [
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "client_ip"
-        "type"        = "STRING"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "request_received"
-        "type"        = "STRING"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "method"
-        "type"        = "STRING"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "url"
-        "type"        = "STRING"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "status"
-        "type"        = "INTEGER"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "protocol"
-        "type"        = "STRING"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "bytes"
-        "type"        = "INTEGER"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "content_type"
-        "type"        = "STRING"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "user_agent"
-        "type"        = "STRING"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "fastly_backend"
-        "type"        = "STRING"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "cache_response"
-        "type"        = "STRING"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "tls_client_protocol"
-        "type"        = "STRING"
-      },
-      {
-        "description" = ""
-        "fields"      = []
-        "mode"        = ""
-        "name"        = "tls_client_cipher"
-        "type"        = "STRING"
-      },
-    ]
-  )
+  schema = file("bigquery_schema.json")
 }

--- a/terraform/deployments/cdn-analytics/bigquery.tf
+++ b/terraform/deployments/cdn-analytics/bigquery.tf
@@ -5,6 +5,11 @@ resource "google_bigquery_dataset" "fastly_logs" {
   storage_billing_model = "PHYSICAL"
 
   access {
+    role          = "roles/bigquery.admin"
+    user_by_email = "terraform-cloud-${var.govuk_environment}@${data.google_project.project.project_id}.iam.gserviceaccount.com"
+  }
+
+  access {
     role           = "roles/bigquery.admin"
     group_by_email = "govuk-gcp-access@digital.cabinet-office.gov.uk"
   }
@@ -16,7 +21,7 @@ resource "google_bigquery_dataset" "fastly_logs" {
 
   access {
     role       = "roles/bigquery.dataEditor"
-    iam_member = "serviceAccount:${google_service_account.fastly_writer.email}"
+    user_by_email = google_service_account.fastly_writer.email
   }
 }
 

--- a/terraform/deployments/cdn-analytics/bigquery_schema.json
+++ b/terraform/deployments/cdn-analytics/bigquery_schema.json
@@ -1,0 +1,93 @@
+[
+  {
+    "name": "client_ip",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "request_received",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "method",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "url",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "status",
+    "mode": "",
+    "type": "INTEGER",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "protocol",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "bytes",
+    "mode": "",
+    "type": "INTEGER",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "content_type",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "user_agent",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "fastly_backend",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "cache_response",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "tls_client_protocol",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  },
+  {
+    "name": "tls_client_cipher",
+    "mode": "",
+    "type": "STRING",
+    "description": "",
+    "fields": []
+  }
+]

--- a/terraform/deployments/cdn-analytics/main.tf
+++ b/terraform/deployments/cdn-analytics/main.tf
@@ -26,7 +26,7 @@ provider "google" {
 }
 
 resource "google_project_service" "services" {
-  for_each = tomap(
+  for_each = toset(
     [
       "bigquery.googleapis.com",
       "iam.googleapis.com"

--- a/terraform/deployments/cdn-analytics/main.tf
+++ b/terraform/deployments/cdn-analytics/main.tf
@@ -25,4 +25,15 @@ provider "google" {
   }
 }
 
+resource "google_project_service" "services" {
+  for_each = tomap(
+    [
+      "bigquery.googleapis.com",
+      "iam.googleapis.com"
+    ]
+  )
+
+  service = each.key
+}
+
 data "google_project" "project" {}

--- a/terraform/deployments/cdn-analytics/outputs.tf
+++ b/terraform/deployments/cdn-analytics/outputs.tf
@@ -7,9 +7,9 @@ output "google_service_account_name" {
 }
 
 output "bigquery_dataset_id" {
-  value = google_bigquery_dataset.fastly_logs.id
+  value = google_bigquery_dataset.fastly_logs.dataset_id
 }
 
 output "bigquery_table_id" {
-  value = google_bigquery_table.fastly_logs.id
+  value = google_bigquery_table.fastly_logs.table_id
 }

--- a/terraform/deployments/cdn-analytics/outputs.tf
+++ b/terraform/deployments/cdn-analytics/outputs.tf
@@ -1,5 +1,5 @@
 output "google_project_id" {
-  value = data.google_project.project.number
+  value = data.google_project.project.project_id
 }
 
 output "google_service_account_name" {

--- a/terraform/deployments/cdn-analytics/outputs.tf
+++ b/terraform/deployments/cdn-analytics/outputs.tf
@@ -1,5 +1,5 @@
 output "google_project_id" {
-  value = data.google_project.project.id
+  value = data.google_project.project.number
 }
 
 output "google_service_account_name" {


### PR DESCRIPTION
Some small fixes for the cdn-analytics deployment:

* IAM and BigQuery services need to be enabled in the project
* Outputs were not in the format Fastly will want them in