### PR TITLE
Only enable `pre-commit` manager in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,6 @@
   "platformAutomerge": true,
   "pre-commit": {
     "enabled": true
-  }
+  },
+  "enabledManagers": ["pre-commit"]
 }


### PR DESCRIPTION
Description:
- Since we are only tracking `pre-commit` dependencies ensure that other in-built managers are disabled (see https://github.com/alphagov/govuk-infrastructure/pull/1515)