### PR TITLE
Tighten up pattern regexes in AMQ policies

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/amazonmq_schema.json.tpl
+++ b/terraform/deployments/govuk-publishing-infrastructure/amazonmq_schema.json.tpl
@@ -123,7 +123,7 @@
     {
       "vhost": "publishing",
       "name": "govuk_chat_retry_dlx",
-      "pattern": "govuk_chat_published_documents",
+      "pattern": "^govuk_chat_published_documents$",
       "apply-to": "queues",
       "definition": {
         "dead-letter-exchange": "govuk_chat_retry_dlx",
@@ -135,7 +135,7 @@
     {
       "vhost": "publishing",
       "name": "govuk_chat_retry",
-      "pattern": "govuk_chat_retry",
+      "pattern": "^govuk_chat_retry$",
       "apply-to": "queues",
       "definition": {
         "dead-letter-exchange": "govuk_chat_dlx",
@@ -160,7 +160,7 @@
     {
       "vhost": "publishing",
       "name": "search_api_to_be_indexed_wait_to_retry_discarded",
-      "pattern": "search_api_to_be_indexed_wait_to_retry",
+      "pattern": "^search_api_to_be_indexed_wait_to_retry$",
       "apply-to": "queues",
       "definition": {
         "dead-letter-exchange": "search_api_to_be_indexed_discarded_dlx",


### PR DESCRIPTION
RabbitMQ policies are defined by applying them to a specific pattern. We
generally use them for applying to queues, and so the pattern matches
against the queue name.

Using the queue name as the pattern has the potential for matching
unintended queues. This has bitten us in the past and is a bit tricky to
figure out.

So this commit tightens up all patterns where we're using the string as
a direct match against the queue name, and ensures that the policy will
only match queues with exactly those names.
