### PR TITLE
Update Slack channel name for Signon token expiry alerts

### DIFF
--- a/terraform/deployments/cluster-services/templates/alertmanager-config.tpl
+++ b/terraform/deployments/cluster-services/templates/alertmanager-config.tpl
@@ -42,7 +42,7 @@ alertmanager:
         client_url: "https://${alertmanager_host}/#/alerts?receiver={{ .Receiver | urlquery }}"
     - name: 'slack-signon-token-expiry'
       slack_configs:
-      - channel: '#govuk-2ndline-tech'
+      - channel: '#govuk-publishing-platform-system-alerts'
         send_resolved: true
         icon_url: https://avatars3.githubusercontent.com/u/3380462
         title: |-


### PR DESCRIPTION
Most of these alerts are already coming into this channel, and the channel #govuk-2ndline-tech is no more. Let's just put all Signon token related alerts into Publishing Platform's alerts channel.