### PR TITLE
Import `datagovuk` namespace into Terraform

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/argo_bootstrap.tf
+++ b/terraform/deployments/datagovuk-infrastructure/argo_bootstrap.tf
@@ -9,3 +9,21 @@ resource "helm_release" "argo_bootstrap" {
     environment = var.govuk_environment
   })]
 }
+
+import {
+  to = kubernetes_namespace.datagovuk
+  id = "datagovuk"
+}
+
+resource "kubernetes_namespace" "datagovuk" {
+  metadata {
+    name = var.datagovuk_namespace
+    annotations = {
+      "argocd.argoproj.io/sync-options" = "ServerSideApply=true"
+    }
+    labels = {
+      "app.kubernetes.io/managed-by"  = "Terraform"
+      "argocd.argoproj.io/managed-by" = "cluster-services"
+    }
+  }
+}

--- a/terraform/deployments/datagovuk-infrastructure/main.tf
+++ b/terraform/deployments/datagovuk-infrastructure/main.tf
@@ -8,6 +8,14 @@ terraform {
 
   required_version = "~> 1.5"
   required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.0"
@@ -42,6 +50,12 @@ provider "aws" {
 
 data "aws_eks_cluster_auth" "cluster_token" {
   name = "govuk"
+}
+
+provider "kubernetes" {
+  host                   = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_endpoint
+  cluster_ca_certificate = base64decode(data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.cluster_token.token
 }
 
 provider "helm" {

--- a/terraform/deployments/datagovuk-infrastructure/variables.tf
+++ b/terraform/deployments/datagovuk-infrastructure/variables.tf
@@ -24,3 +24,9 @@ variable "govuk_environment" {
   type        = string
   description = "Acceptable values are test, integration, staging, production"
 }
+
+variable "datagovuk_namespace" {
+  type        = string
+  description = "Name of the namespace to create for ArgoCD to deploy DGU apps into by default."
+  default     = "datagovuk"
+}


### PR DESCRIPTION
Description:
- Following prior art for the `apps` namespace [here](https://github.com/alphagov/govuk-infrastructure/blob/61bc6d540f08cbf5461692516cfd981f66bdcc16/terraform/deployments/cluster-services/argo.tf#L26)
- Currently running `kubectl get ns datagovuk` reveals no annotations indicating it isn't managed by ArgoCD
- In order for PSS baseline to be enabled certain annotations need to be added to the namespace. But without using Terraform the alternative would be to directly modify the DGU Argo application files [here](https://github.com/alphagov/govuk-dgu-charts/tree/ebf311d645ed911b3cbbe2d093418389d671072a/charts/app-of-apps/templates)
- It is simple and easier to let Terraform handle the namespace
- Part of https://github.com/alphagov/govuk-helm-charts/issues/1883