### PR TITLE
Create legacy subnet variables

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -29,6 +29,26 @@ module "variable-set-integration" {
       c = { az = "eu-west-1c", cidr = "10.1.32.0/22" }
     }
 
+    legacy_public_subnets = {
+      a = { az = "eu-west-1a", cidr = "10.1.1.0/24" }
+      b = { az = "eu-west-1b", cidr = "10.1.2.0/24" }
+      c = { az = "eu-west-1c", cidr = "10.1.3.0/24" }
+    }
+
+    legacy_private_subnets = {
+      a = { az = "eu-west-1a", cidr = "10.1.4.0/24" }
+      b = { az = "eu-west-1b", cidr = "10.1.5.0/24" }
+      c = { az = "eu-west-1c", cidr = "10.1.6.0/24" }
+
+      rds_a = { az = "eu-west-1a", cidr = "10.1.10.0/24" }
+      rds_b = { az = "eu-west-1b", cidr = "10.1.11.0/24" }
+      rds_c = { az = "eu-west-1c", cidr = "10.1.12.0/24" }
+
+      elasticache_a = { az = "eu-west-1a", cidr = "10.1.7.0/24" }
+      elasticache_b = { az = "eu-west-1b", cidr = "10.1.8.0/24" }
+      elasticache_c = { az = "eu-west-1c", cidr = "10.1.9.0/24" }
+    }
+
     govuk_environment  = "integration"
     force_destroy      = true
     enable_arm_workers = true

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -29,6 +29,26 @@ module "variable-set-production" {
       c = { az = "eu-west-1c", cidr = "10.13.32.0/22" }
     }
 
+    legacy_public_subnets = {
+      a = { az = "eu-west-1a", cidr = "10.13.1.0/24" }
+      b = { az = "eu-west-1b", cidr = "10.13.2.0/24" }
+      c = { az = "eu-west-1c", cidr = "10.13.3.0/24" }
+    }
+
+    legacy_private_subnets = {
+      a = { az = "eu-west-1a", cidr = "10.13.4.0/24" }
+      b = { az = "eu-west-1b", cidr = "10.13.5.0/24" }
+      c = { az = "eu-west-1c", cidr = "10.13.6.0/24" }
+
+      rds_a = { az = "eu-west-1a", cidr = "10.13.10.0/24" }
+      rds_b = { az = "eu-west-1b", cidr = "10.13.11.0/24" }
+      rds_c = { az = "eu-west-1c", cidr = "10.13.12.0/24" }
+
+      elasticache_a = { az = "eu-west-1a", cidr = "10.13.7.0/24" }
+      elasticache_b = { az = "eu-west-1b", cidr = "10.13.8.0/24" }
+      elasticache_c = { az = "eu-west-1c", cidr = "10.13.9.0/24" }
+    }
+
     govuk_environment = "production"
 
     publishing_service_domain = "publishing.service.gov.uk"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -29,6 +29,26 @@ module "variable-set-staging" {
       c = { az = "eu-west-1c", cidr = "10.12.32.0/22" }
     }
 
+    legacy_public_subnets = {
+      a = { az = "eu-west-1a", cidr = "10.12.1.0/24" }
+      b = { az = "eu-west-1b", cidr = "10.12.2.0/24" }
+      c = { az = "eu-west-1c", cidr = "10.12.3.0/24" }
+    }
+
+    legacy_private_subnets = {
+      a = { az = "eu-west-1a", cidr = "10.12.4.0/24" }
+      b = { az = "eu-west-1b", cidr = "10.12.5.0/24" }
+      c = { az = "eu-west-1c", cidr = "10.12.6.0/24" }
+
+      rds_a = { az = "eu-west-1a", cidr = "10.12.10.0/24" }
+      rds_b = { az = "eu-west-1b", cidr = "10.12.11.0/24" }
+      rds_c = { az = "eu-west-1c", cidr = "10.12.12.0/24" }
+
+      elasticache_a = { az = "eu-west-1a", cidr = "10.12.7.0/24" }
+      elasticache_b = { az = "eu-west-1b", cidr = "10.12.8.0/24" }
+      elasticache_c = { az = "eu-west-1c", cidr = "10.12.9.0/24" }
+    }
+
     govuk_environment  = "staging"
     enable_arm_workers = true
 


### PR DESCRIPTION
These are the old subnets from govuk-aws, some resources are still using them

#1127 