### PR TITLE
Grant extra permissions to TFC role

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -137,7 +137,6 @@ data "aws_iam_policy_document" "tfc_policy" {
       "iam:*Login*",
       "iam:*Group*",
       "iam:*PermissionsBoundary*",
-      "iam:*User*",
       "iam:CreateServiceLinkedRole",
     ]
   }

--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -40,6 +40,7 @@ data "aws_iam_policy_document" "tfc_policy" {
     actions = [
       "acm:*",
       "apigateway:*",
+      "athena:*",
       "autoscaling:*",
       "cloudfront:*",
       "cloudwatch:*",

--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -119,8 +119,11 @@ data "aws_iam_policy_document" "tfc_policy" {
     resources = ["arn:aws:iam::*:role/AWSLambdaRole-transition-executor"]
   }
   statement {
-    actions   = ["iam:*User"]
-    resources = ["arn:aws:iam::*:user/govuk-*-transition-downloader"]
+    actions = ["iam:*User"]
+    resources = [
+      "arn:aws:iam::*:user/govuk-*-fastly-logs-writer",
+      "arn:aws:iam::*:user/govuk-*-transition-downloader"
+    ]
   }
   statement {
     effect    = "Deny"


### PR DESCRIPTION
These permissions are required for the fastly-logs terraform migration

#1127 