### PR TITLE
Add move block to prevent recreation of publishing_api db in staging

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -166,3 +166,8 @@ resource "aws_secretsmanager_secret_version" "database_passwords" {
     { for k, v in random_string.database_password : k => v.result }
   )
 }
+
+moved {
+  from = aws_db_instance.replica["publishing_api"]
+  to   = aws_db_instance.replica["publishing_api"]
+}


### PR DESCRIPTION
Description:
- Recreation of the database won't recreate the password so upon recreation the database will have a new password but will try to connect using the old password
- Instead tell Terraform to update the database in place instead of replacing it to re-use the old password