### PR TITLE
Create new WAF ACL for Chat

### DIFF
--- a/terraform/deployments/chat/alb_waf_rules.tf
+++ b/terraform/deployments/chat/alb_waf_rules.tf
@@ -1,0 +1,424 @@
+resource "aws_wafv2_web_acl" "chat_waf_rules" {
+  name        = "govuk_chat_web_acl"
+  description = "WAF Ruleset for GOVUK Chat Service"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  # Amazon core rule set (CRS) managed rule group
+  # Contains rules that are generally applicable to web applications. This
+  # provides protection against exploitation of a wide range of vulnerabilities,
+  # including those described in OWASP publications.
+  rule {
+    name     = "aws-managed-rules-common-rule-set"
+    priority = 10
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Amazon IP reputation list managed rule group
+  # The Amazon IP reputation list rule group contains rules that are based on
+  # Amazon internal threat intelligence. This is useful for blocking IP addresses
+  # typically associated with bots or other threats. Blocking these IP addresses
+  # can help mitigate bots and reduce the risk of a malicious actor discovering
+  # a vulnerable application.
+  rule {
+    name     = "aws-managed-rules-common-rule-set"
+    priority = 20
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Anonymous IP list managed rule group
+  # The Anonymous IP list rule group contains rules to block requests from services
+  # that permit the obfuscation of viewer identity. These include requests from
+  # VPNs, proxies, Tor nodes, and web hosting providers. This rule group is useful
+  # for filtering out viewers that might be trying to hide their identity from your
+  # application. Blocking the IP addresses of these services can help mitigate bots
+  # and evasion of geographic restrictions.
+  rule {
+    name     = "aws-managed-rules-common-rule-set"
+    priority = 30
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAnonymousIpList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAnonymousIpList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # this rule matches any request that contains the header X-Always-Block: true
+  # we use it as a simple sense check / acceptance test from smokey to ensure that
+  # the waf is enabled and processing requests
+  rule {
+    name     = "x-always-block-web-acl-rule"
+    priority = 40
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      rule_group_reference_statement {
+        arn = data.aws_wafv2_rule_group.x_always_block.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "x-always-block-rule-group"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # this rule matches any request that contains NAT gateway IPs in the True-Client-IP
+  # header and allows it.
+  rule {
+    name     = "allow-govuk-infra"
+    priority = 50
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = data.aws_wafv2_ip_set.govuk_requesting_ips.arn
+
+        ip_set_forwarded_ip_config {
+          fallback_behavior = "NO_MATCH"
+          header_name       = "true-client-ip"
+          position          = "FIRST"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "govuk-infra-cache-requests"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # allow Fastly healthchecks to pass unhindered
+  rule {
+    name     = "allow-fastly-healthchecks"
+    priority = 60
+
+    action {
+      allow {}
+    }
+
+    statement {
+      byte_match_statement {
+        field_to_match {
+          single_header {
+            name = "rate-limit-token"
+          }
+        }
+
+        positional_constraint = "EXACTLY"
+        search_string         = data.aws_secretsmanager_secret_version.fastly_token.secret_string
+
+        text_transformation {
+          priority = 1
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "fastly-healthcheck-requests"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "ratelimit-exemptions"
+    priority = 70
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = data.aws_wafv2_ip_set.high_request_rate.arn
+
+        ip_set_forwarded_ip_config {
+          fallback_behavior = "NO_MATCH"
+          header_name       = "true-client-ip"
+          position          = "FIRST"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "ratelimit-exempt-requests"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # This rule is intended for monitoring only
+  # set a base rate limit per IP looking back over the last 5 minutes
+  # this is checked every 30s
+  rule {
+    name     = "cache-public-base-rate-warning"
+    priority = 80
+
+    action {
+      count {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.waf_cache_rate_warning
+        aggregate_key_type = "FORWARDED_IP"
+
+        forwarded_ip_config {
+          # We expect all requests to have this header set. As we're counting,
+          #it's a good chance to verify that by matching any that don't
+          fallback_behavior = "MATCH"
+          header_name       = "true-client-ip"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "cache-public-base-rate-warning"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # set a base rate limit per IP looking back over the last 5 minutes
+  # this is checked every 30s
+  rule {
+    name     = "cache-public-base-rate-limit"
+    priority = 90
+
+    action {
+      block {
+        custom_response {
+          response_code = 429
+
+          response_header {
+            name  = "Retry-After"
+            value = 30
+          }
+
+          response_header {
+            name  = "Cache-Control"
+            value = "max-age=0, private"
+          }
+
+          custom_response_body_key = "cache-public-rule-429"
+        }
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.waf_cache_rate_limit
+        aggregate_key_type = "FORWARDED_IP"
+
+        forwarded_ip_config {
+          # We expect all requests to have this header set. As we're counting,
+          #it's a good chance to verify that by matching any that don't
+          fallback_behavior = "MATCH"
+          header_name       = "true-client-ip"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "cache-public-base-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  custom_response_body {
+    key     = "cache-public-rule-429"
+    content = <<HTML
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Welcome to GOV.UK</title>
+          <style>
+            body { font-family: Arial, sans-serif; margin: 0; }
+            header { background: black; }
+            h1 { color: white; font-size: 29px; margin: 0 auto; padding: 10px; max-width: 990px; }
+            p { color: black; margin: 30px auto; max-width: 990px; }
+          </style>
+        </head>
+        <body>
+          <header><h1>GOV.UK</h1></header>
+          <p>Sorry, there have been too many attempts to access this page.</p>
+          <p>Try again in a few minutes.</p>
+        </body>
+      </html>
+      HTML
+
+    content_type = "TEXT_HTML"
+  }
+
+  rule {
+    name     = "block-autodiscover"
+    priority = 100
+    action {
+      block {
+        custom_response {
+          response_code = "404"
+        }
+      }
+    }
+
+    statement {
+      byte_match_statement {
+        field_to_match {
+          uri_path {}
+        }
+        positional_constraint = "EXACTLY"
+        search_string         = "/autodiscover/autodiscover.xml"
+        text_transformation {
+          type     = "LOWERCASE"
+          priority = 1
+        }
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "block-autodiscover"
+    }
+  }
+
+  # Silently ignore requests to the contact form with blank user agents.
+  # This was the signature of a spam attack on 2020-11-18; see doc:
+  # https://docs.google.com/document/d/12DzQsDeu7zUcICy9zVporjprX4qZFIrpOOWtYYRx-nk/edit#
+  rule {
+    name     = "drop-bad-contact-form-requests"
+    priority = 110
+
+    action {
+      block {
+        custom_response {
+          response_code = 302
+          response_header {
+            name  = "Location"
+            value = "/contact/govuk/thankyou"
+          }
+        }
+      }
+    }
+
+    statement {
+      and_statement {
+        statement {
+          byte_match_statement {
+            field_to_match {
+              uri_path {}
+            }
+            positional_constraint = "EXACTLY"
+            search_string         = "/contact/govuk"
+            text_transformation {
+              type     = "LOWERCASE"
+              priority = 0
+            }
+          }
+        }
+        statement {
+          byte_match_statement {
+            field_to_match {
+              method {}
+            }
+            positional_constraint = "EXACTLY"
+            search_string         = "POST"
+            text_transformation {
+              type     = "NONE"
+              priority = 0
+            }
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              size_constraint_statement {
+                comparison_operator = "GE"
+                size                = 1
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+                text_transformation {
+                  type     = "COMPRESS_WHITE_SPACE"
+                  priority = 0
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "drop-bad-contact-form-requests"
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "GOVUK-Chat-Web-ACLs"
+    sampled_requests_enabled   = true
+  }
+}

--- a/terraform/deployments/chat/data.tf
+++ b/terraform/deployments/chat/data.tf
@@ -32,3 +32,21 @@ data "terraform_remote_state" "infra_root_dns_zones" {
   }
 }
 
+data "aws_wafv2_rule_group" "x_always_block" {
+  name  = "x-always-block_rule_group"
+  scope = "REGIONAL"
+}
+
+data "aws_wafv2_ip_set" "govuk_requesting_ips" {
+  name  = "govuk_requesting_ips"
+  scope = "REGIONAL"
+}
+
+data "aws_wafv2_ip_set" "high_request_rate" {
+  name  = "high_request_rate"
+  scope = "REGIONAL"
+}
+
+data "aws_secretsmanager_secret_version" "fastly_token" {
+  secret_id = "govuk/govuk-chat/fastly-token"
+}

--- a/terraform/deployments/chat/variables.tf
+++ b/terraform/deployments/chat/variables.tf
@@ -63,3 +63,12 @@ variable "chat_certificate_arn" {
   description = "ARN of the TLS cert to use for the Chat CloudFront distribution."
 }
 
+variable "waf_cache_rate_warning" {
+  description = "For the cache ALB. Allows us to configure a warning level to detect what happens if we reduce the limit."
+  type        = number
+}
+
+variable "waf_cache_rate_limit" {
+  description = "For the cache ALB. Number of requests to allow in a 5 minute period before rate limiting is applied."
+  type        = number
+}


### PR DESCRIPTION
## What 

Create a WAF ACL for the Chat service

## Why

The Chat service is being moved from the shared load balancer `backend` to it's own load balancer, and this is in preparation for that move