### PR TITLE
Add elasticsearch subnets to legacy subnet list

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -47,6 +47,10 @@ module "variable-set-integration" {
       elasticache_a = { az = "eu-west-1a", cidr = "10.1.7.0/24", nat = false }
       elasticache_b = { az = "eu-west-1b", cidr = "10.1.8.0/24", nat = false }
       elasticache_c = { az = "eu-west-1c", cidr = "10.1.9.0/24", nat = false }
+
+      elasticsearch_a = { az = "eu-west-1a", cidr = "10.1.16.0/24", nat = false }
+      elasticsearch_b = { az = "eu-west-1b", cidr = "10.1.17.0/24", nat = false }
+      elasticsearch_c = { az = "eu-west-1c", cidr = "10.1.18.0/24", nat = false }
     }
 
     govuk_environment  = "integration"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -47,6 +47,10 @@ module "variable-set-production" {
       elasticache_a = { az = "eu-west-1a", cidr = "10.13.7.0/24", nat = false }
       elasticache_b = { az = "eu-west-1b", cidr = "10.13.8.0/24", nat = false }
       elasticache_c = { az = "eu-west-1c", cidr = "10.13.9.0/24", nat = false }
+
+      elasticsearch_a = { az = "eu-west-1a", cidr = "10.13.16.0/24", nat = false }
+      elasticsearch_b = { az = "eu-west-1b", cidr = "10.13.17.0/24", nat = false }
+      elasticsearch_c = { az = "eu-west-1c", cidr = "10.13.18.0/24", nat = false }
     }
 
     govuk_environment = "production"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -47,6 +47,10 @@ module "variable-set-staging" {
       elasticache_a = { az = "eu-west-1a", cidr = "10.12.7.0/24", nat = false }
       elasticache_b = { az = "eu-west-1b", cidr = "10.12.8.0/24", nat = false }
       elasticache_c = { az = "eu-west-1c", cidr = "10.12.9.0/24", nat = false }
+
+      elasticsearch_a = { az = "eu-west-1a", cidr = "10.12.16.0/24", nat = false }
+      elasticsearch_b = { az = "eu-west-1b", cidr = "10.12.17.0/24", nat = false }
+      elasticsearch_c = { az = "eu-west-1c", cidr = "10.12.18.0/24", nat = false }
     }
 
     govuk_environment  = "staging"


### PR DESCRIPTION
These were missed during the initial legacy subnet changes

#1127 