### PR TITLE
Add labels to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,5 +18,6 @@
       "^/terraform/.*\\.tf$"
     ]
   },
-  "prHourlyLimit": 20
+  "prHourlyLimit": 20,
+  "labels": ["dependencies", "renovate"]
 }


### PR DESCRIPTION
This is consistent with Dependabot PRs. It will allow us to filter PRs by the label. A link to filtered search is included in the Seal tool.

It also adds `renovate` label in case we want to distinguish between the tools.

Documentation:
```
"labels": {
  "description": "Labels to set in Pull Request.",
  "type": "array",
  "items": {
    "type": "string"
  }
},
```