### PR TITLE
Remove unnecessary `enableVolumeResizing` parameter

### DIFF
--- a/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
@@ -7,7 +7,6 @@ resource "helm_release" "aws_ebs_csi_driver" {
   create_namespace = true
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
-    enableVolumeResizing = true
     controller = {
       serviceAccount = {
         create = true


### PR DESCRIPTION
Description:
- Latest version of AWS EBS CSI driver has [schema validation](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/9e4030d5db3fe181c3effbde0781ff63aa0ece11/charts/aws-ebs-csi-driver/values.schema.json#L4) which prevents additional global parameters like `enableVolumeResizing`
- But the option for this has already been defined in `allowVolumeExpansion` under `storageClasses`
- Removing this will allow us to upgrade to the next version
- See [here](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/856#discussion_r622603200) for discussion where `enableVolumeResizing` was turned on by default and removed from the Helm chart