### PR TITLE
Fix Dependency issue on Access Entries

### DIFF
--- a/terraform/deployments/cluster-services/eks_access.tf
+++ b/terraform/deployments/cluster-services/eks_access.tf
@@ -36,6 +36,10 @@ resource "aws_eks_access_policy_association" "cluster_admin" {
   access_scope {
     type = "cluster"
   }
+
+  depends_on = [
+    aws_eks_access_entry.cluster-admin
+  ]
 }
 
 resource "aws_eks_access_policy_association" "developer" {
@@ -49,6 +53,10 @@ resource "aws_eks_access_policy_association" "developer" {
     type       = "namespace"
     namespaces = local.developer_namespaces
   }
+
+  depends_on = [
+    aws_eks_access_entry.developer
+  ]
 }
 
 resource "kubernetes_cluster_role_binding" "cluster_admins" {


### PR DESCRIPTION
## What?
We've encountered some intermittent errors during `tf apply` for the Access Entries Policy Associations. We want to set a "depends_on" here to try and stop that from happening.