### PR TITLE
♻️ Replace kanban board link with GitHub projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are also docs in [terraform/docs/](terraform/docs/) and inline READMEs in 
 
 ## Team
 
-[GOV.UK Platform Engineering team](https://github.com/orgs/alphagov/teams/gov-uk-platform-engineering) looks after this repo. If you're inside GDS, you can find us in [#govuk-platform-engineering](https://gds.slack.com/channels/govuk-platform-engineering) or view our [kanban board](https://trello.com/b/u4FCzm53/).
+[GOV.UK Platform Engineering team](https://github.com/orgs/alphagov/teams/gov-uk-platform-engineering) looks after this repo. If you're inside GDS, you can find us in [#govuk-platform-engineering](https://gds.slack.com/channels/govuk-platform-engineering) or view our [kanban board](https://github.com/orgs/alphagov/projects/71).
 
 ## Licence
 


### PR DESCRIPTION
## 👀 Purpose

- Very small change to correct the location of our kanban board.

## ♻️ What's changed

- We now use GitHub projects so the link should reflect that.

## 📝 Notes

-