### PR TITLE
Search API v2: Try fixing automated eval function

### DIFF
--- a/terraform/deployments/search-api-v2/files/automated_evaluation/requirements.txt
+++ b/terraform/deployments/search-api-v2/files/automated_evaluation/requirements.txt
@@ -1,4 +1,5 @@
 functions_framework~=3.4
+numpy~=1.26
 pandas~=1.5
 ranx~=0.3
 matplotlib~=3.8


### PR DESCRIPTION
This pins NumPy to the previous major version which seems like it could be the cause of the function refusing to deploy of late.

Upstream seems to be at 2.x now, which probably isn't supported by the older version of Pandas we're running for this.