### PR TITLE
Rename the ECR Repo used for pub-on-pg app

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -67,7 +67,7 @@ locals {
     "licensify-frontend",
     "govuk-fastly-diff-generator",
     "govuk-e2e-tests",
-    "publisher-on-postgres-branch"
+    "publisher-on-pg"
   ]
 }
 


### PR DESCRIPTION
## What?
This shortens the ECR Repo name for the (hopefully temporary) "publisher on postgres" feature app.