### PR TITLE
Update report-run-failure action usage example

### DIFF
--- a/.github/actions/report-run-failure/README.md
+++ b/.github/actions/report-run-failure/README.md
@@ -30,7 +30,7 @@ jobs:
 
       # copy lines below to report a github failure to your team channel
       - if: ${{ failure() }}
-        uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure.yml@main
+        uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
         with:
           slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
           channel: your-team-slack-channel


### PR DESCRIPTION
The file extension is not needed.
Workflow will automatically look for action the file with .yml or .yaml extension.

Tested as part of https://github.com/alphagov/govuk-dependabot-merger/pull/101