### PR TITLE
Create VPCs for ephemeral clusters as part of cluster start up

### DIFF
--- a/terraform/deployments/cluster-infrastructure/remote.tf
+++ b/terraform/deployments/cluster-infrastructure/remote.tf
@@ -10,5 +10,5 @@ data "tfe_outputs" "root_dns" {
 
 data "tfe_outputs" "vpc" {
   organization = "govuk"
-  workspace    = startswith(var.govuk_environment, "eph-") ? "vpc-ephemeral" : "vpc-${var.govuk_environment}"
+  workspace    = "vpc-${var.govuk_environment}"
 }

--- a/terraform/deployments/ephemeral/shutdown.sh
+++ b/terraform/deployments/ephemeral/shutdown.sh
@@ -197,3 +197,4 @@ helm_shutdown
 retry 2 tfc_do_destroy "datagovuk-infrastructure"
 retry 2 tfc_do_destroy "cluster-services"
 retry 2 tfc_do_destroy "cluster-infrastructure"
+retry 2 tfc_do_destroy "vpc"

--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -27,6 +27,16 @@ module "var_set" {
   }
 }
 
+module "vpc" {
+  source = "./ws"
+
+  name                 = "vpc"
+  ephemeral_cluster_id = var.ephemeral_cluster_id
+  variable_set_id      = module.var_set.id
+
+  depends_on = [tfe_project.project]
+}
+
 module "cluster_infrastructure" {
   source = "./ws"
 
@@ -34,7 +44,7 @@ module "cluster_infrastructure" {
   ephemeral_cluster_id = var.ephemeral_cluster_id
   variable_set_id      = module.var_set.id
 
-  depends_on = [tfe_project.project]
+  depends_on = [module.vpc, tfe_project.project]
 }
 
 module "cluster_services" {


### PR DESCRIPTION
We were using a single VPC for all ephemeral clusters, which was causing issues when trying to run multiple clusters at once due to IP ranges clashing

This was meant to be done once [this issue](https://github.com/alphagov/govuk-infrastructure/issues/1867) was complete, but was missed.

https://github.com/alphagov/govuk-infrastructure/issues/1745