### PR TITLE
Add `search-api-valkey` Elasticache instance in Integration

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -630,6 +630,10 @@ module "variable-set-elasticache-integration" {
 
   tfvars = {
     caches = {
+      search-api = {
+        name        = "search-api-valkey"
+        description = "Search API Valkey Instance"
+      }
       publishing-api = {
         name        = "publishing-api-valkey"
         description = "Publishing API Valkey Instance"


### PR DESCRIPTION
## What

Configure Valkey Elasticache instance to be created for `search-api` service

## Why

This is for further testing of Elasticache instances for #1704