### PR TITLE
Update workflow to support standard format `CHANGELOG` files

### DIFF
--- a/.github/workflows/autorelease-rubygem.yml
+++ b/.github/workflows/autorelease-rubygem.yml
@@ -73,9 +73,13 @@ jobs:
 
         find . -type f \( -iname "version.rb" -o -iname "*.gemspec" \) -exec sed -i "0,/$curr_ver/s//${next_ver}/" {} \;
 
-        printf "# %s\n\n* Update dependencies\n\n" "$next_ver" > NEW_CHANGELOG.md
-        cat CHANGELOG.md >> NEW_CHANGELOG.md
-        mv NEW_CHANGELOG.md CHANGELOG.md
+        if [[ $(head -n1 CHANGELOG.md) == "# Changelog" ]]; then
+          sed -i "s/# Changelog/# Changelog\n\n## $next_ver\n\n* Update dependencies/" CHANGELOG.md
+        else
+          printf "# %s\n\n* Update dependencies\n\n" "$next_ver" > NEW_CHANGELOG.md
+          cat CHANGELOG.md >> NEW_CHANGELOG.md
+          mv NEW_CHANGELOG.md CHANGELOG.md
+        fi
 
         git config --global user.name "GOV.UK Continuous Integration User"
         git config --global user.email "govuk-ci@users.noreply.github.com"


### PR DESCRIPTION
At the moment, the gem autorelease workflow only supports `CHANGELOG` fles that have version numbers with h1 level headings.

Whilst this format is used in most GOV.UK gems, there are some that have been updated to use the more standard format with a single h1 and then h2 level headings for each version.

This latter format meets accessibility standards by only having a single h1 on the page and appears to be a [community standard](https://keepachangelog.com/en/1.1.0/).

Therefore updating the gem autorelease workflow to support both types of file.