### PR TITLE
Create S3 buckets and integration / staging envs

### DIFF
--- a/terraform/deployments/mobile-backend/config-bucket.tf
+++ b/terraform/deployments/mobile-backend/config-bucket.tf
@@ -1,0 +1,45 @@
+resource "aws_s3_bucket" "mobile_backend_remote_config" {
+  bucket = "mobile-backend-remote-config-${var.govuk_environment}"
+}
+
+resource "aws_s3_bucket_versioning" "mobile_backend_remote_config" {
+  bucket = aws_s3_bucket.mobile_backend_remote_config.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_logging" "mobile_backend_remote_config" {
+  bucket        = aws_s3_bucket.mobile_backend_remote_config.id
+  target_bucket = "govuk-${var.govuk_environment}-aws-logging"
+  target_prefix = "s3/mobile-backend-remote-config-${var.govuk_environment}"
+}
+
+data "aws_iam_policy_document" "mobile_backend_remote_config_fastly_read" {
+  statement {
+    sid     = "S3FastlyReadBucket"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.mobile_backend_remote_config.id}",
+      "arn:aws:s3:::${aws_s3_bucket.mobile_backend_remote_config.id}/*"
+    ]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+
+      values = data.fastly_ip_ranges.fastly.cidr_blocks
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "mobile_backend_remote_config_read" {
+  bucket = aws_s3_bucket.mobile_backend_remote_config.id
+  policy = data.aws_iam_policy_document.mobile_backend_remote_config_fastly_read.json
+}

--- a/terraform/deployments/mobile-backend/gha-iam-role.tf
+++ b/terraform/deployments/mobile-backend/gha-iam-role.tf
@@ -61,5 +61,5 @@ data "aws_iam_policy_document" "bucket_write_role_permissions" {
 resource "aws_iam_role_policy" "bucket_deployment" {
   name   = "github_action_mobile_backend_bucket_deployment_policy"
   role   = aws_iam_role.github_action_sign_deploy.id
-  policy = data.aws_iam_policy_document.bucket_write_role_permissions
+  policy = data.aws_iam_policy_document.bucket_write_role_permissions.json
 }

--- a/terraform/deployments/mobile-backend/main.tf
+++ b/terraform/deployments/mobile-backend/main.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    fastly = {
+      source  = "fastly/fastly"
+      version = "~> 5.13"
+    }
   }
 }
 
@@ -29,4 +33,5 @@ provider "aws" {
   }
 }
 
-data "aws_caller_identity" "current" {}
+provider "fastly" { api_key = "test" }
+data "fastly_ip_ranges" "fastly" {}

--- a/terraform/deployments/tfc-configuration/mobile-backend.tf
+++ b/terraform/deployments/tfc-configuration/mobile-backend.tf
@@ -29,3 +29,69 @@ module "mobile-backend-production" {
     "common-production"
   ]
 }
+
+module "mobile-backend-staging" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.10.0"
+
+  organization        = var.organization
+  workspace_name      = "mobile-backend-staging"
+  workspace_desc      = "Infrastucture for GOV.UK App"
+  workspace_tags      = ["staging", "mobile-backend", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/mobile-backend/"
+  trigger_patterns    = ["/terraform/deployments/mobile-backend/**/*"]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Production" = "write"
+  }
+
+  variable_set_names = [
+    "aws-credentials-staging",
+    "common",
+    "common-staging"
+  ]
+}
+
+module "mobile-backend-integration" {
+  source  = "alexbasista/workspacer/tfe"
+  version = "0.10.0"
+
+  organization        = var.organization
+  workspace_name      = "mobile-backend-integration"
+  workspace_desc      = "Infrastucture for GOV.UK App"
+  workspace_tags      = ["integration", "mobile-backend", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/mobile-backend/"
+  trigger_patterns    = ["/terraform/deployments/mobile-backend/**/*"]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production" = "write"
+    "GOV.UK Production"     = "write"
+  }
+
+  variable_set_names = [
+    "aws-credentials-integration",
+    "common",
+    "common-integration"
+  ]
+}
+


### PR DESCRIPTION
Looking to:

- provision S3 buckets in each env (integration, staging, prod)
- grant permissions to GHA to write to those buckets
- some refactoring of the GHA policy