### PR TITLE
Manage GOV.UK Production Deploy GitHub team

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -88,6 +88,17 @@ resource "github_team" "govuk_production_admin" {
   description = "https://docs.publishing.service.gov.uk/manual/rules-for-getting-production-access.html"
 }
 
+resource "github_team" "govuk_production_deploy" {
+  name        = "GOV.UK Production Deploy"
+  privacy     = "closed"
+  description = "https://docs.publishing.service.gov.uk/manual/rules-for-getting-production-access.html"
+}
+
+import {
+  to = github_team.govuk_production_deploy
+  id = "gov-uk-production-deploy"
+}
+
 resource "github_team" "govuk" {
   name    = "GOV.UK"
   privacy = "closed"
@@ -117,6 +128,15 @@ resource "github_team_repository" "govuk_repos" {
   team_id    = github_team.govuk.id
   permission = try(each.value.teams["govuk"], "push")
 }
+
+resource "github_team_repository" "govuk_production_deploy_repos" {
+  for_each   = local.repositories
+  repository = each.key
+  team_id    = github_team.govuk_production_deploy.id
+  # give prod deploy the same permissions as the GOV.UK team
+  permission = try(each.value.teams["govuk"], "push")
+}
+
 
 resource "github_team_repository" "co_platform_engineering_repos" {
   for_each   = toset(["govuk-dns-tf", "govuk-dns", "govuk-dns-config"])


### PR DESCRIPTION
Terraform is trying to perpetually apply changes to the branch protection rules on some repositories. This is because it tries adding the prod deploy team to the branch protection rule without the team having access to the repo itself.

The GitHub API seems to silently fail to add the team to the rule, causing TF to want to apply changes forever.

This PR starts managing the prod deploy team via TF, and adds the team to all of the repos that the GOV.UK team is a part of.