### PR TITLE
Remove privatelink config

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
@@ -8,8 +8,6 @@ resource "aws_lb" "search_nlb" {
   load_balancer_type = "network"
   internal           = true
   subnets            = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
-
-  enforce_security_group_inbound_rules_on_private_link_traffic = "off"
 }
 
 resource "aws_lb_target_group" "search_api_gateway_tg" {


### PR DESCRIPTION
We have not defined security groups on this NLB, as it's just a pass through to an application load balancer.

Because of that, we don't need the configuration to excuse traffic from the VPC link.