### PR TITLE
Send RDS alerts to govuk-platform-support Slack channel

### DIFF
--- a/terraform/deployments/rds/notifications.tf
+++ b/terraform/deployments/rds/notifications.tf
@@ -1,3 +1,11 @@
+data "aws_secretsmanager_secret" "slack_channel" {
+  name = "govuk/slack/platform-support-email"
+}
+
+data "aws_secretsmanager_secret_version" "slack_channel" {
+  secret_id = data.aws_secretsmanager_secret.slack_channel.id
+}
+
 resource "aws_sns_topic" "rds_alerts" {
   name         = "${var.govuk_environment}-rds-alerts"
   display_name = "GOV.UK RDS Alerts"
@@ -6,5 +14,5 @@ resource "aws_sns_topic" "rds_alerts" {
 resource "aws_sns_topic_subscription" "rds_alerts" {
   topic_arn = aws_sns_topic.rds_alerts.arn
   protocol  = "email"
-  endpoint  = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+  endpoint  = data.aws_secretsmanager_secret_version.slack_channel.secret_string
 }


### PR DESCRIPTION
This is a better place for them than the team email, and the alerts are currently broken anyway since the email address its pointing to doesn't allow external messages to be sent to it.