### PR TITLE
Prepare for app-publishing-amazonmq migration

### DIFF
--- a/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
@@ -27,7 +27,8 @@ module "govuk-publishing-infrastructure-integration" {
     "aws-credentials-integration",
     "gcp-credentials-integration",
     "common",
-    "common-integration"
+    "common-integration",
+    "amazonmq-integration"
   ]
 }
 

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -559,3 +559,18 @@ module "variable-set-rds-integration" {
     }
   }
 }
+
+module "variable-set-amazonmq-integration" {
+  source = "./variable-set"
+
+  name = "amazonmq-integration"
+  tfvars = {
+    amazonmq_engine_version                       = "3.11.28"
+    amazonmq_deployment_mode                      = "SINGLE_INSTANCE"
+    amazonmq_maintenance_window_start_day_of_week = "MONDAY"
+    amazonmq_maintenance_window_start_time_utc    = "07:00"
+    amazonmq_host_instance_type                   = "mq.t3.micro"
+
+    amazonmq_govuk_chat_retry_message_ttl = 300000
+  }
+}

--- a/terraform/deployments/vpc/outputs.tf
+++ b/terraform/deployments/vpc/outputs.tf
@@ -14,3 +14,13 @@ output "rds_enhanced_monitoring_role_arn" {
   description = "The ARN of the IAM role for RDS Enhanced Monitoring"
   value       = aws_iam_role.rds_enhanced_monitoring.arn
 }
+
+output "internal_root_zone_id" {
+  description = "ID of the internal Route53 DNS zone"
+  value       = aws_route53_zone.internal_zone.id
+}
+
+output "external_root_zone_id" {
+  description = "ID of the external Route53 DNS zone"
+  value       = aws_route53_zone.external_zone.id
+}


### PR DESCRIPTION
This PR does 2 things necessary for app-publishing-amazonmq to be migrated from govuk-aws:

* Outputs root zone IDs in the vpc module
* Adds a new var set for amazonmq in integration. This was done because its adding a lot of variables that aren't used in any other deployment

The terraform test for `tfc-configuration` will fail because TF expects a var set to exist before being added to a workspace, and this PR does both the creation and assigning.

#1127 