### PR TITLE
Remove duplicate public route table resource in vpc module

### DIFF
--- a/terraform/deployments/vpc/vpc.tf
+++ b/terraform/deployments/vpc/vpc.tf
@@ -22,16 +22,10 @@ resource "aws_internet_gateway" "public" {
   }
 }
 
-resource "aws_route_table" "public" {
-  vpc_id = aws_vpc.vpc.id
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.public.id
-  }
-
-  tags = {
-    Name = "govuk-${var.govuk_environment}"
+removed {
+  from = aws_route_table.public
+  lifecycle {
+    destroy = false
   }
 }
 


### PR DESCRIPTION
This was imported into two different resources by mistake. This removes one of the duplicates.

#1127 