### PR TITLE
Only run terraform CI against changed deployments

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -12,23 +12,36 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
+    
+    - name: Get changed TF deployments
+      id: changed-deployments
+      uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8
+      with:
+        path: terraform/deployments
+        dir_names: true
+        dir_names_max_depth: 1
+        safe_output: false
 
     - name: Determine Terraform version to use
       uses: dflook/terraform-version@ffa43247c162717ecf69316d63c91fa4b341f9aa
       id: terraform-version
+      if: steps.changed-deployments.outputs.any_changed == 'true'
       with:
         path: terraform
 
     - uses: hashicorp/setup-terraform@v3
+      if: steps.changed-deployments.outputs.any_changed == 'true'
       with:
         terraform_version: ${{ steps.terraform-version.outputs.terraform }}
         terraform_wrapper: false
 
     - name: Create Terraform plugin cache dir
       run: mkdir -p "$TF_PLUGIN_CACHE_DIR"
+      if: steps.changed-deployments.outputs.any_changed == 'true'
 
     - name: Cache Terraform plugins
       uses: actions/cache@v4
+      if: steps.changed-deployments.outputs.any_changed == 'true'
       with:
         path: ${{ env.TF_PLUGIN_CACHE_DIR }}
         key:
@@ -36,54 +49,78 @@ jobs:
 
     - uses: actions/cache@v4
       name: Cache TFLint plugins
+      if: steps.changed-deployments.outputs.any_changed == 'true'
       with:
         path: ~/.tflint.d/plugins
         key: tflint-${{ runner.os }}-${{ hashFiles('**/tflint.hcl') }}
 
     - uses: terraform-linters/setup-tflint@v4
       name: Set up TFLint
+      if: steps.changed-deployments.outputs.any_changed == 'true'
       with:
         tflint_version: v0.55.0
 
     - name: terraform fmt
-      working-directory: terraform
+      working-directory: terraform/deployments
+      env:
+        DEPLOYMENTS: ${{ steps.changed-deployments.outputs.all_changed_files }}
+      if: steps.changed-deployments.outputs.any_changed == 'true'
       run: |
-        if ! terraform fmt -check -diff -list=true -recursive .; then
-          >&2 echo "Some terraform files weren't formatted correctly. Run 'terraform fmt' to fix them."
-          exit 1
-        fi
+        for d in ${DEPLOYMENTS}; do
+          cd "$d"
+          if ! terraform fmt -check -diff -list=true .; then
+            >&2 echo "Some terraform files in '$d' weren't formatted correctly. Run 'terraform fmt' to fix them."
+            exit 1
+          fi
+          echo "Deployment '$d' ok"
+          cd "$OLDPWD"
+        done
 
     - name: terraform init
+      working-directory: terraform/deployments
+      env:
+        DEPLOYMENTS: ${{ steps.changed-deployments.outputs.all_changed_files }}
+        TF_TOKEN_app_terraform_io: ${{ secrets.TFC_CI_READ_ONLY_TOKEN }}
+      if: steps.changed-deployments.outputs.any_changed == 'true'
       run: |
-        export TF_TOKEN_app_terraform_io="${{ secrets.TFC_CI_READ_ONLY_TOKEN }}"
         STEP_EXIT_STATUS=0
-        for d in terraform/deployments/*; do
+        for d in ${DEPLOYMENTS}; do
           echo "$d"
           cd "$d"
           if ! terraform init -backend=false; then STEP_EXIT_STATUS=1; fi
-          cd "$OLDPWD"
           echo -e '\n-------------------------\n'
+          cd "$OLDPWD"
         done
         exit $STEP_EXIT_STATUS
 
     - name: terraform validate
+      working-directory: terraform/deployments
+      env:
+        DEPLOYMENTS: ${{ steps.changed-deployments.outputs.all_changed_files }}
+      if: steps.changed-deployments.outputs.any_changed == 'true'
       run: |
         STEP_EXIT_STATUS=0
-        for d in terraform/deployments/*; do
+        for d in ${DEPLOYMENTS}; do
           echo "$d"
           cd "$d"
           if ! terraform validate; then STEP_EXIT_STATUS=1; fi
-          cd "$OLDPWD"
           echo -e '\n-------------------------\n'
+          cd "$OLDPWD"
         done
         exit $STEP_EXIT_STATUS
 
     - name: tflint
+      working-directory: terraform/deployments
+      env:
+        DEPLOYMENTS: ${{ steps.changed-deployments.outputs.all_changed_files }}
+      if: steps.changed-deployments.outputs.any_changed == 'true'
       run: |
-        cd terraform/deployments
         tflint --version
-        tflint --init --recursive -c ${{ github.workspace }}/.tflint.hcl
-        tflint --format compact --call-module-type=all --recursive --force \
+        for d in ${DEPLOYMENTS}; do
+          echo "$d"
+          cd "$d"
+          tflint --init -c ${{ github.workspace }}/.tflint.hcl
+          tflint --format compact --call-module-type=all --recursive --force \
             -c ${{ github.workspace }}/.tflint.hcl \
             --enable-rule=terraform_comment_syntax \
             --enable-rule=terraform_deprecated_index \
@@ -93,3 +130,7 @@ jobs:
             --enable-rule=terraform_unused_declarations \
             --enable-rule=terraform_unused_required_providers \
             --disable-rule=aws_eks_node_group_invalid_ami_type
+          cd "$OLDPWD"
+        done
+        
+        


### PR DESCRIPTION
The amount of time it takes to run the Terraform linting was annoying me, so I've updated the workflow to only run on TF deployments that have been modified.

The linting workflow was taking between 2 and 3 minutes before, and takes around 30-40 seconds now.

Examples:
* [when a change passes linting](https://github.com/alphagov/govuk-infrastructure/actions/runs/13329890591/job/37231273003)
* [when a change fails linting](https://github.com/alphagov/govuk-infrastructure/actions/runs/13329916518/job/37231352673)
* [when no changes are made](https://github.com/alphagov/govuk-infrastructure/actions/runs/13329986321/job/37231578091)