### PR TITLE
Use modules for sensitive WAF config

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -55,6 +55,7 @@ jobs:
 
     - name: terraform init
       run: |
+        export TF_TOKEN_app_terraform_io="${{ secrets.TFC_CI_READ_ONLY_TOKEN }}"
         STEP_EXIT_STATUS=0
         for d in terraform/deployments/*; do
           echo "$d"

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -110,6 +110,18 @@ variable "allow_high_request_rate_from_cidrs" {
   default     = []
 }
 
+variable "cache_public_base_rate_warning" {
+  type        = number
+  description = "A warning rate limit threshold for the public web ACL"
+  default     = 2000
+}
+
+variable "cache_public_base_rate_limit" {
+  type        = number
+  description = "An enforced rate limit threshold for the public web ACL"
+  default     = 1000
+}
+
 variable "backend_public_base_rate_warning" {
   type        = number
   description = "A warning rate limit threshold for the backend public web ACL"
@@ -144,5 +156,11 @@ variable "bouncer_public_base_rate_limit" {
   type        = number
   description = "An enforced rate limit threshold for the bouncer public web ACL"
   default     = 1000
+}
+
+variable "fastly_rate_limit_token" {
+  type        = string
+  description = "Fastly API token for rate limiting"
+  default     = "test"
 }
 

--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -5,7 +5,7 @@
 
 module "infrastructure-sensitive_wafs" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/wafs"
-  version = "0.0.7"
+  version = "0.0.9"
 
   cache_public_base_rate_limit   = var.cache_public_base_rate_limit
   cache_public_base_rate_warning = var.cache_public_base_rate_warning

--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -5,10 +5,11 @@
 
 module "infrastructure-sensitive_wafs" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/wafs"
-  version = "0.0.9"
+  version = "0.0.10"
 
   cache_public_base_rate_limit   = var.cache_public_base_rate_limit
   cache_public_base_rate_warning = var.cache_public_base_rate_warning
+  fastly_rate_limit_token        = var.fastly_rate_limit_token
   govuk_requesting_ips_arn       = aws_wafv2_ip_set.govuk_requesting_ips.arn
   high_request_rate_ips_arn      = aws_wafv2_ip_set.high_request_rate.arn
   x_always_block_arn             = aws_wafv2_rule_group.x_always_block.arn

--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -2,6 +2,24 @@
 # we use it as a simple sanity check / acceptance test from smokey to ensure that
 # the waf is enabled and processing requests
 #
+
+module "infrastructure-sensitive_wafs" {
+  source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/wafs"
+  version = "0.0.7"
+
+  cache_public_base_rate_limit   = var.cache_public_base_rate_limit
+  cache_public_base_rate_warning = var.cache_public_base_rate_warning
+  govuk_requesting_ips_arn       = aws_wafv2_ip_set.govuk_requesting_ips.arn
+  high_request_rate_ips_arn      = aws_wafv2_ip_set.high_request_rate.arn
+  x_always_block_arn             = aws_wafv2_rule_group.x_always_block.arn
+}
+
+
+moved {
+  from = aws_wafv2_web_acl.cache_public
+  to   = module.infrastructure-sensitive_wafs.aws_wafv2_web_acl.cache_public
+}
+
 resource "aws_wafv2_web_acl" "default" {
   name  = "x-always-block_web_acl"
   scope = "REGIONAL"
@@ -532,28 +550,6 @@ resource "aws_wafv2_web_acl_logging_configuration" "public_bouncer_waf" {
   }
 }
 
-resource "aws_wafv2_web_acl" "cache_public" {
-  name  = "cache_public_web_acl"
-  scope = "REGIONAL"
-
-  default_action {
-    allow {}
-  }
-
-  lifecycle {
-    ignore_changes = [
-      rule,
-      custom_response_body
-    ]
-  }
-
-  visibility_config {
-    cloudwatch_metrics_enabled = true
-    metric_name                = "cache-public-web-acl"
-    sampled_requests_enabled   = true
-  }
-}
-
 resource "aws_cloudwatch_log_group" "public_cache_waf" {
   # the name must start with aws-waf-logs
   # https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html#logging-cw-logs-naming
@@ -563,7 +559,7 @@ resource "aws_cloudwatch_log_group" "public_cache_waf" {
 
 resource "aws_wafv2_web_acl_logging_configuration" "public_cache_waf" {
   log_destination_configs = [aws_cloudwatch_log_group.public_cache_waf.arn]
-  resource_arn            = aws_wafv2_web_acl.cache_public.arn
+  resource_arn            = module.infrastructure-sensitive_wafs.public_cache_waf_arn
 
   logging_filter {
     default_behavior = "DROP"

--- a/terraform/deployments/tfc-aws-config/outputs.tf
+++ b/terraform/deployments/tfc-aws-config/outputs.tf
@@ -1,0 +1,15 @@
+output "aws_credentials_id" {
+  value = tfe_variable_set.variable_set.id
+}
+
+output "aws_credentials_name" {
+  value = tfe_variable_set.variable_set.name
+}
+
+output "gcp_credentials_id" {
+  value = tfe_variable_set.gcp_variable_set.id
+}
+
+output "gcp_credentials_name" {
+  value = tfe_variable_set.gcp_variable_set.name
+}

--- a/terraform/deployments/tfc-configuration/cdn-analytics.tf
+++ b/terraform/deployments/tfc-configuration/cdn-analytics.tf
@@ -1,6 +1,5 @@
 module "cdn-analytics-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "cdn-analytics-integration"
@@ -25,15 +24,17 @@ module "cdn-analytics-integration" {
   }
 
   variable_set_names = [
-    "gcp-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name
+    "gcp-credentials-integration"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id
   ]
 }
 
 module "cdn-analytics-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "cdn-analytics-staging"
@@ -57,15 +58,17 @@ module "cdn-analytics-staging" {
   }
 
   variable_set_names = [
-    "gcp-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name
+    "gcp-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id
   ]
 }
 
 module "cdn-analytics-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "cdn-analytics-production"
@@ -89,8 +92,11 @@ module "cdn-analytics-production" {
   }
 
   variable_set_names = [
-    "gcp-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name
+    "gcp-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id
   ]
 }

--- a/terraform/deployments/tfc-configuration/chat.tf
+++ b/terraform/deployments/tfc-configuration/chat.tf
@@ -1,6 +1,5 @@
 module "chat-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "chat-integration"
@@ -25,16 +24,18 @@ module "chat-integration" {
   }
 
   variable_set_names = [
-    "aws-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name,
-    module.variable-set-chat-integration.name
+    "aws-credentials-integration"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id,
+    module.variable-set-chat-integration.id
   ]
 }
 
 module "chat-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "chat-staging"
@@ -59,16 +60,18 @@ module "chat-staging" {
   }
 
   variable_set_names = [
-    "aws-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name,
-    module.variable-set-chat-staging.name
+    "aws-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id,
+    module.variable-set-chat-staging.id
   ]
 }
 
 module "chat-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "chat-production"
@@ -90,9 +93,12 @@ module "chat-production" {
   team_access = { "GOV.UK Production" = "write" }
 
   variable_set_names = [
-    "aws-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name,
-    module.variable-set-chat-production.name
+    "aws-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id,
+    module.variable-set-chat-production.id
   ]
 }

--- a/terraform/deployments/tfc-configuration/cloudfront.tf
+++ b/terraform/deployments/tfc-configuration/cloudfront.tf
@@ -1,6 +1,5 @@
 module "cloudfront-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "cloudfront-staging"
@@ -24,16 +23,18 @@ module "cloudfront-staging" {
   }
 
   variable_set_names = [
-    "aws-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name,
-    module.variable-set-cloudfront-staging.name
+    "aws-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id,
+    module.variable-set-cloudfront-staging.id
   ]
 }
 
 module "cloudfront-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "cloudfront-production"
@@ -57,9 +58,12 @@ module "cloudfront-production" {
   }
 
   variable_set_names = [
-    "aws-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name,
-    module.variable-set-cloudfront-production.name
+    "aws-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id,
+    module.variable-set-cloudfront-production.id
   ]
 }

--- a/terraform/deployments/tfc-configuration/cluster-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/cluster-infrastructure.tf
@@ -1,6 +1,5 @@
 module "cluster-infrastructure-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "cluster-infrastructure-integration"
@@ -25,15 +24,17 @@ module "cluster-infrastructure-integration" {
   }
 
   variable_set_names = [
-    "aws-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name
+    "aws-credentials-integration"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id
   ]
 }
 
 module "cluster-infrastructure-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "cluster-infrastructure-staging"
@@ -58,15 +59,17 @@ module "cluster-infrastructure-staging" {
   }
 
   variable_set_names = [
-    "aws-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name
+    "aws-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id
   ]
 }
 
 module "cluster-infrastructure-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "cluster-infrastructure-production"
@@ -88,8 +91,11 @@ module "cluster-infrastructure-production" {
   team_access = { "GOV.UK Production" = "write" }
 
   variable_set_names = [
-    "aws-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name
+    "aws-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id
   ]
 }

--- a/terraform/deployments/tfc-configuration/cluster-services.tf
+++ b/terraform/deployments/tfc-configuration/cluster-services.tf
@@ -1,6 +1,5 @@
 module "cluster-services-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "cluster-services-integration"
@@ -24,15 +23,17 @@ module "cluster-services-integration" {
   }
 
   variable_set_names = [
-    "aws-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name
+    "aws-credentials-integration"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id
   ]
 }
 
 module "cluster-services-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "cluster-services-staging"
@@ -55,15 +56,17 @@ module "cluster-services-staging" {
   }
 
   variable_set_names = [
-    "aws-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name
+    "aws-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id
   ]
 }
 
 module "cluster-services-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "cluster-services-production"
@@ -86,8 +89,11 @@ module "cluster-services-production" {
   }
 
   variable_set_names = [
-    "aws-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name
+    "aws-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id
   ]
 }

--- a/terraform/deployments/tfc-configuration/csp-reporter.tf
+++ b/terraform/deployments/tfc-configuration/csp-reporter.tf
@@ -1,6 +1,5 @@
 module "csp-reporter-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "csp-reporter-integration"
@@ -24,15 +23,17 @@ module "csp-reporter-integration" {
   }
 
   variable_set_names = [
-    "aws-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name
+    "aws-credentials-integration"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id
   ]
 }
 
 module "csp-reporter-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "csp-reporter-staging"
@@ -55,15 +56,17 @@ module "csp-reporter-staging" {
   }
 
   variable_set_names = [
-    "aws-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name
+    "aws-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id
   ]
 }
 
 module "csp-reporter-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "csp-reporter-production"
@@ -86,8 +89,11 @@ module "csp-reporter-production" {
   }
 
   variable_set_names = [
-    "aws-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name
+    "aws-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id
   ]
 }

--- a/terraform/deployments/tfc-configuration/datagovuk-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/datagovuk-infrastructure.tf
@@ -1,6 +1,5 @@
 module "datagovuk-infrastructure-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "~> 0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "datagovuk-infrastructure-integration"
@@ -28,11 +27,15 @@ module "datagovuk-infrastructure-integration" {
     module.variable-set-common.name,
     module.variable-set-integration.name
   ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id
+  ]
 }
 
 module "datagovuk-infrastructure-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "~> 0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "datagovuk-infrastructure-staging"
@@ -55,15 +58,17 @@ module "datagovuk-infrastructure-staging" {
   }
 
   variable_set_names = [
-    "aws-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name
+    "aws-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id
   ]
 }
 
 module "datagovuk-infrastructure-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "~> 0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "datagovuk-infrastructure-production"
@@ -86,8 +91,11 @@ module "datagovuk-infrastructure-production" {
   }
 
   variable_set_names = [
-    "aws-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name
+    "aws-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id
   ]
 }

--- a/terraform/deployments/tfc-configuration/ecr.tf
+++ b/terraform/deployments/tfc-configuration/ecr.tf
@@ -1,6 +1,5 @@
 module "ecr-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "ecr-production"
@@ -22,9 +21,12 @@ module "ecr-production" {
   team_access = { "GOV.UK Production" = "write" }
 
   variable_set_names = [
-    "aws-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name,
-    module.variable-set-ecr-production.name
+    "aws-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id,
+    module.variable-set-ecr-production.id
   ]
 }

--- a/terraform/deployments/tfc-configuration/gcp-projects.tf
+++ b/terraform/deployments/tfc-configuration/gcp-projects.tf
@@ -1,6 +1,5 @@
 module "gcp-ga4-analytics" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "gcp-ga4-analytics"

--- a/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
@@ -1,6 +1,5 @@
 module "govuk-publishing-infrastructure-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "govuk-publishing-infrastructure-integration"
@@ -25,17 +24,19 @@ module "govuk-publishing-infrastructure-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
-    "gcp-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name,
-    module.variable-set-amazonmq-integration.name,
-    "sensitive-waf-integration"
+    "gcp-credentials-integration"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id,
+    module.variable-set-amazonmq-integration.id,
+    module.sensitive-variables.waf_integration_id
   ]
 }
 
 module "govuk-publishing-infrastructure-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "govuk-publishing-infrastructure-staging"
@@ -59,17 +60,19 @@ module "govuk-publishing-infrastructure-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "gcp-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name,
-    module.variable-set-amazonmq-staging.name,
-    "sensitive-waf-staging"
+    "gcp-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id,
+    module.variable-set-amazonmq-staging.id,
+    module.sensitive-variables.waf_staging_id
   ]
 }
 
 module "govuk-publishing-infrastructure-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "govuk-publishing-infrastructure-production"
@@ -93,10 +96,13 @@ module "govuk-publishing-infrastructure-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "gcp-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name,
-    module.variable-set-amazonmq-production.name,
-    "sensitive-waf-production"
+    "gcp-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id,
+    module.variable-set-amazonmq-production.id,
+    module.sensitive-variables.waf_production_id
   ]
 }

--- a/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
@@ -28,7 +28,8 @@ module "govuk-publishing-infrastructure-integration" {
     "gcp-credentials-integration",
     module.variable-set-common.name,
     module.variable-set-integration.name,
-    module.variable-set-amazonmq-integration.name
+    module.variable-set-amazonmq-integration.name,
+    "sensitive-waf-integration"
   ]
 }
 
@@ -61,7 +62,8 @@ module "govuk-publishing-infrastructure-staging" {
     "gcp-credentials-staging",
     module.variable-set-common.name,
     module.variable-set-staging.name,
-    module.variable-set-amazonmq-staging.name
+    module.variable-set-amazonmq-staging.name,
+    "sensitive-waf-staging"
   ]
 }
 
@@ -94,6 +96,7 @@ module "govuk-publishing-infrastructure-production" {
     "gcp-credentials-production",
     module.variable-set-common.name,
     module.variable-set-production.name,
-    module.variable-set-amazonmq-production.name
+    module.variable-set-amazonmq-production.name,
+    "sensitive-waf-production"
   ]
 }

--- a/terraform/deployments/tfc-configuration/mobile-backend.tf
+++ b/terraform/deployments/tfc-configuration/mobile-backend.tf
@@ -1,6 +1,5 @@
 module "mobile-backend-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "mobile-backend-production"
@@ -24,15 +23,17 @@ module "mobile-backend-production" {
   }
 
   variable_set_names = [
-    "aws-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name
+    "aws-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id
   ]
 }
 
 module "mobile-backend-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "mobile-backend-staging"
@@ -56,15 +57,17 @@ module "mobile-backend-staging" {
   }
 
   variable_set_names = [
-    "aws-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name
+    "aws-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id
   ]
 }
 
 module "mobile-backend-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "mobile-backend-integration"
@@ -89,9 +92,12 @@ module "mobile-backend-integration" {
   }
 
   variable_set_names = [
-    "aws-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name
+    "aws-credentials-integration"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id
   ]
 }
 

--- a/terraform/deployments/tfc-configuration/opensearch.tf
+++ b/terraform/deployments/tfc-configuration/opensearch.tf
@@ -1,6 +1,5 @@
 module "opensearch-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "opensearch-integration"
@@ -24,16 +23,18 @@ module "opensearch-integration" {
   }
 
   variable_set_names = [
-    "aws-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name,
-    module.variable-set-opensearch-integration.name
+    "aws-credentials-integration"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id,
+    module.variable-set-opensearch-integration.id
   ]
 }
 
 module "opensearch-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "opensearch-staging"
@@ -56,16 +57,18 @@ module "opensearch-staging" {
   }
 
   variable_set_names = [
-    "aws-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name,
-    module.variable-set-opensearch-staging.name
+    "aws-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id,
+    module.variable-set-opensearch-staging.id
   ]
 }
 
 module "opensearch-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization      = var.organization
   workspace_name    = "opensearch-production"
@@ -88,9 +91,12 @@ module "opensearch-production" {
   }
 
   variable_set_names = [
-    "aws-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name,
-    module.variable-set-opensearch-production.name
+    "aws-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id,
+    module.variable-set-opensearch-production.id
   ]
 }

--- a/terraform/deployments/tfc-configuration/rds.tf
+++ b/terraform/deployments/tfc-configuration/rds.tf
@@ -1,6 +1,5 @@
 module "rds-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "rds-integration"
@@ -25,16 +24,18 @@ module "rds-integration" {
   }
 
   variable_set_names = [
-    "aws-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name,
-    module.variable-set-rds-integration.name
+    "aws-credentials-integration"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id,
+    module.variable-set-rds-integration.id
   ]
 }
 
 module "rds-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "rds-staging"
@@ -58,16 +59,18 @@ module "rds-staging" {
   }
 
   variable_set_names = [
-    "aws-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name,
-    module.variable-set-rds-staging.name
+    "aws-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id,
+    module.variable-set-rds-staging.id
   ]
 }
 
 module "rds-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "rds-production"
@@ -91,9 +94,12 @@ module "rds-production" {
   }
 
   variable_set_names = [
-    "aws-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name,
-    module.variable-set-rds-production.name
+    "aws-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id,
+    module.variable-set-rds-production.id
   ]
 }

--- a/terraform/deployments/tfc-configuration/remote.tf
+++ b/terraform/deployments/tfc-configuration/remote.tf
@@ -2,3 +2,15 @@ data "tfe_oauth_client" "github" {
   organization     = var.organization
   service_provider = "github"
 }
+
+data "tfe_workspace_ids" "aws_config" {
+  organization = "govuk"
+  tag_names    = ["tfc", "aws", "configuration"]
+}
+
+data "tfe_outputs" "aws_config" {
+  for_each = data.tfe_workspace_ids.aws_config.full_names
+
+  organization = "govuk"
+  workspace    = each.key
+}

--- a/terraform/deployments/tfc-configuration/variables-common.tf
+++ b/terraform/deployments/tfc-configuration/variables-common.tf
@@ -10,9 +10,3 @@ module "variable-set-common" {
     }]
   }
 }
-
-
-module "sensitive-variables" {
-  source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/variables"
-  version = "0.0.9"
-}

--- a/terraform/deployments/tfc-configuration/variables-common.tf
+++ b/terraform/deployments/tfc-configuration/variables-common.tf
@@ -10,3 +10,9 @@ module "variable-set-common" {
     }]
   }
 }
+
+
+module "sensitive-variables" {
+  source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/variables"
+  version = "0.0.9"
+}

--- a/terraform/deployments/tfc-configuration/variables-sensitive.tf
+++ b/terraform/deployments/tfc-configuration/variables-sensitive.tf
@@ -1,26 +1,4 @@
-module "variables-sensitive" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "0.12.0"
-
-  organization        = var.organization
-  workspace_name      = "variables-sensitive"
-  workspace_desc      = "This module manages sensitive variables for Terraform Cloud workspaces."
-  workspace_tags      = ["tfc", "variables", "sensitive"]
-  terraform_version   = var.terraform_version
-  execution_mode      = "remote"
-  working_directory   = "/"
-  trigger_patterns    = ["/**/*"]
-  global_remote_state = true
-
-  project_name = "govuk-infrastructure"
-  vcs_repo = {
-    identifier     = "alphagov/govuk-infrastructure-sensitive"
-    branch         = "main"
-    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
-  }
-
-  team_access = {
-    "GOV.UK Non-Production (r/o)" = "read"
-    "GOV.UK Production"           = "write"
-  }
+module "sensitive-variables" {
+  source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/variables"
+  version = "0.0.9"
 }

--- a/terraform/deployments/tfc-configuration/variables-sensitive.tf
+++ b/terraform/deployments/tfc-configuration/variables-sensitive.tf
@@ -1,4 +1,4 @@
 module "sensitive-variables" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/variables"
-  version = "0.0.9"
+  version = "0.0.10"
 }

--- a/terraform/deployments/tfc-configuration/variables-sensitive.tf
+++ b/terraform/deployments/tfc-configuration/variables-sensitive.tf
@@ -1,4 +1,4 @@
 module "sensitive-variables" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/variables"
-  version = "0.0.10"
+  version = "0.0.13"
 }

--- a/terraform/deployments/tfc-configuration/vpc.tf
+++ b/terraform/deployments/tfc-configuration/vpc.tf
@@ -1,6 +1,5 @@
 module "vpc-integration" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "~> 0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "vpc-integration"
@@ -26,15 +25,17 @@ module "vpc-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
-    "gcp-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name
+    "gcp-credentials-integration"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-integration.id
   ]
 }
 
 module "vpc-staging" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "~> 0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "vpc-staging"
@@ -59,15 +60,17 @@ module "vpc-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "gcp-credentials-staging",
-    module.variable-set-common.name,
-    module.variable-set-staging.name
+    "gcp-credentials-staging"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-staging.id
   ]
 }
 
 module "vpc-production" {
-  source  = "alexbasista/workspacer/tfe"
-  version = "~> 0.12.0"
+  source = "github.com/alphagov/terraform-tfe-workspacer"
 
   organization        = var.organization
   workspace_name      = "vpc-production"
@@ -92,8 +95,11 @@ module "vpc-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "gcp-credentials-production",
-    module.variable-set-common.name,
-    module.variable-set-production.name
+    "gcp-credentials-production"
+  ]
+
+  variable_set_ids = [
+    module.variable-set-common.id,
+    module.variable-set-production.id
   ]
 }


### PR DESCRIPTION
This uses a private module to create privates WAF resources and set private variables. These modules are defined in https://github.com/alphagov/terraform-govuk-infrastructure-sensitive (annoying had to use this name convention for TFC) .

As part of the tfc-configuration workspace, a sensitive variable set for WAFs is created for each environments.

Then for each of the govuk-publishing-infrastructure projects, they are configured to use the respective variable-set and to create the private WAF resource. 

(tfc-configuration project needs to be run twice; once to create the variable set, then to assign it to the relevant projects. Hence will error on review of this PR.)