### PR TITLE
Add variables required for Chat WAF rules

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -78,6 +78,8 @@ module "variable-set-chat-integration" {
     origin_chat_id                                = "Chat origin"
     cloudfront_chat_distribution_aliases          = ["chat.integration.publishing.service.gov.uk"]
     chat_certificate_arn                          = "arn:aws:acm:us-east-1:210287912431:certificate/458b8373-08a4-4cdc-bb00-524bcc480b5b"
+    waf_cache_rate_warning                        = 1500
+    waf_cache_rate_limit                          = 2000
   }
 }
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -109,6 +109,8 @@ module "variable-set-chat-production" {
     origin_chat_id                                = "Chat origin"
     cloudfront_chat_distribution_aliases          = ["chat.publishing.service.gov.uk"]
     chat_certificate_arn                          = "arn:aws:acm:us-east-1:172025368201:certificate/ea27535c-f48a-4755-b6ca-c048c880e02d"
+    waf_cache_rate_warning                        = 2000
+    waf_cache_rate_limit                          = 4000
   }
 }
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -90,6 +90,8 @@ module "variable-set-chat-staging" {
     origin_chat_id                                = "Chat origin"
     cloudfront_chat_distribution_aliases          = ["chat.staging.publishing.service.gov.uk"]
     chat_certificate_arn                          = "arn:aws:acm:us-east-1:696911096973:certificate/642e34ef-71e2-439d-99f7-e79baf9ed482"
+    waf_cache_rate_warning                        = 1500
+    waf_cache_rate_limit                          = 2000
   }
 }
 


### PR DESCRIPTION
## What

New variables for TFC to be consumed by Chat WAF rules

## Why

The Chat service needs to be moved onto it's own load balancer and needs it's own WAF ruleset