### PR TITLE
Allow TFC role to manage firehose resources

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -52,6 +52,7 @@ data "aws_iam_policy_document" "tfc_policy" {
       "elasticfilesystem:*",
       "es:*",
       "events:*",
+      "firehose:*",
       "glue:*",
       "iam:*InstanceProfile*",
       "iam:*CloudFrontPublicKey*",


### PR DESCRIPTION
This is necessary to manage resources for CSP Reporter

#1127 