### PR TITLE
Bump required terraform version to 1.10

### DIFF
--- a/terraform/deployments/cdn-analytics/main.tf
+++ b/terraform/deployments/cdn-analytics/main.tf
@@ -5,7 +5,7 @@ terraform {
       tags = ["cdn-analytics", "gcp"]
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/deployments/chat/main.tf
+++ b/terraform/deployments/chat/main.tf
@@ -5,7 +5,7 @@ terraform {
       tags = ["opensearch", "eks", "aws"]
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/deployments/cloudfront/main.tf
+++ b/terraform/deployments/cloudfront/main.tf
@@ -5,7 +5,7 @@ terraform {
       tags = ["cloudfront", "eks", "aws"]
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -13,7 +13,7 @@ terraform {
       tags = ["cluster-infrastructure", "eks", "aws"]
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -14,7 +14,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/deployments/csp-reporter/main.tf
+++ b/terraform/deployments/csp-reporter/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/deployments/datagovuk-infrastructure/main.tf
+++ b/terraform/deployments/datagovuk-infrastructure/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/deployments/ga4-analytics/main.tf
+++ b/terraform/deployments/ga4-analytics/main.tf
@@ -5,7 +5,7 @@ terraform {
       tags = ["ga4-analytics", "gcp", "production"]
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/terraform/deployments/gcp-search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/main.tf
@@ -18,7 +18,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.7"
+  required_version = "~> 1.10"
 }
 
 module "environment_integration" {

--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
@@ -15,7 +15,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.7"
+  required_version = "~> 1.10"
 }
 
 locals {

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -4,7 +4,7 @@ terraform {
     workspaces { name = "GitHub" }
   }
 
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/deployments/mobile-backend/main.tf
+++ b/terraform/deployments/mobile-backend/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.8"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/deployments/opensearch/main.tf
+++ b/terraform/deployments/opensearch/main.tf
@@ -5,7 +5,7 @@ terraform {
       tags = ["opensearch", "eks", "aws"]
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/deployments/search-api-v2/main.tf
+++ b/terraform/deployments/search-api-v2/main.tf
@@ -28,7 +28,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.7"
+  required_version = "~> 1.10"
 }
 
 provider "google" {

--- a/terraform/deployments/search-api-v2/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/deployments/search-api-v2/modules/google_discovery_engine_restapi/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.7"
+  required_version = "~> 1.10"
 }
 
 locals {

--- a/terraform/deployments/sentry/provider.tf
+++ b/terraform/deployments/sentry/provider.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 
   required_providers {
     sentry = {

--- a/terraform/deployments/tfc-aws-config/provider.tf
+++ b/terraform/deployments/tfc-aws-config/provider.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 
   required_providers {
     aws = {

--- a/terraform/deployments/tfc-bootstrap/provider.tf
+++ b/terraform/deployments/tfc-bootstrap/provider.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 
   required_providers {
     tfe = {

--- a/terraform/deployments/tfc-configuration/provider.tf
+++ b/terraform/deployments/tfc-configuration/provider.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
 
   required_providers {
     tfe = {

--- a/terraform/deployments/vpc/main.tf
+++ b/terraform/deployments/vpc/main.tf
@@ -5,7 +5,7 @@ terraform {
       tags = ["vpc", "eks", "aws"]
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
We've already using 1.10.5, so this sets the minimum requirement. Which then will allow us to update other dependencies that require this later version.