### PR TITLE
Change maintenance window for Link Checker API

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -414,7 +414,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
-        maintenance_window           = "Mon:01:00-Mon:03:00"
+        maintenance_window           = "Mon:00:00-Mon:01:00"
       }
 
       local_links_manager = {

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -436,7 +436,7 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
-        maintenance_window           = "Mon:01:00-Mon:03:00"
+        maintenance_window           = "Mon:00:00-Mon:01:00"
       }
 
       local_links_manager = {

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -426,7 +426,7 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
-        maintenance_window           = "Mon:01:00-Mon:03:00"
+        maintenance_window           = "Mon:00:00-Mon:01:00"
       }
 
       local_links_manager = {


### PR DESCRIPTION
This was added in https://github.com/alphagov/govuk-infrastructure/pull/1807 but won't apply as it overlaps the with the backup window.

Moving the maintenance window earlier.

AWS requires a minimum of 30 minutes for RDS maintenance, so this should be more than adequate.

[Trello card](https://trello.com/c/EvP72jKS)
