### PR TITLE
Add serverless memcached for Chat service

### DIFF
--- a/terraform/deployments/chat/serverless_memcache.tf
+++ b/terraform/deployments/chat/serverless_memcache.tf
@@ -1,0 +1,40 @@
+locals {
+  chat_memcached_name = "chat-memcached"
+}
+
+resource "aws_security_group" "chat_memcached" {
+  name        = local.chat_memcached_name
+  vpc_id      = data.tfe_outputs.vpc.nonsensitive_values.id
+  description = "${local.chat_memcached_name} memcached instance"
+  tags = {
+    Name = local.chat_memcached_name
+  }
+}
+
+resource "aws_elasticache_serverless_cache" "chat_memcached" {
+  name                 = local.chat_memcached_name
+  engine               = "memcached"
+  major_engine_version = "1.6"
+  cache_usage_limits {
+    data_storage {
+      maximum = 10
+      unit    = "GB"
+    }
+    ecpu_per_second {
+      maximum = 4000
+    }
+  }
+  subnet_ids         = local.elasticache_subnets
+  security_group_ids = [aws_security_group.chat_memcached.id]
+  tags = {
+    Name = local.chat_memcached_name
+  }
+}
+
+resource "aws_route53_record" "chat_memcached" {
+  zone_id = local.internal_dns_zone_id
+  name    = local.chat_memcached_name
+  type    = "CNAME"
+  ttl     = 300
+  records = [for k, v in aws_elasticache_serverless_cache.chat_memcached.endpoint : v.address]
+}


### PR DESCRIPTION
## What

We want to have a memcached that [GOV.UK](http://gov.uk/) Chat can use for caching data across pods. We should expect that this cache is accessed when the app is under heavy load so will need to be able to sized according to chat at high activity.

## Why

We want to mitigate against the risk of a user spamming us with sign-ups. To mitigate against that we want to use [Rack::Attack](https://github.com/rack/rack-attack) (A Ruby Gem) which makes use of the Rails caching layer - however as we don’t currently do Rails caching we don’t have this configured.

We decided to go with the serverless option rather than a cluster as this allows for scaling in and out with high usage and over time should save money as we would need a large resilient cluster to cope with peak loads. Maximum storage and throughput limits have been put in place to cap at a bit above what we believe will be the highest traffic levels.