### PR TITLE
Allow EBS CSI driver role to perform ec2:CreateVolume on snapshots

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_ebs_csi_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_ebs_csi_iam.tf
@@ -91,6 +91,18 @@ data "aws_iam_policy_document" "aws_ebs_csi_driver" {
     ]
 
     resources = [
+      "arn:*:ec2:*:*:snapshot/*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateVolume"
+    ]
+
+    resources = [
       "*"
     ]
 


### PR DESCRIPTION
This is required because AWS is going to start checking permissions on snapshots when creating a volume from one

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2190

Closes https://github.com/alphagov/govuk-infrastructure/issues/1546