### PR TITLE
Include environment name in RDS alerts SNS topic

### DIFF
--- a/terraform/deployments/rds/notifications.tf
+++ b/terraform/deployments/rds/notifications.tf
@@ -8,7 +8,7 @@ data "aws_secretsmanager_secret_version" "slack_channel" {
 
 resource "aws_sns_topic" "rds_alerts" {
   name         = "${var.govuk_environment}-rds-alerts"
-  display_name = "GOV.UK RDS Alerts"
+  display_name = "RDS Alerts (${var.govuk_environment})"
 }
 
 resource "aws_sns_topic_subscription" "rds_alerts" {


### PR DESCRIPTION
This is shown in the email sent to Slack, and it'd be useful to know which environment an alert is coming from.