### PR TITLE
Add AWS EFS CSI Driver

### DIFF
--- a/terraform/deployments/cluster-services/aws_efs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_efs_csi_driver.tf
@@ -1,0 +1,24 @@
+resource "helm_release" "efs_csi_driver" {
+  chart      = "aws-efs-csi-driver"
+  name       = "aws-efs-csi-driver"
+  namespace  = "kube-system"
+  repository = "https://kubernetes-sigs.github.io/aws-efs-csi-driver"
+  version    = "3.1.1" # TODO: Dependabot or equivalent so this doesn't get neglected.
+
+  values = [yamlencode({
+    controller = {
+      serviceAccount = {
+        create = true
+        name   = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.aws_efs_csi_driver_controller_service_account_name
+        annotations = {
+          "eks.amazonaws.com/role-arn" = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.aws_efs_csi_driver_iam_role_arn
+        }
+      }
+    }
+    storageClasses = [{
+      name          = "efs-sc"
+      apiVersion    = "storage.k8s.io/v1"
+      reclaimPolicy = "Retain"
+    }]
+  })]
+}

--- a/terraform/deployments/cluster-services/remote.tf
+++ b/terraform/deployments/cluster-services/remote.tf
@@ -11,3 +11,8 @@ data "tfe_outputs" "vpc" {
   organization = "govuk"
   workspace    = "vpc-${var.govuk_environment}"
 }
+
+data "tfe_outputs" "govuk_publishing_infrastructure" {
+  organization = "govuk"
+  workspace    = "govuk-publishing-infrastructure-${var.govuk_environment}"
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/outputs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/outputs.tf
@@ -1,3 +1,8 @@
 output "eks_ingress_www_origin_security_group_name" {
   value = aws_security_group.eks_ingress_www_origin.name
 }
+
+output "assets_efs_id" {
+  description = "EFS Filesystem ID for assets"
+  value       = aws_efs_file_system.assets_efs.id
+}


### PR DESCRIPTION
Description:
- Adds a statically provisioned EFS CSI Driver as part of a series of PRs to move asset-manager from `nfs` volume type. This shouldn't affect the current NFS setup as it only provisions the driver not call the RPCs on it
- https://github.com/alphagov/govuk-infrastructure/pull/1549 added the IAM roles for EKS nodes to access EFS
- See https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/ for configuration details
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883