### PR TITLE
Change argo workflows LB name to include environment name

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -345,7 +345,7 @@ resource "helm_release" "argo_workflows" {
           "alb.ingress.kubernetes.io/group.name"         = "argo-workflows"
           "alb.ingress.kubernetes.io/scheme"             = "internet-facing"
           "alb.ingress.kubernetes.io/target-type"        = "ip"
-          "alb.ingress.kubernetes.io/load-balancer-name" = "argo-workflows"
+          "alb.ingress.kubernetes.io/load-balancer-name" = "argo-workflows-${var.govuk_environment}"
           "alb.ingress.kubernetes.io/listen-ports"       = jsonencode([{ "HTTP" : 80 }, { "HTTPS" : 443 }])
           "alb.ingress.kubernetes.io/ssl-redirect"       = "443"
         }


### PR DESCRIPTION
The name is clashing in ephemeral clusters because it's trying to create multiple ELBs with the same name, which is not permitted

https://github.com/alphagov/govuk-infrastructure/issues/1745