### PR TITLE
Add import statement for aws-auth config map

### DIFF
--- a/terraform/deployments/cluster-services/aws_auth_configmap.tf
+++ b/terraform/deployments/cluster-services/aws_auth_configmap.tf
@@ -74,6 +74,11 @@ resource "kubernetes_config_map" "aws_auth" {
   }
 }
 
+import {
+  to = kubernetes_config_map.aws_auth
+  id = "kube-system/aws-auth"
+}
+
 resource "kubernetes_cluster_role_binding" "cluster_admins" {
   metadata { name = "cluster-admins" }
   role_ref {


### PR DESCRIPTION
This configmap already exists on a new cluster, so we need to import it so TF can manage it

https://github.com/alphagov/govuk-infrastructure/issues/1742