### PR TITLE
Fix perpetual apply in cdn-analytics deployment

### DIFF
--- a/terraform/deployments/cdn-analytics/bigquery.tf
+++ b/terraform/deployments/cdn-analytics/bigquery.tf
@@ -20,7 +20,7 @@ resource "google_bigquery_dataset" "fastly_logs" {
   }
 
   access {
-    role          = "roles/bigquery.dataEditor"
+    role          = "WRITER"
     user_by_email = google_service_account.fastly_writer.email
   }
 }

--- a/terraform/deployments/cdn-analytics/bigquery_schema.json
+++ b/terraform/deployments/cdn-analytics/bigquery_schema.json
@@ -1,93 +1,54 @@
 [
   {
     "name": "client_ip",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   },
   {
     "name": "request_received",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   },
   {
     "name": "method",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   },
   {
     "name": "url",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   },
   {
     "name": "status",
-    "mode": "",
-    "type": "INTEGER",
-    "description": "",
-    "fields": []
+    "type": "INTEGER"
   },
   {
     "name": "protocol",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   },
   {
     "name": "bytes",
-    "mode": "",
-    "type": "INTEGER",
-    "description": "",
-    "fields": []
+    "type": "INTEGER"
   },
   {
     "name": "content_type",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   },
   {
     "name": "user_agent",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   },
   {
     "name": "fastly_backend",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   },
   {
     "name": "cache_response",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   },
   {
     "name": "tls_client_protocol",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   },
   {
     "name": "tls_client_cipher",
-    "mode": "",
-    "type": "STRING",
-    "description": "",
-    "fields": []
+    "type": "STRING"
   }
 ]


### PR DESCRIPTION
No changes to the config, this is just making it match what the GCP API gives back to the TF provider