### PR TITLE
Upsize and Upgrade the Staging Pub API RDS.

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -465,7 +465,7 @@ module "variable-set-rds-staging" {
         allocated_storage            = 1000
         iops                         = 24000
         storage_throughput           = 1000
-        instance_class               = "db.m6g.large"
+        instance_class               = "db.m7g.2xlarge"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         backup_retention_period      = 1


### PR DESCRIPTION
## What?
This changes the Publishing API RDS Instance in Staging to use a larger and newer Instance size, as it appears to have outgrown its current instance size.

### Changes

* From `db.m6g.large` to `db.m7g.2xlarge`