### PR TITLE
Search V2 API - Added bq dataset, table and schema for clickstream data

### DIFF
--- a/terraform/deployments/search-api-v2/automated_evaluation.tf
+++ b/terraform/deployments/search-api-v2/automated_evaluation.tf
@@ -103,6 +103,25 @@ resource "google_storage_bucket_object" "results_seed_file" {
   source = "${path.module}/files/automated_evaluation_default_datasets/results.csv"
 }
 
+# top level dataset to store automated evaluation input datasets
+resource "google_bigquery_dataset" "automated_evaluation_input" {
+  dataset_id                 = "automated_evaluation_input"
+  location                   = var.gcp_region
+  delete_contents_on_destroy = true
+}
+
+# ga4 'select_item' events get transformed and inserted into this time-partitioned sample query set table defined with a vertex schema
+resource "google_bigquery_table" "clickstream" {
+  dataset_id          = google_bigquery_dataset.automated_evaluation_input.dataset_id
+  table_id            = "clickstream"
+  schema              = file("./files/sample-query-set-schema.json")
+  deletion_protection = false
+  time_partitioning {
+    type = "MONTH"
+  }
+
+}
+
 # top level dataset to store automated evaluation output
 resource "google_bigquery_dataset" "automated_evaluation_output" {
   dataset_id                 = "automated_evaluation_output"

--- a/terraform/deployments/search-api-v2/files/sample-query-set-schema.json
+++ b/terraform/deployments/search-api-v2/files/sample-query-set-schema.json
@@ -1,0 +1,32 @@
+[
+    {
+      "name": "queryEntry",
+      "mode": "NULLABLE",
+      "type": "RECORD",
+      "description": "",
+      "fields": [
+        {
+          "name": "query",
+          "mode": "NULLABLE",
+          "type": "STRING",
+          "description": "",
+          "fields": []
+        },
+        {
+          "name": "targets",
+          "mode": "REPEATED",
+          "type": "RECORD",
+          "description": "",
+          "fields": [
+            {
+              "name": "uri",
+              "mode": "NULLABLE",
+              "type": "STRING",
+              "description": "",
+              "fields": []
+            }
+          ]
+        }
+      ]
+    }
+  ]


### PR DESCRIPTION
Added BQ artifacts for Search API v2 clickstream judgement lists
* `automated-evaluation-input` BQ dataset
* `clickstream` BQ table - monthly partitioning
* `sample-query-set-schem.json` BQ table schema following Vertex sample query set format

GA4 Data will be loaded by Dataform pipeline