### PR TITLE
Grant extra permissions to TFC IAM role

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -114,6 +114,14 @@ data "aws_iam_policy_document" "tfc_policy" {
     resources = ["arn:aws:iam::*:role/rds-monitoring-role"]
   }
   statement {
+    actions   = ["iam:*Role"]
+    resources = ["arn:aws:iam::*:role/AWSLambdaRole-transition-executor"]
+  }
+  statement {
+    actions   = ["iam:*User"]
+    resources = ["arn:aws:iam::*:user/govuk-*-transition-downloader"]
+  }
+  statement {
     effect    = "Deny"
     resources = ["*"]
     actions = [

--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -55,6 +55,7 @@ data "aws_iam_policy_document" "tfc_policy" {
       "iam:*CloudFrontPublicKey*",
       "iam:*OpenIDConnectProvider*",
       "iam:*Policy",
+      "iam:*Policies",
       "iam:*PolicyVersion*",
       "iam:*RolePolicies",
       "iam:*RoleTags",

--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -51,6 +51,7 @@ data "aws_iam_policy_document" "tfc_policy" {
       "elasticfilesystem:*",
       "es:*",
       "events:*",
+      "glue:*",
       "iam:*InstanceProfile*",
       "iam:*CloudFrontPublicKey*",
       "iam:*OpenIDConnectProvider*",


### PR DESCRIPTION
This is needed to manage AmazonMQ IAM permissions.

#1127 