### PR TITLE
update GHA policy to include sub-resources

### DIFF
--- a/terraform/deployments/mobile-backend/gha-iam-role.tf
+++ b/terraform/deployments/mobile-backend/gha-iam-role.tf
@@ -55,7 +55,10 @@ data "aws_iam_policy_document" "bucket_write_role_permissions" {
       "s3:PutObject",
       "s3:ListBucket"
     ]
-    resources = [aws_s3_bucket.mobile_backend_remote_config.arn]
+    resources = [
+      aws_s3_bucket.mobile_backend_remote_config.arn,
+      "${aws_s3_bucket.mobile_backend_remote_config.arn}/*"
+    ]
   }
 }
 


### PR DESCRIPTION
Further to previous 'fix', we also need to update the policy to include sub-resources on the S3 bucket (which again makes sense)