### PR TITLE
Extend Ruby workflows to allow setting of Github token

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -2,6 +2,10 @@ name: Run Brakeman
 
 on:
   workflow_call:
+    secrets:
+      BUNDLER_GITHUB_TOKEN:
+        required: false
+        description: "Token used for Bundler to authenticate when installing gems from private Github repos"
 
 jobs:
   run-brakeman:
@@ -19,6 +23,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+        env:
+          BUNDLE_GITHUB__COM: "x-access-token:${{ secrets.BUNDLER_GITHUB_TOKEN }}"
 
       - name: Run Brakeman
         run: |

--- a/.github/workflows/erblint.yml
+++ b/.github/workflows/erblint.yml
@@ -2,6 +2,10 @@ name: Run Erb Lint
 
 on:
   workflow_call:
+    secrets:
+      BUNDLER_GITHUB_TOKEN:
+        required: false
+        description: "Token used for Bundler to authenticate when installing gems from private Github repos"
 
 jobs:
   run-erblint:
@@ -16,6 +20,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+        env:
+          BUNDLE_GITHUB__COM: "x-access-token:${{ secrets.BUNDLER_GITHUB_TOKEN }}"
 
       - name: Run ErbLint
         run: bundle exec erblint --lint-all

--- a/.github/workflows/jasmine.yml
+++ b/.github/workflows/jasmine.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      BUNDLER_GITHUB_TOKEN:
+        required: false
+        description: "Token used for Bundler to authenticate when installing gems from private Github repos"
 
 jobs:
   run-jasmine:
@@ -24,6 +28,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+        env:
+          BUNDLE_GITHUB__COM: "x-access-token:${{ secrets.BUNDLER_GITHUB_TOKEN }}"
 
       - name: Setup Node
         uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main


### PR DESCRIPTION

This allows workflows which call these workflow to optionally set a
`BUNDLER_GITHUB_TOKEN` secret.

Setting a value for this token will set a `BUNDLE_GITHUB__COM` environment
variable in the `setup-ruby` step. This env var is an authentication
string which Bundler will use when attempting to install gems from
private repositories on Github.

Note: omitting this secret when calling the workflow has no effect on
installing gems from Rubygems, or public gems from Github. It only takes
effect when installing gems from a private Github repo.

This PR is an extension of https://github.com/alphagov/govuk-infrastructure/pull/1566
