### PR TITLE
Revert "Update Helm release aws-ebs-csi-driver to v2.41.0"

### DIFF
--- a/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
@@ -2,7 +2,7 @@ resource "helm_release" "aws_ebs_csi_driver" {
   name             = "aws-ebs-csi-driver"
   repository       = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver"
   chart            = "aws-ebs-csi-driver"
-  version          = "2.41.0"
+  version          = "2.39.3"
   namespace        = "kube-system"
   create_namespace = true
   timeout          = var.helm_timeout_seconds


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#1881

Error in Terraform Cloud run,

```
Error: values don't meet the specifications of the schema(s) in the following chart(s): aws-ebs-csi-driver: - (root): Additional property enableVolumeResizing is not allowed
```

This is probably because https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/values.schema.json#L9 was added last month in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/9bee9ee5faf5db3a536c81dac14986a5fcd2ff70