### PR TITLE
Remove special-route-publisher (now retired)

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -667,12 +667,6 @@ repos:
     required_status_checks:
       standard_contexts: *standard_security_checks
 
-  special-route-publisher:
-    required_status_checks:
-      standard_contexts: *standard_security_checks
-      additional_contexts:
-        - test
-
   specialist-publisher:
     homepage_url: "https://docs.publishing.service.gov.uk/apps/specialist-publisher.html"
     required_status_checks:


### PR DESCRIPTION
Retired as of: https://github.com/alphagov/special-route-publisher/pull/353

https://trello.com/c/9rOxWNnD/396-retire-special-route-publisher