### PR TITLE
Create `elasticache-staging` workspace in TFC

### DIFF
--- a/terraform/deployments/tfc-configuration/elasticache.tf
+++ b/terraform/deployments/tfc-configuration/elasticache.tf
@@ -30,3 +30,36 @@ module "elasticache-integration" {
     module.variable-set-elasticache-integration.id
   ]
 }
+
+module "elasticache-staging" {
+  source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
+
+  organization        = var.organization
+  workspace_name      = "elasticache-staging"
+  workspace_desc      = "Serverless ElastiCache instances"
+  workspace_tags      = ["staging", "elasticache", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/elasticache/"
+  trigger_patterns    = ["/terraform/deployments/elasticache/**/*"]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production (r/o)" = "write"
+    "GOV.UK Production"           = "write"
+  }
+
+  variable_set_ids = [
+    local.aws_credentials["integration"],
+    module.variable-set-common.id,
+    module.variable-set-staging.id,
+    module.variable-set-elasticache-staging.id
+  ]
+}

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -630,14 +630,14 @@ module "variable-set-elasticache-integration" {
 
   tfvars = {
     caches = {
-      search-api = {
-        name        = "search-api-valkey"
-        description = "Search API Valkey Instance"
-      }
       publishing-api = {
         name        = "publishing-api-valkey"
         description = "Publishing API Valkey Instance"
         node_type   = "cache.m7g.large"
+      }
+      search-api = {
+        name        = "search-api-valkey"
+        description = "Search API Valkey Instance"
       }
       whitehall-admin = {
         name           = "whitehall-admin-redis"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -594,3 +594,34 @@ module "variable-set-amazonmq-staging" {
     amazonmq_govuk_chat_retry_message_ttl = 300000
   }
 }
+
+module "variable-set-elasticache-staging" {
+  source = "./variable-set"
+
+  name = "elasticache-staging"
+
+  # The configuration of the "caches" variable is in
+  # "govuk-infrastructure/terraform/deployments/elasticache/variables.tf".
+  # Only the name and description are required, the rest of the parameters
+  # are optional, with their defaults as follows:
+  #   name                       = required
+  #   description                = required
+  #   num_cache_clusters         = optional (default = "1")
+  #   node_type                  = optional (default = "cache.t4g.small")
+  #   automatic_failover_enabled = optional (default = false)
+  #   multi_az_enabled           = optional (default = false)
+  #   engine                     = optional (default = "valkey")
+  #   engine_version             = optional (default = "8.0")
+  #   family                     = optional (default = "valkey8")
+  # If any further parameters need to be modified in the
+  # elasticache parameter group, they need to be configured here
+  # for them to take effect, otherwise the values will be ignored:
+  #   parameters = {
+  #     maxmemory-policy = optional (default = "noeviction")
+  #   }
+
+  tfvars = {
+    caches = {
+    }
+  }
+}


### PR DESCRIPTION
## What

Create Terraform Cloud Workspace "elasticache-staging"
Re-order the instances configured in Integration so they are alphabetical

## Why

To deploy stand-alone Elasticache instances for services in Staging