### PR TITLE
Search API v2: Fix completion config resource

### DIFF
--- a/terraform/deployments/search-api-v2/completion.tf
+++ b/terraform/deployments/search-api-v2/completion.tf
@@ -2,7 +2,7 @@ resource "restapi_object" "google_discovery_engine_data_store_completion_config"
   path      = "/dataStores/${google_discovery_engine_data_store.govuk_content.data_store_id}/completionConfig"
   object_id = "completionConfig"
 
-  update_path = "/dataStores/${google_discovery_engine_data_store.govuk_content.data_store_id}/completionConfig?updateMask=name,matching_order,max_suggestions,min_prefix_length,query_model,enable_mode"
+  update_path = "/dataStores/${google_discovery_engine_data_store.govuk_content.data_store_id}/completionConfig?updateMask=matching_order,max_suggestions,min_prefix_length,query_model,enable_mode"
   read_path   = "/dataStores/${google_discovery_engine_data_store.govuk_content.data_store_id}/completionConfig"
 
   data = jsonencode({


### PR DESCRIPTION
`name` isn't allowed in the `updateMask` field, and wouldn't want or be able to change it anyway.