### PR TITLE
Remove unused cluster_infrastructure_state_bucket TF var

### DIFF
--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -33,11 +33,6 @@ variable "govuk_aws_state_bucket" {
   description = "Name of the S3 bucket used for govuk-aws's Terraform state."
 }
 
-variable "cluster_infrastructure_state_bucket" {
-  type        = string
-  description = "Name of the S3 bucket for the cluster-infrastructure module's Terraform state. Must match the name of the bucket specified in the backend config file."
-}
-
 variable "govuk_environment" {
   type        = string
   description = "Acceptable values are test, integration, staging, production"

--- a/terraform/deployments/datagovuk-infrastructure/variables.tf
+++ b/terraform/deployments/datagovuk-infrastructure/variables.tf
@@ -3,11 +3,6 @@ variable "govuk_aws_state_bucket" {
   description = "The name of the S3 bucket used for govuk-aws's Terraform state files."
 }
 
-variable "cluster_infrastructure_state_bucket" {
-  type        = string
-  description = "Name of the S3 bucket for the cluster-infrastructure module's Terraform state. Must match the name of the bucket specified in the backend config file."
-}
-
 variable "ckan_s3_organogram_bucket" {
   type        = string
   description = "Bucket for CKAN organogram data"

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -3,11 +3,6 @@ variable "govuk_aws_state_bucket" {
   description = "The name of the S3 bucket used for govuk-aws's Terraform state files."
 }
 
-variable "cluster_infrastructure_state_bucket" {
-  type        = string
-  description = "Name of the S3 bucket for the cluster-infrastructure module's Terraform state. Must match the name of the bucket specified in the backend config file."
-}
-
 variable "govuk_environment" {
   type        = string
   description = "GOV.UK environment where resources are being deployed"


### PR DESCRIPTION
Description:
- `cluster_infrastructure_state_bucket` is already contained in `variables-integration.tf` (common-integration), `variables-production.tf` (common-production) and `variables-staging.tf` (common-staging) which are pulled in through the workspace configuration
```
variable_set_names = [
    "aws-credentials-integration",
    "gcp-credentials-integration",
    "common",
    "common-integration",
    "amazonmq-integration"
]
```
- See [govuk-publishing-infrastructure](https://github.com/alphagov/govuk-infrastructure/blob/da1a5968115b165261a7af6d6549c54990b13185/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf) as an example