### PR TITLE
Set default authentication mode for EKS clusters to API_AND_CONFIG_MAP

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -202,6 +202,6 @@ variable "govuk_environment" {
 
 variable "authentication_mode" {
   type        = string
-  default     = "CONFIG_MAP"
+  default     = "API_AND_CONFIG_MAP"
   description = "Authentication mode to use for the cluster"
 }


### PR DESCRIPTION
This is to fix an issue introduced during the last sprint, where the eks Terraform module attempts to create an access entry on existing clusters, but the authentication mode is not set to `API_AND_CONFIG_MAP`, which causes the AWS API to return an error. Enabling access entries in existing clusters shouldn't change anything, as it still reads auth info from the config map like it usually does.