### PR TITLE
Fix whitehall-admin Elasticache name

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -631,8 +631,8 @@ module "variable-set-elasticache-staging" {
         description = "Search API Valkey Instance"
       }
       whitehall-admin = {
-        name        = "whitehall-admin-redis"
-        description = "Whitehall Admin Redis Instance"
+        name        = "whitehall-admin-valkey"
+        description = "Whitehall Admin Valkey Instance"
       }
     }
   }


### PR DESCRIPTION
## What

Fix the Elasticache name for `whitehall-admin`

## Why

So the name is consistent with other services