### PR TITLE
Drop the ARM Taint, Increase x86 Desired Nodes

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -93,13 +93,6 @@ locals {
       instance_types        = var.arm_workers_instance_types
       update_config         = { max_unavailable = 1 }
       block_device_mappings = local.x86_managed_node_group.x86.block_device_mappings
-      taints = {
-        arch = {
-          key    = "arch"
-          value  = "arm64"
-          effect = "NO_SCHEDULE"
-        }
-      }
       additional_tags = {
         "k8s.io/cluster-autoscaler/enabled"             = "true"
         "k8s.io/cluster-autoscaler/${var.cluster_name}" = "owned"

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -120,7 +120,7 @@ variable "x86_workers_default_capacity_type" {
 variable "x86_workers_size_desired" {
   type        = number
   description = "Desired capacity of managed node autoscale group."
-  default     = 0
+  default     = 3
 }
 
 variable "x86_workers_size_min" {


### PR DESCRIPTION
## What?
This PR makes two changes:

* It removes the ARM "taint" from the Graviton instances
* It sets the "desired" count of the x86 instances to 3

Our current configuration doesn't allow us to scale a Node Group down to 0 currently and caused some pods to not be scheduled on any nodes. This is because there was also a taint on our Graviton nodes preventing those workloads from running there.

As the vast majority of our workloads now support ARM, we should be able to remove this taint from the node group. But we can still use `nodeAffinity` or `nodeSelector` properties on our pods if we need to run them somewhere specific.