### PR TITLE
Search API v2: Allow Search Admin to manage denylist

### DIFF
--- a/terraform/deployments/search-api-v2/service_accounts.tf
+++ b/terraform/deployments/search-api-v2/service_accounts.tf
@@ -68,6 +68,8 @@ resource "google_project_iam_custom_role" "search_admin" {
     "discoveryengine.servingConfigs.get",
     "discoveryengine.servingConfigs.list",
     "discoveryengine.servingConfigs.update",
+    "discoveryengine.suggestionDenyListEntries.import",
+    "discoveryengine.suggestionDenyListEntries.purge",
   ]
 }
 


### PR DESCRIPTION
This adds the required permissions to the role used by Search Admin's service account for it to be able to manage the autocomplete denylist.