### PR TITLE
Bump argo-bootstrap-ephemeral chart version

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -202,7 +202,7 @@ resource "helm_release" "argo_bootstrap_ephemeral" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
-  version          = "0.0.6"
+  version          = "0.0.7"
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     awsAccountId     = data.aws_caller_identity.current.account_id


### PR DESCRIPTION
This is to pull in changes from https://github.com/alphagov/govuk-helm-charts/pull/3101