### PR TITLE
Use older version of aws provider for cluster-infra and services

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, < 5.90.1"
     }
   }
 }

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -32,7 +32,7 @@ terraform {
     # do not add AWS resources to this module.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.0, < 5.90.1"
     }
   }
 }


### PR DESCRIPTION
The [current version](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.90.1) is broken, and is stopping us from running Terraform

