### PR TITLE
Search API v2: Exclude `dataStore` from control update mask

### DIFF
--- a/terraform/deployments/search-api-v2/modules/control/main.tf
+++ b/terraform/deployments/search-api-v2/modules/control/main.tf
@@ -27,6 +27,7 @@ locals {
   action_keys = flatten([
     for key, value in var.action : [
       for subkey in keys(value) : "${key}.${subkey}"
+      if subkey != "dataStore" # immutable subkey used in several action types
     ] if can(keys(value))
   ])
 


### PR DESCRIPTION
Some nested control actions have an immutable `dataStore` property, which we need to exclude from the updateMask to avoid an error.