### PR TITLE
Search API v2: Update ignored GOV.UK app links

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_default.tf
@@ -108,11 +108,15 @@ module "control_boost_demote_pages" {
 locals {
   # Pages to temporarily exclude from search results
   filtered_pages = [
-    # GOV.UK app beta
+    # GOV.UK app beta (note double appearance of HTML publications)
     "/government/publications/govuk-app-terms-and-conditions",
+    "/government/publications/govuk-app-terms-and-conditions/govuk-app-terms-and-conditions",
     "/government/publications/govuk-app-privacy-notice-how-we-use-your-data",
-    "/government/publications/govuk-app-test-privacy-notice-how-we-use-your-data",
+    "/government/publications/govuk-app-privacy-notice-how-we-use-your-data/govuk-app-privacy-notice-how-we-use-your-data",
+    "/government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data",
+    "/government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data/govuk-app-testing-privacy-notice-how-we-use-your-data",
     "/government/publications/accessibility-statement-for-the-govuk-app",
+    "/government/publications/accessibility-statement-for-the-govuk-app/accessibility-statement-for-the-govuk-app",
     "/sign-up-test-govuk-app",
     "/contact/govuk-app-support",
   ]


### PR DESCRIPTION
We need two of these for each HTML publication (the publication info page parent, and the publication itself).

Also updates one of the links to the correct one (`test` -> `testing`).