### PR TITLE
Bump Argo Bootstrap Ephemeral to 0.0.9

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -202,7 +202,7 @@ resource "helm_release" "argo_bootstrap_ephemeral" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
-  version          = "0.0.8"
+  version          = "0.0.9"
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     awsAccountId     = data.aws_caller_identity.current.account_id


### PR DESCRIPTION
Description:
- See https://github.com/alphagov/govuk-helm-charts/pull/3115
- Bump chart to 0.0.9
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1744