### PR TITLE
Update WAFs to 0.0.15

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -122,6 +122,12 @@ variable "cache_public_base_rate_limit" {
   default     = 1000
 }
 
+variable "cache_public_post_rate_warning" {
+  type        = number
+  description = "An warning rate limit threshold for posts to the public web ACL"
+  default     = 1000
+}
+
 variable "backend_public_base_rate_warning" {
   type        = number
   description = "A warning rate limit threshold for the backend public web ACL"

--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -5,10 +5,11 @@
 
 module "infrastructure-sensitive_wafs" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/wafs"
-  version = "0.0.10"
+  version = "0.0.15"
 
   cache_public_base_rate_limit   = var.cache_public_base_rate_limit
   cache_public_base_rate_warning = var.cache_public_base_rate_warning
+  cache_public_post_rate_warning = var.cache_public_post_rate_warning
   fastly_rate_limit_token        = var.fastly_rate_limit_token
   govuk_requesting_ips_arn       = aws_wafv2_ip_set.govuk_requesting_ips.arn
   high_request_rate_ips_arn      = aws_wafv2_ip_set.high_request_rate.arn


### PR DESCRIPTION
[This version](https://github.com/alphagov/terraform-govuk-infrastructure-sensitive/commit/49b802c664351669da0afdf2529335150443de6a) has been published in the private registry.