### PR TITLE
Enable ARM Workers pool on Staging

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -29,7 +29,8 @@ module "variable-set-staging" {
       c = { az = "eu-west-1c", cidr = "10.12.32.0/22" }
     }
 
-    govuk_environment = "staging"
+    govuk_environment  = "staging"
+    enable_arm_workers = true
 
     publishing_service_domain = "staging.publishing.service.gov.uk"
 


### PR DESCRIPTION
## What?
As part of our gradual transition to ARM workloads, we would like to enable ARM support for our Staging cluster. Just like Integration, this change will allow us to run ARM and x86 workloads side-by-side while we check compatibility and update helm charts to select the different architecture.