### PR TITLE
Add IOPS and Throughput options to RDS

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -50,10 +50,8 @@ resource "aws_db_instance" "instance" {
   engine_version          = each.value.engine_version
   username                = var.database_admin_username
   password                = random_string.database_password[each.key].result
-  allocated_storage       = each.value.allocated_storage
   instance_class          = each.value.instance_class
   identifier              = "${var.govuk_environment}-${each.value.name}-${each.value.engine}"
-  storage_type            = "gp3"
   db_subnet_group_name    = aws_db_subnet_group.subnet_group.name
   multi_az                = var.multi_az
   parameter_group_name    = aws_db_parameter_group.engine_params[each.key].name
@@ -69,6 +67,11 @@ resource "aws_db_instance" "instance" {
 
   performance_insights_enabled          = each.value.performance_insights_enabled
   performance_insights_retention_period = each.value.performance_insights_enabled ? 7 : 0
+
+  allocated_storage  = each.value.allocated_storage
+  iops               = try(each.value.iops, null)
+  storage_throughput = try(each.value.storage_throughput, null)
+  storage_type       = "gp3"
 
   timeouts {
     create = var.terraform_create_rds_timeout

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -451,6 +451,8 @@ module "variable-set-rds-integration" {
         engine_params_family         = "postgres13"
         name                         = "publishing-api"
         allocated_storage            = 1000
+        iops                         = 24000
+        storage_throughput           = 1000
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -470,6 +470,8 @@ module "variable-set-rds-production" {
         engine_params_family         = "postgres13"
         name                         = "publishing-api"
         allocated_storage            = 1000
+        iops                         = 24000
+        storage_throughput           = 1000
         instance_class               = "db.m6g.4xlarge"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -463,6 +463,8 @@ module "variable-set-rds-staging" {
         engine_params_family         = "postgres13"
         name                         = "publishing-api"
         allocated_storage            = 1000
+        iops                         = 24000
+        storage_throughput           = 1000
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"


### PR DESCRIPTION
## What?
This adds configuration support for setting IOPS and Throughput values for RDS instances, and also increases these values for the Publishing API instances.