### PR TITLE
Search API v2: Remove `move` block and update `imports`

### DIFF
--- a/terraform/deployments/search-api-v2/imports.tf
+++ b/terraform/deployments/search-api-v2/imports.tf
@@ -5,7 +5,9 @@ import {
   to = module.serving_config_default.restapi_object.serving_config
 }
 
-moved {
-  from = module.govuk_content_discovery_engine.restapi_object.discovery_engine_datastore_completion_config
-  to   = restapi_object.google_discovery_engine_data_store_completion_config
+# The completion config resource is a permanent, pre-existing subresource on the datastore, so we
+# never want to create it even if the state is empty.
+import {
+  id = "/dataStores/${google_discovery_engine_data_store.govuk_content.data_store_id}/completionConfig"
+  to = restapi_object.google_discovery_engine_data_store_completion_config
 }


### PR DESCRIPTION
This removes the `move` block for the moved completion config now that it has successfully been applied across environments.

We originally managed "static" resources that always exist on VAIS by overriding the REST API provider's `create_*` properties to be the same as the corresponding `update_*` ones, but a semantically more meaningful way of dealing with these is through Terraform's `import` blocks. This adds an `import` block for the completion config.