### PR TITLE
Use var set ID from tfc-aws-config output instead of hardcoded var set name

### DIFF
--- a/terraform/deployments/tfc-configuration/cdn-analytics.tf
+++ b/terraform/deployments/tfc-configuration/cdn-analytics.tf
@@ -23,11 +23,8 @@ module "cdn-analytics-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "gcp-credentials-integration"
-  ]
-
   variable_set_ids = [
+    local.gcp_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id
   ]
@@ -57,11 +54,8 @@ module "cdn-analytics-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "gcp-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.gcp_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id
   ]
@@ -91,11 +85,8 @@ module "cdn-analytics-production" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "gcp-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.gcp_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id
   ]

--- a/terraform/deployments/tfc-configuration/chat.tf
+++ b/terraform/deployments/tfc-configuration/chat.tf
@@ -23,11 +23,8 @@ module "chat-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-integration"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id,
     module.variable-set-chat-integration.id
@@ -59,11 +56,8 @@ module "chat-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id,
     module.variable-set-chat-staging.id
@@ -92,11 +86,8 @@ module "chat-production" {
   }
   team_access = { "GOV.UK Production" = "write" }
 
-  variable_set_names = [
-    "aws-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id,
     module.variable-set-chat-production.id

--- a/terraform/deployments/tfc-configuration/cloudfront.tf
+++ b/terraform/deployments/tfc-configuration/cloudfront.tf
@@ -22,11 +22,8 @@ module "cloudfront-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id,
     module.variable-set-cloudfront-staging.id
@@ -57,11 +54,8 @@ module "cloudfront-production" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id,
     module.variable-set-cloudfront-production.id

--- a/terraform/deployments/tfc-configuration/cluster-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/cluster-infrastructure.tf
@@ -23,11 +23,8 @@ module "cluster-infrastructure-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-integration"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id
   ]
@@ -58,11 +55,8 @@ module "cluster-infrastructure-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id
   ]
@@ -90,11 +84,8 @@ module "cluster-infrastructure-production" {
   }
   team_access = { "GOV.UK Production" = "write" }
 
-  variable_set_names = [
-    "aws-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id
   ]

--- a/terraform/deployments/tfc-configuration/cluster-services.tf
+++ b/terraform/deployments/tfc-configuration/cluster-services.tf
@@ -22,11 +22,8 @@ module "cluster-services-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-integration"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id
   ]
@@ -55,11 +52,8 @@ module "cluster-services-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id
   ]
@@ -88,11 +82,8 @@ module "cluster-services-production" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id
   ]

--- a/terraform/deployments/tfc-configuration/csp-reporter.tf
+++ b/terraform/deployments/tfc-configuration/csp-reporter.tf
@@ -22,11 +22,8 @@ module "csp-reporter-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-integration"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id
   ]
@@ -55,11 +52,8 @@ module "csp-reporter-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id
   ]
@@ -88,11 +82,8 @@ module "csp-reporter-production" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id
   ]

--- a/terraform/deployments/tfc-configuration/datagovuk-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/datagovuk-infrastructure.tf
@@ -22,13 +22,8 @@ module "datagovuk-infrastructure-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-integration",
-    module.variable-set-common.name,
-    module.variable-set-integration.name
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id
   ]
@@ -57,11 +52,8 @@ module "datagovuk-infrastructure-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id
   ]
@@ -90,11 +82,8 @@ module "datagovuk-infrastructure-production" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id
   ]

--- a/terraform/deployments/tfc-configuration/ecr.tf
+++ b/terraform/deployments/tfc-configuration/ecr.tf
@@ -20,11 +20,8 @@ module "ecr-production" {
   }
   team_access = { "GOV.UK Production" = "write" }
 
-  variable_set_names = [
-    "aws-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id,
     module.variable-set-ecr-production.id

--- a/terraform/deployments/tfc-configuration/gcp-projects.tf
+++ b/terraform/deployments/tfc-configuration/gcp-projects.tf
@@ -24,7 +24,7 @@ module "gcp-ga4-analytics" {
     "GOV.UK Non-Production (r/o)"  = "read"
   }
 
-  variable_set_names = [
-    "gcp-credentials-production"
+  variable_set_ids = [
+    local.gcp_credentials["production"],
   ]
 }

--- a/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
@@ -22,12 +22,9 @@ module "govuk-publishing-infrastructure-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-integration",
-    "gcp-credentials-integration"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["integration"],
+    local.gcp_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id,
     module.variable-set-amazonmq-integration.id,
@@ -58,12 +55,9 @@ module "govuk-publishing-infrastructure-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging",
-    "gcp-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
+    local.gcp_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id,
     module.variable-set-amazonmq-staging.id,
@@ -94,12 +88,9 @@ module "govuk-publishing-infrastructure-production" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-production",
-    "gcp-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
+    local.gcp_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id,
     module.variable-set-amazonmq-production.id,

--- a/terraform/deployments/tfc-configuration/mobile-backend.tf
+++ b/terraform/deployments/tfc-configuration/mobile-backend.tf
@@ -22,11 +22,8 @@ module "mobile-backend-production" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id
   ]
@@ -56,11 +53,8 @@ module "mobile-backend-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id
   ]
@@ -91,11 +85,8 @@ module "mobile-backend-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-integration"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id
   ]

--- a/terraform/deployments/tfc-configuration/opensearch.tf
+++ b/terraform/deployments/tfc-configuration/opensearch.tf
@@ -22,11 +22,8 @@ module "opensearch-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-integration"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id,
     module.variable-set-opensearch-integration.id
@@ -56,11 +53,8 @@ module "opensearch-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id,
     module.variable-set-opensearch-staging.id
@@ -90,11 +84,8 @@ module "opensearch-production" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id,
     module.variable-set-opensearch-production.id

--- a/terraform/deployments/tfc-configuration/rds.tf
+++ b/terraform/deployments/tfc-configuration/rds.tf
@@ -23,11 +23,8 @@ module "rds-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-integration"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id,
     module.variable-set-rds-integration.id
@@ -58,11 +55,8 @@ module "rds-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id,
     module.variable-set-rds-staging.id
@@ -93,11 +87,8 @@ module "rds-production" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id,
     module.variable-set-rds-production.id

--- a/terraform/deployments/tfc-configuration/remote.tf
+++ b/terraform/deployments/tfc-configuration/remote.tf
@@ -5,7 +5,7 @@ data "tfe_oauth_client" "github" {
 
 data "tfe_workspace_ids" "aws_config" {
   organization = "govuk"
-  tag_names    = ["tfc", "aws", "configuration"]
+  names        = ["tfc-aws-config-*"]
 }
 
 data "tfe_outputs" "aws_config" {
@@ -13,4 +13,9 @@ data "tfe_outputs" "aws_config" {
 
   organization = "govuk"
   workspace    = each.key
+}
+
+locals {
+  aws_credentials = { for k, v in data.tfe_outputs.aws_config : trimprefix(k, "tfc-aws-config-") => lookup(v.nonsensitive_values, "aws_credentials_id", null) }
+  gcp_credentials = { for k, v in data.tfe_outputs.aws_config : trimprefix(k, "tfc-aws-config-") => lookup(v.nonsensitive_values, "gcp_credentials_id", null) }
 }

--- a/terraform/deployments/tfc-configuration/vpc.tf
+++ b/terraform/deployments/tfc-configuration/vpc.tf
@@ -23,12 +23,9 @@ module "vpc-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-integration",
-    "gcp-credentials-integration"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["integration"],
+    local.gcp_credentials["integration"],
     module.variable-set-common.id,
     module.variable-set-integration.id
   ]
@@ -58,12 +55,9 @@ module "vpc-staging" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-staging",
-    "gcp-credentials-staging"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["staging"],
+    local.gcp_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id
   ]
@@ -93,12 +87,9 @@ module "vpc-production" {
     "GOV.UK Production" = "write"
   }
 
-  variable_set_names = [
-    "aws-credentials-production",
-    "gcp-credentials-production"
-  ]
-
   variable_set_ids = [
+    local.aws_credentials["production"],
+    local.gcp_credentials["production"],
     module.variable-set-common.id,
     module.variable-set-production.id
   ]


### PR DESCRIPTION
This brings the way we handle the AWS/GCP credentials var sets in line with the rest of them

#1127 