### PR TITLE
Upgrade Argo Workflows from `3.5.8` to `3.5.12`

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -184,7 +184,7 @@ resource "helm_release" "argo_workflows" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "0.41.11" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.42.7" # TODO: Dependabot or equivalent so this doesn't get neglected.
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     controller = {


### PR DESCRIPTION
Description:
- Previous version: `0.41.11` corresponds to `3.5.8`
- New version: `0.42.7` corresponds to `v3.5.12`
- Part of https://github.com/alphagov/govuk-helm-charts/issues/1883