### PR TITLE
Add ephemeral cluster TF module

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -120,7 +120,7 @@ jobs:
           echo "$d"
           cd "$d"
           tflint --init -c ${{ github.workspace }}/.tflint.hcl
-          tflint --format compact --call-module-type=all --recursive --force \
+          tflint --format compact --call-module-type=all --force \
             -c ${{ github.workspace }}/.tflint.hcl \
             --enable-rule=terraform_comment_syntax \
             --enable-rule=terraform_deprecated_index \

--- a/terraform/deployments/ephemeral/README.md
+++ b/terraform/deployments/ephemeral/README.md
@@ -1,0 +1,25 @@
+This module is used to provision ephemeral EKS clusters via Terraform Cloud.
+
+## Basic Usage
+
+1. Ensure you have logged in to Terraform Cloud via the Terraform CLI (`terraform login`)
+2. Do a `terraform init`
+3. Run an apply with your chosen ephemeral cluster ID (this isn't generated for you)
+   `terraform apply -var ephemeral_cluster_id=eph-da2f44`
+
+You will probably have to run the apply a couple of times due to Terraform not waiting for
+things like Load Balancers becoming available.
+
+State for the ephemeral module is stored locally for now.
+
+### Teardown
+
+This hasn't been properly tested yet, and just running a `terraform apply -destroy` in the ephemeral module
+isn't enough to destroy all resources correctly. (TF tries to destroy things like variable sets while running the destroys, which causes things to break)
+
+1. Remove all `Application` resources on the cluster (these will mostly be in the `cluster-services` NS). This will cause the ELB controller and EBS CSI driver to delete any Load Balancers and block storage used by apps in the cluster
+2. Run destroys on the underlying Terraform Cloud workspaces. Assuming your cluster ID is `eph-aaa111`, these will be:
+   1. `datagovuk-infrastructure-eph-aaa111`
+   2. `cluster-services-eph-aaa111`
+   3. `cluster-infrastructure-eph-aaa111`
+3. Run a destroy on your ephemeral module via the Terraform CLI

--- a/terraform/deployments/ephemeral/provider.tf
+++ b/terraform/deployments/ephemeral/provider.tf
@@ -1,0 +1,3 @@
+provider "tfe" {
+  organization = "govuk"
+}

--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -1,0 +1,55 @@
+resource "tfe_project" "project" {
+  organization = "govuk"
+  name         = var.ephemeral_cluster_id
+}
+
+module "var_set" {
+  source = "../tfc-configuration/variable-set"
+
+  name     = var.ephemeral_cluster_id
+  priority = true
+
+  tfvars = {
+    govuk_environment      = var.ephemeral_cluster_id
+    cluster_name           = var.ephemeral_cluster_id
+    external_dns_subdomain = var.ephemeral_cluster_id
+
+    govuk_aws_state_bucket    = ""
+    publishing_service_domain = "${var.ephemeral_cluster_id}.publishing.service.gov.uk"
+    authentication_mode       = "API_AND_CONFIG_MAP"
+
+    enable_arm_workers  = true
+    enable_main_workers = false
+    enable_x86_workers  = false
+  }
+}
+
+module "cluster_infrastructure" {
+  source = "./ws"
+
+  name                 = "cluster-infrastructure"
+  ephemeral_cluster_id = var.ephemeral_cluster_id
+  variable_set_id      = module.var_set.id
+
+  depends_on = [tfe_project.project]
+}
+
+module "cluster_services" {
+  source = "./ws"
+
+  name                 = "cluster-services"
+  ephemeral_cluster_id = var.ephemeral_cluster_id
+  variable_set_id      = module.var_set.id
+
+  depends_on = [module.cluster_infrastructure, tfe_project.project]
+}
+
+module "datagovuk_infrastructure" {
+  source = "./ws"
+
+  name                 = "datagovuk-infrastructure"
+  ephemeral_cluster_id = var.ephemeral_cluster_id
+  variable_set_id      = module.var_set.id
+
+  depends_on = [module.cluster_services, tfe_project.project]
+}

--- a/terraform/deployments/ephemeral/variables.tf
+++ b/terraform/deployments/ephemeral/variables.tf
@@ -1,0 +1,9 @@
+variable "ephemeral_cluster_id" {
+  type    = string
+  default = "eph-aaa113"
+}
+
+variable "organization" {
+  type    = string
+  default = "govuk"
+}

--- a/terraform/deployments/ephemeral/ws/outputs.tf
+++ b/terraform/deployments/ephemeral/ws/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = module.workspace.workspace_id
+}

--- a/terraform/deployments/ephemeral/ws/remote.tf
+++ b/terraform/deployments/ephemeral/ws/remote.tf
@@ -1,0 +1,4 @@
+data "tfe_oauth_client" "github" {
+  organization     = var.organization
+  service_provider = "github"
+}

--- a/terraform/deployments/ephemeral/ws/variables.tf
+++ b/terraform/deployments/ephemeral/ws/variables.tf
@@ -1,0 +1,21 @@
+variable "ephemeral_cluster_id" {
+  type = string
+}
+
+variable "organization" {
+  type    = string
+  default = "govuk"
+}
+
+variable "name" {
+  type = string
+}
+
+variable "terraform_version" {
+  type    = string
+  default = "~> 1.11.0"
+}
+
+variable "variable_set_id" {
+  type = string
+}

--- a/terraform/deployments/ephemeral/ws/workspace.tf
+++ b/terraform/deployments/ephemeral/ws/workspace.tf
@@ -1,0 +1,49 @@
+module "workspace" {
+  source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
+
+  organization        = var.organization
+  workspace_name      = "${var.name}-${var.ephemeral_cluster_id}"
+  workspace_desc      = "Resources for an ephemeral cluster"
+  workspace_tags      = ["ephemeral", "${var.name}", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/${var.name}/"
+  trigger_patterns    = ["/terraform/deployments/${var.name}/**/*"]
+  global_remote_state = true
+  queue_all_runs      = false
+
+  project_name = var.ephemeral_cluster_id
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production (r/o)" = "write"
+    "GOV.UK Production"           = "write"
+  }
+
+  variable_set_ids   = [var.variable_set_id]
+  variable_set_names = [
+    "aws-credentials-test",
+    "common",
+    "common-ephemeral"
+  ]
+}
+
+resource "tfe_workspace_run" "run" {
+  workspace_id = module.workspace.workspace_id
+
+  apply {
+    manual_confirm = false
+    wait_for_run   = true
+    retry          = false
+  }
+
+  destroy {
+    manual_confirm = false
+    wait_for_run   = true
+    retry          = false
+  }
+}


### PR DESCRIPTION
This is the module to provision ephemeral EKS clusters in the AWS test account

I thought I had already committed this, but apparently I haven't

https://github.com/alphagov/govuk-infrastructure/issues/1742