### PR TITLE
Fix Argo Workflow `govuk-e2e-test` read-only-file-system error

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -267,7 +267,6 @@ resource "helm_release" "argo_workflows" {
         }
       }
       securityContext = {
-        readOnlyRootFilesystem   = true
         allowPrivilegeEscalation = false
         capabilities = {
           drop = ["ALL"]
@@ -277,7 +276,6 @@ resource "helm_release" "argo_workflows" {
 
     mainContainer = {
       securityContext = {
-        readOnlyRootFilesystem   = true
         allowPrivilegeEscalation = false
         capabilities = {
           drop = ["ALL"]


### PR DESCRIPTION
Description:
- Currently the `govuk-e2e-tests` step in Argo Workflows is giving this error:

```
yarn run v1.22.19
error Could not write file "/app/yarn-error.log": "EROFS: read-only file system, open '/app/yarn-error.log'"
error An unexpected error occurred: "EROFS: read-only file system, mkdir '/tmp/.cache'".
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
time="2024-11-19T12:40:29 UTC" level=info msg="sub-process exited" argo=true error="<nil>"
Error: exit status 1
```
- This is due to the addition of `readOnlyRootFilesystem = true` in the `securityContext` of the workflow pod in https://github.com/alphagov/govuk-infrastructure/pull/1508
- Removing the restriction will allow `govuk-e2e-tests` to write to `/app` and allow the workflow to complete