### PR TITLE
Fix chat deployment in TFC

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -101,7 +101,7 @@ module "variable-set-chat-integration" {
     chat_redis_cluster_multi_az_enabled           = false
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"
-    cloudfront_create                             = 1
+    cloudfront_create                             = true
     cloudfront_enable                             = true
     service_disabled                              = false
     origin_chat_domain                            = "chat.eks.integration.govuk.digital"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -124,7 +124,7 @@ module "variable-set-chat-production" {
     chat_redis_cluster_multi_az_enabled           = true
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "2"
-    cloudfront_create                             = 1
+    cloudfront_create                             = true
     cloudfront_enable                             = true
     service_disabled                              = false
     origin_chat_domain                            = "chat.eks.production.govuk.digital"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -114,7 +114,7 @@ module "variable-set-chat-staging" {
     chat_redis_cluster_multi_az_enabled           = false
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"
-    cloudfront_create                             = 1
+    cloudfront_create                             = true
     cloudfront_enable                             = true
     service_disabled                              = false
     origin_chat_domain                            = "chat.eks.staging.govuk.digital"


### PR DESCRIPTION
## What

Update value of variables `cloudfront_create` from "1" to "true"

## Why

Bumping Terraform to 1.10 appears to have caused the following error:
```
Error: Invalid value for input variable
on /home/tfc-agent/.tfc-agent/component/terraform/runs/run-zMME98VooKS9PwTX/terraform.tfvars line 9:
cloudfront_create = 1
The given value is not suitable for var.cloudfront_create declared at variables.tf:35,1-29: bool required.
```