### PR TITLE
Add simple rate limit WAF for search-api

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
@@ -94,6 +94,48 @@ resource "aws_api_gateway_base_path_mapping" "search_api_mapping" {
   api_id      = aws_api_gateway_rest_api.search_rest_api.id
 }
 
+resource "aws_wafv2_web_acl" "search_api_waf" {
+  name        = "search-api-waf"
+  description = "WAF for Search API"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rate-limit-rule"
+    priority = 1
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.search_api_rate_limit
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "search-api-rate-limit-rule"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "search-api-waf"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "waf_association" {
+  resource_arn = aws_api_gateway_stage.search_v0_1.arn
+  web_acl_arn  = aws_wafv2_web_acl.search_api_waf.arn
+}
+
 output "api_gateway_cname" {
   value       = aws_api_gateway_domain_name.search_api_domain.cloudfront_domain_name
   description = "CNAME to use in your DNS settings"

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -72,3 +72,8 @@ variable "publishing_certificate_arn" {
   type        = string
   description = "The ARN of the publishing certificate"
 }
+
+variable "search_api_rate_limit" {
+  type        = string
+  description = "The rate limit applied to search API over 5 minutes"
+}


### PR DESCRIPTION
This is [applied to the API gateway stage](https://docs.aws.amazon.com/waf/latest/APIReference/API_AssociateWebACL.html), not the internal LB.

The rate limit is set in TF Cloud's variable set.