### PR TITLE
Add AWS EFS CSI Driver Terraform

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_efs_csi_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_efs_csi_iam.tf
@@ -1,0 +1,251 @@
+locals {
+  efs_csi_driver_controller_service_account_name = "efs-csi-controller-sa"
+}
+
+module "aws_efs_csi_driver_iam_role" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "~> 5.0"
+  create_role                   = true
+  role_name                     = "${local.efs_csi_driver_controller_service_account_name}-${var.cluster_name}"
+  role_description              = "Role for the AWS EFS CSI driver controller. Corresponds to ${local.efs_csi_driver_controller_service_account_name} k8s ServiceAccount."
+  provider_url                  = module.eks.oidc_provider
+  role_policy_arns              = [aws_iam_policy.aws_efs_csi_driver.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:${local.efs_csi_driver_controller_service_account_name}"]
+}
+
+data "aws_iam_policy_document" "aws_efs_csi_driver" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "elasticfilesystem:DescribeAccessPoints",
+      "elasticfilesystem:DescribeFileSystems",
+      "elasticfilesystem:DescribeMountTargets",
+      "ec2:DescribeAvailabilityZones"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "elasticfilesystem:CreateAccessPoint"
+    ]
+
+    resources = [
+      "arn:aws:ec2:*:*:volume/*",
+      "arn:aws:ec2:*:*:snapshot/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:CreateAction"
+      values   = ["CreateVolume", "CreateSnapshot"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:DeleteTags"
+    ]
+
+    resources = [
+      "arn:aws:ec2:*:*:volume/*",
+      "arn:aws:ec2:*:*:snapshot/*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateVolume"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/ebs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateVolume"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/CSIVolumeName"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateVolume"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/kubernetes.io/cluster/*"
+      values   = ["owned"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:DeleteVolume"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/ebs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:DeleteVolume"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/CSIVolumeName"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:DeleteVolume"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/kubernetes.io/cluster/*"
+      values   = ["owned"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:DeleteSnapshot"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/CSIVolumeSnapshotName"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "elasticfilesystem:CreateAccessPoint"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/efs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "elasticfilesystem:TagResource"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/efs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "elasticfilesystem:DeleteAccessPoint"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/efs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "aws_efs_csi_driver" {
+  name        = "AWSEfsCsiController-${var.cluster_name}"
+  description = "Allow the driver to manage AWS EFS"
+
+  # Verbatim contents of
+  # https://raw.githubusercontent.com/kubernetes-sigs/aws-efs-csi-driver/refs/heads/master/docs/iam-policy-example.json
+  # (except for whitespace changes from terraform fmt).
+  policy = data.aws_iam_policy_document.aws_efs_csi_driver.json
+}

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -18,6 +18,11 @@ output "aws_ebs_csi_driver_iam_role_arn" {
   value       = module.aws_ebs_csi_driver_iam_role.iam_role_arn
 }
 
+output "aws_efs_csi_driver_iam_role_arn" {
+  description = "IAM role ARN for AWS EFS CSI controller role"
+  value       = module.aws_efs_csi_driver_iam_role.iam_role_arn
+}
+
 output "control_plane_security_group_id" {
   description = "ID of the security group which contains the (AWS-owned) control plane nodes."
   value       = module.eks.cluster_primary_security_group_id
@@ -106,6 +111,11 @@ output "aws_lb_controller_service_account_name" {
 output "aws_ebs_csi_driver_controller_service_account_name" {
   description = "Name of the k8s service account for the AWS EBS CSI Controller"
   value       = local.ebs_csi_driver_controller_service_account_name
+}
+
+output "aws_efs_csi_driver_controller_service_account_name" {
+  description = "Name of the k8s service account for the AWS EFS CSI Controller"
+  value       = local.efs_csi_driver_controller_service_account_name
 }
 
 output "grafana_iam_role_arn" {


### PR DESCRIPTION
Description:
- Add a statically provisioned EFS CSI Driver as part of a series of PRs to move asset-manager from `nfs` volume type. This is because dynamic provisioning causes errors - see https://trello.com/c/2XkadNJ2/1011-resolve-asset-manager-pvc-related-errors
- PR only setups the IAM roles for the EFS CSI Driver. Follow up PR will install the EFS CSI driver.
- See https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883