### PR TITLE
Remove Terraform configuration from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,17 +4,6 @@
     "config:base"
   ],
   "platformAutomerge": true,
-  "terraform":{
-    "commitMessageTopic": "Terraform {{depName}}",
-    "fileMatch": [
-      "\\.tf$"
-    ],
-    "packageRules": [
-      {
-        "matchDepTypes": ["helm_release", "provider", "tfe_workspace"]
-      }
-    ]
-  },
   "pre-commit": {
     "enabled": true
   }


### PR DESCRIPTION
Description:
- Renovate is [currently disabled](https://github.com/alphagov/govuk-helm-charts/pull/1950) for `govuk-infrastructure` due to too many dependencies. Since we aren't using it for Terraform we can remove the Terraform configuration and use it for `pre-commit`