### PR TITLE
Switch to renovate to update terraform dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: terraform
-    directories: ["/terraform/**/*"]
-    schedule:
-      interval: weekly
   - package-ecosystem: bundler
     directory: /
     schedule:

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "platformAutomerge": true,
   "pre-commit": {
     "enabled": true
   },
-  "enabledManagers": ["pre-commit"]
+  "enabledManagers": ["pre-commit", "terraform"],
+  "terraform": {
+    "fileMatch": ["^/terraform/.*\\.tf$"]
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": ["/alexbasista\/workspacer\/tfe/"],
+      "groupName": "alexbasista/workspacer/tfe"
+    }
+  ]
 }


### PR DESCRIPTION
Dependbot doesn't support dependency grouping into a single PR. This causes a lot of noise as specify the dependencies in lots of files.