### PR TITLE
Search API v2: Create experimental synonyms control

### DIFF
--- a/terraform/deployments/search-api-v2/modules/control/main.tf
+++ b/terraform/deployments/search-api-v2/modules/control/main.tf
@@ -14,6 +14,7 @@ locals {
 
   dynamic_properties = {
     displayName = var.display_name
+    conditions  = length(var.conditions) > 0 ? var.conditions : null
   }
   # These properties are required on creation, but not updatable
   static_properties = {

--- a/terraform/deployments/search-api-v2/modules/control/variables.tf
+++ b/terraform/deployments/search-api-v2/modules/control/variables.tf
@@ -17,3 +17,9 @@ variable "action" {
   description = "The action for the control (merged into the control properties)"
   type        = any
 }
+
+variable "conditions" {
+  description = "The conditions for the control (merged into the control properties)"
+  type        = list(any)
+  default     = []
+}

--- a/terraform/deployments/search-api-v2/serving_config_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_default.tf
@@ -153,3 +153,29 @@ module "control_synonym_hmrc" {
     }
   }
 }
+
+module "control_synonym_spring_statement" {
+  source = "./modules/control"
+
+  id           = "syn_spring_statement"
+  display_name = "Synonyms: Budget/spring statement"
+  engine_id    = google_discovery_engine_search_engine.govuk.engine_id
+
+  conditions = [
+    {
+      queryTerm = {
+        value     = "budget"
+        fullMatch = true
+      }
+    }
+  ]
+  action = {
+    synonymsAction = {
+      synonyms = [
+        "budget",
+        "spring forecast",
+        "spring statement",
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds a new synonyms control for "spring statement" to be considered equivalent to "budget" if the latter is being searched for.

It also adds the ability to specify `conditions` on a control which is required to get this to work.