### PR TITLE
Enforce `readOnlyRootFileSystem` for Argo Workflows:

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -267,6 +267,7 @@ resource "helm_release" "argo_workflows" {
         }
       }
       securityContext = {
+        readOnlyRootFilesystem   = true
         allowPrivilegeEscalation = false
         capabilities = {
           drop = ["ALL"]
@@ -276,6 +277,7 @@ resource "helm_release" "argo_workflows" {
 
     mainContainer = {
       securityContext = {
+        readOnlyRootFilesystem   = true
         allowPrivilegeEscalation = false
         capabilities = {
           drop = ["ALL"]


### PR DESCRIPTION
Description:
- Previously `govuk-e2e-tests` was giving an error due to `readOnlyRootFileSystem: true` (see [here](https://github.com/alphagov/govuk-infrastructure/pull/1510)) but this has now been fixed in https://github.com/alphagov/govuk-helm-charts/pull/2781
- Now we can turn on `readOnlyRootFileSystem`
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883