### PR TITLE
Turn off the Main Groups in Non-Prod

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -107,7 +107,7 @@ locals {
     }
   }
 
-  eks_managed_node_groups = merge(local.main_managed_node_group, var.enable_x86_workers ? local.x86_managed_node_group : {}, var.enable_arm_workers ? local.arm_managed_node_group : {})
+  eks_managed_node_groups = merge(var.enable_main_workers ? local.main_managed_node_group : {}, var.enable_x86_workers ? local.x86_managed_node_group : {}, var.enable_arm_workers ? local.arm_managed_node_group : {})
 }
 
 provider "aws" {

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -87,6 +87,12 @@ variable "arm_workers_size_max" {
   default     = 12
 }
 
+variable "enable_main_workers" {
+  type        = bool
+  description = "TEMPORARRY - Whether to enable the legacy Main-prefixed x86/AMD64 Managed Node Group"
+  default     = true
+}
+
 variable "enable_x86_workers" {
   type        = bool
   description = "Whether to enable the x86/AMD64 Managed Node Group"

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -53,10 +53,12 @@ module "variable-set-integration" {
       elasticsearch_c = { az = "eu-west-1c", cidr = "10.1.18.0/24", nat = false }
     }
 
-    govuk_environment  = "integration"
-    force_destroy      = true
-    enable_arm_workers = true
-    enable_x86_workers = true
+    govuk_environment = "integration"
+    force_destroy     = true
+
+    enable_arm_workers  = true
+    enable_main_workers = false
+    enable_x86_workers  = true
 
     main_workers_instance_types = ["m6i.4xlarge", "m6a.4xlarge", "m6i.2xlarge", "m6a.2xlarge"]
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -53,8 +53,11 @@ module "variable-set-production" {
       elasticsearch_c = { az = "eu-west-1c", cidr = "10.13.18.0/24", nat = false }
     }
 
-    govuk_environment  = "production"
-    enable_x86_workers = false
+    govuk_environment = "production"
+
+    enable_arm_workers  = false
+    enable_main_workers = true
+    enable_x86_workers  = false
 
     publishing_service_domain = "publishing.service.gov.uk"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -53,9 +53,11 @@ module "variable-set-staging" {
       elasticsearch_c = { az = "eu-west-1c", cidr = "10.12.18.0/24", nat = false }
     }
 
-    govuk_environment  = "staging"
-    enable_arm_workers = true
-    enable_x86_workers = true
+    govuk_environment = "staging"
+
+    enable_arm_workers  = true
+    enable_main_workers = false
+    enable_x86_workers  = true
 
     main_workers_instance_types = ["m6i.4xlarge", "m6a.4xlarge", "m6i.2xlarge", "m6a.2xlarge"]
 


### PR DESCRIPTION
## What?
This PR allows us to turn off the old "main" Node Groups in Integration and Staging and allows us to turn on/off each of the Node Groups independently of each other and in each environment.

(Apologies for all the short PRs - it's hard to test many of the changes without first applying config changes to the `tfc-configuration` workgroup.)