### PR TITLE
Add repo to allow deployment from publisher-on-postgres-branch

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -66,7 +66,8 @@ locals {
     "licensify-feed",
     "licensify-frontend",
     "govuk-fastly-diff-generator",
-    "govuk-e2e-tests"
+    "govuk-e2e-tests",
+    "publisher-on-postgres-branch"
   ]
 }
 


### PR DESCRIPTION
Mainstream publisher is migrating to postgres. In order to be able to deploy and test in integration, one of the option is to have a separate app and to be able to do this we want to be able to create a separate repo to allow image build from "publisher-on-postgres" branch have this repo as its target.