### PR TITLE
Add GitHub GOVUK_SLACK_WEBHOOK_URL secret to all GOV.UK repos

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -254,5 +254,5 @@ resource "github_actions_organization_secret_repositories" "pact_broker_username
 
 resource "github_actions_organization_secret_repositories" "slack_webhook_url" {
   secret_name             = "GOVUK_SLACK_WEBHOOK_URL" # pragma: allowlist secret
-  selected_repository_ids = [for repo in local.deployable_repos : repo.repo_id]
+  selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
 }


### PR DESCRIPTION
We want to add this secret to all GOV.UK repos in addition to deployable repos as tools such as Seal can also use the Report run failure GitHub action.

The documentation already mentions "It’s added to all GOV.UK repositories"

https://github.com/alphagov/govuk-infrastructure/issues/1578