### PR TITLE
Fix aws_api_gateway_deployment deployment reliability

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
@@ -80,6 +80,19 @@ resource "aws_api_gateway_integration" "search_lb_integration" {
 # Create a deployment for the API Gateway
 resource "aws_api_gateway_deployment" "search_deployment" {
   rest_api_id = aws_api_gateway_rest_api.search_rest_api.id
+
+  triggers = {
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_integration.search_lb_integration,
+      aws_api_gateway_method.get_search_method,
+      aws_api_gateway_resource.search_resource,
+      aws_api_gateway_rest_api.search_rest_api,
+    ]))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_api_gateway_stage" "search_v0_1" {


### PR DESCRIPTION
There's a bit of trickery with actually deploying a `deployment`. It's not always able to figure out whether things have changed, and therefore needs to be triggered.

The docs contain some [further context on this][1] (and there's a [Github issue][2] where it's discussed):

> When the REST API configuration involves other Terraform resources (aws_api_gateway_integration resource, etc.), the dependency setup can be done with implicit resource references in the triggers argument or explicit resource references using the resource depends_on meta-argument. The triggers argument should be preferred over depends_on, since depends_on can only capture dependency ordering and will not cause the resource to recreate (redeploy the REST API) with upstream configuration changes.

In addition, we want to ensure that we don't have downtime while deployments occur, so we need to add a bit of boilerplate to ensure that this happens properly.

[1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment
[2]: https://github.com/hashicorp/terraform-provider-aws/issues/162#issuecomment-532593939