### PR TITLE
Temporarily remove WAF configuration

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
@@ -57,55 +57,6 @@ resource "aws_api_gateway_base_path_mapping" "search_api_mapping" {
   api_id      = aws_api_gateway_rest_api.search_rest_api.id
 }
 
-# WAF settings
-resource "aws_wafv2_web_acl" "search_api_waf" {
-  name        = "search-api-waf"
-  description = "WAF for Search API with rate limiting"
-  scope       = "CLOUDFRONT"
-
-  default_action {
-    allow {}
-  }
-
-  rule {
-    name     = "rate-limit-rule"
-    priority = 1
-    action {
-      block {}
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = 100 # Limit 100 requests per IP in 5 minutes
-        aggregate_key_type = "IP"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "search-api-rate-limit-rule"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  visibility_config {
-    cloudwatch_metrics_enabled = true
-    metric_name                = "search-api-waf"
-    sampled_requests_enabled   = true
-  }
-}
-
-resource "aws_wafv2_web_acl_association" "waf_association" {
-  resource_arn = aws_api_gateway_domain_name.search_api_domain.cloudfront_domain_name
-  web_acl_arn  = aws_wafv2_web_acl.search_api_waf.arn
-}
-
-resource "aws_shield_protection" "search_api_shield" {
-  name         = "search-api-shield"
-  resource_arn = aws_api_gateway_rest_api.search_rest_api.execution_arn
-}
-
-
 output "api_gateway_cname" {
   value       = aws_api_gateway_domain_name.search_api_domain.cloudfront_domain_name
   description = "CNAME to use in your DNS settings"

--- a/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
@@ -48,7 +48,12 @@ resource "aws_api_gateway_integration" "search_lb_integration" {
 # Create a deployment for the API Gateway
 resource "aws_api_gateway_deployment" "search_deployment" {
   rest_api_id = aws_api_gateway_rest_api.search_rest_api.id
-  stage_name  = "v0_1" # Version embedded in the published URL
+}
+
+resource "aws_api_gateway_stage" "search_v0_1" {
+  deployment_id = aws_api_gateway_deployment.search_deployment.id
+  rest_api_id   = aws_api_gateway_rest_api.search_rest_api.id
+  stage_name    = "v0_1" # Version embedded in the published URL
 }
 
 # Map API Gateway stages to custom domain


### PR DESCRIPTION
There are some complexities around defining regions on WAFs for CloudFront resources, and it's unclear from the docs where these apply to API gateways in the edge mode. Removing temporarily to get the API gateway deploying properly.

Also It's recommended to have a [separate definition for the stage and deployment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment#stage_name), so have split that out.
