### PR TITLE
Revert "Update Helm release external-dns to v1.16.0"

### DIFF
--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -2,7 +2,7 @@ resource "helm_release" "external_dns" {
   name             = "external-dns"
   repository       = "https://kubernetes-sigs.github.io/external-dns"
   chart            = "external-dns"
-  version          = "1.16.0"
+  version          = "1.15.2"
   namespace        = local.services_ns
   create_namespace = true
 


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#1871

Error is:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s): external-dns: - automountServiceAccountToken: Invalid type. Expected: null, given: boolean - provider: Invalid type. Expected: object, given: string - serviceAccount.name: Invalid type. Expected: null, given: string
```

Looks like the [schema validation](https://github.com/kubernetes-sigs/external-dns/issues/5206) in `v1.16.0` caused the bug.