### PR TITLE
Fix missing 's' in developer cluster role binding subject

### DIFF
--- a/terraform/deployments/cluster-services/eks_access.tf
+++ b/terraform/deployments/cluster-services/eks_access.tf
@@ -107,7 +107,7 @@ resource "kubernetes_cluster_role_binding" "developer" {
   }
   subject {
     kind      = "Group"
-    name      = "developer"
+    name      = "developers"
     api_group = "rbac.authorization.k8s.io"
   }
 }


### PR DESCRIPTION
The group is called developers, not developer, so it wasn't binding the role correctly