### PR TITLE
Properly override default maintenance window

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -57,7 +57,7 @@ resource "aws_db_instance" "instance" {
   db_subnet_group_name    = aws_db_subnet_group.subnet_group.name
   multi_az                = var.multi_az
   parameter_group_name    = aws_db_parameter_group.engine_params[each.key].name
-  maintenance_window      = var.maintenance_window
+  maintenance_window      = try(each.value.maintenance_window, var.maintenance_window)
   backup_retention_period = var.backup_retention_period
   backup_window           = var.backup_window
   copy_tags_to_snapshot   = true

--- a/terraform/deployments/rds/variables.tf
+++ b/terraform/deployments/rds/variables.tf
@@ -15,7 +15,19 @@ variable "govuk_aws_state_bucket" {
 }
 
 variable "databases" {
-  type        = map(any)
+  type = map(object({
+    engine                       = string
+    engine_version               = string
+    engine_params                = map(any)
+    engine_params_family         = string
+    name                         = string
+    allocated_storage            = number
+    instance_class               = string
+    performance_insights_enabled = bool
+    freestoragespace_threshold   = number
+    project                      = string
+    maintenance_window           = optional(string)
+  }))
   description = "Databases to create and their configuration."
 }
 


### PR DESCRIPTION
A value was added in the variables for Link Checker API in https://github.com/alphagov/govuk-infrastructure/pull/1807, but wasn't being used anywhere.