### PR TITLE
Search v2: Remove superfluous env configuration

### DIFF
--- a/terraform/deployments/search-api-v2/discovery_engine.tf
+++ b/terraform/deployments/search-api-v2/discovery_engine.tf
@@ -13,10 +13,7 @@ module "govuk_content_discovery_engine" {
 # TODO: These IDs/paths are semi-hardcoded here as there aren't first party resources/data sources
 # available for them yet.
 locals {
-  discovery_engine_datastore_branch_path           = "${google_discovery_engine_data_store.govuk_content.name}/branches/default_branch"
-  discovery_engine_default_collection_name         = "projects/${var.gcp_project_id}/locations/${var.discovery_engine_location}/collections/default_collection"
-  discovery_engine_serving_config_path             = "${google_discovery_engine_search_engine.govuk.name}/servingConfigs/default_search"
-  discovery_engine_site_search_serving_config_path = "${google_discovery_engine_search_engine.govuk.name}/servingConfigs/site_search"
+  discovery_engine_default_collection_name = "projects/${var.gcp_project_id}/locations/${var.discovery_engine_location}/collections/default_collection"
 }
 
 resource "google_discovery_engine_data_store" "govuk_content" {
@@ -71,10 +68,7 @@ resource "aws_secretsmanager_secret_version" "discovery_engine_configuration" {
   secret_string = jsonencode({
     "GOOGLE_CLOUD_CREDENTIALS"                 = base64decode(google_service_account_key.api.private_key)
     "GOOGLE_CLOUD_PROJECT_ID"                  = var.gcp_project_id
-    "DISCOVERY_ENGINE_DATASTORE_BRANCH"        = local.discovery_engine_datastore_branch_path,
-    "DISCOVERY_ENGINE_DATASTORE"               = google_discovery_engine_data_store.govuk_content.name,
     "DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME" = local.discovery_engine_default_collection_name
-    "DISCOVERY_ENGINE_SERVING_CONFIG"          = local.discovery_engine_serving_config_path
   })
 }
 
@@ -87,10 +81,7 @@ resource "aws_secretsmanager_secret_version" "discovery_engine_configuration_sea
   secret_id = aws_secretsmanager_secret.discovery_engine_configuration_search_admin.id
   secret_string = jsonencode({
     "GOOGLE_CLOUD_CREDENTIALS"                 = base64decode(google_service_account_key.search_admin.private_key)
-    "DISCOVERY_ENGINE_DATASTORE"               = google_discovery_engine_data_store.govuk_content.name
     "DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME" = local.discovery_engine_default_collection_name
-    "DISCOVERY_ENGINE_ENGINE"                  = google_discovery_engine_search_engine.govuk.name
-    "DISCOVERY_ENGINE_SERVING_CONFIG"          = local.discovery_engine_site_search_serving_config_path
   })
 }
 

--- a/terraform/deployments/search-api-v2/outputs.tf
+++ b/terraform/deployments/search-api-v2/outputs.tf
@@ -3,17 +3,7 @@ output "google_cloud_discovery_engine_datastore_path" {
   value       = google_discovery_engine_data_store.govuk_content.name
 }
 
-output "google_cloud_discovery_engine_datastore_branch_path" {
-  description = "The full path of the default branch of the datastore created by the module (for data ingestion)"
-  value       = local.discovery_engine_datastore_branch_path
-}
-
-output "google_cloud_discovery_engine_serving_config_path" {
-  description = "The full path of the default serving config on the engine created by the module (for querying)"
-  value       = local.discovery_engine_serving_config_path
-}
-
-output "google_cloud_discovery_engine_site_seach_serving_config_path" {
-  description = "The full path of the site search serving config on the engine created by the module (for querying)"
-  value       = local.discovery_engine_site_search_serving_config_path
+output "google_cloud_discovery_engine_default_collection_name" {
+  description = "The fully qualified name of the default collection on the GCP project"
+  value       = local.discovery_engine_default_collection_name
 }


### PR DESCRIPTION
This removes all of the `DISCOVERY_ENGINE_*` env vars from the Secrets Manager secrets for Search API v2 and Search Admin except for the `DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME` (which the apps now infer the other values from).

Note that we're leaving the datastore in the module outputs (and adding in the default collection) even though the outputs are not used by other modules, just because it's handy to see those (non-sensitive) values in the Terraform Cloud UI for a quick sense check.

see https://github.com/alphagov/govuk-helm-charts/pull/2986