### PR TITLE
Enable EKS Access Entries support (in Integration)

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -71,6 +71,9 @@ module "variable-set-integration" {
     # Non-production-only access is sufficient to access tools in this cluster.
     github_read_write_team = "alphagov:gov-uk"
 
+    # Enable EKS Access Entries support in prep for aws-auth deprecation.
+    authentication_mode = "API_AND_CONFIG_MAP"
+
     grafana_db_auto_pause       = true
     maintenance_window          = "Sun:04:00-Sun:06:00"
     rds_apply_immediately       = true


### PR DESCRIPTION
## What?
This will enable EKS "Access Entries" support (only in Integration for now) so we can test and prepare for the aws-auth ConfigMap deprecation.