### PR TITLE
Remove DGU dependency on RDS in the ephemeral environment

### DIFF
--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -95,7 +95,7 @@ module "datagovuk_infrastructure" {
   ephemeral_cluster_id = var.ephemeral_cluster_id
   variable_set_id      = module.var_set.id
 
-  depends_on = [module.cluster_services, module.rds, tfe_project.project]
+  depends_on = [module.cluster_services, tfe_project.project]
 }
 
 


### PR DESCRIPTION
Description:
- Setting up RDS still has some sharp edges. Until this is fixed allow DGU to run without depending on RDS in the ephemeral cluster