### PR TITLE
Remove search-v2-infrastructure from GitHub config

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -608,12 +608,6 @@ repos:
 
   search-v2-evaluator:
 
-  search-v2-infrastructure:
-    required_status_checks:
-      ignore_jenkins: true
-      additional_contexts:
-        - lint_and_validate
-
   service-manual-publisher:
     homepage_url: "https://docs.publishing.service.gov.uk/apps/service-manual-publisher.html"
     required_status_checks:


### PR DESCRIPTION
Repo was archived.

Manually removed from TF state.
