### PR TITLE
Remove import for Licensify namespace

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -41,11 +41,6 @@ resource "kubernetes_namespace" "apps" {
   }
 }
 
-import {
-  to = kubernetes_namespace.licensify
-  id = "licensify"
-}
-
 resource "kubernetes_namespace" "licensify" {
   metadata {
     name = var.licensify_namespace


### PR DESCRIPTION
Description:
- Licensify is currently managed by Terraform in https://github.com/alphagov/govuk-infrastructure/pull/1571 so import is no longer needed
- As part of https://github.com/alphagov/govuk-helm-charts/issues/1883