### PR TITLE
Bump WAF version

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -110,12 +110,6 @@ variable "allow_high_request_rate_from_cidrs" {
   default     = []
 }
 
-variable "cache_public_base_rate_warning" {
-  type        = number
-  description = "A warning rate limit threshold for the public web ACL"
-  default     = 2000
-}
-
 variable "cache_public_base_rate_limit" {
   type        = number
   description = "An enforced rate limit threshold for the public web ACL"

--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -5,10 +5,9 @@
 
 module "infrastructure-sensitive_wafs" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/wafs"
-  version = "0.0.16"
+  version = "0.0.17"
 
   cache_public_base_rate_limit   = var.cache_public_base_rate_limit
-  cache_public_base_rate_warning = var.cache_public_base_rate_warning
   cache_public_post_rate_warning = var.cache_public_post_rate_warning
   fastly_rate_limit_token        = var.fastly_rate_limit_token
   govuk_requesting_ips_arn       = aws_wafv2_ip_set.govuk_requesting_ips.arn


### PR DESCRIPTION
This removes [a monitoring only rule](https://github.com/alphagov/terraform-govuk-infrastructure-sensitive/commit/6dc123e21f8f9fa3a37eb04b9216c2803f903e13).

It should have no other effect.