### PR TITLE
Enable metrics server for Argo Workflows

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -235,6 +235,10 @@ resource "helm_release" "argo_workflows" {
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     controller = {
+      metricsConfig = {
+        enabled = true
+        secure  = false
+      }
       podSecurityContext = {
         runAsNonRoot = true
         seccompProfile = {


### PR DESCRIPTION
The metrics server needs configuring to disable HTTPS. HTTPS wouldn't be useful in this situation, since it'd be using a self-signed cert that Prometheus can't verify and the data transferred is not sensitive in any way.

This has been tested in integration

https://github.com/alphagov/govuk-infrastructure/issues/2138