### PR TITLE
Add sanity check to github repositories data source

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -43,6 +43,13 @@ provider "github" {
 
 data "github_repositories" "govuk" {
   query = "topic:govuk org:alphagov archived:false"
+
+  lifecycle {
+    postcondition {
+      condition     = length(self.full_names) > 100
+      error_message = "not enough repositories were found by data source"
+    }
+  }
 }
 
 data "github_repository" "govuk" {


### PR DESCRIPTION
This should hopefully protect us from a complete GitHub Search API outage like we had a few weeks ago

https://github.com/alphagov/govuk-platform-internal/issues/9