### PR TITLE
Update AMQ for search-api retry mechanism

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/amazonmq_schema.json.tpl
+++ b/terraform/deployments/govuk-publishing-infrastructure/amazonmq_schema.json.tpl
@@ -148,7 +148,7 @@
     {
       "vhost": "publishing",
       "name": "search_api_to_be_indexed_retry",
-      "pattern": "search_api_to_be_indexed",
+      "pattern": "^search_api_to_be_indexed$",
       "apply-to": "queues",
       "definition": {
         "dead-letter-exchange": "search_api_to_be_indexed_retry_dlx",
@@ -419,10 +419,18 @@
       "routing_key": "*.links",
       "arguments": {}
     },
-     {
+    {
       "source": "search_api_to_be_indexed_discarded_dlx",
       "vhost": "publishing",
       "destination": "search_api_to_be_indexed",
+      "destination_type": "queue",
+      "routing_key": "#",
+      "arguments": {}
+    },
+    {
+      "source": "search_api_to_be_indexed_retry_dlx",
+      "vhost": "publishing",
+      "destination": "search_api_to_be_indexed_wait_to_retry",
       "destination_type": "queue",
       "routing_key": "#",
       "arguments": {}


### PR DESCRIPTION

Previously we added some configuration to allow for automatic retries of
a message using RabbitMQ.

The idea is:

* A consumer processes a message
* The message raises an exception and the consumer calls `discard` on it
* That message gets routed to a dlx with a TTL of 60s
* Nothing consumes the queue on that dlx, so after 60s the message is
  discarded and put on another queue, where it's routed back to the
  original queue for re-processing

When testing on integration, this didn't work quite right, and hopefully
this fixes it.

First off, there was an issue with policies. We have 2 policies
configured:

1. `search_api_to_be_indexed_retry` applied to the
   `search_api_to_be_indexed` queue
2. `search_api_to_be_indexed_wait_to_retry_discarded` applied to the
   `search_api_to_be_indexed_wait_to_retry` queue

However what happened in reality was that the
`search_api_to_be_indexed_retry` policy was being applied to both
queues. This is because the `pattern` attribute here is a regex, not a
string match. Because the pattern is "search_api_to_be_indexed", this
was matching both of the queues here because they both match that regex.
So this commit tightens up that regex so it only applies to the one
specific queue.

Secondly I missed a binding when configuring this previously. The
`search_api_to_be_indexed_wait_to_retry` queue was created, but it was
never bound to the exchange. So no messages were being put on that
queue.
