### PR TITLE
Restore the main node group config temporarily...

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -93,6 +93,12 @@ variable "enable_x86_workers" {
   default     = true
 }
 
+variable "main_workers_instance_types" {
+  type        = list(string)
+  description = "TEMPORARY - List of instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
+  default     = ["m6i.4xlarge", "m6a.4xlarge", "m6i.2xlarge", "m6a.2xlarge"]
+}
+
 variable "x86_workers_instance_types" {
   type        = list(string)
   description = "List of instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -58,6 +58,8 @@ module "variable-set-integration" {
     enable_arm_workers = true
     enable_x86_workers = true
 
+    main_workers_instance_types = ["m6i.4xlarge", "m6a.4xlarge", "m6i.2xlarge", "m6a.2xlarge"]
+
     publishing_service_domain = "integration.publishing.service.gov.uk"
 
     frontend_memcached_node_type = "cache.t4g.micro"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -57,6 +57,8 @@ module "variable-set-staging" {
     enable_arm_workers = true
     enable_x86_workers = true
 
+    main_workers_instance_types = ["m6i.4xlarge", "m6a.4xlarge", "m6i.2xlarge", "m6a.2xlarge"]
+
     publishing_service_domain = "staging.publishing.service.gov.uk"
 
     frontend_memcached_node_type = "cache.t4g.medium"


### PR DESCRIPTION
## What?
So we've discovered that the EKS modules doesn't really like in-place updates for things like changing instance types, or updating name prefixes. The Terraform plan would prefer to destroy and replace the node group. Attempting to use the `moved` declaration confirmed that Terraform was going to force a replacement of the launch template and node group anyway.

In order to avoid any risk of downtime, we've decided instead to create the new node group by hand, and then tear down the old one once the new node group is in place.

To make this a bit easier, I've added a temporary variable so we don't affect the node group in production for the time being.