### PR TITLE
Output root zone names in vpc module

### DIFF
--- a/terraform/deployments/vpc/outputs.tf
+++ b/terraform/deployments/vpc/outputs.tf
@@ -20,7 +20,17 @@ output "internal_root_zone_id" {
   value       = aws_route53_zone.internal_zone.id
 }
 
+output "internal_root_zone_name" {
+  description = "Name of the internal Route53 DNS zone"
+  value       = aws_route53_zone.internal_zone.name
+}
+
 output "external_root_zone_id" {
   description = "ID of the external Route53 DNS zone"
   value       = aws_route53_zone.external_zone.id
+}
+
+output "external_root_zone_name" {
+  description = "Name of the external Route53 DNS zone"
+  value       = aws_route53_zone.external_zone.name
 }


### PR DESCRIPTION
This is needed to create route53 records in other modules

#1127 