### PR TITLE
Extend Rubocop workflow to allow setting of Github token

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -2,6 +2,10 @@ name: Run RuboCop
 
 on:
   workflow_call:
+    secrets:
+      BUNDLER_GITHUB_TOKEN:
+        required: false
+        description: "Token used for Bundler to authenticate when installing gems from private Github repos"
 
 jobs:
   run-rubocop:
@@ -16,6 +20,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+        env:
+          BUNDLE_GITHUB__COM: "x-access-token:${{ secrets.BUNDLER_GITHUB_TOKEN }}"
 
       - name: Run RuboCop
         run: bundle exec rubocop --parallel --format github --format progress


### PR DESCRIPTION
This allows workflows which call this reusable workflow to optionally set a
`BUNDLER_GITHUB_TOKEN` secret.

Setting a value for this token will set a `BUNDLE_GITHUB__COM` environment
variable in the `setup-ruby` step. This env var is an authentication
string which Bundler will use when attempting to install gems from
private repositories on Github.

Note: this is backwards-compatible. Omitting this secret when calling the 
workflow has no effect on installing gems from Rubygems, or public gems 
from Github. It only takes effect when installing gems from a private Github repo.
