### PR TITLE
Remove S3 lifecycle configuration from chat opensearch snapshot bucket

### DIFF
--- a/terraform/deployments/opensearch/s3.tf
+++ b/terraform/deployments/opensearch/s3.tf
@@ -32,32 +32,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "opensearch_snapsh
   }
 }
 
-resource "aws_s3_bucket_lifecycle_configuration" "opensearch_snapshot" {
-  bucket = aws_s3_bucket.opensearch_snapshot.id
-  rule {
-    id     = "production"
-    status = var.govuk_environment == "production" ? "Enabled" : "Disabled"
-    filter {}
-    transition {
-      days          = 30
-      storage_class = "STANDARD_IA"
-    }
-    transition {
-      days          = 60
-      storage_class = "GLACIER"
-    }
-    expiration { days = 120 }
-    noncurrent_version_expiration { noncurrent_days = 1 }
-  }
-  rule {
-    id     = "non-production"
-    status = var.govuk_environment != "production" ? "Enabled" : "Disabled"
-    filter {}
-    expiration { days = 2 }
-    noncurrent_version_expiration { noncurrent_days = 1 }
-  }
-}
-
 resource "aws_s3_bucket_policy" "opensearch_snapshot" {
   bucket = aws_s3_bucket.opensearch_snapshot.id
   policy = data.aws_iam_policy_document.opensearch_snapshot_bucket_policy.json


### PR DESCRIPTION
## What

Remove the lifecycle configuration from the Chat Opensearch Snapshot buckets

## Why

We have discovered that all the files in the bucket are required when the restore of a snapshot takes place. When older files have transitioned into Glacier, the result is that the restore fails. As we are restoring indices from Production into Staging & Integration on a daily basis, to prevent the process from causing them to become unavailable this change is to stop any further files being transitioned.

The daily snapshot job is configured to delete previous snapshots, leaving only the latest in place, which should prevent the bucket from building up with unnecessary files that are no longer required.