### PR TITLE
Add mobile-backend workspace

### DIFF
--- a/terraform/deployments/tfc-configuration/mobile-backend.tf
+++ b/terraform/deployments/tfc-configuration/mobile-backend.tf
@@ -1,0 +1,31 @@
+module "mobile-backend-production" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.10.0"
+
+  organization        = var.organization
+  workspace_name      = "mobile-backend-production"
+  workspace_desc      = "Infrastucture for GOV.UK App"
+  workspace_tags      = ["production", "mobile-backend", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/mobile-backend/"
+  trigger_patterns    = ["/terraform/deployments/mobile-backend/**/*"]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Production" = "write"
+  }
+
+  variable_set_names = [
+    "aws-credentials-production",
+    "common",
+    "common-production"
+  ]
+}


### PR DESCRIPTION
This application only needs to be configured for the AWS Production account.