### PR TITLE
Remove gds_zendesk from GitHub config

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -843,7 +843,6 @@ repos:
   govuk-rfcs: {}
   govuk-ruby-images: {}
   govuk-s3-mirror: {}
-  gds_zendesk: {}
   govuk-design-guide: {
     teams: {
       govuk: "maintain"


### PR DESCRIPTION
This repo was archived https://github.com/alphagov/govuk-developer-docs/pull/4791 This will prevent gds_zendesk repo getting un-archived when the TF configuration is applied.