### PR TITLE
repos: add govuk-display-screen to repos yml

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -214,3 +214,8 @@ import {
   id = "govuk-e2e-tests"
   to = github_repository.govuk_repos["govuk-e2e-tests"]
 }
+
+import {
+  id = "govuk-display-screen"
+  to = github_repository.govuk_repos["govuk-display-screen"]
+}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -276,6 +276,9 @@ repos:
     need_production_access_to_merge: false
     allow_squash_merge: true
     standard_contexts: *standard_security_checks
+    teams: {
+      govuk: "maintain"
+      }
 
   govuk-dns-tf:
     strict: true

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -271,6 +271,11 @@ repos:
     need_production_access_to_merge: false
     allow_squash_merge: true
     push_allowances: []
+  
+  govuk-display-screen:
+    need_production_access_to_merge: false
+    allow_squash_merge: true
+    standard_contexts: *standard_security_checks
 
   govuk-dns-tf:
     strict: true


### PR DESCRIPTION
Our team `#govuk-insights-and-analytics-team` now owns the `govuk-display-screen` repository.

In order to be able to push and merge PRs, and entry must be added to `repos.yml` in accordance with the [developer docs](https://docs.publishing.service.gov.uk/manual/github-new-repo.html).

### Question

The goal is to give our github team `@alphagov/gov-uk-data` the permissions to perform push and merge on this repository.
Will these changes allow that? It's not clear to me how this yml  file works.