### PR TITLE
Revert "Set `readOnlyRootFileSystem = true` on `main` and `init` and `wait` containers for Argo Workflow pods"

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -267,7 +267,6 @@ resource "helm_release" "argo_workflows" {
         }
       }
       securityContext = {
-        readOnlyRootFileSystem   = true
         allowPrivilegeEscalation = false
         capabilities = {
           drop = ["ALL"]
@@ -277,7 +276,6 @@ resource "helm_release" "argo_workflows" {
 
     mainContainer = {
       securityContext = {
-        readOnlyRootFileSystem   = true
         allowPrivilegeEscalation = false
         capabilities = {
           drop = ["ALL"]


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#1530