### PR TITLE
Brakeman: return a zero status code if any warnings are found

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -21,9 +21,9 @@ jobs:
           bundler-cache: true
 
       - name: Run Brakeman
-        continue-on-error: true
         run: |
           bundle exec brakeman . --except CheckRenderInline --quiet \
+            --no-exit-on-warn --no-exit-on-error \
             -o brakeman.json -o brakeman.sarif
 
       - name: Upload SARIF to GitHub


### PR DESCRIPTION
Brakeman [returns a non-zero status code](https://brakemanscanner.org/docs/options/) when there are warnings found or errors during the scan.

In 9fc187bb67bec2837df429fd3c26cefbf3452978, we allowed the GitHub Action to continue on error, so that the warning/error would be uploaded to GitHub code scanning.

However the non-zero status code still gets written to the GitHub Action output. This led to confusion in
https://github.com/alphagov/asset-manager/pull/1583 as we thought the error meant brakeman did not complete properly, when in fact it did but was only returning that code because a code scanning warning had been found.

Therefore updating the brakeman configuration to report a zero status code when a warning or error is found. This means we can remove the previous change, as any completed run will not return a non-zero status code. This will also stop the non-zero code causing confusion in the GitHub Actions output.

[Trello card](https://trello.com/c/p1A4ztJl)