### PR TITLE
Increase lifetime of non-prod db backups

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/db_backup_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/db_backup_s3.tf
@@ -103,7 +103,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "backup_main" {
     id     = "non-production"
     status = var.govuk_environment != "production" ? "Enabled" : "Disabled"
     filter {}
-    expiration { days = 2 }
+    expiration { days = 8 }
     noncurrent_version_expiration { noncurrent_days = 1 }
   }
 }


### PR DESCRIPTION
Now that integration backups occur weekly, we need to extend the lifecycle run to not delete them before new backups are available. This is useful for local development.