### PR TITLE
Add sentry project for govuk-graphql

### DIFF
--- a/terraform/deployments/sentry/locals.tf
+++ b/terraform/deployments/sentry/locals.tf
@@ -26,6 +26,7 @@ locals {
     "frontend"                 = [],
     "government-frontend"      = [],
     "govspeak-preview"         = ["govuk-publishing-platform"],
+    "govuk-graphql"            = [],
     "govuk-sli-collector"      = ["govuk-publishing-platform"],
     "hmrc-manuals-api"         = ["govuk-publishing-platform"],
     "licensify"                = [],


### PR DESCRIPTION
... I don't actually want sentry at this point, but the configuration insists on having a DSN for it, so I kind of need the project.