### PR TITLE
Enforce Argo Workflow controller to be compliant with PSS restricted

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -188,7 +188,19 @@ resource "helm_release" "argo_workflows" {
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     controller = {
-      podSecurityContext = { runAsNonRoot = true }
+      podSecurityContext = {
+        runAsNonRoot = true
+        seccompProfile = {
+          type = "RuntimeDefault"
+        }
+      }
+      securityContext = {
+        readOnlyRootFilesystem   = true
+        allowPrivilegeEscalation = false
+        capabilities = {
+          drop = ["ALL"]
+        }
+      }
       workflowNamespaces = concat([local.services_ns], var.argo_workflows_namespaces)
       workflowDefaults = {
         spec = {


### PR DESCRIPTION
Description:
- Enforce the Argo workflow controller to be compliant when PSS is said to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Helm values for this chart are found [here](https://github.com/argoproj/argo-helm/blob/main/charts/argo-workflows/values.yaml)
- `SecurityContext` in the Helm chart has sensible defaults but it is better to define it explicitly here
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883