### PR TITLE
Add backup retention period for Publishing API in staging

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -483,6 +483,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         freestoragespace_threshold   = 10737418240
+        backup_retention_period      = 1
         project                      = "GOV.UK - Publishing"
       }
 


### PR DESCRIPTION
[Trello](https://trello.com/c/yvkqI642/1630-set-up-the-read-replica-in-staging)

Backups must be enabled in order to create a read replica in RDS. We don't otherwise need backups, so this sets them to have the shortest possible retention period, per 4f2a2ab920ae95845e7ba16b57e8434180cdc6ec