### PR TITLE
Add BatchGet IAM permission for External Secrets

### DIFF
--- a/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
@@ -35,7 +35,8 @@ data "aws_iam_policy_document" "external_secrets" {
       "secretsmanager:GetResourcePolicy",
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",
-      "secretsmanager:ListSecretVersionIds"
+      "secretsmanager:ListSecretVersionIds",
+      "secretsmanager:BatchGetSecretValue"
     ]
 
     resources = [


### PR DESCRIPTION
External Secrets now support bulk fetching secrets to reduce AWS API calls. This adds the IAM permission to support this feature,