### PR TITLE
Remove Whitehall Elasticahce Redis from integration

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -638,13 +638,6 @@ module "variable-set-elasticache-integration" {
         name        = "search-api-valkey"
         description = "Search API Valkey Instance"
       }
-      whitehall-admin-redis = {
-        name           = "whitehall-admin-redis"
-        description    = "Whitehall Admin Redis Instance"
-        engine         = "redis"
-        engine_version = "7.1"
-        family         = "redis7"
-      }
       whitehall-admin = {
         name        = "whitehall-admin-valkey"
         description = "Whitehall Admin Valkey Instance"


### PR DESCRIPTION
We switched over to Valkey in https://github.com/alphagov/govuk-helm-charts/commit/c0ddce94649309bf258486b6409f39680a380ce6 so it's no longer used.

Closes https://github.com/alphagov/govuk-infrastructure/issues/1995