### PR TITLE
Add govuk_content_block_tools repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -369,6 +369,13 @@ repos:
       additional_contexts:
         - test
 
+  govuk_content_block_tools:
+    homepage_url: "https://rubygems.org/gems/content_block_tools"
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
+
   govuk_personalisation:
     homepage_url: "https://github.com/alphagov/govuk_personalisation"
     required_status_checks:


### PR DESCRIPTION
This adds the new [govuk_content_block_tools](https://github.com/alphagov/govuk_content_block_tools) repo, so the various Github settings etc can be automagically applied.