### PR TITLE
Update aws-load-balancer-controller IAM policy to match reference

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam_policy.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam_policy.tf
@@ -29,6 +29,7 @@ data "aws_iam_policy_document" "aws_lb_controller" {
       "ec2:DescribeTags",
       "ec2:GetCoipPoolUsage",
       "ec2:DescribeCoipPools",
+      "ec2:GetSecurityGroupsForVpc",
       "elasticloadbalancing:DescribeLoadBalancers",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",
       "elasticloadbalancing:DescribeListeners",
@@ -38,7 +39,10 @@ data "aws_iam_policy_document" "aws_lb_controller" {
       "elasticloadbalancing:DescribeTargetGroups",
       "elasticloadbalancing:DescribeTargetGroupAttributes",
       "elasticloadbalancing:DescribeTargetHealth",
-      "elasticloadbalancing:DescribeTags"
+      "elasticloadbalancing:DescribeTags",
+      "elasticloadbalancing:DescribeTrustStores",
+      "elasticloadbalancing:DescribeListenerAttributes",
+      "elasticloadbalancing:DescribeCapacityReservation"
     ]
     resources = ["*"]
   }
@@ -215,7 +219,9 @@ data "aws_iam_policy_document" "aws_lb_controller" {
       "elasticloadbalancing:DeleteLoadBalancer",
       "elasticloadbalancing:ModifyTargetGroup",
       "elasticloadbalancing:ModifyTargetGroupAttributes",
-      "elasticloadbalancing:DeleteTargetGroup"
+      "elasticloadbalancing:DeleteTargetGroup",
+      "elasticloadbalancing:ModifyListenerAttributes",
+      "elasticloadbalancing:ModifyCapacityReservation"
     ]
     resources = ["*"]
     condition {


### PR DESCRIPTION
The [reference policy](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json) for the LB controller has been updated since the controller needs some new permissions. This brings our policy in line with the reference that AWS provides.