### PR TITLE
Fix imports for subnets

### DIFF
--- a/terraform/deployments/vpc/subnets_import.tf
+++ b/terraform/deployments/vpc/subnets_import.tf
@@ -12,42 +12,6 @@ import {
   id       = data.aws_subnet.private_subnet_import[each.key].id
 }
 
-data "aws_subnet" "public_subnet_import" {
-  for_each = var.legacy_public_subnets
-  filter {
-    name   = "tag:Name"
-    values = ["govuk_public_${each.key}"]
-  }
-}
-
-data "aws_eip" "nat_eip_import" {
-  for_each = local.azs
-  filter {
-    name   = "tag:Name"
-    values = ["govuk-legacy-nat-${each.value}"]
-  }
-}
-
-import {
-  for_each = local.azs
-  to       = aws_eip.private_subnet_nat[each.key]
-  id       = data.aws_eip.nat_eip_import[each.key].id
-}
-
-data "aws_nat_gateway" "private_subnet_import" {
-  for_each = local.azs
-  filter {
-    name   = "tag:Name"
-    values = ["govuk-legacy-${each.value}"]
-  }
-}
-
-import {
-  for_each = local.azs
-  to       = aws_nat_gateway.private_subnet[each.key]
-  id       = data.aws_nat_gateway.private_subnet_import[each.key].id
-}
-
 data "aws_route_table" "private_subnet_import" {
   for_each  = var.legacy_private_subnets
   subnet_id = data.aws_subnet.private_subnet_import[each.key].id
@@ -69,33 +33,4 @@ import {
   for_each = local.nat_legacy_private_subnets
   to       = aws_route.private_subnet_nat[each.key]
   id       = "${data.aws_route_table.private_subnet_import[each.key].id}_0.0.0.0/0"
-}
-
-import {
-  for_each = var.legacy_public_subnets
-  to       = aws_subnet.public_subnet[each.key]
-  id       = data.aws_subnet.public_subnet_import[each.key].id
-}
-
-data "aws_route_table" "public_subnet_import" {
-  filter {
-    name   = "tag:Name"
-    values = ["govuk-${var.govuk_environment}"]
-  }
-}
-
-import {
-  to = aws_route_table.public_subnet
-  id = data.aws_route_table.public_subnet_import.id
-}
-
-import {
-  for_each = var.legacy_public_subnets
-  to       = aws_route_table_association.public_subnet[each.key]
-  id       = "${data.aws_subnet.public_subnet_import[each.key].id}/${data.aws_route_table.public_subnet_import.id}"
-}
-
-import {
-  to = aws_route.public_subnet_igw
-  id = "${data.aws_route_table.public_subnet_import.id}_0.0.0.0/0"
 }


### PR DESCRIPTION
Imports of public subnets required things to have specific names that have been changed by the terraform, so it causes errors. This removes the broken imports so the elasticsearch subnets can be imported

#1127 