### PR TITLE
Set argoNamespace when installing ephemeral bootstrap chart

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -209,6 +209,7 @@ resource "helm_release" "argo_bootstrap_ephemeral" {
     govukEnvironment = "ephemeral"
     clusterId        = var.cluster_name
     argocdUrl        = "https://${local.argo_host}"
+    argoNamespace    = local.services_ns
     argoWorkflowsUrl = "https://${local.argo_workflows_host}"
     iamRoleServiceAccounts = {
       tagImageWorkflow = {


### PR DESCRIPTION
This being missing is causing some charts to be installed to the wrong namespace