### PR TITLE
Add explicit dependencies for some resources in cluster-services

### DIFF
--- a/terraform/deployments/cluster-services/aws_auth_configmap.tf
+++ b/terraform/deployments/cluster-services/aws_auth_configmap.tf
@@ -164,6 +164,7 @@ resource "kubernetes_role_binding" "poweruser" {
 }
 
 resource "kubernetes_role" "licensing" {
+  depends_on = [kubernetes_namespace.licensify]
   metadata {
     name      = "licensing"
     namespace = "licensify"
@@ -183,6 +184,7 @@ resource "kubernetes_role" "licensing" {
 }
 
 resource "kubernetes_role_binding" "licensing" {
+  depends_on = [kubernetes_role.licensing]
   metadata {
     name      = "licensing"
     namespace = "licensify"

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -47,6 +47,11 @@ resource "random_password" "dex_cookie_secret" {
 
 resource "kubernetes_secret" "dex_client" {
   for_each = local.dex_clients_namespaces
+  depends_on = [
+    kubernetes_namespace.apps,
+    kubernetes_namespace.monitoring,
+    helm_release.dex
+  ]
 
   metadata {
     name      = "dex-client-${each.value.client}"
@@ -77,7 +82,9 @@ resource "random_password" "eph_account" {
 }
 
 resource "kubernetes_secret" "eph_account" {
-  count = startswith(var.govuk_environment, "eph-") ? 1 : 0
+  count      = startswith(var.govuk_environment, "eph-") ? 1 : 0
+  depends_on = [helm_release.dex]
+
   metadata {
     name      = "dex-account"
     namespace = "cluster-services"


### PR DESCRIPTION
Terraform is failing to apply these resources on a first run because the namespaces required for these resources doesn't exist before TF attempts to create the resources. These explicit dependencies will make TF create the namespaces before attempting to create these resources.

https://github.com/alphagov/govuk-infrastructure/issues/1742