### PR TITLE
Update WAF version to 0.0.19

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -5,7 +5,7 @@
 
 module "infrastructure-sensitive_wafs" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/wafs"
-  version = "0.0.17"
+  version = "0.0.19"
 
   cache_public_base_rate_limit   = var.cache_public_base_rate_limit
   cache_public_post_rate_warning = var.cache_public_post_rate_warning


### PR DESCRIPTION
This includes [changes to non-HEAD and GET monitoring](https://github.com/alphagov/terraform-govuk-infrastructure-sensitive/pull/9)

The version has jumped 2 because of a typo in the v0.0.18

https://trello.com/c/MleZdn8e/21-local-council-waf