### PR TITLE
Only allow one release workflow to run at once for a given app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       GH_TOKEN:
         required: true
 
+concurrency:
+  group: release-${{ github.event.workflow_run.repository.name }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
This should help mitigate a race condition where version tags could be generated out-of-order.

It has been tested with the govuk-replatform-test-app and is working as expected.

https://github.com/alphagov/govuk-infrastructure/issues/2056