### PR TITLE
explicitly enable NAT for legacy subnets that need it

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -36,9 +36,9 @@ module "variable-set-integration" {
     }
 
     legacy_private_subnets = {
-      a = { az = "eu-west-1a", cidr = "10.1.4.0/24" }
-      b = { az = "eu-west-1b", cidr = "10.1.5.0/24" }
-      c = { az = "eu-west-1c", cidr = "10.1.6.0/24" }
+      a = { az = "eu-west-1a", cidr = "10.1.4.0/24", nat = true }
+      b = { az = "eu-west-1b", cidr = "10.1.5.0/24", nat = true }
+      c = { az = "eu-west-1c", cidr = "10.1.6.0/24", nat = true }
 
       rds_a = { az = "eu-west-1a", cidr = "10.1.10.0/24", nat = false }
       rds_b = { az = "eu-west-1b", cidr = "10.1.11.0/24", nat = false }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -36,9 +36,9 @@ module "variable-set-production" {
     }
 
     legacy_private_subnets = {
-      a = { az = "eu-west-1a", cidr = "10.13.4.0/24" }
-      b = { az = "eu-west-1b", cidr = "10.13.5.0/24" }
-      c = { az = "eu-west-1c", cidr = "10.13.6.0/24" }
+      a = { az = "eu-west-1a", cidr = "10.13.4.0/24", nat = true }
+      b = { az = "eu-west-1b", cidr = "10.13.5.0/24", nat = true }
+      c = { az = "eu-west-1c", cidr = "10.13.6.0/24", nat = true }
 
       rds_a = { az = "eu-west-1a", cidr = "10.13.10.0/24", nat = false }
       rds_b = { az = "eu-west-1b", cidr = "10.13.11.0/24", nat = false }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -36,9 +36,9 @@ module "variable-set-staging" {
     }
 
     legacy_private_subnets = {
-      a = { az = "eu-west-1a", cidr = "10.12.4.0/24" }
-      b = { az = "eu-west-1b", cidr = "10.12.5.0/24" }
-      c = { az = "eu-west-1c", cidr = "10.12.6.0/24" }
+      a = { az = "eu-west-1a", cidr = "10.12.4.0/24", nat = true }
+      b = { az = "eu-west-1b", cidr = "10.12.5.0/24", nat = true }
+      c = { az = "eu-west-1c", cidr = "10.12.6.0/24", nat = true }
 
       rds_a = { az = "eu-west-1a", cidr = "10.12.10.0/24", nat = false }
       rds_b = { az = "eu-west-1b", cidr = "10.12.11.0/24", nat = false }


### PR DESCRIPTION
This is required due to type constraints on the variable in the vpc module

#1127 