### PR TITLE
Update govuk-knowledge-graph-search pull_request_bypassers

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -800,7 +800,7 @@ repos:
     homepage_url: "https://docs.data-community.publishing.service.gov.uk/tools/govsearch/"
     required_pull_request_reviews:
       pull_request_bypassers:
-        - "/guilhem-fry"
+        - "/gfry"
         - "/nacnudus"
         - "/somme"
 


### PR DESCRIPTION
The username appears to have changed and is now causing TF errors

```
Error: Could not resolve to a User with the login of 'guilhem-fry'. 
with github_branch_protection.govuk_repos[govuk-knowledge-graph-search] 
on main.tf line 143, in resource github_branch_protection govuk_repos
```

<img width="849" alt="Screenshot 2025-01-22 at 18 54 45" src="https://github.com/user-attachments/assets/1df2195b-a884-419c-b982-577b0f02e9b1" />

### Plan output

<img width="814" alt="Screenshot 2025-01-23 at 09 39 50" src="https://github.com/user-attachments/assets/7e2fdb8d-500d-4505-a763-507766630373" />
