### PR TITLE
Enable pre-commit on Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,8 @@
         "matchDepTypes": ["helm_release", "provider", "tfe_workspace"]
       }
     ]
+  },
+  "pre-commit": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
Description:
- Enable Renovate to automate updates for `pre-commit-hooks`, `detect-secrets` and `pre-commit-terraform`