### PR TITLE
Fix correct root dns workspace name for ephemeral

### DIFF
--- a/terraform/deployments/cluster-infrastructure/remote.tf
+++ b/terraform/deployments/cluster-infrastructure/remote.tf
@@ -5,7 +5,7 @@ data "aws_caller_identity" "current" {}
 
 data "tfe_outputs" "root_dns" {
   organization = "govuk"
-  workspace    = "root-dns-${var.govuk_environment}"
+  workspace    = startswith(var.govuk_environment, "eph-") ? "root-dns-ephemeral" : "root-dns-${var.govuk_environment}"
 }
 
 data "tfe_outputs" "vpc" {


### PR DESCRIPTION
Description:
- Workspace name is `root-dns-ephemeral`
- As part of https://github.com/alphagov/govuk-infrastructure/issues/1915