### PR TITLE
Search API v2: Add a "temporary exclusions" control

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_variant.tf
@@ -21,6 +21,10 @@ module "serving_config_variant" {
     # explicitly not included in serving_config_variant
     # module.control_boost_demote_strong.id,
   ]
+  filter_control_ids = [
+    # identical to serving_config_default
+    module.control_filter_temporary_exclusions.id,
+  ]
   synonyms_control_ids = [
     # identical to serving_config_default
     module.control_synonym_hmrc.id,


### PR DESCRIPTION
This filter control allows us to temporarily exclude some results from being shown to users.

In particular, we want to remove some results relating to the not yet live GOV.UK app beta to avoid confusing users who are looking for T&C or contact pages for other entities.