### PR TITLE
Remove glue table import for CSP reporter

### DIFF
--- a/terraform/deployments/csp-reporter/imports.tf
+++ b/terraform/deployments/csp-reporter/imports.tf
@@ -139,11 +139,6 @@ import {
   id = "Content Security Policy reports"
 }
 
-import {
-  to = aws_glue_catalog_table.reports
-  id = "${data.aws_caller_identity.current.account_id}:csp_reports:reports"
-}
-
 # lambda.tf
 
 import {


### PR DESCRIPTION
This doesn't exist in staging for some reason, and is stopping terraform from importing everything else

#1127 