### PR TITLE
Lower Instance & Capacity Preferences in Non-Production

### DIFF
--- a/terraform/deployments/cluster-infrastructure/grafana.tf
+++ b/terraform/deployments/cluster-infrastructure/grafana.tf
@@ -74,8 +74,9 @@ resource "aws_iam_policy" "grafana" {
 }
 
 data "aws_rds_engine_version" "postgresql" {
-  engine  = "aurora-postgresql"
-  version = "13"
+  engine       = "aurora-postgresql"
+  version      = "13"
+  default_only = true
 }
 
 resource "random_password" "grafana_db" { length = 20 }

--- a/terraform/deployments/cluster-infrastructure/grafana.tf
+++ b/terraform/deployments/cluster-infrastructure/grafana.tf
@@ -76,10 +76,6 @@ resource "aws_iam_policy" "grafana" {
 data "aws_rds_engine_version" "postgresql" {
   engine  = "aurora-postgresql"
   version = "13"
-  filter {
-    name   = "engine-mode"
-    values = ["serverless"]
-  }
 }
 
 resource "random_password" "grafana_db" { length = 20 }

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -64,7 +64,7 @@ locals {
       min_size              = var.arm_workers_size_min
       instance_types        = var.arm_workers_instance_types
       update_config         = { max_unavailable = 1 }
-      block_device_mappings = local.x86_managed_node_group.main.block_device_mappings
+      block_device_mappings = local.x86_managed_node_group.x86.block_device_mappings
       taints = {
         arch = {
           key    = "arch"

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -27,15 +27,15 @@ locals {
   secrets_prefix             = "govuk"
   monitoring_namespace       = "monitoring"
 
-  main_managed_node_group = {
-    main = {
+  x86_managed_node_group = {
+    x86 = {
       name_prefix = var.cluster_name
       # TODO: set iam_role_permissions_boundary
       # TODO: apply provider default_tags to instances; might need to set launch_template_tags.
-      desired_size   = var.workers_size_desired
-      max_size       = var.workers_size_max
-      min_size       = var.workers_size_min
-      instance_types = var.workers_instance_types
+      desired_size   = var.x86_workers_size_desired
+      max_size       = var.x86_workers_size_max
+      min_size       = var.x86_workers_size_min
+      instance_types = var.x86_workers_instance_types
       update_config  = { max_unavailable = 1 }
       block_device_mappings = {
         xvda = {
@@ -64,7 +64,7 @@ locals {
       min_size              = var.arm_workers_size_min
       instance_types        = var.arm_workers_instance_types
       update_config         = { max_unavailable = 1 }
-      block_device_mappings = local.main_managed_node_group.main.block_device_mappings
+      block_device_mappings = local.x86_managed_node_group.main.block_device_mappings
       taints = {
         arch = {
           key    = "arch"
@@ -79,7 +79,7 @@ locals {
     }
   }
 
-  eks_managed_node_groups = merge(local.main_managed_node_group, var.enable_arm_workers ? local.arm_managed_node_group : {})
+  eks_managed_node_groups = merge(var.enable_x86_workers ? local.x86_managed_node_group : {}, var.enable_arm_workers ? local.arm_managed_node_group : {})
 }
 
 provider "aws" {
@@ -193,7 +193,7 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     ami_type              = "AL2023_x86_64_STANDARD"
-    capacity_type         = var.workers_default_capacity_type
+    capacity_type         = var.x86_workers_default_capacity_type
     subnet_ids            = [for s in aws_subnet.eks_private : s.id]
     create_security_group = false
     create_iam_role       = false

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -90,7 +90,7 @@ variable "arm_workers_size_max" {
 variable "workers_instance_types" {
   type        = list(string)
   description = "List of instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
-  default     = ["m6i.4xlarge", "m6a.4xlarge", "m6i.2xlarge", "m6a.2xlarge"]
+  default     = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
 }
 
 variable "workers_default_capacity_type" {
@@ -102,19 +102,19 @@ variable "workers_default_capacity_type" {
 variable "workers_size_desired" {
   type        = number
   description = "Desired capacity of managed node autoscale group."
-  default     = 6
+  default     = 0
 }
 
 variable "workers_size_min" {
   type        = number
   description = "Min capacity of managed node autoscale group."
-  default     = 3
+  default     = 0
 }
 
 variable "workers_size_max" {
   type        = number
   description = "Max capacity of managed node autoscale group."
-  default     = 12
+  default     = 6
 }
 
 variable "node_disk_size" {

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -87,31 +87,37 @@ variable "arm_workers_size_max" {
   default     = 12
 }
 
-variable "workers_instance_types" {
+variable "enable_x86_workers" {
+  type        = bool
+  description = "Whether to enable the x86/AMD64 Managed Node Group"
+  default     = true
+}
+
+variable "x86_workers_instance_types" {
   type        = list(string)
   description = "List of instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
   default     = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
 }
 
-variable "workers_default_capacity_type" {
+variable "x86_workers_default_capacity_type" {
   type        = string
   description = "Default capacity type for managed node groups: SPOT or ON_DEMAND."
   default     = "ON_DEMAND"
 }
 
-variable "workers_size_desired" {
+variable "x86_workers_size_desired" {
   type        = number
   description = "Desired capacity of managed node autoscale group."
   default     = 0
 }
 
-variable "workers_size_min" {
+variable "x86_workers_size_min" {
   type        = number
   description = "Min capacity of managed node autoscale group."
   default     = 0
 }
 
-variable "workers_size_max" {
+variable "x86_workers_size_max" {
   type        = number
   description = "Max capacity of managed node autoscale group."
   default     = 6

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -56,6 +56,7 @@ module "variable-set-integration" {
     govuk_environment  = "integration"
     force_destroy      = true
     enable_arm_workers = true
+    enable_x86_workers = true
 
     publishing_service_domain = "integration.publishing.service.gov.uk"
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -54,14 +54,15 @@ module "variable-set-production" {
     }
 
     govuk_environment = "production"
+    enable_x86_workers = true
 
     publishing_service_domain = "publishing.service.gov.uk"
 
-    workers_instance_types = ["m6i.8xlarge", "m6a.8xlarge"]
+    x86_workers_instance_types = ["m6i.8xlarge", "m6a.8xlarge"]
 
-    workers_size_desired = 6
-    workers_size_min     = 3
-    workers_size_max     = 12
+    x86_workers_size_desired = 6
+    x86_workers_size_min     = 3
+    x86_workers_size_max     = 12
 
     frontend_memcached_node_type = "cache.r6g.large"
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -57,7 +57,12 @@ module "variable-set-production" {
 
     publishing_service_domain = "publishing.service.gov.uk"
 
-    workers_instance_types       = ["m6i.8xlarge", "m6a.8xlarge"]
+    workers_instance_types = ["m6i.8xlarge", "m6a.8xlarge"]
+
+    workers_size_desired = 6
+    workers_size_min     = 3
+    workers_size_max     = 12
+
     frontend_memcached_node_type = "cache.r6g.large"
 
     ckan_s3_organogram_bucket = "datagovuk-production-ckan-organogram"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -53,7 +53,7 @@ module "variable-set-production" {
       elasticsearch_c = { az = "eu-west-1c", cidr = "10.13.18.0/24", nat = false }
     }
 
-    govuk_environment = "production"
+    govuk_environment  = "production"
     enable_x86_workers = true
 
     publishing_service_domain = "publishing.service.gov.uk"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -55,6 +55,7 @@ module "variable-set-staging" {
 
     govuk_environment  = "staging"
     enable_arm_workers = true
+    enable_x86_workers = true
 
     publishing_service_domain = "staging.publishing.service.gov.uk"
 


### PR DESCRIPTION
## What?
This PR changes the default "worker instance types" for x86/AMD64 workloads to be a preference of one of the following:

* `r7i.large`
* `r7a.large`
* `m7i-flex.xlarge`
* `m6i.xlarge`

The basis here is that all these instances are specced with 16GB of RAM. Our current instances in Integration and Staging are using `m6i.4xlarge` which come with 64GB of RAM and is currently underutilised as most workloads are now running on our `m7g.4xlarge` instances.

Further, we can set the minimum instance counts to 0 for this node group, so that our clusters retain the ability (in theory) to support x86/AMD64 workloads without necessarily needing to pay for that availability 24/7.

There may be some further tweaking necessary if we find the node group trying to scale beyond its set limits, e.g. we may find a scheduled task that favours CPU over RAM and can accommodate this accordingly.

I've also "overridden" the min/desired/max counts on the Production config so we keep that as it is until we're ready to do the switch in Production. Which is probably soon!