### PR TITLE
Harden Dex Pods

### DIFF
--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -345,6 +345,20 @@ resource "helm_release" "dex" {
       }
     }
 
+    volumes = [
+      {
+        name     = "dex-temp-volume"
+        emptyDir = {}
+      }
+    ]
+
+    volumeMounts = [
+      {
+        name      = "dex-temp-volume"
+        mountPath = "/tmp"
+      }
+    ]
+
     ingress = {
       enabled = true
       annotations = {

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -326,6 +326,25 @@ resource "helm_release" "dex" {
       }
     }
 
+    podSecurityContext = {
+      fsGroup = 1001
+    }
+
+    securityContext = {
+      allowPrivilegeEscalation = false
+      privileged               = false
+      readOnlyRootFilesystem   = true
+      runAsNonRoot             = true
+      runAsUser                = 1001
+      runAsGroup               = 1001
+      capabilities = {
+        drop = ["ALL"]
+      }
+      seccompProfile = {
+        type = "RuntimeDefault"
+      }
+    }
+
     ingress = {
       enabled = true
       annotations = {


### PR DESCRIPTION
## What?
This now attempts to harden the Dex Pods in the cluster to not use root and to prevent privilege escalation. It also shouldn't need any capabilities (unless we find things don't work).

### Related

* https://github.com/alphagov/govuk-platform-internal/issues/18