### PR TITLE
Set create-before-destroy on external_secrets

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -35,6 +35,10 @@ resource "helm_release" "external_secrets" {
       replicaCount = var.desired_ha_replicas
     }
   })]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "helm_release" "cluster_secret_store" {


### PR DESCRIPTION
Description:
- Revert isn't working because Terraform is trying to patch the Helm chart in place
- Force the Helm chart to re-create and destroy
- See https://github.com/alphagov/govuk-infrastructure/pull/2022