### PR TITLE
Declare Aurora v2 Instances for Grafana

### DIFF
--- a/terraform/deployments/cluster-infrastructure/grafana.tf
+++ b/terraform/deployments/cluster-infrastructure/grafana.tf
@@ -121,6 +121,13 @@ module "grafana_db" {
     seconds_until_auto_pause = 300
   }
 
+  instance_class = "db.serverless"
+  instances = {
+    one = {
+      identifier = "${local.grafana_db_name}-instance-1"
+    }
+  }
+
   apply_immediately            = var.rds_apply_immediately
   backup_retention_period      = var.rds_backup_retention_period
   skip_final_snapshot          = var.rds_skip_final_snapshot


### PR DESCRIPTION
## What?
We appear to be having some issues in test with the Aurora Module that configures our Grafana DB. A quick chat with Support for why the Endpoints weren't progressing beyond "Creating" was because there were no instances configured - even if using Aurora Serverless v2, you still need to declare an "Instance".