### PR TITLE
✨ Add an issue template to capture user stories

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,0 +1,52 @@
+---
+name: User Story
+about: Capture a user story from stakeholders.
+title: ''
+labels: user-story
+assignees: ''
+
+---
+
+**User Need**
+
+**As a** (type of user)
+**I want** (some action)
+**so that** (some result)
+
+**Functional Requirements (What):**
+
+- [ ]
+- [ ]
+
+**Non-Functional Requirements (How):**
+
+- [ ]
+- [ ]
+
+
+**Acceptance Criteria:**
+
+- [ ]
+- [ ]
+
+**Notes:**
+
+<!-- Here's a brief explanation of each field:
+
+As a (type of user): This is the role that the stakeholder or user plays. It could be a developer, project manager, security team, etc.
+
+I want (some action): This describes what the user wants to do. It should be a specific action or feature.
+
+so that (some result): This is the reason or benefit that the user expects from performing the action.
+
+Functional Requirements: Here, you list what you are going to do - the functional requirements associated with the user story. These could be based on what you learned from the stakeholder interviews, what functionality they need.
+
+[Non-Functional Requirements](https://en.wikipedia.org/wiki/Non-functional_requirement): Here, you list how you are going to do it - the non-functional requirements associated with the user story. These could be about the system's performance, security, usability, standards etc, these are likely more technical than the functional requirements description.
+
+Acceptance Criteria: These are the conditions that must be met for the user story to be considered "done". It should clearly define the boundaries of the user story and help in testing.
+
+Assumptions (optional): Where appropriate list any important assumptions here.
+
+Risks and Mitigation (optional): Where appropriate list any important risks relevant to this ticket and if possible a mitigation strategy.
+
+Notes: This is for any additional information or details about the user story. -->


### PR DESCRIPTION
## 👀 Purpose

- Creating a template issue allows us to standardise how we narrate the tickets we work on. This gives people unfamiliar with the context a chance to read who is the intended target, what's important to them and how we should define when the ticket is done.

## ♻️ What's changed

- A new directory called `ISSUE_TEMPLATE` now exists and is GitHub's default template location upon creating a new issue.
A new file called `user-story.md` exists with a fairly basic set-up of how we should structure our tickets. This file comes with comments on how to fill in the issue and what each field means.

## 📝 Notes

- This can be adjusted and will mature as our needs see fit.