### PR TITLE
Add retry and wait_to_retry support for Search API queue

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/amazonmq_schema.json.tpl
+++ b/terraform/deployments/govuk-publishing-infrastructure/amazonmq_schema.json.tpl
@@ -147,6 +147,31 @@
     },
     {
       "vhost": "publishing",
+      "name": "search_api_to_be_indexed_retry",
+      "pattern": "search_api_to_be_indexed",
+      "apply-to": "queues",
+      "definition": {
+        "dead-letter-exchange": "search_api_to_be_indexed_retry_dlx",
+        "ha-mode": "all",
+        "ha-sync-mode": "automatic"
+      },
+      "priority": 0
+    },
+    {
+      "vhost": "publishing",
+      "name": "search_api_to_be_indexed_wait_to_retry_discarded",
+      "pattern": "search_api_to_be_indexed_wait_to_retry",
+      "apply-to": "queues",
+      "definition": {
+        "dead-letter-exchange": "search_api_to_be_indexed_discarded_dlx",
+        "message-ttl": ${/* value in milliseconds */ "60000"}
+        "ha-mode": "all",
+        "ha-sync-mode": "automatic"
+      },
+      "priority": 0
+    },
+    {
+      "vhost": "publishing",
       "name": "ha-all",
       "pattern": ".*",
       "apply-to": "all",
@@ -181,6 +206,13 @@
     },
     {
       "name": "search_api_to_be_indexed",
+      "vhost": "publishing",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
+      "name": "search_api_to_be_indexed_wait_to_retry",
       "vhost": "publishing",
       "durable": true,
       "auto_delete": false,
@@ -286,6 +318,24 @@
       "auto_delete": false,
       "internal": false,
       "arguments": {}
+    },
+    {
+      "name": "search_api_to_be_indexed_discarded_dlx",
+      "vhost": "publishing",
+      "type": "topic",
+      "durable": true,
+      "auto_delete": false,
+      "internal": false,
+      "arguments": {}
+    },
+    {
+      "name": "search_api_to_be_indexed_retry_dlx",
+      "vhost": "publishing",
+      "type": "topic",
+      "durable": true,
+      "auto_delete": false,
+      "internal": false,
+      "arguments": {}
     }
   ],
   "bindings": [
@@ -369,6 +419,14 @@
       "routing_key": "*.links",
       "arguments": {}
     },
+     {
+      "source": "search_api_to_be_indexed_discarded_dlx",
+      "vhost": "publishing",
+      "destination": "search_api_to_be_indexed",
+      "destination_type": "queue",
+      "routing_key": "#",
+      "arguments": {}
+    }
     {
       "source": "published_documents",
       "vhost": "publishing",

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -101,7 +101,7 @@ variable "amazonmq_host_instance_type" {
 variable "amazonmq_govuk_chat_retry_message_ttl" {
   type        = number
   default     = 300000
-  description = "Time in miliseconds before messages in the govuk_chat_retry queue expires and are sent back to the govuk_chat_published_ducoments queue through the dead letter mechanism"
+  description = "Time in miliseconds before messages in the govuk_chat_retry queue expires and are sent back to the govuk_chat_published_documents queue through the dead letter mechanism"
 }
 
 variable "allow_high_request_rate_from_cidrs" {


### PR DESCRIPTION

This adds some new configuration to allow messages on the
`search_api_to_be_indexed` queue to be retried by the consumer.

For context, this is to support an effort to remove Sidekiq from Search
API. Currently we consume messages then enqueue them directly on Sidekiq
for processing. This is sometimes causing issues where Redis crashes if
lots of jobs are being processed at once. The aim is to remove Sidekiq
and process all jobs in the consumer directly.

However in doing this, we'll lose the automatic retry functionality that
Sidekiq provides. So instead we'll implement our own retry mechanism
using RabbitMQ only.

The idea is as follows:

* A consumer picks up a job from the `search_api_to_be_indexed` queue
for processing
* If an exception is raised, it's caught and the message is rejected
* The `search_api_to_be_indexed` queue is now configured to have a new
dead letter exchange of `search_api_to_be_indexed_retry_dlx` where
messages have a specific TTL of 30 seconds
* We have a new `search_api_to_be_indexed_wait_to_retry` queue bound to
that dlx
* Nothing is listening on the `search_api_to_be_indexed_wait_to_retry`
queue, so messages are never processed. Instead, when their TTL
expires, they're routes to another dlx,
`search_api_to_be_indexed_discarded_dlx`. This has a binding back to
the original `search_api_to_be_indexed` queue which applies to all
messages.
* Now messages are back on the `search_api_to_be_indexed` queue they're
picked up by the consumer again. The consumer can then decide whether
it wants to try to process the message again (e.g. by inspecting the
retry count)

