### PR TITLE
Search API v2: Avoid resource drift

### DIFF
--- a/terraform/deployments/search-api-v2/completion.tf
+++ b/terraform/deployments/search-api-v2/completion.tf
@@ -2,16 +2,17 @@ resource "restapi_object" "google_discovery_engine_data_store_completion_config"
   path      = "/dataStores/${google_discovery_engine_data_store.govuk_content.data_store_id}/completionConfig"
   object_id = "completionConfig"
 
-  update_path = "/dataStores/${google_discovery_engine_data_store.govuk_content.data_store_id}/completionConfig?updateMask=matching_order,max_suggestions,min_prefix_length,query_model,enable_mode"
+  update_path = "/dataStores/${google_discovery_engine_data_store.govuk_content.data_store_id}/completionConfig?updateMask=matching_order,max_suggestions,min_prefix_length,query_model,enable_mode,query_frequency_treshold"
   read_path   = "/dataStores/${google_discovery_engine_data_store.govuk_content.data_store_id}/completionConfig"
 
   data = jsonencode({
-    name            = "completionConfig"
-    matchingOrder   = "out-of-order"
-    maxSuggestions  = 5,
-    minPrefixLength = 3,
-    queryModel      = "automatic",
-    enableMode      = "AUTOMATIC"
+    name                   = "completionConfig"
+    matchingOrder          = "out-of-order"
+    maxSuggestions         = 5,
+    minPrefixLength        = 3,
+    queryFrequencyTreshold = 250,
+    queryModel             = "automatic",
+    enableMode             = "AUTOMATIC"
   })
 }
 

--- a/terraform/deployments/search-api-v2/modules/control/main.tf
+++ b/terraform/deployments/search-api-v2/modules/control/main.tf
@@ -46,4 +46,10 @@ resource "restapi_object" "control" {
 
   # Set updateMask to ensure we don't accidentally overwrite other fields with `null`
   update_path = "${local.path}/${var.id}?updateMask=${local.update_mask}"
+
+  # VAIS adds some properties dynamically, which creates false positive drift
+  ignore_changes_to = [
+    "associatedServingConfigIds",
+    "name",
+  ]
 }

--- a/terraform/deployments/search-api-v2/modules/serving_config/main.tf
+++ b/terraform/deployments/search-api-v2/modules/serving_config/main.tf
@@ -38,4 +38,11 @@ resource "restapi_object" "serving_config" {
 
   # Set updateMask to ensure we don't accidentally overwrite other fields with `null`
   update_path = "${local.path}/${var.id}?updateMask=${local.update_mask}"
+
+  # VAIS adds some properties dynamically, which creates false positive drift
+  ignore_changes_to = [
+    "name",
+    "createTime",
+    "updateTime",
+  ]
 }

--- a/terraform/deployments/search-api-v2/modules/serving_config/variables.tf
+++ b/terraform/deployments/search-api-v2/modules/serving_config/variables.tf
@@ -16,17 +16,20 @@ variable "engine_id" {
 variable "boost_control_ids" {
   description = "The IDs of the boost controls to attach to the serving config"
   type        = list(string)
-  default     = []
+  # VAIS internally uses null instead of an empty array, so we do the same to avoid drift
+  default     = null
 }
 
 variable "filter_control_ids" {
   description = "The IDs of the filter controls to attach to the serving config"
   type        = list(string)
-  default     = []
+  # VAIS internally uses null instead of an empty array, so we do the same to avoid drift
+  default     = null
 }
 
 variable "synonyms_control_ids" {
   description = "The IDs of the synonym controls to attach to the serving config"
   type        = list(string)
-  default     = []
+  # VAIS internally uses null instead of an empty array, so we do the same to avoid drift
+  default     = null
 }


### PR DESCRIPTION
We have a number of resources that continuously present drift false
positives due to the API returning additional or subtly different
(e.g. `null` instead of `[]`) values compared to what we set in the
resource definitions.

This has been exacerbated by a recent major update of the REST API
Terraform provider, which now refreshes resource state based on
remote state.

This uses a combination of the REST API provider's `ignore_changes`
attribute, more sensible default values, and adding of missing values
to work around some of this drift.
