### PR TITLE
EKS Auth to API exclusively on Integration first

### DIFF
--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -18,7 +18,7 @@ module "var_set" {
 
     govuk_aws_state_bucket    = ""
     publishing_service_domain = "${var.ephemeral_cluster_id}.publishing.service.gov.uk"
-    authentication_mode       = "API_AND_CONFIG_MAP"
+    authentication_mode       = "API"
 
     enable_arm_workers         = true
     enable_main_workers        = false

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -72,7 +72,7 @@ module "variable-set-integration" {
     github_read_write_team = "alphagov:gov-uk"
 
     # Enable EKS Access Entries support in prep for aws-auth deprecation.
-    authentication_mode = "API_AND_CONFIG_MAP"
+    authentication_mode = "API"
 
     grafana_db_auto_pause       = true
     maintenance_window          = "Sun:04:00-Sun:06:00"


### PR DESCRIPTION
## What?
This follows on from the previous PR to empty the aws-auth ConfigMap and move all permissions over to Access Entries.

We will first be switching Test and Integration to use the "API" setting, as this cannot be reversed once set. If all goes fine, we can switch the default on all environments.

### Related

* https://github.com/alphagov/govuk-infrastructure/pull/2097