### PR TITLE
Set `readOnlyRootFileSystem` on Argo Workflow pods

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -267,6 +267,7 @@ resource "helm_release" "argo_workflows" {
         }
       }
       securityContext = {
+        readOnlyRootFileSystem   = true
         allowPrivilegeEscalation = false
         capabilities = {
           drop = ["ALL"]
@@ -276,6 +277,7 @@ resource "helm_release" "argo_workflows" {
 
     mainContainer = {
       securityContext = {
+        readOnlyRootFileSystem   = true
         allowPrivilegeEscalation = false
         capabilities = {
           drop = ["ALL"]


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/1516 failed because `update-image-step` was writing to `/home/user`
- Because of https://github.com/alphagov/govuk-helm-charts/pull/2792 and https://github.com/alphagov/govuk-helm-charts/pull/2793 `update-image-tag` now sets `.gitconfig` to `/tmp` mounted from a volume allowing us to set `readOnlyRootFileSystem`
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883