### PR TITLE
Upgrade Chat Production RDS database

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -196,7 +196,7 @@ module "variable-set-rds-production" {
         engine_params_family         = "postgres16"
         name                         = "chat"
         allocated_storage            = 100
-        instance_class               = "db.t4g.small"
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - AI"


### PR DESCRIPTION
## What

Change the Instance Type of the Postgres RDS database for Chat from `db.t4g.small` to `db.m6g.large` 

## Why

To cope with the expected traffic levels when the service goes live. This should increase `max_connections` from 190 to around 760 and improve network performance from up to 5Gbs to 10Gbs.