### PR TITLE
Search API v2: Add config for global engine

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_default.tf
@@ -1,0 +1,146 @@
+module "serving_config_global_default" {
+  source = "./modules/serving_config"
+
+  id           = "default_search"
+  display_name = "Default (used by live Search API v2)"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+
+  boost_control_ids = [
+    module.control_global_boost_demote_low.id,
+    module.control_global_boost_demote_medium.id,
+    module.control_global_boost_demote_pages.id,
+    module.control_global_boost_demote_strong.id,
+    module.control_global_boost_promote_low.id,
+    module.control_global_boost_promote_medium.id,
+  ]
+  filter_control_ids = [
+    module.control_global_filter_temporary_exclusions.id,
+  ]
+  synonyms_control_ids = [
+    module.control_global_synonym_hmrc.id,
+  ]
+}
+
+module "control_global_boost_promote_medium" {
+  source = "./modules/control"
+
+  id           = "boost_promote_medium"
+  display_name = "Boost: Promote medium"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      filter     = "content_purpose_supergroup: ANY(\"services\") OR document_type: ANY(\"calendar\", \"detailed_guide\", \"document_collection\", \"external_content\", \"organisation\")",
+      fixedBoost = 0.2
+      dataStore  = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
+module "control_global_boost_promote_low" {
+  source = "./modules/control"
+
+  id           = "boost_promote_low"
+  display_name = "Boost: Promote low"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      filter     = "document_type: ANY(\"guidance\", \"mainstream_browse_page\", \"policy_paper\", \"travel_advice\")",
+      fixedBoost = 0.05
+      dataStore  = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
+module "control_global_boost_demote_low" {
+  source = "./modules/control"
+
+  id           = "boost_demote_low"
+  display_name = "Boost: Demote low"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      filter     = "document_type: ANY(\"about\", \"taxon\", \"world_news_story\")",
+      fixedBoost = -0.25
+      dataStore  = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
+module "control_global_boost_demote_medium" {
+  source = "./modules/control"
+
+  id           = "boost_demote_medium"
+  display_name = "Boost: Demote medium"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      filter     = "document_type: ANY(\"employment_tribunal_decision\", \"foi_release\", \"service_standard_report\") OR organisation_state: ANY(\"devolved\", \"closed\")",
+      fixedBoost = -0.5
+      dataStore  = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
+module "control_global_boost_demote_strong" {
+  source = "./modules/control"
+
+  id           = "boost_demote_strong"
+  display_name = "Boost: Demote strong"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      filter     = "is_historic = 1",
+      fixedBoost = -0.75
+      dataStore  = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
+module "control_global_boost_demote_pages" {
+  source = "./modules/control"
+
+  id           = "boost_demote_pages"
+  display_name = "Boost: Demote specific pages"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      filter     = "link: ANY(\"/government/publications/pension-credit-claim-form--2\")",
+      fixedBoost = -0.75
+      dataStore  = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
+# TODO: This reuses the existing locals for filtered pages from serving_config_default.tf. Once we
+# remove that, we need to move them over to this file.
+module "control_global_filter_temporary_exclusions" {
+  source = "./modules/control"
+
+  id           = "filter_temporary_exclusions"
+  display_name = "Filter: Temporary exclusions"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+
+  action = {
+    filterAction = {
+      filter    = "NOT link: ANY(${local.filtered_pages_expr})"
+      dataStore = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
+module "control_global_synonym_hmrc" {
+  source = "./modules/control"
+
+  id           = "syn_hmrc"
+  display_name = "Synonyms: HMRC"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    synonymsAction = {
+      synonyms = [
+        "inland revenue",
+        "hmrc",
+        "hm revenue and customs",
+      ]
+    }
+  }
+}

--- a/terraform/deployments/search-api-v2/serving_config_global_raw.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_raw.tf
@@ -1,0 +1,7 @@
+module "serving_config_global_raw" {
+  source = "./modules/serving_config"
+
+  id           = "raw_search"
+  display_name = "Raw (without any attached controls, used for internal testing)"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+}

--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -1,0 +1,78 @@
+module "serving_config_global_variant" {
+  source = "./modules/serving_config"
+
+  id           = "variant_search"
+  display_name = "Variant (used as the 'B' variant when AB testing live Search API v2)"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+
+  boost_control_ids = [
+    # specific to serving_config_global_variant
+    module.control_global_boost_demote_historic.id,
+    module.control_global_boost_freshness_general.id,
+
+    # identical to serving_config_global_default
+    module.control_global_boost_promote_medium.id,
+    module.control_global_boost_promote_low.id,
+    module.control_global_boost_demote_low.id,
+    module.control_global_boost_demote_medium.id,
+    module.control_global_boost_demote_pages.id,
+
+    # explicitly not included in serving_config_global_variant
+    # module.control_global_boost_demote_strong.id,
+  ]
+  filter_control_ids = [
+    # identical to serving_config_global_default
+    module.control_global_filter_temporary_exclusions.id,
+  ]
+  synonyms_control_ids = [
+    # identical to serving_config_global_default
+    module.control_global_synonym_hmrc.id,
+  ]
+}
+
+module "control_global_boost_demote_historic" {
+  source = "./modules/control"
+
+  id           = "boost_demote_historic"
+  display_name = "Boost: Demote historic"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      filter     = "is_historic = 1",
+      fixedBoost = -0.25
+      dataStore  = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
+module "control_global_boost_freshness_general" {
+  source = "./modules/control"
+
+  id           = "boost_freshness_general"
+  display_name = "Boost: Freshness (general)"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      dataStore = google_discovery_engine_data_store.govuk_content.name,
+      interpolationBoostSpec = {
+        fieldName         = "public_timestamp_datetime",
+        attributeType     = "FRESHNESS",
+        interpolationType = "LINEAR",
+        controlPoints = [
+          {
+            attributeValue = "0D",
+            boostAmount    = 0.4
+          },
+          {
+            attributeValue = "30D",
+            boostAmount    = 0.1
+          },
+          {
+            attributeValue = "1460D",
+            # boostAmount = 0 is the default, setting it explicitly causes state drift
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
We've recently added a `govuk_global` engine to our setup, with the
intent of replacing the existing `govuk` engine with it.

This commit duplicates the existing `govuk` engine's serving config
and controls to ensure the new engine is configured in the same way.
It uses the new `fixedBoost` and `dataStore` attributes on controls
to be in line with how controls work now (the existing ones use
legacy attributes).
