### PR TITLE
Various cluster-services ephemeral fixes

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -152,7 +152,10 @@ resource "helm_release" "argo_cd" {
 
 resource "helm_release" "argo_bootstrap" {
   # Relies on CRDs
-  depends_on       = [helm_release.argo_cd]
+  depends_on = [
+    helm_release.argo_cd,
+    helm_release.external_secrets
+  ]
   chart            = "argo-bootstrap"
   name             = "argo-bootstrap"
   namespace        = local.services_ns

--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -181,6 +181,11 @@ resource "helm_release" "argo_bootstrap" {
 }
 
 resource "helm_release" "argo_workflows" {
+  depends_on = [
+    kubernetes_secret.dex_client,
+    helm_release.aws_lb_controller
+  ]
+
   chart            = "argo-workflows"
   name             = "argo-workflows"
   namespace        = local.services_ns

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -154,24 +154,6 @@ locals {
     local.dex_github_env_var,
     [
       {
-        name = "GITHUB_CLIENT_ID"
-        valueFrom = {
-          secretKeyRef = {
-            name = "govuk-dex-github"
-            key  = "clientID"
-          }
-        }
-      },
-      {
-        name = "GITHUB_CLIENT_SECRET"
-        valueFrom = {
-          secretKeyRef = {
-            name = "govuk-dex-github"
-            key  = "clientSecret"
-          }
-        }
-      },
-      {
         name = "ARGO_WORKFLOWS_CLIENT_ID"
         valueFrom = {
           secretKeyRef = {

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -50,7 +50,11 @@ resource "kubernetes_secret" "dex_client" {
   depends_on = [
     kubernetes_namespace.apps,
     kubernetes_namespace.monitoring,
-    helm_release.dex
+    # we depend on the namespace existing
+    # but aren't managing it explicitly in TF
+    # so we need to depend on something that will
+    # create it implicitly
+    helm_release.aws_lb_controller
   ]
 
   metadata {

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -124,75 +124,31 @@ locals {
       }
     }
   ]
-}
 
-resource "helm_release" "dex" {
-  depends_on       = [helm_release.aws_lb_controller, helm_release.cluster_secrets]
-  chart            = "dex"
-  name             = "dex"
-  namespace        = local.services_ns
-  create_namespace = true
-  repository       = "https://charts.dexidp.io"
-  version          = "0.22.1"
-  values = [yamlencode({
-    replicaCount = var.desired_ha_replicas
-    config = {
-      issuer = "https://${local.dex_host}"
-
-      oauth2 = {
-        skipApprovalScreen = true
-      }
-
-      storage = {
-        type = "kubernetes"
-        config = {
-          inCluster = true
+  dex_github_env_var = startswith(var.govuk_environment, "eph-") ? [] : [
+    {
+      name = "GITHUB_CLIENT_ID"
+      valueFrom = {
+        secretKeyRef = {
+          name = "govuk-dex-github"
+          key  = "clientID"
         }
       }
-
-      # static account for ephemeral environments
-      enablePasswordDB = local.dex_enable_passworddb
-      staticPasswords  = local.dex_static_passwords
-
-      connectors = local.dex_connectors
-
-      # staticClients uses a different method for expansion of environment
-      # variables, see [bug](https://github.com/gabibbo97/charts/issues/36#issuecomment-736911424)
-      staticClients = [
-        {
-          name         = "argo-workflows"
-          idEnv        = "ARGO_WORKFLOWS_CLIENT_ID"
-          secretEnv    = "ARGO_WORKFLOWS_CLIENT_SECRET"
-          redirectURIs = ["https://${local.argo_workflows_host}/oauth2/callback"]
-        },
-        {
-          name         = "argocd"
-          idEnv        = "ARGOCD_CLIENT_ID"
-          secretEnv    = "ARGOCD_CLIENT_SECRET"
-          redirectURIs = ["https://${local.argo_host}/auth/callback"]
-        },
-        {
-          name         = "grafana"
-          idEnv        = "GRAFANA_CLIENT_ID"
-          secretEnv    = "GRAFANA_CLIENT_SECRET"
-          redirectURIs = ["https://${local.grafana_host}/login/generic_oauth"]
-        },
-        {
-          name         = "prometheus"
-          idEnv        = "PROMETHEUS_CLIENT_ID"
-          secretEnv    = "PROMETHEUS_CLIENT_SECRET"
-          redirectURIs = ["https://${local.prometheus_host}/oauth2/callback"]
-        },
-        {
-          name         = "alert-manager"
-          idEnv        = "ALERT_MANAGER_CLIENT_ID"
-          secretEnv    = "ALERT_MANAGER_CLIENT_SECRET"
-          redirectURIs = ["https://${local.alertmanager_host}/oauth2/callback"]
+    },
+    {
+      name = "GITHUB_CLIENT_SECRET"
+      valueFrom = {
+        secretKeyRef = {
+          name = "govuk-dex-github"
+          key  = "clientSecret"
         }
-      ]
+      }
     }
+  ]
 
-    envVars = [
+  dex_env_vars = concat(
+    local.dex_github_env_var,
+    [
       {
         name = "GITHUB_CLIENT_ID"
         valueFrom = {
@@ -302,6 +258,76 @@ resource "helm_release" "dex" {
         }
       }
     ]
+  )
+}
+
+resource "helm_release" "dex" {
+  depends_on       = [helm_release.aws_lb_controller, helm_release.cluster_secrets]
+  chart            = "dex"
+  name             = "dex"
+  namespace        = local.services_ns
+  create_namespace = true
+  repository       = "https://charts.dexidp.io"
+  version          = "0.22.1"
+  values = [yamlencode({
+    replicaCount = var.desired_ha_replicas
+    config = {
+      issuer = "https://${local.dex_host}"
+
+      oauth2 = {
+        skipApprovalScreen = true
+      }
+
+      storage = {
+        type = "kubernetes"
+        config = {
+          inCluster = true
+        }
+      }
+
+      # static account for ephemeral environments
+      enablePasswordDB = local.dex_enable_passworddb
+      staticPasswords  = local.dex_static_passwords
+
+      connectors = local.dex_connectors
+
+      # staticClients uses a different method for expansion of environment
+      # variables, see [bug](https://github.com/gabibbo97/charts/issues/36#issuecomment-736911424)
+      staticClients = [
+        {
+          name         = "argo-workflows"
+          idEnv        = "ARGO_WORKFLOWS_CLIENT_ID"
+          secretEnv    = "ARGO_WORKFLOWS_CLIENT_SECRET"
+          redirectURIs = ["https://${local.argo_workflows_host}/oauth2/callback"]
+        },
+        {
+          name         = "argocd"
+          idEnv        = "ARGOCD_CLIENT_ID"
+          secretEnv    = "ARGOCD_CLIENT_SECRET"
+          redirectURIs = ["https://${local.argo_host}/auth/callback"]
+        },
+        {
+          name         = "grafana"
+          idEnv        = "GRAFANA_CLIENT_ID"
+          secretEnv    = "GRAFANA_CLIENT_SECRET"
+          redirectURIs = ["https://${local.grafana_host}/login/generic_oauth"]
+        },
+        {
+          name         = "prometheus"
+          idEnv        = "PROMETHEUS_CLIENT_ID"
+          secretEnv    = "PROMETHEUS_CLIENT_SECRET"
+          redirectURIs = ["https://${local.prometheus_host}/oauth2/callback"]
+        },
+        {
+          name         = "alert-manager"
+          idEnv        = "ALERT_MANAGER_CLIENT_ID"
+          secretEnv    = "ALERT_MANAGER_CLIENT_SECRET"
+          redirectURIs = ["https://${local.alertmanager_host}/oauth2/callback"]
+        }
+      ]
+    }
+
+    envVars = local.dex_env_vars
 
     service = {
       ports = {

--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -12,6 +12,8 @@ resource "kubernetes_namespace" "monitoring" {
 }
 
 resource "helm_release" "external_secrets" {
+  depends_on = [helm_release.aws_lb_controller]
+
   name             = "external-secrets"
   repository       = "https://charts.external-secrets.io"
   chart            = "external-secrets"

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -1,6 +1,9 @@
 # logging.tf manages Filebeat, which ships logs to Logit.io, a managed ELK stack.
 
 resource "helm_release" "filebeat" {
+  # don't install in ephemeral environments
+  count = startswith(var.govuk_environment, "eph-") ? 0 : 1
+
   name       = "filebeat"
   repository = "https://helm.elastic.co"
   chart      = "filebeat"


### PR DESCRIPTION
This PR does 3 things:
* Doesn't install filebeat in ephemeral envs. It is failing to install due to missing secrets, and we don't need to send logs to logit anyway
* Add explicit dependencies on AWS LB controller. Some charts are failing to install because they are being installed while the LB controller is installed. The LB controller includes a webhook for ingress and the pods that serve this webhook haven't started yet when it tries to install the other charts.
* Only add GitHub OAuth env vars to Dex if we aren't in an ephemeral env
* Give all users admin role in ArgoCD in ephemeral envs

https://github.com/alphagov/govuk-infrastructure/issues/1742