### PR TITLE
BAU - Upgrade external-dns to 1.16.1

### DIFF
--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -2,12 +2,14 @@ resource "helm_release" "external_dns" {
   name             = "external-dns"
   repository       = "https://kubernetes-sigs.github.io/external-dns"
   chart            = "external-dns"
-  version          = "1.15.2"
+  version          = "1.16.1"
   namespace        = local.services_ns
   create_namespace = true
 
   values = [yamlencode({
-    provider = "aws"
+    provider = {
+      name = "aws"
+    }
     env = [
       {
         name  = "AWS_DEFAULT_REGION"


### PR DESCRIPTION
Description:
- Previous chart version of v1.16.0 caused a [schema generation bug](https://github.com/kubernetes-sigs/external-dns/issues/5209). See also https://github.com/alphagov/govuk-infrastructure/pull/1878
- The schema generation bug is fixed in [v1.16.1](https://github.com/kubernetes-sigs/external-dns/pull/5270)
- `provider` has to be turned into object as per the [schema validation](https://github.com/kubernetes-sigs/external-dns/blob/5eaf814b9420f88152a5f76aa0e48991eaead9ee/charts/external-dns/values.schema.json#L263)