### PR TITLE
Move DGU namespace role binding to DGU infra module

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -23,42 +23,6 @@ locals {
   }
 }
 
-resource "kubernetes_namespace" "apps" {
-  metadata {
-    name = var.apps_namespace
-    annotations = {
-      "argocd.argoproj.io/sync-options" = "ServerSideApply=true"
-    }
-    labels = {
-      "app.kubernetes.io/managed-by"  = "Terraform"
-      "argocd.argoproj.io/managed-by" = "cluster-services"
-      # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/
-      "elbv2.k8s.aws/pod-readiness-gate-inject" = "enabled"
-      "pod-security.kubernetes.io/audit"        = "restricted"
-      "pod-security.kubernetes.io/enforce"      = "restricted"
-      "pod-security.kubernetes.io/warn"         = "restricted"
-    }
-  }
-}
-
-resource "kubernetes_namespace" "licensify" {
-  metadata {
-    name = var.licensify_namespace
-    annotations = {
-      "argocd.argoproj.io/sync-options" = "ServerSideApply=true"
-    }
-    labels = {
-      "app.kubernetes.io/managed-by"  = "Terraform"
-      "argocd.argoproj.io/managed-by" = "cluster-services"
-      # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/
-      "elbv2.k8s.aws/pod-readiness-gate-inject" = "enabled"
-      "pod-security.kubernetes.io/audit"        = "restricted"
-      "pod-security.kubernetes.io/enforce"      = "restricted"
-      "pod-security.kubernetes.io/warn"         = "restricted"
-    }
-  }
-}
-
 resource "helm_release" "argo_cd" {
   chart            = "argo-cd"
   name             = "argo-cd"

--- a/terraform/deployments/cluster-services/aws_auth_configmap.tf
+++ b/terraform/deployments/cluster-services/aws_auth_configmap.tf
@@ -147,11 +147,9 @@ resource "kubernetes_cluster_role" "poweruser" {
 }
 
 resource "kubernetes_role_binding" "poweruser" {
-  for_each = toset([kubernetes_namespace.apps.metadata[0].name, "datagovuk"])
-
   metadata {
-    name      = "poweruser-${each.key}"
-    namespace = each.key
+    name      = "poweruser-${kubernetes_namespace.apps.metadata[0].name}"
+    namespace = kubernetes_namespace.apps.metadata[0].name
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"

--- a/terraform/deployments/cluster-services/namespaces.tf
+++ b/terraform/deployments/cluster-services/namespaces.tf
@@ -1,0 +1,35 @@
+resource "kubernetes_namespace" "apps" {
+  metadata {
+    name = var.apps_namespace
+    annotations = {
+      "argocd.argoproj.io/sync-options" = "ServerSideApply=true"
+    }
+    labels = {
+      "app.kubernetes.io/managed-by"  = "Terraform"
+      "argocd.argoproj.io/managed-by" = "cluster-services"
+      # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/
+      "elbv2.k8s.aws/pod-readiness-gate-inject" = "enabled"
+      "pod-security.kubernetes.io/audit"        = "restricted"
+      "pod-security.kubernetes.io/enforce"      = "restricted"
+      "pod-security.kubernetes.io/warn"         = "restricted"
+    }
+  }
+}
+
+resource "kubernetes_namespace" "licensify" {
+  metadata {
+    name = var.licensify_namespace
+    annotations = {
+      "argocd.argoproj.io/sync-options" = "ServerSideApply=true"
+    }
+    labels = {
+      "app.kubernetes.io/managed-by"  = "Terraform"
+      "argocd.argoproj.io/managed-by" = "cluster-services"
+      # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/pod_readiness_gate/
+      "elbv2.k8s.aws/pod-readiness-gate-inject" = "enabled"
+      "pod-security.kubernetes.io/audit"        = "restricted"
+      "pod-security.kubernetes.io/enforce"      = "restricted"
+      "pod-security.kubernetes.io/warn"         = "restricted"
+    }
+  }
+}

--- a/terraform/deployments/datagovuk-infrastructure/auth.tf
+++ b/terraform/deployments/datagovuk-infrastructure/auth.tf
@@ -1,0 +1,16 @@
+resource "kubernetes_role_binding" "poweruser" {
+  metadata {
+    name      = "poweruser-${var.datagovuk_namespace}"
+    namespace = var.datagovuk_namespace
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "poweruser"
+  }
+  subject {
+    kind      = "Group"
+    name      = "powerusers"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}


### PR DESCRIPTION
This fixes a dependency on the DGU namespace in cluster-services, which is applied before the module which creates the namespace

https://github.com/alphagov/govuk-infrastructure/issues/1742