### PR TITLE
Renovate: pin GitHub Action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "platformAutomerge": true,
   "pre-commit": {
     "enabled": true
   },
   "enabledManagers": [
+    "github-actions",
     "pre-commit",
     "terraform"
   ],


### PR DESCRIPTION
This will cause Renovate to pin the digests of external GHA workflows/steps to hopefully avoid the effects of a compromised GHA step

https://github.com/alphagov/govuk-platform-internal/issues/23