### PR TITLE
Update WAF module to v0.0.20

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -116,9 +116,9 @@ variable "cache_public_base_rate_limit" {
   default     = 1000
 }
 
-variable "cache_public_post_rate_warning" {
+variable "cache_public_post_rate_limit" {
   type        = number
-  description = "An warning rate limit threshold for posts to the public web ACL"
+  description = "A rate limit threshold for posts to the public web ACL"
   default     = 1000
 }
 

--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -5,14 +5,14 @@
 
 module "infrastructure-sensitive_wafs" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/wafs"
-  version = "0.0.19"
+  version = "0.0.20"
 
-  cache_public_base_rate_limit   = var.cache_public_base_rate_limit
-  cache_public_post_rate_warning = var.cache_public_post_rate_warning
-  fastly_rate_limit_token        = var.fastly_rate_limit_token
-  govuk_requesting_ips_arn       = aws_wafv2_ip_set.govuk_requesting_ips.arn
-  high_request_rate_ips_arn      = aws_wafv2_ip_set.high_request_rate.arn
-  x_always_block_arn             = aws_wafv2_rule_group.x_always_block.arn
+  cache_public_base_rate_limit = var.cache_public_base_rate_limit
+  cache_public_post_rate_limit = var.cache_public_post_rate_limit
+  fastly_rate_limit_token      = var.fastly_rate_limit_token
+  govuk_requesting_ips_arn     = aws_wafv2_ip_set.govuk_requesting_ips.arn
+  high_request_rate_ips_arn    = aws_wafv2_ip_set.high_request_rate.arn
+  x_always_block_arn           = aws_wafv2_rule_group.x_always_block.arn
 }
 
 


### PR DESCRIPTION
This includes the changes in https://github.com/alphagov/terraform-govuk-infrastructure-sensitive/pull/11 and therefore introduces a new blocking rule

https://trello.com/c/MleZdn8e/21-local-council-waf