### PR TITLE
Replace freestoragespace_threshold RDS value with storage_alarm_threshold_percentage

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -163,7 +163,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -182,7 +181,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -200,7 +198,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - AI"
       }
       ckan = {
@@ -217,7 +214,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - DGU"
       }
 
@@ -232,7 +228,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -247,7 +242,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -265,7 +259,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -288,7 +281,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 500
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 536870912000
         project                      = "GOV.UK - Publishing"
       }
 
@@ -306,7 +298,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -324,7 +315,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 500
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -342,7 +332,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -360,7 +349,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 500
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -378,7 +366,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -397,7 +384,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -415,7 +401,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
       }
@@ -434,7 +419,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -452,7 +436,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -473,7 +456,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
         backup_retention_period      = 1
         has_read_replica             = true
@@ -493,7 +475,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -508,7 +489,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Infrastructure"
       }
 
@@ -523,7 +503,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Search"
       }
 
@@ -541,7 +520,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -556,7 +534,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -574,7 +551,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 200
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -592,7 +568,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 120
         instance_class               = "db.m6g.large" # TODO: downsize this after migration if required
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -607,7 +582,6 @@ module "variable-set-rds-integration" {
         allocated_storage            = 400
         instance_class               = "db.t4g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
     }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -181,7 +181,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -200,7 +199,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -218,7 +216,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - AI"
       }
 
@@ -236,7 +233,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.2xlarge"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - DGU"
       }
 
@@ -251,7 +247,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -266,7 +261,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -284,7 +278,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -307,7 +300,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 1024
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 307200000000
         project                      = "GOV.UK - Publishing"
       }
 
@@ -325,7 +317,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -343,7 +334,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.2xlarge"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -361,7 +351,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -379,7 +368,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.2xlarge"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -397,7 +385,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 4500
         instance_class               = "db.m7g.2xlarge"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -416,7 +403,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -434,7 +420,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
       }
@@ -453,7 +438,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -471,7 +455,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -489,7 +472,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.4xlarge"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
         has_read_replica             = true
       }
@@ -505,7 +487,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Infrastructure"
       }
 
@@ -520,7 +501,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Search"
       }
 
@@ -538,7 +518,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -553,7 +532,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 100
         instance_class               = "db.t4g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -571,7 +549,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 200
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -589,7 +566,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 120
         instance_class               = "db.m6g.large" # TODO: downsize this after migration if required
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -604,7 +580,6 @@ module "variable-set-rds-production" {
         allocated_storage            = 300
         instance_class               = "db.m7g.xlarge"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
     }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -171,7 +171,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -190,7 +189,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -208,7 +206,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - AI"
       }
 
@@ -226,7 +223,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - DGU"
       }
 
@@ -241,7 +237,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -256,7 +251,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -274,7 +268,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -297,7 +290,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 1024
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 536870912000
         project                      = "GOV.UK - Publishing"
       }
 
@@ -315,7 +307,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -333,7 +324,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 500
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -351,7 +341,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -369,7 +358,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 500
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -387,7 +375,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.xlarge"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -406,7 +393,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -424,7 +410,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
       }
@@ -443,7 +428,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -461,7 +445,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Web"
       }
 
@@ -482,7 +465,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
         backup_retention_period      = 1
         has_read_replica             = true
@@ -499,7 +481,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Infrastructure"
       }
 
@@ -514,7 +495,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Search"
       }
 
@@ -532,7 +512,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -547,7 +526,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -565,7 +543,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 200
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -583,7 +560,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 120
         instance_class               = "db.m6g.large" # TODO: downsize this after migration if required
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
 
@@ -598,7 +574,6 @@ module "variable-set-rds-staging" {
         allocated_storage            = 400
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
-        freestoragespace_threshold   = 10737418240
         project                      = "GOV.UK - Publishing"
       }
     }


### PR DESCRIPTION
This also sets the threshold to 10% by default for all RDS instances

https://github.com/alphagov/govuk-infrastructure/issues/2028