### PR TITLE
Import DGU organogram S3 settings into Terraform

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/organogram_bucket.tf
+++ b/terraform/deployments/datagovuk-infrastructure/organogram_bucket.tf
@@ -49,3 +49,30 @@ resource "aws_s3_bucket_policy" "govuk_datagovuk_organogram_read_policy" {
   bucket = aws_s3_bucket.datagovuk-organogram.id
   policy = data.aws_iam_policy_document.s3_fastly_read_policy_doc.json
 }
+
+import {
+  to = aws_s3_bucket_public_access_block.datagovuk_organogram
+  id = aws_s3_bucket.datagovuk-organogram.id
+}
+
+resource "aws_s3_bucket_public_access_block" "datagovuk_organogram" {
+  bucket = aws_s3_bucket.datagovuk-organogram.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+import {
+  to = aws_s3_bucket_ownership_controls.datagovuk_organogram
+  id = aws_s3_bucket.datagovuk-organogram.id
+}
+
+resource "aws_s3_bucket_ownership_controls" "datagovuk_organogram" {
+  bucket = aws_s3_bucket.datagovuk-organogram.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}


### PR DESCRIPTION
Description:
- Enabled ACLs and S3 block public access settings were clickopsed and not managed by Terraform
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1746