### PR TITLE
Add Chat's CloudFront to protected resources

### DIFF
--- a/terraform/deployments/chat/cloudfront.tf
+++ b/terraform/deployments/chat/cloudfront.tf
@@ -113,3 +113,8 @@ resource "aws_cloudfront_function" "add_index" {
   runtime = "cloudfront-js-2.0"
   code    = file("${path.module}/add_index.js")
 }
+
+resource "aws_shield_protection" "chat_shield_protection" {
+  name         = "Chat"
+  resource_arn = aws_cloudfront_distribution.chat_distribution[0].arn
+}


### PR DESCRIPTION
We pay for [Shield Advanced][1] already, and it's [advised in the GDS Way.][2]

[1]: https://aws.amazon.com/shield/features/
[2]: https://gds-way.digital.cabinet-office.gov.uk/manuals/security-overview-for-websites.html#7-content-delivery-network