### PR TITLE
Search API v2: Add new Search Admin serving configs

### DIFF
--- a/terraform/deployments/search-api-v2/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/deployments/search-api-v2/modules/google_discovery_engine_restapi/main.tf
@@ -67,19 +67,52 @@ resource "restapi_object" "discovery_engine_serving_config" {
   })
 }
 
-# Future serving config managed by Search Admin
-resource "restapi_object" "discovery_engine_serving_config_site_search" {
-  path      = "/engines/${var.engine_id}/servingConfigs/site_search"
-  object_id = "site_search"
+# Future serving configs managed by Search Admin
+# NOTE: These are created in TF for now, but should migrate to being fully managed by Search Admin
+# as soon as that is supported by the Discovery Engine Ruby client, at which point they should be
+# removed from state and deleted from this config.
+resource "restapi_object" "discovery_engine_serving_config_govuk_default" {
+  path      = "/engines/${var.engine_id}/servingConfigs/govuk_default"
+  object_id = "govuk_default"
 
   create_method = "POST"
-  create_path   = "/engines/${var.engine_id}/servingConfigs?servingConfigId=site_search"
+  create_path   = "/engines/${var.engine_id}/servingConfigs?servingConfigId=govuk_default"
   update_method = "PATCH"
-  update_path   = "/engines/${var.engine_id}/servingConfigs/site_search"
-  read_path     = "/engines/${var.engine_id}/servingConfigs/site_search"
+  update_path   = "/engines/${var.engine_id}/servingConfigs/govuk_default"
+  read_path     = "/engines/${var.engine_id}/servingConfigs/govuk_default"
 
   data = jsonencode({
-    displayName  = "Site Search serving config (controls managed by Search Admin)"
+    displayName  = "The default serving config used for live search (managed by Search Admin)"
+    solutionType = "SOLUTION_TYPE_SEARCH"
+  })
+}
+resource "restapi_object" "discovery_engine_serving_config_govuk_preview" {
+  path      = "/engines/${var.engine_id}/servingConfigs/govuk_preview"
+  object_id = "govuk_preview"
+
+  create_method = "POST"
+  create_path   = "/engines/${var.engine_id}/servingConfigs?servingConfigId=govuk_preview"
+  update_method = "PATCH"
+  update_path   = "/engines/${var.engine_id}/servingConfigs/govuk_preview"
+  read_path     = "/engines/${var.engine_id}/servingConfigs/govuk_preview"
+
+  data = jsonencode({
+    displayName  = "A preview serving config used for trying out new controls (managed by Search Admin)"
+    solutionType = "SOLUTION_TYPE_SEARCH"
+  })
+}
+resource "restapi_object" "discovery_engine_serving_config_govuk_raw" {
+  path      = "/engines/${var.engine_id}/servingConfigs/govuk_raw"
+  object_id = "govuk_raw"
+
+  create_method = "POST"
+  create_path   = "/engines/${var.engine_id}/servingConfigs?servingConfigId=govuk_raw"
+  update_method = "PATCH"
+  update_path   = "/engines/${var.engine_id}/servingConfigs/govuk_raw"
+  read_path     = "/engines/${var.engine_id}/servingConfigs/govuk_raw"
+
+  data = jsonencode({
+    displayName  = "A raw serving config without controls attached to it (managed by Search Admin)"
     solutionType = "SOLUTION_TYPE_SEARCH"
   })
 }


### PR DESCRIPTION
This removes a temporary serving config for Search Admin, and sets up three new ones:
- `govuk_default`
- `govuk_preview`
- `govuk_raw`

Eventually, their lifecycle management should be fully in Search Admin, but the Ruby client doesn't support creating them yet, so we're doing it in TF instead.

This also removes the temporary serving config from the Search Admin AWS secret, and the outputs.