### PR TITLE
Enforce Argo workflow server to be compliant with PSS restricted

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -308,6 +308,19 @@ resource "helm_release" "argo_workflows" {
           memory = "512Mi"
         }
       }
+      podSecurityContext = {
+        runAsNonRoot = true
+        seccompProfile = {
+          type = "RuntimeDefault"
+        }
+      }
+      securityContext = {
+        readOnlyRootFilesystem   = true
+        allowPrivilegeEscalation = false
+        capabilities = {
+          drop = ["ALL"]
+        }
+      }
       replicas = var.desired_ha_replicas
     }
   })]


### PR DESCRIPTION
Description:
- Enforce the Argo workflow server to be compliant when PSS is said to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
- Helm values for this chart are found [here](https://github.com/argoproj/argo-helm/blob/main/charts/argo-workflows/values.yaml)
- `SecurityContext` in the Helm chart has sensible defaults but it is better to define it explicitly here
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883