### PR TITLE
Add ability to specify GitHub Team permissions

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -90,21 +90,21 @@ resource "github_team_repository" "govuk_production_admin_repos" {
   for_each   = local.repositories
   repository = each.key
   team_id    = github_team.govuk_production_admin.id
-  permission = "admin"
+  permission = try(each.value.teams["govuk_production_admin"], "admin")
 }
 
 resource "github_team_repository" "govuk_ci_bots_repos" {
   for_each   = local.repositories
   repository = each.key
   team_id    = github_team.govuk_ci_bots.id
-  permission = "admin"
+  permission = try(each.value.teams["govuk_ci_bots"], "admin")
 }
 
 resource "github_team_repository" "govuk_repos" {
   for_each   = local.repositories
   repository = each.key
   team_id    = github_team.govuk.id
-  permission = "push"
+  permission = try(each.value.teams["govuk"], "push")
 }
 
 resource "github_repository" "govuk_repos" {

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -844,4 +844,8 @@ repos:
   govuk-ruby-images: {}
   govuk-s3-mirror: {}
   gds_zendesk: {}
-  govuk-design-guide: {}
+  govuk-design-guide: {
+    teams: {
+      govuk: "maintain"
+    }
+  }


### PR DESCRIPTION
We need to govuk team maintainer permissions for the govuk-design-guide as non production team members need merge permissions.