### PR TITLE
Search API v2: Disable variant news freshness boost

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_variant.tf
@@ -8,7 +8,6 @@ module "serving_config_variant" {
   boost_control_ids = [
     # specific to serving_config_variant
     module.control_boost_demote_historic.id,
-    module.control_boost_freshness_news.id,
     module.control_boost_freshness_general.id,
 
     # identical to serving_config_default


### PR DESCRIPTION
We've established this double-boosting of news isn't helpful. This disables the boost (it will have to be removed separately once disabled, we can't do it in one go due to the dependency of the serving config on the control).