### PR TITLE
RDS: don't send alert emails for the 'availability' category

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -91,7 +91,7 @@ resource "aws_db_event_subscription" "subscription" {
 
   source_type      = "db-instance"
   source_ids       = [for i in aws_db_instance.instance : i.identifier]
-  event_categories = ["availability", "deletion", "failure", "low storage"]
+  event_categories = ["deletion", "failure", "low storage"]
 }
 
 # Alarm if free storage space is below threshold (typically 10 GiB) for 10m.


### PR DESCRIPTION
This category includes alerts for when a DB instance is restarted, which happens a lot during maintenance windows. The 'availability' category doesn't include any alerts we actually care about so it's just creating noise