### PR TITLE
Fix renovate configuration to remove packageRule and increase PRs per hr limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,6 @@
   "enabledManagers": ["pre-commit", "terraform"],
   "terraform": {
     "fileMatch": ["^/terraform/.*\\.tf$"]
-  }
+  },
+  "prHourlyLimit": 20
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,11 +8,5 @@
   "enabledManagers": ["pre-commit", "terraform"],
   "terraform": {
     "fileMatch": ["^/terraform/.*\\.tf$"]
-  },
-  "packageRules": [
-    {
-      "matchPackageNames": ["/alexbasista\/workspacer\/tfe/"],
-      "groupName": "alexbasista/workspacer/tfe"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Remove redundant packageRule for workspaces/tfe as it's the default behaviour. This also bumps up the PR per hr rule, as we want to speed up the creation of all our dependency PRs.