### PR TITLE
Use Node JS 22 in CSP reporter Lambda

### DIFF
--- a/terraform/deployments/csp-reporter/lambda-source/README.md
+++ b/terraform/deployments/csp-reporter/lambda-source/README.md
@@ -4,6 +4,6 @@ This lambda is to receive Content Security Policy reports using the [report-uri]
 
 It is not configured for the CSP [report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) usage where a different JSON structure is used, at the time of writing report-to is not available in all browsers. It is also caught up in the browser [Reporting API](https://www.w3.org/TR/reporting-1/) which is currently a draft standard.
 
-This was built targeting nodejs 18 and needs and an env var of FIREHOSE_DELIVERY_STREAM to specify the Kinesis
+This was built targeting nodejs 22 and needs and an env var of FIREHOSE_DELIVERY_STREAM to specify the Kinesis
 
 You can test this lambda in the AWS console by setting up a test event based on `apigateway-aws-proxy` with a customised body and Content-Type, you may want to comment out the Kinesis Firehose aspect for easier testing.

--- a/terraform/deployments/csp-reporter/lambda.tf
+++ b/terraform/deployments/csp-reporter/lambda.tf
@@ -12,7 +12,7 @@ resource "aws_lambda_function" "lambda" {
   description   = "Handles Content Security Policy reports, passing valid ones to Kinesis Firehose"
   role          = aws_iam_role.lambda_role.arn
   handler       = "index.handler"
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs22.x"
 
   environment {
     variables = {


### PR DESCRIPTION
Update from Node JS 18 to 22 in the CSP Reporter Lambda.

https://github.com/alphagov/govuk-infrastructure/issues/1724