### PR TITLE
Search API v2: Add `cdoc_url` to data store schema

### DIFF
--- a/terraform/deployments/search-api-v2/files/datastore-schema.json
+++ b/terraform/deployments/search-api-v2/files/datastore-schema.json
@@ -11,6 +11,13 @@
       "format": "uuid",
       "retrievable": true
     },
+    "cdoc_url": {
+      "$comment": "This is only used to compare results for evaluation purposes, and is not a URL despite the name. We decided against using the alternative 'uri' field name to avoid confusion with our existing 'url' field and 'uri' key property (see https://cloud.google.com/generative-ai-app-builder/docs/evaluate-search-quality)",
+      "description": "Unique identifier for search quality evaluation (identical to content_id)",
+      "type": "string",
+      "format": "uuid",
+      "retrievable": true
+    },
     "title": {
       "description": "The main title (shown in search results)",
       "type": "string",
@@ -181,6 +188,7 @@
   },
   "required": [
     "content_id",
+    "cdoc_url",
     "title",
     "link",
     "url",

--- a/terraform/deployments/search-api-v2/files/datastore-schema.json
+++ b/terraform/deployments/search-api-v2/files/datastore-schema.json
@@ -44,9 +44,10 @@
       "indexable": true
     },
     "url": {
-      "description": "Absolute URL including protocol and host even for content on GOV.UK proper (used for Vertex to incorporate popularity/event signals)",
+      "description": "Absolute URL including protocol and host even for content on GOV.UK proper (used for Vertex to incorporate popularity/event signals and for internal purposes)",
       "type": "string",
       "format": "url",
+      "retrievable": true,
       "keyPropertyMapping": "uri"
     },
     "public_timestamp": {


### PR DESCRIPTION
This adds a `cdoc_url` field to the data store schema, which we will populate with the document's `content_id` value.

This field doesn't have to contain a URL, just an arbitrary unique reference of our choice. We decided that since we already use `content_id` as an identifier across the board, we will use it for this purpose too.

This also makes `url` retrievable so we can use it internally.