### PR TITLE
Add 'Platform Engineering onboarding' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding.md
+++ b/.github/ISSUE_TEMPLATE/onboarding.md
@@ -1,0 +1,51 @@
+---
+name: Platform Engineering onboarding
+about: Information and tasks required to assist new starter in the team
+title: 'Onboard <name> - a new team member'
+labels: ["KTLO"]
+projects: 'alphagov/71'
+assignees: ''
+
+---
+
+### User need
+
+**As a** new member of the Platform Engineering team,
+**I want** a structured and supportive onboarding experience,
+**so that** I can get settled in quickly and have all the tools, access and context I need to be productive and contribute effectively.
+
+### Delivery Manager/Tech Lead tasks
+
+- [ ] Add them to [GOV.UK Platform Engineering Google Group](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-platform-engineering/members), which also adds them to team calendar and events
+- [ ] Introduce them to the team during a stand up
+- [ ] Arrange a call to introduce the Platform Engineering leads and Platform Engineering area (platform architecture, workflows etc.)
+- [ ] Add them to Private and Public Slack channels
+- [ ] Add them to [Trello](https://trello.com/w/gds_govuk/members) (for access to our historical cards and other teams' backlogs)
+- [ ] Add them to the [GOV.UK Platform Engineering GitHub team](https://github.com/orgs/alphagov/teams/gov-uk-platform-engineering)
+- [ ] Add them to the @platform-engineering-team Slack user group
+- [ ] Schedule fortnightly 121 meetings with DM
+- [ ] Assign an onboarding buddy - ask the team for a volunteer
+
+### Additional Buddy/Tech Lead tasks for engineers
+
+- [ ] Add them to [govuk-user-reviewer](https://github.com/alphagov/govuk-user-reviewer?tab=readme-ov-file#adding-users)
+- [ ] Invite them to [Sentry](https://govuk.sentry.io/settings/members/)
+- [ ] Invite them to [Signon in integration](https://signon.integration.publishing.service.gov.uk/users/invitation/new) with 'Superadmin' permissions
+- [ ] Invite them to [Signon in production](https://signon.publishing.service.gov.uk/users/invitation/new) with 'Normal' permissions and access to the ‘Release’ app **only** and no other apps
+- [ ] Add them to 'GOV.UK Integration Users' and 'GOV.UK Users' in [Logit](https://dashboard.logit.io/a/1c6b2316-16e2-4ca5-a3df-ff18631b0e74/settings/teams). Check as a member then "Apply Changes"
+- [ ] Identify a first issue for the new joiner to work or pair on within the first week or two
+
+
+### New joiner tasks
+
+- [ ] Familiarise yourself with [Guide to Platform Engineering Team & Ways of Working](https://docs.google.com/document/d/1IJ5jFOojl_1hNcTZUxse2JwIkA6gtJJyZ1QwToyy_VE/edit?tab=t.0#heading=h.614wri5x7vxr)
+- [ ] _(optional)_ Write a 'Manual for me' in our [team's folder](https://drive.google.com/drive/folders/11FFOwenbMyW5N0jlQZXQBlAe3tdq1djo) and share it with the team
+
+#### Additional tasks for engineers
+
+Ask the team or your buddy for help via Slack when needed.
+
+- [ ] Follow the steps in the [Getting started on GOV.UK](https://docs.publishing.service.gov.uk/manual/get-started.html) guide to set up your development environment and access to our tools
+- [ ] Accept the invite to Sentry
+- [ ] Join [GDS Technology](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gds-technology-members), [GOV.UK Tech](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-tech-members) and [GOV.UK](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-members) Google Groups
+- [ ] [Create a Zendesk account](https://govuk.zendesk.com/auth/v2/login/registration?auth_origin=3194076%2Cfalse%2Ctrue&amp;brand_id=3194076&amp;return_to=https%3A%2F%2Fgovuk.zendesk.com%2Fhc%2Fen-us&amp;theme=hc). Then create a new ticket assigned to `2nd/3rd Line--Zendesk Administration` asking to assign you the 'Light agent' role with access to 'GOV.UK Platform Support' group.


### PR DESCRIPTION
Task list to ensure new joiners get settled in, and have the tools and access they need to get going.