### PR TITLE
Bump argo-bootstrap-ephemeral to 0.0.4

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -202,7 +202,7 @@ resource "helm_release" "argo_bootstrap_ephemeral" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
-  version          = "0.0.3"
+  version          = "0.0.4"
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     awsAccountId     = data.aws_caller_identity.current.account_id


### PR DESCRIPTION
## What?
This just bumps the argo-bootstrap-ephemeral Chart to 0.0.4, 'cause we gotta do this manually.