### PR TITLE
Remove TODOs about potential downsizing

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -565,7 +565,7 @@ module "variable-set-rds-integration" {
         engine_params_family         = "postgres13"
         name                         = "transition"
         allocated_storage            = 120
-        instance_class               = "db.m6g.large" # TODO: downsize this after migration if required
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
       }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -566,7 +566,7 @@ module "variable-set-rds-production" {
         engine_params_family         = "postgres13"
         name                         = "transition"
         allocated_storage            = 120
-        instance_class               = "db.m6g.large" # TODO: downsize this after migration if required
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
       }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -560,7 +560,7 @@ module "variable-set-rds-staging" {
         engine_params_family         = "postgres13"
         name                         = "transition"
         allocated_storage            = 120
-        instance_class               = "db.m6g.large" # TODO: downsize this after migration if required
+        instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
       }


### PR DESCRIPTION
We've reviewed usage and downsizing isn't needed. 