### PR TITLE
Manage developer role for datagovuk namespace in datagovuk-infrastructure instead of cluster-services

### DIFF
--- a/terraform/deployments/cluster-services/eks_access.tf
+++ b/terraform/deployments/cluster-services/eks_access.tf
@@ -3,7 +3,7 @@ data "aws_iam_roles" "cluster-admin" { name_regex = "(\\..*-admin$|\\..*-fulladm
 data "aws_iam_roles" "developer" { name_regex = "\\..*-developer$" }
 
 locals {
-  developer_namespaces = ["apps", "datagovuk", "licensify"]
+  developer_namespaces = ["apps", "licensify"]
 }
 
 resource "aws_eks_access_entry" "cluster-admin" {
@@ -152,7 +152,7 @@ resource "kubernetes_role_binding" "developer" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = kubernetes_role.developer[each.key].metadata[0].name
+    name      = "developer"
   }
   subject {
     kind      = "Group"

--- a/terraform/deployments/datagovuk-infrastructure/auth.tf
+++ b/terraform/deployments/datagovuk-infrastructure/auth.tf
@@ -1,4 +1,8 @@
+data "aws_iam_roles" "developer" { name_regex = "\\..*-developer$" }
+
 resource "kubernetes_role_binding" "poweruser" {
+  depends_on = [kubernetes_namespace.datagovuk]
+
   metadata {
     name      = "poweruser-${var.datagovuk_namespace}"
     namespace = var.datagovuk_namespace
@@ -12,5 +16,69 @@ resource "kubernetes_role_binding" "poweruser" {
     kind      = "Group"
     name      = "powerusers"
     api_group = "rbac.authorization.k8s.io"
+  }
+}
+
+resource "kubernetes_role" "developer" {
+  depends_on = [kubernetes_namespace.datagovuk]
+
+  metadata {
+    name      = "developer"
+    namespace = var.datagovuk_namespace
+    labels    = { "app.kubernetes.io/managed-by" = "Terraform" }
+  }
+
+  rule {
+    api_groups = ["", "apps"]
+    resources  = ["pods", "pods/logs", "deployments", "replicasets", "statefulsets"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = ["batch"]
+    resources  = ["jobs", "cronjobs"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods/exec"]
+    verbs      = ["create"]
+  }
+}
+
+resource "kubernetes_role_binding" "developer" {
+  depends_on = [
+    kubernetes_namespace.datagovuk,
+    kubernetes_role.developer
+  ]
+
+  metadata {
+    name      = "developer-binding"
+    namespace = var.datagovuk_namespace
+    labels    = { "app.kubernetes.io/managed-by" = "Terraform" }
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.developer.metadata[0].name
+  }
+  subject {
+    kind      = "Group"
+    name      = "developer"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
+resource "aws_eks_access_policy_association" "developer" {
+  for_each = data.aws_iam_roles.developer.arns
+
+  cluster_name  = local.cluster_id
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+  principal_arn = each.value
+
+  access_scope {
+    type       = "namespace"
+    namespaces = ["datagovuk"]
   }
 }


### PR DESCRIPTION
This resolves a dependency where the role needs the namespace to exist, but it is created in datagovuk-infrastructure which is applied after cluster-services

https://github.com/alphagov/govuk-infrastructure/issues/1833