### PR TITLE
Increase content-data-api RDS storage to 500GB in integration

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -282,7 +282,7 @@ module "variable-set-rds-integration" {
         }
         engine_params_family         = "postgres13"
         name                         = "blue-content-data-api-postgresql-primary"
-        allocated_storage            = 400
+        allocated_storage            = 500
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
         freestoragespace_threshold   = 536870912000


### PR DESCRIPTION
This database has run out of storage, so it needs to be increased.

The storage increase has already been done via the AWS console.