### PR TITLE
Remove cluster-enabled from parameters

### DIFF
--- a/terraform/deployments/chat/redis.tf
+++ b/terraform/deployments/chat/redis.tf
@@ -22,11 +22,6 @@ resource "aws_elasticache_parameter_group" "chat_redis_cluster" {
   family = "redis7"
 
   parameter {
-    name  = "cluster-enabled"
-    value = "yes"
-  }
-
-  parameter {
     name  = "maxmemory-policy"
     value = "noeviction"
   }


### PR DESCRIPTION
Continuing my whack-a-mole process of trying to get a Terraform plan that will apply from
https://github.com/alphagov/govuk-infrastructure/pull/1443.

It turns out we don't want to set cluster enabled to yes and the default option is no, so we shouldn't have been trying to change it.

I've been through and compared all the other parameters and they seem to match.