### PR TITLE
Remove 2xl instance types from arm worker node group

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -66,7 +66,7 @@ variable "enable_arm_workers" {
 variable "arm_workers_instance_types" {
   type        = list(string)
   description = "List of ARM-based instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
-  default     = ["m7g.4xlarge", "m6g.4xlarge", "m7g.2xlarge", "m6g.2xlarge"]
+  default     = ["m7g.4xlarge", "m6g.4xlarge"]
 }
 
 variable "arm_workers_default_capacity_type" {


### PR DESCRIPTION
The 2xl instances are causing EKS to impose a 58 pod limit on our nodes (due to the fact they can only have 60 IP addresses). This is causing inefficient pod scheduling as nodes are filling up with pods with plenty of resources remaining.