### PR TITLE
Add Graviton (ARM) hardware support to Production

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -55,14 +55,15 @@ module "variable-set-production" {
 
     govuk_environment = "production"
 
-    enable_metrics_server = false
+    enable_metrics_server = true
 
-    enable_arm_workers  = false
+    enable_arm_workers  = true
     enable_main_workers = true
     enable_x86_workers  = false
 
     publishing_service_domain = "publishing.service.gov.uk"
 
+    arm_workers_instance_types  = ["r8g.4xlarge", "r7g.4xlarge", "m7g.8xlarge", "m6g.8xlarge"]
     main_workers_instance_types = ["m6i.8xlarge", "m6a.8xlarge"]
     x86_workers_instance_types  = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
 


### PR DESCRIPTION
## What?
This adds Graviton hardware support to Production, paving the way for us to make the final switchover.

I am also enabling Metrics Server, because this had no adverse reactions outside of production and also opens up the possibility to use Horizontal Pod Autoscaling in the future.

We'll be using r8g.4xlarge as our workloads are memory-intensive rather than CPU-intensive.