### PR TITLE
Add initial serverless ElastiCache resources

### DIFF
--- a/terraform/deployments/elasticache/elasticache.tf
+++ b/terraform/deployments/elasticache/elasticache.tf
@@ -1,0 +1,50 @@
+locals {
+  default_max_ecpus_per_second = 5000
+  default_max_storage_gb       = 10
+  default_engine_version       = "8"
+}
+
+resource "aws_security_group" "cache" {
+  for_each    = var.instances
+  name        = "elasticache-${each.key}"
+  vpc_id      = data.tfe_outputs.vpc.nonsensitive_values.id
+  description = "EKS to ElastiCache instance ${each.key} (govuk-infrastructure/terraform/deployments/elasticache)"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "cache" {
+  for_each          = var.instances
+  security_group_id = aws_security_group.cache[each.key].id
+
+  from_port                    = 6379
+  to_port                      = 6379
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
+}
+
+resource "aws_elasticache_serverless_cache" "cache" {
+  for_each             = var.instances
+  name                 = each.key
+  engine               = "valkey"
+  major_engine_version = try(each.value.major_engine_version, local.default_engine_version)
+  security_group_ids   = [aws_security_group.cache[each.key].id]
+  subnet_ids           = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.private_subnets
+
+  cache_usage_limits {
+    data_storage {
+      maximum = try(each.value.max_storage_gb, local.default_max_storage_gb)
+      unit    = "GB"
+    }
+    ecpu_per_second {
+      maximum = try(each.value.max_ecpus_per_second, local.default_max_ecpus_per_second)
+    }
+  }
+}
+
+resource "aws_secretsmanager_secret" "urls" {
+  name = "govuk/elasticache/urls"
+}
+
+resource "aws_secretsmanager_secret_version" "urls" {
+  secret_id     = "govuk/elasticache/urls"
+  secret_string = jsonencode({ for name, cache in aws_elasticache_serverless_cache.cache : name => "rediss://${cache.endpoint[0].address}:${cache.endpoint[0].port}" })
+}

--- a/terraform/deployments/elasticache/main.tf
+++ b/terraform/deployments/elasticache/main.tf
@@ -13,3 +13,17 @@ terraform {
     }
   }
 }
+
+provider "aws" {
+  region = "eu-west-1"
+  default_tags {
+    tags = {
+      Product              = "GOV.UK"
+      System               = "Serverless ElastiCache"
+      Environment          = var.govuk_environment
+      Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      repository           = "govuk-infrastructure"
+      terraform_deployment = basename(abspath(path.root))
+    }
+  }
+}

--- a/terraform/deployments/elasticache/remote.tf
+++ b/terraform/deployments/elasticache/remote.tf
@@ -1,0 +1,9 @@
+data "tfe_outputs" "cluster_infrastructure" {
+  organization = "govuk"
+  workspace    = "cluster-infrastructure-${var.govuk_environment}"
+}
+
+data "tfe_outputs" "vpc" {
+  organization = "govuk"
+  workspace    = "vpc-${var.govuk_environment}"
+}

--- a/terraform/deployments/elasticache/variables.tf
+++ b/terraform/deployments/elasticache/variables.tf
@@ -1,0 +1,9 @@
+variable "govuk_environment" {
+  type        = string
+  description = "GOV.UK environment name"
+}
+
+variable "instances" {
+  type        = map(any)
+  description = "Map of instance name -> settings"
+}

--- a/terraform/deployments/tfc-configuration/elasticache.tf
+++ b/terraform/deployments/tfc-configuration/elasticache.tf
@@ -3,7 +3,7 @@ module "elasticache-integration" {
 
   organization        = var.organization
   workspace_name      = "elasticache-integration"
-  workspace_desc      = "This module manages AWS resources for creating RDS databases."
+  workspace_desc      = "Serverless ElastiCache instances"
   workspace_tags      = ["integration", "elasticache", "aws"]
   terraform_version   = var.terraform_version
   execution_mode      = "remote"

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -631,10 +631,8 @@ module "variable-set-elasticache-integration" {
   tfvars = {
     instances = {
       test = {
-        limits = {
-          storage_gb       = 10
-          ecpus_per_second = 5000
-        }
+        max_storage_gb       = 20
+        max_ecpus_per_second = 6000
       }
       test_defaults = {}
     }

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -630,11 +630,14 @@ module "variable-set-elasticache-integration" {
 
   tfvars = {
     instances = {
-      test = {
-        max_storage_gb       = 20
-        max_ecpus_per_second = 6000
+      /*
+      "example" = {
+        max_storage_gb       = 30
+        max_ecpus_per_second = 7000
+        major_engine_version = "7"
       }
-      test_defaults = {}
+      */
+      "publishing-api" = {}
     }
   }
 }


### PR DESCRIPTION
* adds a new var set which can be used to create elasticache instances. A blank value in the map uses defaults
* creates a secret in Secrets Manager which maps the names of the instances to the addresses. This can be used in k8s to set `REDIS_URL` for apps
* creates a publishing-api instance in integration to test with

https://github.com/alphagov/govuk-infrastructure/issues/1704