### PR TITLE
✨Add template for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -1,0 +1,22 @@
+<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
+## :eyes: Purpose
+
+•
+
+<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
+## :recycle: What's Changed
+
+•
+
+<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
+## :memo: Notes
+
+•
+
+---
+<!-- Optionally, check you've completed the following actions before submitting the PR -->
+### :white_check_mark: Things to Check (Optional)
+
+- [ ] I have run all unit tests, and they pass.
+- [ ] I have ensured my code follows the project's coding standards.
+


### PR DESCRIPTION
## 👀 Purpose

- This PR adds an optional PR template for the team to use. This will help us standardise how we present PRs, enabling us to capture the change, any history related to the change, and if there are any notes associated with the change.

## ♻️ What's changed

- This PR adds one directory and one new file using the format outlined by [GitHub](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).

## 📝 Notes

- Having a template is optional. It certainly helps me structure a pull request, making it easier to review and capture information for posterity.
- This can evolve and change as the team sees fit.