### PR TITLE
Remove `readOnlyRootFileSystem` from Argo Workflows

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -267,7 +267,6 @@ resource "helm_release" "argo_workflows" {
         }
       }
       securityContext = {
-        readOnlyRootFilesystem   = true
         allowPrivilegeEscalation = false
         capabilities = {
           drop = ["ALL"]
@@ -277,7 +276,6 @@ resource "helm_release" "argo_workflows" {
 
     mainContainer = {
       securityContext = {
-        readOnlyRootFilesystem   = true
         allowPrivilegeEscalation = false
         capabilities = {
           drop = ["ALL"]


### PR DESCRIPTION
Description:
- `update-image-tag` step in production is failing due to:
```
error: could not lock config file /home/user/.gitconfig: Read-only file system
time="2024-11-20T11:25:20 UTC" level=info msg="sub-process exited" argo=true error="<nil>"
Error: exit status 255
```
- Remove the restriction on Argo Workflows to enable `update-image-tag` step to work
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883