### PR TITLE
Set maxmemory-policy=noeviction parameter for Chat Redis

### DIFF
--- a/terraform/deployments/chat/redis.tf
+++ b/terraform/deployments/chat/redis.tf
@@ -25,8 +25,8 @@ resource "aws_elasticache_replication_group" "chat_redis_cluster" {
   num_cache_clusters         = var.chat_redis_cluster_num_cache_clusters
   automatic_failover_enabled = var.chat_redis_cluster_automatic_failover_enabled
   multi_az_enabled           = var.chat_redis_cluster_multi_az_enabled
-  parameter_group_name       = var.chat_redis_cluster_parameter_group_name
-  engine_version             = var.chat_redis_cluster_engine_version
+  parameter_group_name       = "default.redis7"
+  engine_version             = "7.1"
   subnet_group_name          = aws_elasticache_subnet_group.chat_redis_cluster.name
   security_group_ids         = [aws_security_group.chat_redis_cluster.id]
   tags = {

--- a/terraform/deployments/chat/redis.tf
+++ b/terraform/deployments/chat/redis.tf
@@ -17,6 +17,25 @@ resource "aws_security_group" "chat_redis_cluster" {
   }
 }
 
+resource "aws_elasticache_parameter_group" "chat_redis_cluster" {
+  name   = local.chat_redis_name
+  family = "redis7.1"
+
+  parameter {
+    name  = "cluster-enabled"
+    value = "yes"
+  }
+
+  parameter {
+    name  = "maxmemory-policy"
+    value = "noeviction"
+  }
+
+  tags = {
+    Name = local.chat_redis_name
+  }
+}
+
 resource "aws_elasticache_replication_group" "chat_redis_cluster" {
   apply_immediately          = var.chat_redis_cluster_apply_immediately
   replication_group_id       = local.chat_redis_name
@@ -25,7 +44,7 @@ resource "aws_elasticache_replication_group" "chat_redis_cluster" {
   num_cache_clusters         = var.chat_redis_cluster_num_cache_clusters
   automatic_failover_enabled = var.chat_redis_cluster_automatic_failover_enabled
   multi_az_enabled           = var.chat_redis_cluster_multi_az_enabled
-  parameter_group_name       = "default.redis7"
+  parameter_group_name       = aws_elasticache_parameter_group.chat_redis_cluster.name
   engine_version             = "7.1"
   subnet_group_name          = aws_elasticache_subnet_group.chat_redis_cluster.name
   security_group_ids         = [aws_security_group.chat_redis_cluster.id]

--- a/terraform/deployments/chat/redis.tf
+++ b/terraform/deployments/chat/redis.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "chat_redis_cluster" {
 resource "aws_elasticache_replication_group" "chat_redis_cluster" {
   apply_immediately          = var.chat_redis_cluster_apply_immediately
   replication_group_id       = local.chat_redis_name
-  description                = "Redis for GOV.UK Chat"
+  description                = "Redis for GOV.UK Chat Sidekiq"
   node_type                  = var.chat_redis_cluster_node_type
   num_cache_clusters         = var.chat_redis_cluster_num_cache_clusters
   automatic_failover_enabled = var.chat_redis_cluster_automatic_failover_enabled

--- a/terraform/deployments/chat/variables.tf
+++ b/terraform/deployments/chat/variables.tf
@@ -32,14 +32,6 @@ variable "chat_redis_cluster_multi_az_enabled" {
   type        = bool
   description = "Specifies whether to enable Multi-AZ Support for the replication group."
 }
-variable "chat_redis_cluster_parameter_group_name" {
-  type        = string
-  description = "Name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used."
-}
-variable "chat_redis_cluster_engine_version" {
-  type        = string
-  description = "Version number of the cache engine to be used for the cache clusters in this replication group."
-}
 variable "cloudfront_create" {
   description = "Create Cloudfront resources."
   type        = bool

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -68,11 +68,9 @@ module "variable-set-chat-integration" {
   tfvars = {
     chat_redis_cluster_apply_immediately          = true
     chat_redis_cluster_automatic_failover_enabled = false
-    chat_redis_cluster_engine_version             = "7.1"
     chat_redis_cluster_multi_az_enabled           = false
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"
-    chat_redis_cluster_parameter_group_name       = "default.redis7"
     cloudfront_create                             = 1
     cloudfront_enable                             = true
     service_disabled                              = false

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -99,11 +99,9 @@ module "variable-set-chat-production" {
   tfvars = {
     chat_redis_cluster_apply_immediately          = false
     chat_redis_cluster_automatic_failover_enabled = true
-    chat_redis_cluster_engine_version             = "7.1"
     chat_redis_cluster_multi_az_enabled           = true
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "2"
-    chat_redis_cluster_parameter_group_name       = "default.redis7"
     cloudfront_create                             = 1
     cloudfront_enable                             = true
     service_disabled                              = false

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -80,11 +80,9 @@ module "variable-set-chat-staging" {
   tfvars = {
     chat_redis_cluster_apply_immediately          = true
     chat_redis_cluster_automatic_failover_enabled = false
-    chat_redis_cluster_engine_version             = "7.1"
     chat_redis_cluster_multi_az_enabled           = false
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"
-    chat_redis_cluster_parameter_group_name       = "default.redis7"
     cloudfront_create                             = 1
     cloudfront_enable                             = true
     service_disabled                              = false


### PR DESCRIPTION
This configures the Redis instance that GOV.UK Chat uses for Sidekiq to use it's own parameter group and for that group to have `maxmemory-policy=noeviction`. This is to resolve the warning we get from Sidekiq of:

```
WARNING: Your Redis instance will evict Sidekiq data under heavy load.
The 'noeviction' maxmemory policy is recommended (current policy: 'volatile-lru').
See: https://github.com/mperham/sidekiq/wiki/Using-Redis#memory
```

I need to confirm that this terraform a) actually works and b) doesn't mess up any other parameters.