### PR TITLE
BAU - Bump Terraform provider versions to 5.29.1

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0, < 5.90.1"
+      version = "~> 5.0, < 5.92.1"
     }
   }
 }

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -32,7 +32,7 @@ terraform {
     # do not add AWS resources to this module.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0, < 5.90.1"
+      version = "~> 5.0, < 5.92.1"
     }
   }
 }

--- a/terraform/deployments/search-api-v2/main.tf
+++ b/terraform/deployments/search-api-v2/main.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.89.0"
+      version = "~> 5.92.0"
     }
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
Description:
- See https://github.com/alphagov/govuk-infrastructure/pull/1796