### PR TITLE
Use correct source database identifier

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -130,7 +130,7 @@ resource "aws_db_instance" "replica" {
 
   instance_class      = each.value.instance_class
   identifier          = "${var.govuk_environment}-${each.value.name}-${each.value.engine}-replica"
-  replicate_source_db = "aws_db_instance.${var.govuk_environment}-${each.value.name}-${each.value.engine}"
+  replicate_source_db = aws_db_instance.instance[each.key].identifier
 
   tags = { Name = "govuk-rds-${each.value.name}-${each.value.engine}-replica", project = lookup(each.value, "project", "GOV.UK - Other") }
 


### PR DESCRIPTION
On applying this Terraform, the following error was returned:

```
Error: creating RDS DB Instance (read replica) (integration-publishing-api-postgres-replica): operation error RDS: CreateDBInstanceReadReplica, https response error StatusCode: 400, RequestID: fb6ddccd-40fa-4d71-ad8b-aab147c03499, api error InvalidParameterValue: The parameter SourceDBInstanceIdentifier is not a valid identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.
```

Updating to use the actual identifier, not a plain string.

[Trello card](https://trello.com/c/9c3J919n)