### PR TITLE
Switch Production to smaller/fewer x86 Nodes

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -58,18 +58,14 @@ module "variable-set-production" {
     enable_metrics_server = true
 
     enable_arm_workers  = true
-    enable_main_workers = true
-    enable_x86_workers  = false
+    enable_main_workers = false
+    enable_x86_workers  = true
 
     publishing_service_domain = "publishing.service.gov.uk"
 
     arm_workers_instance_types  = ["r8g.4xlarge", "r7g.4xlarge", "m7g.8xlarge", "m6g.8xlarge"]
     main_workers_instance_types = ["m6i.8xlarge", "m6a.8xlarge"]
     x86_workers_instance_types  = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
-
-    x86_workers_size_desired = 6
-    x86_workers_size_min     = 3
-    x86_workers_size_max     = 12
 
     frontend_memcached_node_type = "cache.r6g.large"
 


### PR DESCRIPTION
## What?
Now that our workloads are running on ARM/Graviton in Production, we can now change the x86 Node Groups around to use smaller/fewer instances for the few workloads that may still require x86 support.

Once we're confident we don't need "legacy" x86 support,  we can then go and turn off the x86 workers entirely.