### PR TITLE
Fix credentials for Elasticache Staging Workspace

### DIFF
--- a/terraform/deployments/tfc-configuration/elasticache.tf
+++ b/terraform/deployments/tfc-configuration/elasticache.tf
@@ -57,7 +57,7 @@ module "elasticache-staging" {
   }
 
   variable_set_ids = [
-    local.aws_credentials["integration"],
+    local.aws_credentials["staging"],
     module.variable-set-common.id,
     module.variable-set-staging.id,
     module.variable-set-elasticache-staging.id


### PR DESCRIPTION
## What

Fix AWS credentials for Elasticache Staging Workspace

## Why

Currently using Integration credentials instead of Staging