### PR TITLE
Change ArgoCD and Dex LB names to include environment name

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -106,7 +106,7 @@ resource "helm_release" "argo_cd" {
       ingress = {
         enabled = true
         annotations = {
-          "alb.ingress.kubernetes.io/group.name"         = "argo"
+          "alb.ingress.kubernetes.io/group.name"         = "argo-${var.govuk_environment}"
           "alb.ingress.kubernetes.io/scheme"             = "internet-facing"
           "alb.ingress.kubernetes.io/target-type"        = "ip"
           "alb.ingress.kubernetes.io/load-balancer-name" = "argo"

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -329,7 +329,7 @@ resource "helm_release" "dex" {
     ingress = {
       enabled = true
       annotations = {
-        "alb.ingress.kubernetes.io/group.name"         = "dex"
+        "alb.ingress.kubernetes.io/group.name"         = "dex-${var.govuk_environment}"
         "alb.ingress.kubernetes.io/scheme"             = "internet-facing"
         "alb.ingress.kubernetes.io/target-type"        = "ip"
         "alb.ingress.kubernetes.io/load-balancer-name" = "dex"


### PR DESCRIPTION
The name is clashing in ephemeral clusters because it's trying to create multiple ELBs with the same name, which is not permitted

https://github.com/alphagov/govuk-infrastructure/issues/1745