### PR TITLE
Import dns resources from VPC module into root-dns module

### DIFF
--- a/terraform/deployments/root-dns/import.tf
+++ b/terraform/deployments/root-dns/import.tf
@@ -1,0 +1,22 @@
+locals {
+  internal_dns_zone_import = {
+    integration = "Z15X3KXNVBQPDX"
+    staging     = "Z3NWZWKZO6M8LD"
+    production  = "Z2Q1IA44B0B7UR"
+  }
+  external_dns_zone_import = {
+    integration = "ZNHYJS6IH772R"
+    staging     = "Z2W7W2S1Y9HA8Q"
+    production  = "Z23V51RSQPRS0P"
+  }
+}
+
+import {
+  to = aws_route53_zone.internal_zone
+  id = local.internal_dns_zone_import[var.govuk_environment]
+}
+
+import {
+  to = aws_route53_zone.external_zone
+  id = local.external_dns_zone_import[var.govuk_environment]
+}

--- a/terraform/deployments/root-dns/main.tf
+++ b/terraform/deployments/root-dns/main.tf
@@ -15,7 +15,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-1"
+  region = var.aws_region
   default_tags {
     tags = {
       Product              = "GOV.UK"

--- a/terraform/deployments/root-dns/outputs.tf
+++ b/terraform/deployments/root-dns/outputs.tf
@@ -1,0 +1,19 @@
+output "internal_root_zone_id" {
+  description = "ID of the internal Route53 DNS zone"
+  value       = aws_route53_zone.internal_zone.id
+}
+
+output "internal_root_zone_name" {
+  description = "Name of the internal Route53 DNS zone"
+  value       = aws_route53_zone.internal_zone.name
+}
+
+output "external_root_zone_id" {
+  description = "ID of the external Route53 DNS zone"
+  value       = aws_route53_zone.external_zone.id
+}
+
+output "external_root_zone_name" {
+  description = "Name of the external Route53 DNS zone"
+  value       = aws_route53_zone.external_zone.name
+}

--- a/terraform/deployments/root-dns/remote.tf
+++ b/terraform/deployments/root-dns/remote.tf
@@ -1,0 +1,4 @@
+data "tfe_outputs" "vpc" {
+  organization = "govuk"
+  workspace    = "vpc-${var.govuk_environment}"
+}

--- a/terraform/deployments/root-dns/root_dns_zones.tf
+++ b/terraform/deployments/root-dns/root_dns_zones.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_zone" "internal_zone" {
+  name = "${var.govuk_environment}.govuk-internal.digital."
+
+  vpc {
+    vpc_id = data.tfe_outputs.vpc.nonsensitive_values.id
+  }
+}
+
+resource "aws_route53_zone" "external_zone" {
+  name = "${var.govuk_environment}.govuk.digital."
+}

--- a/terraform/deployments/root-dns/variables.tf
+++ b/terraform/deployments/root-dns/variables.tf
@@ -1,0 +1,10 @@
+variable "govuk_environment" {
+  type        = string
+  description = "GOV.UK environment where resources are being deployed"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region"
+  default     = "eu-west-1"
+}


### PR DESCRIPTION
#### Depends on
- https://github.com/alphagov/govuk-infrastructure/pull/1945

### User Need

**As a** platform engineer
**I want to** extract the root DNS zone configuration from the shared VPC module into a dedicated Terraform module
**so that** I can allow multiple ephemeral Kubernetes clusters to provision and manage their own DNS zones independently and concurrently

https://github.com/alphagov/govuk-infrastructure/issues/1915

#### Follow up work
- Update references to DNS resources' outputs and remove import statements 