### PR TITLE
Only use LB name suffix in ephemeral environments

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -106,10 +106,10 @@ resource "helm_release" "argo_cd" {
       ingress = {
         enabled = true
         annotations = {
-          "alb.ingress.kubernetes.io/group.name"         = "argo-${var.govuk_environment}"
+          "alb.ingress.kubernetes.io/group.name"         = "argo${local.elb_name_suffix}"
           "alb.ingress.kubernetes.io/scheme"             = "internet-facing"
           "alb.ingress.kubernetes.io/target-type"        = "ip"
-          "alb.ingress.kubernetes.io/load-balancer-name" = "argo"
+          "alb.ingress.kubernetes.io/load-balancer-name" = "argo${local.elb_name_suffix}"
           "alb.ingress.kubernetes.io/listen-ports"       = jsonencode([{ "HTTP" : 80 }, { "HTTPS" : 443 }])
           "alb.ingress.kubernetes.io/ssl-redirect"       = "443"
         }
@@ -123,10 +123,10 @@ resource "helm_release" "argo_cd" {
         enabled  = true
         isAWSALB = true
         annotations = {
-          "alb.ingress.kubernetes.io/group.name"         = "argo"
+          "alb.ingress.kubernetes.io/group.name"         = "argo${local.elb_name_suffix}"
           "alb.ingress.kubernetes.io/scheme"             = "internet-facing"
           "alb.ingress.kubernetes.io/target-type"        = "ip"
-          "alb.ingress.kubernetes.io/load-balancer-name" = "argo"
+          "alb.ingress.kubernetes.io/load-balancer-name" = "argo${local.elb_name_suffix}"
           "alb.ingress.kubernetes.io/listen-ports"       = jsonencode([{ "HTTP" : 80 }, { "HTTPS" : 443 }])
           "alb.ingress.kubernetes.io/ssl-redirect"       = "443"
         }
@@ -342,10 +342,10 @@ resource "helm_release" "argo_workflows" {
       ingress = {
         enabled = true
         annotations = {
-          "alb.ingress.kubernetes.io/group.name"         = "argo-workflows"
+          "alb.ingress.kubernetes.io/group.name"         = "argo-workflows${local.elb_name_suffix}"
           "alb.ingress.kubernetes.io/scheme"             = "internet-facing"
           "alb.ingress.kubernetes.io/target-type"        = "ip"
-          "alb.ingress.kubernetes.io/load-balancer-name" = "argo-workflows-${var.govuk_environment}"
+          "alb.ingress.kubernetes.io/load-balancer-name" = "argo-workflows${local.elb_name_suffix}"
           "alb.ingress.kubernetes.io/listen-ports"       = jsonencode([{ "HTTP" : 80 }, { "HTTPS" : 443 }])
           "alb.ingress.kubernetes.io/ssl-redirect"       = "443"
         }

--- a/terraform/deployments/cluster-services/dex.tf
+++ b/terraform/deployments/cluster-services/dex.tf
@@ -329,10 +329,10 @@ resource "helm_release" "dex" {
     ingress = {
       enabled = true
       annotations = {
-        "alb.ingress.kubernetes.io/group.name"         = "dex-${var.govuk_environment}"
+        "alb.ingress.kubernetes.io/group.name"         = "dex${local.elb_name_suffix}"
         "alb.ingress.kubernetes.io/scheme"             = "internet-facing"
         "alb.ingress.kubernetes.io/target-type"        = "ip"
-        "alb.ingress.kubernetes.io/load-balancer-name" = "dex"
+        "alb.ingress.kubernetes.io/load-balancer-name" = "dex${local.elb_name_suffix}"
         "alb.ingress.kubernetes.io/listen-ports"       = jsonencode([{ "HTTP" : 80 }, { "HTTPS" : 443 }])
         "alb.ingress.kubernetes.io/ssl-redirect"       = "443"
       }

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -90,4 +90,5 @@ locals {
   prometheus_internal_url   = "http://kube-prometheus-stack-prometheus:9090"
   alertmanager_internal_url = "http://kube-prometheus-stack-alertmanager:9093"
   is_ephemeral              = startswith(var.govuk_environment, "eph-")
+  elb_name_suffix           = local.is_ephemeral ? "-${var.govuk_environment}" : ""
 }


### PR DESCRIPTION
This is to avoid issues in existing envs since it would cause the ELB controller to recreate load balancers

https://github.com/alphagov/govuk-infrastructure/issues/1745