### PR TITLE
Search API v2: Proper semantics for synonyms control

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_default.tf
@@ -163,10 +163,10 @@ module "control_synonym_spring_statement" {
 
   conditions = [
     {
-      queryTerm = {
+      queryTerms = [{
         value     = "budget"
         fullMatch = true
-      }
+      }]
     }
   ]
   action = {


### PR DESCRIPTION
This didn't apply as:
- it's `queryTerms`, not `queryTerm`
- the value of `queryTerms` should be an array, not a single object