### PR TITLE
Allow secrets to be set when building image

### DIFF
--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -22,6 +22,10 @@ on:
         required: false
         type: string
         default: ${{ github.sha }}
+    secrets:
+      BUILD_SECRETS:
+        description: "Allows adding secrets to the docker build task - https://docs.docker.com/build/ci/github-actions/secrets"
+        required: false
     outputs:
       imageTag:
         description: "The image tag for the built image"
@@ -91,6 +95,7 @@ jobs:
           outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=build-${{ inputs.imageName }}-${{ matrix.arch }}
           cache-to: type=gha,scope=build-${{ inputs.imageName }}-${{ matrix.arch }},mode=max
+          secrets: ${{ secrets.BUILD_SECRETS }}
 
       - id: export-digests
         env:


### PR DESCRIPTION
This adds an optional configuration for allowing the calling workflow to set one or more build secrets, which get passed in to the `build-image` step.

The driver for this is the GOV.UK Chat Rails app which has a private gem dependency. In order to run `bundle install` when building that app, we need a secret token set, which we'll access via secret mounts in the Dockerfile[1]. In order to mount the secret, we need to pass it in using the `secrets` option in the docker/build-push-action action[2].

This change is backwards-compatible with existing callers of the workflow, as omitting the secret has no effect on the build step.

[1] https://docs.docker.com/build/ci/github-actions/secrets/
[2] https://github.com/docker/build-push-action?tab=readme-ov-file#inputs