### PR TITLE
Fix directory reference for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: terraform
-    directory: /terraform
+    directories: ["/terraform/**/*"]
     schedule:
       interval: weekly
   - package-ecosystem: bundler


### PR DESCRIPTION
Dependabot fails to scan for dependency updates as it can find dependency manifests. This explicitly tells Dependabot to search all folders/files under `/terraform`.