### PR TITLE
Update AmazonMQ instance type for integration publishing

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -620,7 +620,7 @@ module "variable-set-amazonmq-integration" {
     amazonmq_deployment_mode                      = "SINGLE_INSTANCE"
     amazonmq_maintenance_window_start_day_of_week = "MONDAY"
     amazonmq_maintenance_window_start_time_utc    = "07:00"
-    amazonmq_host_instance_type                   = "mq.t3.micro"
+    amazonmq_host_instance_type                   = "mq.m5.large"
 
     amazonmq_govuk_chat_retry_message_ttl = 300000
   }


### PR DESCRIPTION
The current instance for the publishing broker on integration is
`mq.m5.large`, but the configuration here shows `mq.t3.micro`.

Trying to apply a TF plan that touches the AMQ instance fails with
the following:

```
Error: updating MQ Broker host instance type: operation error mq:
UpdateBroker, https response error StatusCode: 400
BadRequestException: Downgrading from current instance type [mq.m5.large] to requested
instance type [mq.t3.micro] is not supported for RabbitMQ brokers.
```

I think maybe this was just a typo from when things were moved into this
repo from `govuk-aws`.
