### PR TITLE
Change Chat WAF ACL `SizeRestrictions_BODY` from `Block` to `Allow`

### DIFF
--- a/terraform/deployments/chat/alb_waf_rules.tf
+++ b/terraform/deployments/chat/alb_waf_rules.tf
@@ -23,6 +23,13 @@ resource "aws_wafv2_web_acl" "chat_waf_rules" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        rule_action_override {
+          action_to_use {
+            allow {}
+          }
+          name = "SizeRestrictions_BODY"
+        }
       }
     }
 


### PR DESCRIPTION
## What

Change Chat WAF ACL `SizeRestrictions_BODY` from `Block` to `Allow`

## Why

It is possible this rule could block some of the admin pages being accessed