### PR TITLE
Switch all environments to EKS API auth only

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -202,6 +202,6 @@ variable "govuk_environment" {
 
 variable "authentication_mode" {
   type        = string
-  default     = "API_AND_CONFIG_MAP"
+  default     = "API"
   description = "Authentication mode to use for the cluster"
 }

--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -18,7 +18,6 @@ module "var_set" {
 
     govuk_aws_state_bucket    = ""
     publishing_service_domain = "${var.ephemeral_cluster_id}.publishing.service.gov.uk"
-    authentication_mode       = "API"
 
     enable_arm_workers         = true
     enable_main_workers        = false

--- a/terraform/deployments/tfc-configuration/release.tf
+++ b/terraform/deployments/tfc-configuration/release.tf
@@ -20,7 +20,7 @@ module "release-integration" {
 
   team_access = {
     "GOV.UK Non-Production (r/o)" = "write"
-    "GOV.UK Production" = "write"
+    "GOV.UK Production"           = "write"
   }
 
   variable_set_ids = [

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -71,9 +71,6 @@ module "variable-set-integration" {
     # Non-production-only access is sufficient to access tools in this cluster.
     github_read_write_team = "alphagov:gov-uk"
 
-    # Enable EKS Access Entries support in prep for aws-auth deprecation.
-    authentication_mode = "API"
-
     grafana_db_auto_pause       = true
     maintenance_window          = "Sun:04:00-Sun:06:00"
     rds_apply_immediately       = true


### PR DESCRIPTION
## What?
This switches the Authentication Mode for all clusters to `API` (only) as the default, thereby removing the deprecated ConfigMap authentication model.

### Related
* Closes https://github.com/alphagov/govuk-infrastructure/issues/1833