### PR TITLE
Set DGU PSS to baseline

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/argo_bootstrap.tf
+++ b/terraform/deployments/datagovuk-infrastructure/argo_bootstrap.tf
@@ -10,11 +10,6 @@ resource "helm_release" "argo_bootstrap" {
   })]
 }
 
-import {
-  to = kubernetes_namespace.datagovuk
-  id = "datagovuk"
-}
-
 resource "kubernetes_namespace" "datagovuk" {
   metadata {
     name = var.datagovuk_namespace
@@ -22,8 +17,11 @@ resource "kubernetes_namespace" "datagovuk" {
       "argocd.argoproj.io/sync-options" = "ServerSideApply=true"
     }
     labels = {
-      "app.kubernetes.io/managed-by"  = "Terraform"
-      "argocd.argoproj.io/managed-by" = "cluster-services"
+      "app.kubernetes.io/managed-by"       = "Terraform"
+      "argocd.argoproj.io/managed-by"      = "cluster-services"
+      "pod-security.kubernetes.io/audit"   = "restricted"
+      "pod-security.kubernetes.io/enforce" = "baseline"
+      "pod-security.kubernetes.io/warn"    = "restricted"
     }
   }
 }


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/1499 imported `datagovuk` namespace into Terraform so now we can remove the `import`
- Set Pod Security Standards (PSS) to enforce `baseline` but audit and warn on `restricted` by adding the relevant [annotations](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces)
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883