### PR TITLE
Skip final snapshots for RDS read replicas

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -132,6 +132,8 @@ resource "aws_db_instance" "replica" {
   identifier          = "${var.govuk_environment}-${each.value.name}-${each.value.engine}-replica"
   replicate_source_db = aws_db_instance.instance[each.key].identifier
 
+  skip_final_snapshot = true
+
   tags = { Name = "govuk-rds-${each.value.name}-${each.value.engine}-replica", project = lookup(each.value, "project", "GOV.UK - Other") }
 
   lifecycle { ignore_changes = [identifier] }


### PR DESCRIPTION
We don't need snapshots of read replicas, and the AWS API is complaining because it defaults to creating a final snapshot and we aren't setting a final snapshot name for them