### PR TITLE
Allow GOV.UK "Power Users" to list k8s Namespaces

### DIFF
--- a/terraform/deployments/cluster-services/aws_auth_configmap.tf
+++ b/terraform/deployments/cluster-services/aws_auth_configmap.tf
@@ -127,10 +127,17 @@ resource "kubernetes_cluster_role_binding" "read_crs_and_crbs" {
 
 resource "kubernetes_cluster_role" "poweruser" {
   metadata { name = "poweruser" }
+
   rule {
     api_groups = ["*"]
     resources  = ["*"]
     verbs      = ["*"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces"]
+    verbs      = ["get", "list"]
   }
 }
 


### PR DESCRIPTION
## What?
At present, users with the `poweruser` Role are unable to run things like `kubectl get namespaces` or any alias tools such as `kubens` that are dependant on being able to execute the "get" or "list" verbs on namespace resources in the legacy "blank" apiGroup.

This should hopefully address the issue so that "Power Users" can still view namespaces in the EKS Clusters without needing to use the Cluster Admin role.

## How?
Merge this PR, then apply the Terraform.

Terraform Plan (Integration):
```
  # kubernetes_cluster_role.poweruser will be updated in-place
  ~ resource "kubernetes_cluster_role" "poweruser" {
        id = "poweruser"

      + rule {
          + api_groups = [
              + null,
            ]
          + resources  = [
              + "namespaces",
            ]
          + verbs      = [
              + "get",
              + "list",
            ]
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```