### PR TITLE
Use developer_namespaces local var for developer role binding

### DIFF
--- a/terraform/deployments/cluster-services/eks_access.tf
+++ b/terraform/deployments/cluster-services/eks_access.tf
@@ -141,7 +141,7 @@ resource "kubernetes_role" "developer" {
 }
 
 resource "kubernetes_role_binding" "developer" {
-  for_each   = toset(["apps", "datagovuk", "licensify"])
+  for_each   = toset(local.developer_namespaces)
   depends_on = [kubernetes_role.developer]
 
   metadata {


### PR DESCRIPTION
This shouldn't be creating a DGU role binding anymore, so update it to use the same set of namespaces that every other resource is using

https://github.com/alphagov/govuk-infrastructure/issues/1833