### PR TITLE
Increase threshold for content-data-api db

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -307,7 +307,7 @@ module "variable-set-rds-production" {
         allocated_storage            = 1024
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 536870912000
+        freestoragespace_threshold   = 307200000000
         project                      = "GOV.UK - Publishing"
       }
 


### PR DESCRIPTION
This increases the threshold so it warns when there is only 30% free (from 50%), to reduce noisy unhelpful alarms. A short term fix while we explore something better. 