### PR TITLE
Import `licensify` namespace into Terraform

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -41,6 +41,29 @@ resource "kubernetes_namespace" "apps" {
   }
 }
 
+import {
+  to = kubernetes_namespace.licensify
+  id = "licensify"
+}
+
+resource "kubernetes_namespace" "licensify" {
+  metadata {
+    name = var.licensify_namespace
+    annotations = {
+      "argocd.argoproj.io/sync-options" = "ServerSideApply=true"
+    }
+    labels = {
+      "app.kubernetes.io/managed-by"  = "Terraform"
+      "argocd.argoproj.io/managed-by" = "cluster-services"
+      # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/
+      "elbv2.k8s.aws/pod-readiness-gate-inject" = "enabled"
+      "pod-security.kubernetes.io/audit"        = "restricted"
+      "pod-security.kubernetes.io/enforce"      = "baseline"
+      "pod-security.kubernetes.io/warn"         = "restricted"
+    }
+  }
+}
+
 resource "helm_release" "argo_cd" {
   chart            = "argo-cd"
   name             = "argo-cd"

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -4,6 +4,12 @@ variable "apps_namespace" {
   default     = "apps"
 }
 
+variable "licensify_namespace" {
+  type        = string
+  description = "Name of the namespace to create for ArgoCD to deploy licensify apps into by default."
+  default     = "licensify"
+}
+
 variable "argo_workflows_namespaces" {
   type        = list(string)
   description = "Namespaces in which Argo will run workflows."


### PR DESCRIPTION
Description:
- Currently the `licensify` namespace is created through ArgoCD [here](https://github.com/alphagov/govuk-helm-charts/blob/124ad9cfa5a25916d843838aa096dc0a5ab3f780/charts/app-config/templates/govuk-application.yaml#L61)
- However in the case of the `apps` namespace the annotations set are managed by Terraform [here](https://github.com/alphagov/govuk-infrastructure/blob/00d22761c5d9e8cfde4dd517dd459ded54a87f37/terraform/deployments/cluster-services/argo.tf#L26). The [ArgoCD docs](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#namespace-metadata) mentions that if we have another manifest file for the same namespace the data in ArgoCD will be overwritten. Currently this isn't an issue but it makes sense to have a single entity managing things. It's easier to have the `licensify` namespace in Terraform as we currently have for `apps` and `datagovuk`
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883