### PR TITLE
Don't create organogram S3 bucket logging config in ephemeral envs

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/organogram_bucket.tf
+++ b/terraform/deployments/datagovuk-infrastructure/organogram_bucket.tf
@@ -24,11 +24,14 @@ resource "aws_s3_bucket" "datagovuk-organogram" {
 }
 
 resource "aws_s3_bucket_versioning" "datagovuk_organogram" {
+
   bucket = aws_s3_bucket.datagovuk-organogram.id
   versioning_configuration { status = "Enabled" }
 }
 
 resource "aws_s3_bucket_logging" "datagovuk_organogram" {
+  count = startswith(var.govuk_environment, "eph-") ? 0 : 1
+
   bucket        = aws_s3_bucket.datagovuk-organogram.id
   target_bucket = "govuk-${var.govuk_environment}-aws-logging"
   target_prefix = "s3/datagovuk-${var.govuk_environment}-ckan-organogram/"

--- a/terraform/deployments/datagovuk-infrastructure/static_data_bucket.tf
+++ b/terraform/deployments/datagovuk-infrastructure/static_data_bucket.tf
@@ -10,6 +10,8 @@ resource "aws_s3_bucket_versioning" "datagovuk_static" {
 }
 
 resource "aws_s3_bucket_logging" "datagovuk_static" {
+  count = startswith(var.govuk_environment, "eph-") ? 0 : 1
+
   bucket        = aws_s3_bucket.datagovuk_static.id
   target_bucket = "govuk-${var.govuk_environment}-aws-logging"
   target_prefix = "s3/datagovuk-${var.govuk_environment}-ckan-static-data/"


### PR DESCRIPTION
We don't need this for ephemeral environments, and the target bucket doesn't exist so its causing terraform errors

https://github.com/alphagov/govuk-infrastructure/issues/1746