### PR TITLE
Add API Gateway for Search-API

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
@@ -1,0 +1,52 @@
+# VPC Link to allow API Gateway to connect to the search load balancer
+resource "aws_api_gateway_vpc_link" "search_vpc_link" {
+  name = "search_api_vpc_link"
+  target_arns = [
+    var.search_api_lb_arn
+  ]
+}
+
+resource "aws_api_gateway_rest_api" "search_rest_api" {
+  name        = "search_api"
+  description = "API Gateway for Search API"
+
+  endpoint_configuration {
+    types = ["EDGE"]  # "Edge-optimized" routes traffic through CloudFront
+  }
+}
+
+resource "aws_api_gateway_resource" "search_resource" {
+  rest_api_id = aws_api_gateway_rest_api.search_rest_api.id
+  parent_id   = aws_api_gateway_rest_api.search_rest_api.root_resource_id
+  path_part   = "search.json"
+}
+
+resource "aws_api_gateway_method" "get_search_method" {
+  rest_api_id   = aws_api_gateway_rest_api.search_rest_api.id
+  resource_id   = aws_api_gateway_resource.search_resource.id
+  http_method   = "GET"
+  authorization = "NONE" # We can add API keys or other auth options should we need them
+}
+
+# Connect to the Search-API-v2 load balancer
+resource "aws_api_gateway_integration" "search_lb_integration" {
+  rest_api_id             = aws_api_gateway_rest_api.search_rest_api.id
+  resource_id             = aws_api_gateway_resource.search_resource.id
+  http_method             = aws_api_gateway_method.get_search_method.http_method
+  integration_http_method = "GET"
+  type                    = "HTTP_PROXY"
+  connection_type         = "VPC_LINK"
+  connection_id           = aws_api_gateway_vpc_link.search_vpc_link.id
+  uri                     = var.search_api_lb_dns_name
+}
+
+# Create a deployment for the API Gateway
+resource "aws_api_gateway_deployment" "search_deployment" {
+  rest_api_id = aws_api_gateway_rest_api.search_rest_api.id
+  stage_name  = "v0.1" # Version embedded in the published URL
+}
+
+output "api_gateway_cname" {
+  value       = aws_api_gateway_domain_name.search_api_domain.cloudfront_domain_name
+  description = "CNAME to use in your DNS settings"
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
@@ -1,3 +1,8 @@
+resource "aws_api_gateway_domain_name" "search_api_domain" {
+  domain_name     = var.search_api_domain
+  certificate_arn = var.publishing_certificate_arn
+}
+
 # VPC Link to allow API Gateway to connect to the search load balancer
 resource "aws_api_gateway_vpc_link" "search_vpc_link" {
   name = "search_api_vpc_link"
@@ -11,7 +16,7 @@ resource "aws_api_gateway_rest_api" "search_rest_api" {
   description = "API Gateway for Search API"
 
   endpoint_configuration {
-    types = ["EDGE"]  # "Edge-optimized" routes traffic through CloudFront
+    types = ["EDGE"] # "Edge-optimized" routes traffic through CloudFront
   }
 }
 
@@ -45,6 +50,61 @@ resource "aws_api_gateway_deployment" "search_deployment" {
   rest_api_id = aws_api_gateway_rest_api.search_rest_api.id
   stage_name  = "v0.1" # Version embedded in the published URL
 }
+
+# Map API Gateway stages to custom domain
+resource "aws_api_gateway_base_path_mapping" "search_api_mapping" {
+  domain_name = aws_api_gateway_domain_name.search_api_domain.domain_name
+  api_id      = aws_api_gateway_rest_api.search_rest_api.id
+}
+
+# WAF settings
+resource "aws_wafv2_web_acl" "search_api_waf" {
+  name        = "search-api-waf"
+  description = "WAF for Search API with rate limiting"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rate-limit-rule"
+    priority = 1
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100 # Limit 100 requests per IP in 5 minutes
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "search-api-rate-limit-rule"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "search-api-waf"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "waf_association" {
+  resource_arn = aws_api_gateway_domain_name.search_api_domain.cloudfront_domain_name
+  web_acl_arn  = aws_wafv2_web_acl.search_api_waf.arn
+}
+
+resource "aws_shield_protection" "search_api_shield" {
+  name         = "search-api-shield"
+  resource_arn = aws_api_gateway_rest_api.search_rest_api.execution_arn
+}
+
 
 output "api_gateway_cname" {
   value       = aws_api_gateway_domain_name.search_api_domain.cloudfront_domain_name

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -52,3 +52,13 @@ variable "shared_documentdb_backup_retention_period" {
   default     = 5
   description = "Number of days to keep shared DocumentDB backups for"
 }
+
+variable "search_api_lb_arn" {
+  type        = string
+  description = "The ARN of the search-api-v2 load balancer"
+}
+
+variable "search_api_lb_dns_name" {
+  type        = string
+  description = "The DNS name of the search-api-v2 load balancer"
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -62,3 +62,13 @@ variable "search_api_lb_dns_name" {
   type        = string
   description = "The DNS name of the search-api-v2 load balancer"
 }
+
+variable "search_api_domain" {
+  type        = string
+  description = "The domain name of the API gateway"
+}
+
+variable "publishing_certificate_arn" {
+  type        = string
+  description = "The ARN of the publishing certificate"
+}


### PR DESCRIPTION
This sets up a route to search-api-v2's search endpoint.

This is a REST API because it allows [the following advantages](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html) over an HTTP API:
- edge optimization (CloudFront integration)
- WAF
- rate limiting/throttling
- cache control
- request validation/modification

Not all of these are immediately necessary, but they are likely to be used in the near future.

The stage name is "v0.1" which indicates that the API is subject to change. This results in a URL like example.gov.uk/v0.1/search.json as the stage name is automatically injected into the path.

## Domain/WAF

This applies to the API gateway we're setting up, not to internal traffic.

It permits 100 requests per client per 5 minutes, which is 1 every 3 seconds on average. This is probably sufficient for now, though if lots of users are behind a single IP, then this will need amending.
This WAF also applies across the whole deployment, so should we add another API that is likely to be more frequently used, we'll definitely want to relax it and do more management at the API layer.

This also registers the API Gateway with AWS Shield Advanced.