### PR TITLE
Miscellaneous ephemeral cluster changes

### DIFF
--- a/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
@@ -30,7 +30,7 @@ resource "helm_release" "aws_ebs_csi_driver" {
         parameters = {
           type = "gp3"
         }
-        reclaimPolicy        = "Retain"
+        reclaimPolicy        = local.is_ephemeral ? "Delete" : "Retain"
         volumeBindingMode    = "WaitForFirstConsumer"
         allowVolumeExpansion = true
       }

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -89,4 +89,5 @@ locals {
   prometheus_host           = "prometheus.${local.external_dns_zone_name}"
   prometheus_internal_url   = "http://kube-prometheus-stack-prometheus:9090"
   alertmanager_internal_url = "http://kube-prometheus-stack-alertmanager:9093"
+  is_ephemeral = startswith(var.govuk_environment, "eph-")
 }

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -89,5 +89,5 @@ locals {
   prometheus_host           = "prometheus.${local.external_dns_zone_name}"
   prometheus_internal_url   = "http://kube-prometheus-stack-prometheus:9090"
   alertmanager_internal_url = "http://kube-prometheus-stack-alertmanager:9093"
-  is_ephemeral = startswith(var.govuk_environment, "eph-")
+  is_ephemeral              = startswith(var.govuk_environment, "eph-")
 }

--- a/terraform/deployments/cluster-services/tempo.tf
+++ b/terraform/deployments/cluster-services/tempo.tf
@@ -5,6 +5,8 @@ locals {
 
 resource "aws_s3_bucket" "tempo" {
   bucket = "govuk-${var.govuk_environment}-tempo"
+
+  force_destroy = var.force_destroy
 }
 
 module "tempo_iam_role" {

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -67,3 +67,9 @@ variable "cluster_name" {
   description = "Name of the EKS cluster to create resources in"
   default     = "govuk"
 }
+
+variable "force_destroy" {
+  type        = bool
+  description = "Setting for force_destroy on resources such as Route53 zones. For use in non-production environments to allow for automated tear-down."
+  default     = false
+}

--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -14,13 +14,16 @@ module "var_set" {
     cluster_name           = var.ephemeral_cluster_id
     external_dns_subdomain = var.ephemeral_cluster_id
 
+    force_destroy = true
+
     govuk_aws_state_bucket    = ""
     publishing_service_domain = "${var.ephemeral_cluster_id}.publishing.service.gov.uk"
     authentication_mode       = "API_AND_CONFIG_MAP"
 
-    enable_arm_workers  = true
-    enable_main_workers = false
-    enable_x86_workers  = false
+    enable_arm_workers         = true
+    enable_main_workers        = false
+    enable_x86_workers         = false
+    arm_workers_instance_types = ["m7g.2xlarge"]
   }
 }
 

--- a/terraform/deployments/ephemeral/variables.tf
+++ b/terraform/deployments/ephemeral/variables.tf
@@ -1,5 +1,5 @@
 variable "ephemeral_cluster_id" {
-  type    = string
+  type = string
 }
 
 variable "organization" {

--- a/terraform/deployments/ephemeral/variables.tf
+++ b/terraform/deployments/ephemeral/variables.tf
@@ -1,6 +1,5 @@
 variable "ephemeral_cluster_id" {
   type    = string
-  default = "eph-aaa113"
 }
 
 variable "organization" {

--- a/terraform/deployments/ephemeral/ws/workspace.tf
+++ b/terraform/deployments/ephemeral/ws/workspace.tf
@@ -4,7 +4,7 @@ module "workspace" {
   organization        = var.organization
   workspace_name      = "${var.name}-${var.ephemeral_cluster_id}"
   workspace_desc      = "Resources for an ephemeral cluster"
-  workspace_tags      = ["ephemeral", "${var.name}", "aws"]
+  workspace_tags      = ["ephemeral", var.name, "aws", var.ephemeral_cluster_id]
   terraform_version   = var.terraform_version
   execution_mode      = "remote"
   working_directory   = "/terraform/deployments/${var.name}/"
@@ -36,12 +36,6 @@ resource "tfe_workspace_run" "run" {
   workspace_id = module.workspace.workspace_id
 
   apply {
-    manual_confirm = false
-    wait_for_run   = true
-    retry          = false
-  }
-
-  destroy {
     manual_confirm = false
     wait_for_run   = true
     retry          = false

--- a/terraform/deployments/ephemeral/ws/workspace.tf
+++ b/terraform/deployments/ephemeral/ws/workspace.tf
@@ -24,7 +24,7 @@ module "workspace" {
     "GOV.UK Production"           = "write"
   }
 
-  variable_set_ids   = [var.variable_set_id]
+  variable_set_ids = [var.variable_set_id]
   variable_set_names = [
     "aws-credentials-test",
     "common",
@@ -38,6 +38,7 @@ resource "tfe_workspace_run" "run" {
   apply {
     manual_confirm = false
     wait_for_run   = true
-    retry          = false
+    retry          = true
+    retry_attempts = 2
   }
 }


### PR DESCRIPTION
This PR has a few small changes:
* Updates the default variable set for ephemeral clusters to use smaller instances and sets `force_destroy = true` so S3 buckets, Route53 zones, etc are destroyed even if they aren't empty
* Stops the ephemeral module from doing TF destroy runs on the workspaces it manages when it is destroyed. Destroys are going to be handled via a script from now on
* Sets the default reclaim policy for the EBS CSI driver to `Delete` on ephemeral clusters so it automatically deletes any EBS volumes when PVCs are deleted

https://github.com/alphagov/govuk-infrastructure/issues/1972