### PR TITLE
s3 sync operation requires s3:ListBucket permission

### DIFF
--- a/terraform/deployments/mobile-backend/gha-iam-role.tf
+++ b/terraform/deployments/mobile-backend/gha-iam-role.tf
@@ -52,7 +52,8 @@ resource "aws_iam_role_policy" "config_signing" {
 data "aws_iam_policy_document" "bucket_write_role_permissions" {
   statement {
     actions = [
-      "s3:PutObject"
+      "s3:PutObject",
+      "s3:ListBucket"
     ]
     resources = [aws_s3_bucket.mobile_backend_remote_config.arn]
   }


### PR DESCRIPTION
In our GHA we are using `s3 sync <local> <remote>` to publish the config in S3. As per https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html this requires the `s3:ListBucket` permission