### PR TITLE
Search API v2: Remove spring statement synonym

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_default.tf
@@ -153,29 +153,3 @@ module "control_synonym_hmrc" {
     }
   }
 }
-
-module "control_synonym_spring_statement" {
-  source = "./modules/control"
-
-  id           = "syn_spring_statement"
-  display_name = "Synonyms: Budget/spring statement"
-  engine_id    = google_discovery_engine_search_engine.govuk.engine_id
-
-  conditions = [
-    {
-      queryTerms = [{
-        value     = "budget"
-        fullMatch = true
-      }]
-    }
-  ]
-  action = {
-    synonymsAction = {
-      synonyms = [
-        "budget",
-        "spring forecast",
-        "spring statement",
-      ]
-    }
-  }
-}


### PR DESCRIPTION
It turns out we can't use `queryTerms` for synonyms controls, so removing this as it causes an error on apply.