### PR TITLE
Enforce Argo Workflow pods to be compliant with PSS restricted

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -216,6 +216,11 @@ resource "helm_release" "argo_workflows" {
           securityContext = {
             runAsNonRoot = true
             runAsUser    = 1001
+            runAsGroup   = 1001
+            fsGroup      = 1001
+            seccompProfile = {
+              type = "RuntimeDefault"
+            }
           }
           podSpecPatch = yamlencode({
             containers = [
@@ -259,6 +264,23 @@ resource "helm_release" "argo_workflows" {
         limits = {
           cpu    = "500m"
           memory = "512Mi"
+        }
+      }
+      securityContext = {
+        readOnlyRootFilesystem   = true
+        allowPrivilegeEscalation = false
+        capabilities = {
+          drop = ["ALL"]
+        }
+      }
+    }
+
+    mainContainer = {
+      securityContext = {
+        readOnlyRootFilesystem   = true
+        allowPrivilegeEscalation = false
+        capabilities = {
+          drop = ["ALL"]
         }
       }
     }


### PR DESCRIPTION
Description:
- Each step in a Workflow creates a (i) init, (ii) main and a (iii) wait container. By default the Workflow pods for each step run as root.
- The default executor for Argo Workflows is [emissary](https://argo-workflows.readthedocs.io/en/latest/workflow-executors/) which configures the customization for the `init` and `wait` containers. The Helm values for the executor are found [here](https://github.com/argoproj/argo-helm/blob/main/charts/argo-workflows/values.yaml)
- Since emissary according to [this commit]() mounts an `emptyDir` in all containers this allows us to set `readOnlyRootFileSystem`
- Lock down the `securityContext` and `podSecurityContext` to ensure compliance with PSS restricted. Note that `securityContext` under `workflowDefaults` is really `podSecurityContext`
- Part of https://github.com/alphagov/govuk-helm-charts/issues/1883