### PR TITLE
allow CI pipeline to delete files from mobile backend

### DIFF
--- a/terraform/deployments/mobile-backend/gha-iam-role.tf
+++ b/terraform/deployments/mobile-backend/gha-iam-role.tf
@@ -53,7 +53,8 @@ data "aws_iam_policy_document" "bucket_write_role_permissions" {
   statement {
     actions = [
       "s3:PutObject",
-      "s3:ListBucket"
+      "s3:ListBucket",
+      "s3:DeleteObject"
     ]
     resources = [
       aws_s3_bucket.mobile_backend_remote_config.arn,


### PR DESCRIPTION
We're updating our CI pipeline to tidy up files when they are no longer needed by the backend config (using an `aws s3 sync --delete` operation). This needs the `s3:DeleteObject` action to be permitted on the IAM policy that is applied to the CI pipeline