### PR TITLE
Revert "Update Helm release aws-ebs-csi-driver to v2.41.0"

### DIFF
--- a/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
@@ -2,7 +2,7 @@ resource "helm_release" "aws_ebs_csi_driver" {
   name             = "aws-ebs-csi-driver"
   repository       = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver"
   chart            = "aws-ebs-csi-driver"
-  version          = "2.41.0"
+  version          = "2.39.3"
   namespace        = "kube-system"
   create_namespace = true
   timeout          = var.helm_timeout_seconds


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#1824

Terraform Cloud crashed before I could test this. Reverting it to leave the repository in a workable and testable state.