### PR TITLE
Add Metrics Server support, enable on non-prod...

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -27,6 +27,18 @@ locals {
   secrets_prefix             = "govuk"
   monitoring_namespace       = "monitoring"
 
+  default_cluster_addons = {
+    coredns    = { most_recent = true }
+    kube-proxy = { most_recent = true }
+    vpc-cni    = { most_recent = true }
+  }
+
+  metrics_server_addon = {
+    metrics-server = { most_recent = true }
+  }
+
+  enabled_cluster_addons = merge(local.default_cluster_addons, var.enable_metrics_server ? local.metrics_server_addon : {})
+
   main_managed_node_group = {
     main = {
       name_prefix = var.cluster_name
@@ -187,11 +199,7 @@ module "eks" {
   subnet_ids      = [for s in aws_subnet.eks_control_plane : s.id]
   vpc_id          = data.terraform_remote_state.infra_vpc.outputs.vpc_id
 
-  cluster_addons = {
-    coredns    = { most_recent = true }
-    kube-proxy = { most_recent = true }
-    vpc-cni    = { most_recent = true }
-  }
+  cluster_addons = local.enabled_cluster_addons
 
   cluster_endpoint_public_access         = true
   cloudwatch_log_group_retention_in_days = var.cluster_log_retention_in_days

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -51,6 +51,12 @@ variable "force_destroy" {
   default     = false
 }
 
+variable "enable_metrics_server" {
+  type        = bool
+  description = "Enable the Metrics Server EKS Add-on. For Pod Metrics and HPA support."
+  default     = false
+}
+
 variable "enable_arm_workers" {
   type        = bool
   description = "Whether to enable the ARM/Graviton-based Managed Node Group"

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -56,6 +56,8 @@ module "variable-set-integration" {
     govuk_environment = "integration"
     force_destroy     = true
 
+    enable_metrics_server = true
+
     enable_arm_workers  = true
     enable_main_workers = false
     enable_x86_workers  = true

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -55,6 +55,8 @@ module "variable-set-production" {
 
     govuk_environment = "production"
 
+    enable_metrics_server = false
+
     enable_arm_workers  = false
     enable_main_workers = true
     enable_x86_workers  = false

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -55,6 +55,8 @@ module "variable-set-staging" {
 
     govuk_environment = "staging"
 
+    enable_metrics_server = true
+
     enable_arm_workers  = true
     enable_main_workers = false
     enable_x86_workers  = true


### PR DESCRIPTION
## What?
This PR adds the ability for us to enable the metrics-server add-on on a per environment basis. And enables it on Integration and Staging (but not Production) so we can test the change first for any potential unknown issues.

## Why?
With the metrics-server add-on enabled, we'll be able to:

* Use `kubectl top` to view Pod Metrics (we cannot currently do this)
* Use the `kube-capacity` plugin for `kubectl1 to get a breakdown of our node and pod utilisation.
* Enable Horizontal Pod Autoscaling in the future