### PR TITLE
Provision Postgres for Publisher on Integration

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -462,6 +462,24 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
       }
 
+      publisher = {
+        engine         = "postgres"
+        engine_version = "14"
+        engine_params = {
+          log_min_duration_statement = { value = 10000 }
+          log_statement              = { value = "all" }
+          deadlock_timeout           = { value = 2500 }
+          log_lock_waits             = { value = 1 }
+        }
+        engine_params_family         = "postgres14"
+        name                         = "publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
+        performance_insights_enabled = true
+        freestoragespace_threshold   = 10737418240
+        project                      = "GOV.UK - Publishing"
+      }
+
       release = {
         engine         = "mysql"
         engine_version = "8.0"


### PR DESCRIPTION
We are in the process of migrating Publisher from MongoDB to Postgres, and for purposes of setup and testing we need to have a database ready to go on Integration.

Related card: https://trello.com/c/7TgXoJSL/586-enable-eks-for-postgres-branch-of-publisher 