### PR TITLE
Give Platform Engies full Cluster Admin Access

### DIFF
--- a/terraform/deployments/cluster-services/eks_access.tf
+++ b/terraform/deployments/cluster-services/eks_access.tf
@@ -1,5 +1,5 @@
 
-data "aws_iam_roles" "cluster-admin" { name_regex = "(\\..*-admin$|\\..*-fulladmin$)" }
+data "aws_iam_roles" "cluster-admin" { name_regex = "(\\..*-fulladmin$|\\..*-platformengineer$)" }
 data "aws_iam_roles" "developer" { name_regex = "\\..*-developer$" }
 data "aws_iam_roles" "licensing" { name_regex = "\\..*-licensinguser$" }
 


### PR DESCRIPTION
## What?
This small change will give users with the `platformengineer` role cluster-admin RBAC on our EKS Clusters.

## Why?
This will allow us to tell the difference between Platform Engineering Team Members who need routine access to manage the EKS Clusters across all Nodes and Namespaces, versus GOV.UK Developers who only require scoped access to the GOV.UK Applications.

### Related

* https://github.com/alphagov/govuk-infrastructure/issues/2137
* https://github.com/alphagov/govuk-user-reviewer/pull/1550