### PR TITLE
Setup RDS DGU Ephemeral

### DIFF
--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -23,6 +23,29 @@ module "var_set" {
     enable_main_workers        = false
     enable_x86_workers         = false
     arm_workers_instance_types = ["m7g.2xlarge"]
+
+    backup_retention_period = 0
+    skip_final_snapshot     = true
+    multi_az                = true
+
+    databases = {
+      ckan = {
+        engine         = "postgres"
+        engine_version = "13"
+        engine_params = {
+          log_min_duration_statement = { value = 10000 }
+          log_statement              = { value = "all" }
+          deadlock_timeout           = { value = 2500 }
+          log_lock_waits             = { value = 1 }
+        }
+        engine_params_family         = "postgres13"
+        name                         = "ckan"
+        allocated_storage            = 1000
+        instance_class               = "db.m6g.large"
+        performance_insights_enabled = true
+        project                      = "GOV.UK - DGU"
+      }
+    }
   }
 }
 
@@ -56,6 +79,15 @@ module "cluster_services" {
   depends_on = [module.cluster_infrastructure, tfe_project.project]
 }
 
+module "rds" {
+  source               = "./ws"
+  name                 = "rds"
+  ephemeral_cluster_id = var.ephemeral_cluster_id
+  variable_set_id      = module.var_set.id
+
+  depends_on = [module.vpc, tfe_project.project]
+}
+
 module "datagovuk_infrastructure" {
   source = "./ws"
 
@@ -63,5 +95,7 @@ module "datagovuk_infrastructure" {
   ephemeral_cluster_id = var.ephemeral_cluster_id
   variable_set_id      = module.var_set.id
 
-  depends_on = [module.cluster_services, tfe_project.project]
+  depends_on = [module.cluster_services, module.rds, tfe_project.project]
 }
+
+


### PR DESCRIPTION
Description:
- In order to test blue/green deployments in the ephemeral environment we need to have the RDS workspace setup
- Sets up CKAN RDS Postgres 13 Multi-AZ