### PR TITLE
Search API v2: Add user events purge permission

### DIFF
--- a/terraform/deployments/search-api-v2/service_accounts.tf
+++ b/terraform/deployments/search-api-v2/service_accounts.tf
@@ -29,6 +29,7 @@ resource "google_project_iam_custom_role" "api" {
     "discoveryengine.suggestionDenyListEntries.import",
     "discoveryengine.suggestionDenyListEntries.purge",
     "discoveryengine.userEvents.import",
+    "discoveryengine.userEvents.purge",
   ]
 }
 


### PR DESCRIPTION
This adds the purge permission for user events to the Search API v2 GCP service user to allow it to purge events at the end of the retention period.