### PR TITLE
Search API v2: Fix incorrect serving config argument

### DIFF
--- a/terraform/deployments/search-api-v2/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/deployments/search-api-v2/modules/google_discovery_engine_restapi/main.tf
@@ -10,8 +10,8 @@ terraform {
 }
 
 locals {
-  boostControls   = yamldecode(file("${path.module}/files/controls/boosts.yml"))
-  synonymControls = yamldecode(file("${path.module}/files/controls/synonyms.yml"))
+  boostControls    = yamldecode(file("${path.module}/files/controls/boosts.yml"))
+  synonymsControls = yamldecode(file("${path.module}/files/controls/synonyms.yml"))
 }
 
 ############## DATASTORE ##############
@@ -48,12 +48,12 @@ module "serving_config_default" {
   display_name = "Default (used by live Search API v2)"
   engine_id    = var.engine_id
 
-  boost_control_ids   = keys(local.boostControls)
-  synonym_control_ids = keys(local.synonymControls)
+  boost_control_ids    = keys(local.boostControls)
+  synonyms_control_ids = keys(local.synonymsControls)
 
   # TODO: We can probably remove this once we have visible dependencies in this file and don't
   # create controls through YAML
-  depends_on = [local.boostControls, local.synonymControls]
+  depends_on = [local.boostControls, local.synonymsControls]
 }
 
 resource "restapi_object" "discovery_engine_boost_control" {
@@ -81,7 +81,7 @@ resource "restapi_object" "discovery_engine_boost_control" {
 }
 
 resource "restapi_object" "discovery_engine_synonym_control" {
-  for_each = local.synonymControls
+  for_each = local.synonymsControls
 
   path      = "/engines/${var.engine_id}/controls"
   object_id = each.key

--- a/terraform/deployments/search-api-v2/modules/serving_config/main.tf
+++ b/terraform/deployments/search-api-v2/modules/serving_config/main.tf
@@ -12,10 +12,10 @@ terraform {
 locals {
   path = "/engines/${var.engine_id}/servingConfigs"
   properties = {
-    displayName       = var.display_name
-    boostControlIds   = var.boost_control_ids
-    filterControlIds  = var.filter_control_ids
-    synonymControlIds = var.synonym_control_ids
+    displayName        = var.display_name
+    boostControlIds    = var.boost_control_ids
+    filterControlIds   = var.filter_control_ids
+    synonymsControlIds = var.synonyms_control_ids
 
     solutionType = "SOLUTION_TYPE_SEARCH"
   }

--- a/terraform/deployments/search-api-v2/modules/serving_config/variables.tf
+++ b/terraform/deployments/search-api-v2/modules/serving_config/variables.tf
@@ -25,7 +25,7 @@ variable "filter_control_ids" {
   default     = []
 }
 
-variable "synonym_control_ids" {
+variable "synonyms_control_ids" {
   description = "The IDs of the synonym controls to attach to the serving config"
   type        = list(string)
   default     = []


### PR DESCRIPTION
This kind of controls is called synonyms (plural) rather than synonym (singular).