### PR TITLE
Give CO Platform Engineering team read-only access to dns repos

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -86,6 +86,10 @@ resource "github_team" "govuk" {
   privacy = "closed"
 }
 
+data "github_team" "co_platform_engineering" {
+  slug = "co-platform-engineering"
+}
+
 resource "github_team_repository" "govuk_production_admin_repos" {
   for_each   = local.repositories
   repository = each.key
@@ -105,6 +109,13 @@ resource "github_team_repository" "govuk_repos" {
   repository = each.key
   team_id    = github_team.govuk.id
   permission = try(each.value.teams["govuk"], "push")
+}
+
+resource "github_team_repository" "co_platform_engineering_repos" {
+  for_each   = toset(["govuk-dns-tf", "govuk-dns", "govuk-dns-config"])
+  repository = each.key
+  team_id    = data.github_team.co_platform_engineering.id
+  permission = "pull"
 }
 
 resource "github_repository" "govuk_repos" {


### PR DESCRIPTION
CO Platform Engineering wants to use it in the process of finding owners of subdomains.

This will reduce burden on the GOV.UK Platform Engineering team as the CO team will be able to obtain the information by themselves.

https://github.com/alphagov/govuk-infrastructure/issues/1599