### PR TITLE
Add temporary secret as payload to google secret resource

### DIFF
--- a/terraform/deployments/search-api-v2/dataform.tf
+++ b/terraform/deployments/search-api-v2/dataform.tf
@@ -33,7 +33,8 @@ import {
 }
 
 resource "google_secret_manager_secret_version" "github_ssh" {
-  secret = google_secret_manager_secret.github_ssh.id
+  secret      = google_secret_manager_secret.github_ssh.id
+  secret_data = "secret holder"
 }
 
 import {


### PR DESCRIPTION
This is an attempt to fix a problem when terraforming this resource as it won't terraform without a payload.
We set a temporary secret as the real secret value is imported from an existing secret in google secret manager.