### PR TITLE
Add additional security controls on mobile config bucket

### DIFF
--- a/terraform/deployments/mobile-backend/config-bucket.tf
+++ b/terraform/deployments/mobile-backend/config-bucket.tf
@@ -5,7 +5,8 @@ resource "aws_s3_bucket" "mobile_backend_remote_config" {
 resource "aws_s3_bucket_versioning" "mobile_backend_remote_config" {
   bucket = aws_s3_bucket.mobile_backend_remote_config.id
   versioning_configuration {
-    status = "Enabled"
+    status     = "Enabled"
+    mfa_delete = "Enabled"
   }
 }
 
@@ -30,6 +31,13 @@ data "aws_iam_policy_document" "mobile_backend_remote_config_fastly_read" {
       variable = "aws:SourceIp"
 
       values = data.fastly_ip_ranges.fastly.cidr_blocks
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+
+      values = ["true"]
     }
 
     principals {


### PR DESCRIPTION
Following an external pen test, two areas have been highlighted where we could enhance the security of our mobile config S3 bucket. Namely:

- enable MFA delete
- configure secure transport policy

Both of these seem fairly minor to me given the nature of the bucket, how we're using it, and what's inside it, but we may as well update the configuration to reflect the suggestions.
