### PR TITLE
Search API v2: Use `structSchema` for datastore schema

### DIFF
--- a/terraform/deployments/search-api-v2/discovery_engine.tf
+++ b/terraform/deployments/search-api-v2/discovery_engine.tf
@@ -28,7 +28,7 @@ resource "restapi_object" "google_discovery_engine_datastore_schema" {
   object_id = "default_schema"
 
   data = jsonencode({
-    jsonSchema = file("${path.module}/files/datastore-schema.json")
+    structSchema = jsondecode(file("${path.module}/files/datastore-schema.json"))
   })
 }
 


### PR DESCRIPTION
This changes the datastore schema to use the `structSchema` rather than the `jsonSchema` field to provide the schema.

The `jsonSchema` field contains a single JSON string, and any changes to that string (whether semantically relevant or not, e.g. whitespace) cause the resource to be considered changed and trigger an unnecessary remote update. Using the `structSchema` key means we don't have that issue, and also get more meaningful Terraform state diffs when we do make changes.