### PR TITLE
Search API v2: Simplify apply process

### DIFF
--- a/terraform/deployments/gcp-search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/main.tf
@@ -34,8 +34,7 @@ module "environment_integration" {
 module "environment_staging" {
   source = "./modules/search-api-v2"
 
-  name                      = "staging"
-  upstream_environment_name = "integration"
+  name = "staging"
 
   google_cloud_billing_account = var.google_cloud_billing_account
   google_cloud_folder          = var.google_cloud_folder
@@ -46,8 +45,7 @@ module "environment_staging" {
 module "environment_production" {
   source = "./modules/search-api-v2"
 
-  name                      = "production"
-  upstream_environment_name = "staging"
+  name = "production"
 
   google_cloud_billing_account = var.google_cloud_billing_account
   google_cloud_folder          = var.google_cloud_folder

--- a/terraform/deployments/tfc-configuration/modules/search-api-v2/variables.tf
+++ b/terraform/deployments/tfc-configuration/modules/search-api-v2/variables.tf
@@ -17,12 +17,6 @@ variable "tfc_project" {
   description = "The Terraform Cloud/Enterprise project to create workspaces under"
 }
 
-variable "upstream_environment_name" {
-  type        = string
-  description = "The name of the upstream environment, if any (used to wait for a successful apply on a 'lower' environment before applying this one)"
-  default     = null
-}
-
 variable "tfc_organization_name" {
   type        = string
   description = "The name of the Terraform Cloud/Enterprise organization to use"

--- a/terraform/deployments/tfc-configuration/search-api-v2.tf
+++ b/terraform/deployments/tfc-configuration/search-api-v2.tf
@@ -104,17 +104,12 @@ import {
   id = "govuk/search-api-v2-staging/aws-credentials-staging"
 }
 
-import {
-  to = module.environment_staging.tfe_run_trigger.apply_after_upstream_workspace[0]
-  id = "rt-MrZrhrnX5Ui29A49"
-}
 
 # Main staging module
 module "environment_staging" {
   source = "./modules/search-api-v2"
 
   name                          = "staging"
-  upstream_environment_name     = "integration"
   google_project_id             = "search-api-v2-staging"
   google_project_number         = "773027887517"
   google_workload_provider_name = "projects/773027887517/locations/global/workloadIdentityPools/terraform-cloud-id-pool/providers/terraform-cloud-provider-oidc"
@@ -164,17 +159,12 @@ import {
   id = "govuk/search-api-v2-production/aws-credentials-production"
 }
 
-import {
-  to = module.environment_production.tfe_run_trigger.apply_after_upstream_workspace[0]
-  id = "rt-uR7ws5qAzQovR8v1"
-}
 
 # Main production module
 module "environment_production" {
   source = "./modules/search-api-v2"
 
   name                          = "production"
-  upstream_environment_name     = "staging"
   google_project_id             = "search-api-v2-production"
   google_project_number         = "931453572747"
   google_workload_provider_name = "projects/931453572747/locations/global/workloadIdentityPools/terraform-cloud-id-pool/providers/terraform-cloud-provider-oidc"


### PR DESCRIPTION
This simplifies the way Terraform changes are applied by removing the superfluous run triggers (which cause double runs to be queued up for staging and production as one already gets queued on VCS change anyway).

It also changes the auto-apply logic to always autoapply except in production, which means that staging no longer needs to be applied manually going forwards (saving a bit of toil).