### PR TITLE
Use encode_expr instead of a hack to convert values to strings for terraform variables

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -43,7 +43,7 @@ jobs:
     - uses: terraform-linters/setup-tflint@v4
       name: Set up TFLint
       with:
-        tflint_version: v0.47.0
+        tflint_version: v0.55.0
 
     - name: terraform fmt
       working-directory: terraform
@@ -82,11 +82,12 @@ jobs:
         cd terraform/deployments
         tflint --version
         tflint --init --recursive 
-        tflint --format compact --module --recursive --force \
+        tflint --format compact --call-module-type=all --recursive --force \
             --enable-rule=terraform_comment_syntax \
             --enable-rule=terraform_deprecated_index \
             --enable-rule=terraform_required_providers \
             --enable-rule=terraform_standard_module_structure \
             --enable-rule=terraform_typed_variables \
             --enable-rule=terraform_unused_declarations \
-            --enable-rule=terraform_unused_required_providers
+            --enable-rule=terraform_unused_required_providers \
+            --disable-rule=aws_eks_node_group_invalid_ami_type

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -81,8 +81,9 @@ jobs:
       run: |
         cd terraform/deployments
         tflint --version
-        tflint --init --recursive 
+        tflint --init --recursive -c ${{ github.workspace }}/.tflint.hcl
         tflint --format compact --call-module-type=all --recursive --force \
+            -c ${{ github.workspace }}/.tflint.hcl \
             --enable-rule=terraform_comment_syntax \
             --enable-rule=terraform_deprecated_index \
             --enable-rule=terraform_required_providers \

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,11 @@
+plugin "aws" {
+  enabled = true
+  version = "0.30.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+plugin "google" {
+    enabled = true
+    version = "0.30.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-google"
+}

--- a/terraform/deployments/cluster-infrastructure/.tflint.hcl
+++ b/terraform/deployments/cluster-infrastructure/.tflint.hcl
@@ -1,6 +1,0 @@
-plugin "aws" {
-  enabled = true
-  version = "0.30.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}
-

--- a/terraform/deployments/cluster-services/.tflint.hcl
+++ b/terraform/deployments/cluster-services/.tflint.hcl
@@ -1,6 +1,0 @@
-plugin "aws" {
-  enabled = true
-  version = "0.30.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}
-

--- a/terraform/deployments/datagovuk-infrastructure/.tflint.hcl
+++ b/terraform/deployments/datagovuk-infrastructure/.tflint.hcl
@@ -1,6 +1,0 @@
-plugin "aws" {
-  enabled = true
-  version = "0.30.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}
-

--- a/terraform/deployments/ecr/.tflint.hcl
+++ b/terraform/deployments/ecr/.tflint.hcl
@@ -1,5 +1,0 @@
-plugin "aws" {
-  enabled = true
-  version = "0.30.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}

--- a/terraform/deployments/github/.tflint.hcl
+++ b/terraform/deployments/github/.tflint.hcl
@@ -1,6 +1,0 @@
-plugin "aws" {
-  enabled = true
-  version = "0.30.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}
-

--- a/terraform/deployments/govuk-publishing-infrastructure/.tflint.hcl
+++ b/terraform/deployments/govuk-publishing-infrastructure/.tflint.hcl
@@ -1,5 +1,0 @@
-plugin "aws" {
-  enabled = true
-  version = "0.30.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}

--- a/terraform/deployments/mobile-backend/.tflint.hcl
+++ b/terraform/deployments/mobile-backend/.tflint.hcl
@@ -1,5 +1,0 @@
-plugin "aws" {
-  enabled = true
-  version = "0.30.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}

--- a/terraform/deployments/tfc-configuration/.tflint.hcl
+++ b/terraform/deployments/tfc-configuration/.tflint.hcl
@@ -1,6 +1,0 @@
-plugin "aws" {
-  enabled = true
-  version = "0.30.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}
-

--- a/terraform/deployments/tfc-configuration/variable-set/main.tf
+++ b/terraform/deployments/tfc-configuration/variable-set/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    terraform = {
+      source = "terraform.io/builtin/terraform"
+    }
+  }
+}
+
 resource "tfe_variable_set" "set" {
   name         = var.name
   organization = "govuk"
@@ -10,7 +18,7 @@ resource "tfe_variable" "vars" {
 
   variable_set_id = tfe_variable_set.set.id
   key             = each.key
-  value           = try(tostring(each.value), replace(jsonencode(each.value), ":", "="))
-  hcl             = try(tostring(each.value), "nostring") == "nostring" ? true : false
+  value           = provider::terraform::encode_expr(each.value)
+  hcl             = true
   category        = "terraform"
 }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -106,24 +106,14 @@ module "variable-set-ecr-production" {
   name = "ecr-production"
   tfvars = {
     emails = ["govuk-platform-engineering+ecr-inspector@digital.cabinet-office.gov.uk"]
-  }
-}
 
-# This has to be separate because the ':' get replaced with '='
-#  by the var set module
-resource "tfe_variable" "ecr-puller-arns" {
-  variable_set_id = module.variable-set-ecr-production.variable_set_id
-  key             = "puller_arns"
-  category        = "terraform"
-  value = jsonencode(
-    [
+    puller_arns = [
       "arn:aws:iam::172025368201:root", # Production
       "arn:aws:iam::696911096973:root", # Staging
       "arn:aws:iam::210287912431:root", # Integration
       "arn:aws:iam::430354129336:root", # Test
     ]
-  )
-  hcl = true
+  }
 }
 
 module "variable-set-chat-production" {


### PR DESCRIPTION
The [`provider::terraform::encode_expr`](https://developer.hashicorp.com/terraform/language/functions/terraform-encode_expr) function was introduced in Terraform 1.8 and allows us to encode any object as a HCL string.

This removes the need for the hacky way we've been doing it in the past (converting to JSON then replacing `:`s with `=`s). This means we no longer have to specif `puller_arns` separately since it no longer breaks when the value has a colon in it.