### PR TITLE
Change maintenance window for link-checker-api database

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -414,6 +414,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
+        maintenance_window           = "Mon:01:00-Mon:03:00"
       }
 
       local_links_manager = {

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -436,6 +436,7 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
+        maintenance_window           = "Mon:01:00-Mon:03:00"
       }
 
       local_links_manager = {

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -426,6 +426,7 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
+        maintenance_window           = "Mon:01:00-Mon:03:00"
       }
 
       local_links_manager = {

--- a/terraform/deployments/tfc-configuration/variables-test.tf
+++ b/terraform/deployments/tfc-configuration/variables-test.tf
@@ -1,7 +1,7 @@
 module "variable-set-ephemeral" {
   source = "./variable-set"
 
-  name = "common-ephemeral"
+  name     = "common-ephemeral"
   priority = false
   tfvars = {
     cluster_version               = "1.31"


### PR DESCRIPTION
The current maintenance window is 04:00 to 06:00 on Monday mornings.

Whitehall sends a large batch of requests to Link Checker API every day at 04:00, which can overlap with the maintenance window resulting to errors.

Moving the maintenance window earlier to avoid this batch of requests.

[Trello card](https://trello.com/c/EvP72jKS)