### PR TITLE
Add variables for creating a read replica of Publishing API in integration

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -58,7 +58,7 @@ resource "aws_db_instance" "instance" {
   multi_az                = var.multi_az
   parameter_group_name    = aws_db_parameter_group.engine_params[each.key].name
   maintenance_window      = lookup(each.value, "maintenance_window", var.maintenance_window)
-  backup_retention_period = var.backup_retention_period
+  backup_retention_period = lookup(each.value, "backup_retention_period", var.backup_retention_period)
   backup_window           = var.backup_window
   copy_tags_to_snapshot   = true
   monitoring_interval     = 60

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -472,6 +472,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
+        backup_retention_period      = 1
       }
 
       publisher = {

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -473,6 +473,7 @@ module "variable-set-rds-integration" {
         freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
         backup_retention_period      = 1
+        has_read_replica             = true
       }
 
       publisher = {


### PR DESCRIPTION
This adds the variables needed to create a read replica of Publishing API in integration.
    
Once this is merged and deployed, a later PR (https://github.com/alphagov/govuk-infrastructure/pull/1825) will actually use this value to create the read replica.

[Trello card](https://trello.com/c/9c3J919n)