### PR TITLE
Rename the sensitive infrastructure repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -299,7 +299,7 @@ repos:
     strict: true
     up_to_date_branches: true
 
-  govuk-infrastructure-sensitive:
+  terraform-govuk-infrastructure-sensitive:
     strict: true
     up_to_date_branches: true
 


### PR DESCRIPTION
This repo is to be used to store private terraform modules, where Terraform Cloud requires a specific name convention.