### PR TITLE
Replace variable set names with references to a variable-set module output

### DIFF
--- a/terraform/deployments/tfc-configuration/cdn-analytics.tf
+++ b/terraform/deployments/tfc-configuration/cdn-analytics.tf
@@ -26,8 +26,8 @@ module "cdn-analytics-integration" {
 
   variable_set_names = [
     "gcp-credentials-integration",
-    "common",
-    "common-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name
   ]
 }
 
@@ -58,8 +58,8 @@ module "cdn-analytics-staging" {
 
   variable_set_names = [
     "gcp-credentials-staging",
-    "common",
-    "common-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name
   ]
 }
 
@@ -90,7 +90,7 @@ module "cdn-analytics-production" {
 
   variable_set_names = [
     "gcp-credentials-production",
-    "common",
-    "common-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/chat.tf
+++ b/terraform/deployments/tfc-configuration/chat.tf
@@ -26,9 +26,9 @@ module "chat-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
-    "common",
-    "common-integration",
-    "chat-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name,
+    module.variable-set-chat-integration.name
   ]
 }
 
@@ -60,9 +60,9 @@ module "chat-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "common",
-    "common-staging",
-    "chat-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name,
+    module.variable-set-chat-staging.name
   ]
 }
 
@@ -91,8 +91,8 @@ module "chat-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "common",
-    "common-production",
-    "chat-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name,
+    module.variable-set-chat-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/cloudfront.tf
+++ b/terraform/deployments/tfc-configuration/cloudfront.tf
@@ -25,9 +25,9 @@ module "cloudfront-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "common",
-    "common-staging",
-    "cloudfront-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name,
+    module.variable-set-cloudfront-staging.name
   ]
 }
 
@@ -58,8 +58,8 @@ module "cloudfront-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "common",
-    "common-production",
-    "cloudfront-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name,
+    module.variable-set-cloudfront-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/cluster-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/cluster-infrastructure.tf
@@ -26,8 +26,8 @@ module "cluster-infrastructure-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
-    "common",
-    "common-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name
   ]
 }
 
@@ -59,8 +59,8 @@ module "cluster-infrastructure-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "common",
-    "common-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name
   ]
 }
 
@@ -89,7 +89,7 @@ module "cluster-infrastructure-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "common",
-    "common-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/cluster-services.tf
+++ b/terraform/deployments/tfc-configuration/cluster-services.tf
@@ -25,8 +25,8 @@ module "cluster-services-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
-    "common",
-    "common-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name
   ]
 }
 
@@ -56,8 +56,8 @@ module "cluster-services-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "common",
-    "common-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name
   ]
 }
 
@@ -87,7 +87,7 @@ module "cluster-services-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "common",
-    "common-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/csp-reporter.tf
+++ b/terraform/deployments/tfc-configuration/csp-reporter.tf
@@ -25,8 +25,8 @@ module "csp-reporter-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
-    "common",
-    "common-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name
   ]
 }
 
@@ -56,8 +56,8 @@ module "csp-reporter-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "common",
-    "common-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name
   ]
 }
 
@@ -87,7 +87,7 @@ module "csp-reporter-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "common",
-    "common-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/datagovuk-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/datagovuk-infrastructure.tf
@@ -25,8 +25,8 @@ module "datagovuk-infrastructure-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
-    "common",
-    "common-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name
   ]
 }
 
@@ -56,8 +56,8 @@ module "datagovuk-infrastructure-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "common",
-    "common-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name
   ]
 }
 
@@ -87,7 +87,7 @@ module "datagovuk-infrastructure-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "common",
-    "common-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/ecr.tf
+++ b/terraform/deployments/tfc-configuration/ecr.tf
@@ -23,8 +23,8 @@ module "ecr-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "common",
-    "common-production",
-    "ecr-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name,
+    module.variable-set-ecr-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
@@ -26,9 +26,9 @@ module "govuk-publishing-infrastructure-integration" {
   variable_set_names = [
     "aws-credentials-integration",
     "gcp-credentials-integration",
-    "common",
-    "common-integration",
-    "amazonmq-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name,
+    module.variable-set-amazonmq-integration.name
   ]
 }
 
@@ -59,9 +59,9 @@ module "govuk-publishing-infrastructure-staging" {
   variable_set_names = [
     "aws-credentials-staging",
     "gcp-credentials-staging",
-    "common",
-    "common-staging",
-    "amazonmq-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name,
+    module.variable-set-amazonmq-staging.name
   ]
 }
 
@@ -92,8 +92,8 @@ module "govuk-publishing-infrastructure-production" {
   variable_set_names = [
     "aws-credentials-production",
     "gcp-credentials-production",
-    "common",
-    "common-production",
-    "amazonmq-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name,
+    module.variable-set-amazonmq-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/mobile-backend.tf
+++ b/terraform/deployments/tfc-configuration/mobile-backend.tf
@@ -25,8 +25,8 @@ module "mobile-backend-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "common",
-    "common-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name
   ]
 }
 
@@ -57,8 +57,8 @@ module "mobile-backend-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "common",
-    "common-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name
   ]
 }
 
@@ -90,8 +90,8 @@ module "mobile-backend-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
-    "common",
-    "common-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name
   ]
 }
 

--- a/terraform/deployments/tfc-configuration/opensearch.tf
+++ b/terraform/deployments/tfc-configuration/opensearch.tf
@@ -25,9 +25,9 @@ module "opensearch-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
-    "common",
-    "common-integration",
-    "opensearch-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name,
+    module.variable-set-opensearch-integration.name
   ]
 }
 
@@ -57,9 +57,9 @@ module "opensearch-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "common",
-    "common-staging",
-    "opensearch-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name,
+    module.variable-set-opensearch-staging.name
   ]
 }
 
@@ -89,8 +89,8 @@ module "opensearch-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "common",
-    "common-production",
-    "opensearch-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name,
+    module.variable-set-opensearch-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/rds.tf
+++ b/terraform/deployments/tfc-configuration/rds.tf
@@ -26,9 +26,9 @@ module "rds-integration" {
 
   variable_set_names = [
     "aws-credentials-integration",
-    "common",
-    "common-integration",
-    "rds-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name,
+    module.variable-set-rds-integration.name
   ]
 }
 
@@ -59,9 +59,9 @@ module "rds-staging" {
 
   variable_set_names = [
     "aws-credentials-staging",
-    "common",
-    "common-staging",
-    "rds-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name,
+    module.variable-set-rds-staging.name
   ]
 }
 
@@ -92,8 +92,8 @@ module "rds-production" {
 
   variable_set_names = [
     "aws-credentials-production",
-    "common",
-    "common-production",
-    "rds-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name,
+    module.variable-set-rds-production.name
   ]
 }

--- a/terraform/deployments/tfc-configuration/variable-set/outputs.tf
+++ b/terraform/deployments/tfc-configuration/variable-set/outputs.tf
@@ -1,3 +1,7 @@
-output "variable_set_id" {
+output "id" {
   value = tfe_variable_set.set.id
+}
+
+output "name" {
+  value = tfe_variable_set.set.name
 }

--- a/terraform/deployments/tfc-configuration/vpc.tf
+++ b/terraform/deployments/tfc-configuration/vpc.tf
@@ -27,8 +27,8 @@ module "vpc-integration" {
   variable_set_names = [
     "aws-credentials-integration",
     "gcp-credentials-integration",
-    "common",
-    "common-integration"
+    module.variable-set-common.name,
+    module.variable-set-integration.name
   ]
 }
 
@@ -60,8 +60,8 @@ module "vpc-staging" {
   variable_set_names = [
     "aws-credentials-staging",
     "gcp-credentials-staging",
-    "common",
-    "common-staging"
+    module.variable-set-common.name,
+    module.variable-set-staging.name
   ]
 }
 
@@ -93,7 +93,7 @@ module "vpc-production" {
   variable_set_names = [
     "aws-credentials-production",
     "gcp-credentials-production",
-    "common",
-    "common-production"
+    module.variable-set-common.name,
+    module.variable-set-production.name
   ]
 }


### PR DESCRIPTION
This is to fix an issue where if you attempt to create a var set and assign it to workspaces in the same apply, it will error because the workspace module tries to get var set details via a data source, and it doesn't exist yet.

This works because it creates a dependency on the variable set for the workspace module, so it won't try to get the var set details before the var set has been created.

#1127 