### PR TITLE
Remove explicit config to log to stdout for clamav

### DIFF
--- a/images/clamav/Dockerfile
+++ b/images/clamav/Dockerfile
@@ -2,10 +2,6 @@ FROM --platform=$TARGETPLATFORM clamav/clamav-debian:1.3
 
 COPY "./images/clamav/scripts/unprivileged-entrypoint.sh" "/unpriv-init"
 
-RUN sed -i 's/^LogFile .*/LogFile \/dev\/stdout/' /etc/clamav/clamd.conf && \
-    sed -i 's/^LogFile .*/LogFile \/dev\/stdout/' /etc/clamav/clamav-milter.conf && \
-    sed -i 's/^UpdateLogFile .*/UpdateLogFile \/dev\/stdout/' /etc/clamav/freshclam.conf
-
 RUN chown -R clamav:clamav /var/lib/clamav /unpriv-init
 
 USER clamav


### PR DESCRIPTION
Clamav 1.3.2 was released and contained a fix for security issue which disabled it from following symlinks for logfiles. This causes the container to fail to startup as it cannot follow /dev/stdout symlink. We can remove this explicit config, as by default the logger logs to stdout.

https://github.com/Cisco-Talos/clamav/pull/1363

https://github.com/Cisco-Talos/clamav/releases/tag/clamav-1.3.2