### PR TITLE
Fix VPC ephemeral workspace for root-dns

### DIFF
--- a/terraform/deployments/tfc-configuration/root-dns.tf
+++ b/terraform/deployments/tfc-configuration/root-dns.tf
@@ -1,3 +1,35 @@
+module "root-dns-ephemeral" {
+  source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
+
+  organization        = var.organization
+  workspace_name      = "root-dns-ephemeral"
+  workspace_desc      = "Internal and external DNS zones for ephemeral environment"
+  workspace_tags      = ["ephemeral", "dns", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/root-dns/"
+  trigger_patterns    = ["/terraform/deployments/root-dns/**/*"]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production (r/o)" = "write"
+    "GOV.UK Production"           = "write"
+  }
+
+  variable_set_ids = [
+    local.aws_credentials["test"],
+    module.variable-set-common.id,
+    module.variable-set-ephemeral.id
+  ]
+}
+
 module "root-dns-integration" {
   source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
 


### PR DESCRIPTION
Description:
- Grafana expects a `root-dns` workspace for the ephemeral environment [here](https://github.com/alphagov/govuk-infrastructure/blob/b92fbeb6386113f76e5dc4e17aa6e4dabd03b8fe/terraform/deployments/cluster-infrastructure/grafana.tf#L140)
- Change adds the `root-dns` TFE workspace for ephemeral
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1915