### PR TITLE
Fixup: add back imports for AWS WAFs

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -590,15 +590,69 @@ resource "aws_wafv2_web_acl_logging_configuration" "public_cache_waf" {
 
 # Import existing resources - using the data object retrieve the exsiting WAF ids
 
+data "aws_wafv2_ip_set" "existing_govuk_requesting_ips" {
+  name  = "govuk_requesting_ips"
+  scope = "REGIONAL"
+}
+
+import {
+  to = aws_wafv2_ip_set.govuk_requesting_ips
+  id = "${data.aws_wafv2_ip_set.existing_govuk_requesting_ips.id}/govuk_requesting_ips/REGIONAL"
+}
+
+data "aws_wafv2_ip_set" "existing_high_request_rate" {
+  name  = "high_request_rate"
+  scope = "REGIONAL"
+}
+
+import {
+  to = aws_wafv2_ip_set.high_request_rate
+  id = "${data.aws_wafv2_ip_set.existing_high_request_rate.id}/high_request_rate/REGIONAL"
+}
+
 data "aws_wafv2_web_acl" "existing_default" {
   name  = "x-always-block_web_acl"
   scope = "REGIONAL"
 }
 
+import {
+  to = aws_wafv2_web_acl.default
+  id = "${data.aws_wafv2_web_acl.existing_default.id}/x-always-block_web_acl/REGIONAL"
+}
+
+data "aws_wafv2_regex_pattern_set" "existing_x_always_block" {
+  name  = "x-always-block_pattern"
+  scope = "REGIONAL"
+}
+
+import {
+  to = aws_wafv2_regex_pattern_set.x_always_block
+  id = "${data.aws_wafv2_regex_pattern_set.existing_x_always_block.id}/x-always-block_pattern/REGIONAL"
+}
+
+data "aws_wafv2_rule_group" "existing_x_always_block" {
+  name  = "x-always-block_rule_group"
+  scope = "REGIONAL"
+}
+
+import {
+  to = aws_wafv2_rule_group.x_always_block
+  id = "${data.aws_wafv2_rule_group.existing_x_always_block.id}/x-always-block_rule_group/REGIONAL"
+}
 
 data "aws_wafv2_web_acl" "existing_backend_public" {
   name  = "backend_public_web_acl"
   scope = "REGIONAL"
+}
+
+import {
+  to = aws_wafv2_web_acl.backend_public
+  id = "${data.aws_wafv2_web_acl.existing_backend_public.id}/backend_public_web_acl/REGIONAL"
+}
+
+import {
+  to = aws_cloudwatch_log_group.public_backend_waf
+  id = "aws-waf-logs-backend-public-${var.govuk_environment}"
 }
 
 data "aws_wafv2_web_acl" "existing_bouncer_public" {
@@ -606,9 +660,29 @@ data "aws_wafv2_web_acl" "existing_bouncer_public" {
   scope = "REGIONAL"
 }
 
+import {
+  to = aws_wafv2_web_acl.bouncer_public
+  id = "${data.aws_wafv2_web_acl.existing_bouncer_public.id}/bouncer_public_web_acl/REGIONAL"
+}
+
+import {
+  to = aws_cloudwatch_log_group.public_bouncer_waf
+  id = "aws-waf-logs-bouncer-public-${var.govuk_environment}"
+}
+
 data "aws_wafv2_web_acl" "existing_cache_public" {
   name  = "cache_public_web_acl"
   scope = "REGIONAL"
+}
+
+import {
+  to = aws_wafv2_web_acl.cache_public
+  id = "${data.aws_wafv2_web_acl.existing_cache_public.id}/cache_public_web_acl/REGIONAL"
+}
+
+import {
+  to = aws_cloudwatch_log_group.public_cache_waf
+  id = "aws-waf-logs-cache-public-${var.govuk_environment}"
 }
 
 import {


### PR DESCRIPTION
Part of the infra-public-wafs migration, prematurely removed the imports before running the Terraform.