### PR TITLE
disable NAT for RDS and ElastiCache subnets

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -40,13 +40,13 @@ module "variable-set-integration" {
       b = { az = "eu-west-1b", cidr = "10.1.5.0/24" }
       c = { az = "eu-west-1c", cidr = "10.1.6.0/24" }
 
-      rds_a = { az = "eu-west-1a", cidr = "10.1.10.0/24" }
-      rds_b = { az = "eu-west-1b", cidr = "10.1.11.0/24" }
-      rds_c = { az = "eu-west-1c", cidr = "10.1.12.0/24" }
+      rds_a = { az = "eu-west-1a", cidr = "10.1.10.0/24", nat = false }
+      rds_b = { az = "eu-west-1b", cidr = "10.1.11.0/24", nat = false }
+      rds_c = { az = "eu-west-1c", cidr = "10.1.12.0/24", nat = false }
 
-      elasticache_a = { az = "eu-west-1a", cidr = "10.1.7.0/24" }
-      elasticache_b = { az = "eu-west-1b", cidr = "10.1.8.0/24" }
-      elasticache_c = { az = "eu-west-1c", cidr = "10.1.9.0/24" }
+      elasticache_a = { az = "eu-west-1a", cidr = "10.1.7.0/24", nat = false }
+      elasticache_b = { az = "eu-west-1b", cidr = "10.1.8.0/24", nat = false }
+      elasticache_c = { az = "eu-west-1c", cidr = "10.1.9.0/24", nat = false }
     }
 
     govuk_environment  = "integration"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -40,13 +40,13 @@ module "variable-set-production" {
       b = { az = "eu-west-1b", cidr = "10.13.5.0/24" }
       c = { az = "eu-west-1c", cidr = "10.13.6.0/24" }
 
-      rds_a = { az = "eu-west-1a", cidr = "10.13.10.0/24" }
-      rds_b = { az = "eu-west-1b", cidr = "10.13.11.0/24" }
-      rds_c = { az = "eu-west-1c", cidr = "10.13.12.0/24" }
+      rds_a = { az = "eu-west-1a", cidr = "10.13.10.0/24", nat = false }
+      rds_b = { az = "eu-west-1b", cidr = "10.13.11.0/24", nat = false }
+      rds_c = { az = "eu-west-1c", cidr = "10.13.12.0/24", nat = false }
 
-      elasticache_a = { az = "eu-west-1a", cidr = "10.13.7.0/24" }
-      elasticache_b = { az = "eu-west-1b", cidr = "10.13.8.0/24" }
-      elasticache_c = { az = "eu-west-1c", cidr = "10.13.9.0/24" }
+      elasticache_a = { az = "eu-west-1a", cidr = "10.13.7.0/24", nat = false }
+      elasticache_b = { az = "eu-west-1b", cidr = "10.13.8.0/24", nat = false }
+      elasticache_c = { az = "eu-west-1c", cidr = "10.13.9.0/24", nat = false }
     }
 
     govuk_environment = "production"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -40,13 +40,13 @@ module "variable-set-staging" {
       b = { az = "eu-west-1b", cidr = "10.12.5.0/24" }
       c = { az = "eu-west-1c", cidr = "10.12.6.0/24" }
 
-      rds_a = { az = "eu-west-1a", cidr = "10.12.10.0/24" }
-      rds_b = { az = "eu-west-1b", cidr = "10.12.11.0/24" }
-      rds_c = { az = "eu-west-1c", cidr = "10.12.12.0/24" }
+      rds_a = { az = "eu-west-1a", cidr = "10.12.10.0/24", nat = false }
+      rds_b = { az = "eu-west-1b", cidr = "10.12.11.0/24", nat = false }
+      rds_c = { az = "eu-west-1c", cidr = "10.12.12.0/24", nat = false }
 
-      elasticache_a = { az = "eu-west-1a", cidr = "10.12.7.0/24" }
-      elasticache_b = { az = "eu-west-1b", cidr = "10.12.8.0/24" }
-      elasticache_c = { az = "eu-west-1c", cidr = "10.12.9.0/24" }
+      elasticache_a = { az = "eu-west-1a", cidr = "10.12.7.0/24", nat = false }
+      elasticache_b = { az = "eu-west-1b", cidr = "10.12.8.0/24", nat = false }
+      elasticache_c = { az = "eu-west-1c", cidr = "10.12.9.0/24", nat = false }
     }
 
     govuk_environment  = "staging"


### PR DESCRIPTION
These subnets don't currently have a NAT gateway, and we want to avoid creating one for them

#1127 