### PR TITLE
Revert "Search API v2: Migrate to new control structure"

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_default.tf
@@ -29,9 +29,8 @@ module "control_boost_promote_medium" {
   engine_id    = google_discovery_engine_search_engine.govuk.engine_id
   action = {
     boostAction = {
-      filter     = "content_purpose_supergroup: ANY(\"services\") OR document_type: ANY(\"calendar\", \"detailed_guide\", \"document_collection\", \"external_content\", \"organisation\")",
-      fixedBoost = 0.2
-      dataStore  = google_discovery_engine_data_store.govuk_content.name
+      filter = "content_purpose_supergroup: ANY(\"services\") OR document_type: ANY(\"calendar\", \"detailed_guide\", \"document_collection\", \"external_content\", \"organisation\")",
+      boost  = 0.2
     }
   }
 }
@@ -44,9 +43,8 @@ module "control_boost_promote_low" {
   engine_id    = google_discovery_engine_search_engine.govuk.engine_id
   action = {
     boostAction = {
-      filter     = "document_type: ANY(\"guidance\", \"mainstream_browse_page\", \"policy_paper\", \"travel_advice\")",
-      fixedBoost = 0.05
-      dataStore  = google_discovery_engine_data_store.govuk_content.name
+      filter = "document_type: ANY(\"guidance\", \"mainstream_browse_page\", \"policy_paper\", \"travel_advice\")",
+      boost  = 0.05
     }
   }
 }
@@ -59,9 +57,8 @@ module "control_boost_demote_low" {
   engine_id    = google_discovery_engine_search_engine.govuk.engine_id
   action = {
     boostAction = {
-      filter     = "document_type: ANY(\"about\", \"taxon\", \"world_news_story\")",
-      fixedBoost = -0.25
-      dataStore  = google_discovery_engine_data_store.govuk_content.name
+      filter = "document_type: ANY(\"about\", \"taxon\", \"world_news_story\")",
+      boost  = -0.25
     }
   }
 }
@@ -74,9 +71,8 @@ module "control_boost_demote_medium" {
   engine_id    = google_discovery_engine_search_engine.govuk.engine_id
   action = {
     boostAction = {
-      filter     = "document_type: ANY(\"employment_tribunal_decision\", \"foi_release\", \"service_standard_report\") OR organisation_state: ANY(\"devolved\", \"closed\")",
-      fixedBoost = -0.5
-      dataStore  = google_discovery_engine_data_store.govuk_content.name
+      filter = "document_type: ANY(\"employment_tribunal_decision\", \"foi_release\", \"service_standard_report\") OR organisation_state: ANY(\"devolved\", \"closed\")",
+      boost  = -0.5
     }
   }
 }
@@ -89,9 +85,8 @@ module "control_boost_demote_strong" {
   engine_id    = google_discovery_engine_search_engine.govuk.engine_id
   action = {
     boostAction = {
-      filter     = "is_historic = 1",
-      fixedBoost = -0.75
-      dataStore  = google_discovery_engine_data_store.govuk_content.name
+      filter = "is_historic = 1",
+      boost  = -0.75
     }
   }
 }
@@ -104,9 +99,8 @@ module "control_boost_demote_pages" {
   engine_id    = google_discovery_engine_search_engine.govuk.engine_id
   action = {
     boostAction = {
-      filter     = "link: ANY(\"/government/publications/pension-credit-claim-form--2\")",
-      fixedBoost = -0.75
-      dataStore  = google_discovery_engine_data_store.govuk_content.name
+      filter = "link: ANY(\"/government/publications/pension-credit-claim-form--2\")",
+      boost  = -0.75
     }
   }
 }


### PR DESCRIPTION
This reverts commit ff141b8de8ed256b73d65c56c909f32edfe5b401.

It turns out that controls created using the old schema cannot be updated to the new schema, the PATCH just fails.