### PR TITLE
Harden security context for filebeat DaemonSet

### DIFF
--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -26,6 +26,9 @@ resource "helm_release" "filebeat" {
           add  = ["DAC_READ_SEARCH"]
           drop = ["ALL"]
         }
+        seccompProfile = {
+          type = "RuntimeDefault"
+        }
       }
       secretMounts = []
       tolerations = [{ # TODO: remove once we no longer run amd64 (Intel) nodes.

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -20,8 +20,9 @@ resource "helm_release" "filebeat" {
         allowPrivilegeEscalation = false
         privileged               = false
         runAsUser                = 1000
-        runAsNonRoot             = true
         runAsGroup               = 1000
+        fsGroup                  = 1000
+        runAsNonRoot             = true
         capabilities = {
           add  = ["DAC_READ_SEARCH"]
           drop = ["ALL"]

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -16,6 +16,17 @@ resource "helm_release" "filebeat" {
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     daemonset = {
+      securityContext = {
+        allowPrivilegeEscalation = false
+        privileged               = false
+        runAsUser                = 1000
+        runAsNonRoot             = true
+        runAsGroup               = 1000
+        capabilities = {
+          add  = ["DAC_READ_SEARCH"]
+          drop = ["ALL"]
+        }
+      }
       secretMounts = []
       tolerations = [{ # TODO: remove once we no longer run amd64 (Intel) nodes.
         key      = "arch"

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -18,10 +18,10 @@ resource "helm_release" "filebeat" {
     daemonset = {
       securityContext = {
         allowPrivilegeEscalation = false
+        readOnlyRootFilesystem   = true
         privileged               = false
         runAsUser                = 1000
-        runAsGroup               = 1000
-        fsGroup                  = 1000
+        runAsGroup               = 0
         runAsNonRoot             = true
         capabilities = {
           add  = ["DAC_READ_SEARCH"]

--- a/terraform/deployments/cluster-services/logging.tf
+++ b/terraform/deployments/cluster-services/logging.tf
@@ -20,9 +20,8 @@ resource "helm_release" "filebeat" {
         allowPrivilegeEscalation = false
         readOnlyRootFilesystem   = true
         privileged               = false
-        runAsUser                = 1000
-        runAsGroup               = 0
-        runAsNonRoot             = true
+        runAsUser                = 0
+        runAsNonRoot             = false
         capabilities = {
           add  = ["DAC_READ_SEARCH"]
           drop = ["ALL"]


### PR DESCRIPTION
## What?
This adds security context configuration to the Filebeat Daemonsets running on our clusters. This should allow Filebeat to run with the necessary security scope without continuing to need to run as user 0 (root).

We will want to test this on Integration first to make sure that filebeat can continue to operate normally.

We will also want to replace this with the eck-beat chart in the future, as the Chart we are currently using has been deprecated.

This also adds the `DAC_READ_SEARCH` Capability which would allow filebeat to override read and execute permissions, which it kind of needs to in order to be able to correctly read logs. This is not as permissive as giving it `DAC_OVERRIDE` or root, which would be even more permissive.

### Related Resources
Link to the relevant chart:

* https://github.com/elastic/helm-charts/tree/main/filebeat