### PR TITLE
Move DGU role binding and namespace back to cluster-services 

### DIFF
--- a/terraform/deployments/cluster-services/eks_access.tf
+++ b/terraform/deployments/cluster-services/eks_access.tf
@@ -141,7 +141,7 @@ resource "kubernetes_role" "developer" {
 }
 
 resource "kubernetes_role_binding" "developer" {
-  for_each   = toset(["apps", "datagovuk", "licensify"])
+  for_each   = toset(local.developer_namespaces)
   depends_on = [kubernetes_role.developer]
 
   metadata {

--- a/terraform/deployments/cluster-services/eks_access.tf
+++ b/terraform/deployments/cluster-services/eks_access.tf
@@ -3,7 +3,7 @@ data "aws_iam_roles" "cluster-admin" { name_regex = "(\\..*-admin$|\\..*-fulladm
 data "aws_iam_roles" "developer" { name_regex = "\\..*-developer$" }
 
 locals {
-  developer_namespaces = ["apps", "licensify"]
+  developer_namespaces = ["apps", "datagovuk", "licensify"]
 }
 
 resource "aws_eks_access_entry" "cluster-admin" {

--- a/terraform/deployments/cluster-services/namespaces.tf
+++ b/terraform/deployments/cluster-services/namespaces.tf
@@ -33,3 +33,24 @@ resource "kubernetes_namespace" "licensify" {
     }
   }
 }
+
+resource "kubernetes_namespace" "datagovuk" {
+  metadata {
+    name = var.datagovuk_namespace
+    annotations = {
+      "argocd.argoproj.io/sync-options" = "ServerSideApply=true"
+    }
+    labels = {
+      "app.kubernetes.io/managed-by"       = "Terraform"
+      "argocd.argoproj.io/managed-by"      = "cluster-services"
+      "pod-security.kubernetes.io/audit"   = "restricted"
+      "pod-security.kubernetes.io/enforce" = "restricted"
+      "pod-security.kubernetes.io/warn"    = "restricted"
+    }
+  }
+}
+
+import {
+  to = kubernetes_namespace.datagovuk
+  id = var.datagovuk_namespace
+}

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -10,6 +10,12 @@ variable "licensify_namespace" {
   default     = "licensify"
 }
 
+variable "datagovuk_namespace" {
+  type        = string
+  description = "Name of the namespace to create for ArgoCD to deploy DGU apps into by default."
+  default     = "datagovuk"
+}
+
 variable "argo_workflows_namespaces" {
   type        = list(string)
   description = "Namespaces in which Argo will run workflows."

--- a/terraform/deployments/datagovuk-infrastructure/argo_bootstrap.tf
+++ b/terraform/deployments/datagovuk-infrastructure/argo_bootstrap.tf
@@ -10,18 +10,9 @@ resource "helm_release" "argo_bootstrap" {
   })]
 }
 
-resource "kubernetes_namespace" "datagovuk" {
-  metadata {
-    name = var.datagovuk_namespace
-    annotations = {
-      "argocd.argoproj.io/sync-options" = "ServerSideApply=true"
-    }
-    labels = {
-      "app.kubernetes.io/managed-by"       = "Terraform"
-      "argocd.argoproj.io/managed-by"      = "cluster-services"
-      "pod-security.kubernetes.io/audit"   = "restricted"
-      "pod-security.kubernetes.io/enforce" = "restricted"
-      "pod-security.kubernetes.io/warn"    = "restricted"
-    }
+removed {
+  from = kubernetes_namespace.datagovuk
+  lifecycle {
+    destroy = false
   }
 }

--- a/terraform/deployments/datagovuk-infrastructure/auth.tf
+++ b/terraform/deployments/datagovuk-infrastructure/auth.tf
@@ -1,8 +1,4 @@
-data "aws_iam_roles" "developer" { name_regex = "\\..*-developer$" }
-
 resource "kubernetes_role_binding" "poweruser" {
-  depends_on = [kubernetes_namespace.datagovuk]
-
   metadata {
     name      = "poweruser-${var.datagovuk_namespace}"
     namespace = var.datagovuk_namespace
@@ -16,69 +12,5 @@ resource "kubernetes_role_binding" "poweruser" {
     kind      = "Group"
     name      = "powerusers"
     api_group = "rbac.authorization.k8s.io"
-  }
-}
-
-resource "kubernetes_role" "developer" {
-  depends_on = [kubernetes_namespace.datagovuk]
-
-  metadata {
-    name      = "developer"
-    namespace = var.datagovuk_namespace
-    labels    = { "app.kubernetes.io/managed-by" = "Terraform" }
-  }
-
-  rule {
-    api_groups = ["", "apps"]
-    resources  = ["pods", "pods/logs", "deployments", "replicasets", "statefulsets"]
-    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
-  }
-
-  rule {
-    api_groups = ["batch"]
-    resources  = ["jobs", "cronjobs"]
-    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
-  }
-
-  rule {
-    api_groups = [""]
-    resources  = ["pods/exec"]
-    verbs      = ["create"]
-  }
-}
-
-resource "kubernetes_role_binding" "developer" {
-  depends_on = [
-    kubernetes_namespace.datagovuk,
-    kubernetes_role.developer
-  ]
-
-  metadata {
-    name      = "developer-binding"
-    namespace = var.datagovuk_namespace
-    labels    = { "app.kubernetes.io/managed-by" = "Terraform" }
-  }
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "Role"
-    name      = kubernetes_role.developer.metadata[0].name
-  }
-  subject {
-    kind      = "Group"
-    name      = "developer"
-    api_group = "rbac.authorization.k8s.io"
-  }
-}
-
-resource "aws_eks_access_policy_association" "developer" {
-  for_each = data.aws_iam_roles.developer.arns
-
-  cluster_name  = local.cluster_id
-  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
-  principal_arn = each.value
-
-  access_scope {
-    type       = "namespace"
-    namespaces = ["datagovuk"]
   }
 }


### PR DESCRIPTION
We get infinite applies if we try to manage the access policies in two places, since they're only identified by values that are common to each. Moving all of this to cluster-services isn't ideal since it creates more coupling between the 'normal' infra and DGU, but there isn't really another way to do this

https://github.com/alphagov/govuk-infrastructure/issues/1833