### PR TITLE
Move pub-infra away from TF Remote State Outputs

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/amazonmq.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/amazonmq.tf
@@ -62,8 +62,8 @@ resource "aws_mq_broker" "publishing_amazonmq" {
   security_groups = [aws_security_group.rabbitmq.id]
   subnet_ids = (
     var.amazonmq_deployment_mode == "SINGLE_INSTANCE"
-    ? [data.terraform_remote_state.infra_networking.outputs.private_subnet_ids[0]]
-    : data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
+    ? [local.private_subnet_ids[0]]
+    : local.private_subnet_ids
   )
 
   auto_minor_version_upgrade = true

--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -29,9 +29,12 @@ terraform {
 
 locals {
   cluster_name         = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id
-  internal_dns_zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
+  internal_dns_zone_id = data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_id
   external_dns_zone_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.external_dns_zone_id
-  elasticache_subnets  = data.terraform_remote_state.infra_networking.outputs.private_subnet_elasticache_ids
+  elasticache_subnets  = [for name, subnet in data.tfe_outputs.vpc.nonsensitive_values.private_subnet_ids : subnet if startswith(name, "elasticache_")]
+
+  target_private_subnets = ["a", "b", "c"]
+  private_subnet_ids     = [for name, subnet in data.tfe_outputs.vpc.nonsensitive_values.private_subnet_ids : subnet if contains(local.target_private_subnets, name)]
 
   default_tags = {
     Product              = "GOV.UK"

--- a/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_api_gateway.tf
@@ -7,7 +7,7 @@ resource "aws_lb" "search_nlb" {
   name               = "search-nlb"
   load_balancer_type = "network"
   internal           = true
-  subnets            = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
+  subnets            = local.private_subnet_ids
 }
 
 resource "aws_lb_target_group" "search_api_gateway_tg" {

--- a/terraform/deployments/govuk-publishing-infrastructure/shared_documentdb.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/shared_documentdb.tf
@@ -8,7 +8,7 @@ resource "aws_docdb_cluster_instance" "shared_cluster_instances" {
 
 resource "aws_docdb_subnet_group" "shared_cluster_subnet" {
   name       = "shared-documentdb-${var.govuk_environment}"
-  subnet_ids = data.terraform_remote_state.infra_networking.outputs.private_subnet_ids
+  subnet_ids = local.private_subnet_ids
 }
 
 resource "aws_docdb_cluster_parameter_group" "shared_parameter_group" {
@@ -36,6 +36,69 @@ resource "random_password" "shared_documentdb_master" {
   length = 100
 }
 
+data "aws_kms_key" "shared_documentdb_kms_key_migrate" {
+  key_id = data.terraform_remote_state.infra_security.outputs.shared_documentdb_kms_key_arn
+}
+
+# TODO: Remove me once KMS Key is Imported across all environments.
+import {
+  id = data.aws_kms_key.shared_documentdb_kms_key_migrate.id
+  to = aws_kms_key.shared_documentdb_kms_key
+}
+
+# TODO: Remove me once KMS Key is Imported across all environments.
+resource "aws_kms_key" "shared_documentdb_kms_key" {
+  description = "Encryption key for Shared DocumentDB"
+  key_usage   = "ENCRYPT_DECRYPT"
+}
+
+resource "aws_kms_alias" "shared_documentdb_kms_alias" {
+  name          = "alias/documentdb/shared-documentdb-kms-key"
+  target_key_id = aws_kms_key.shared_documentdb_kms_key.id
+}
+
+resource "aws_kms_key_policy" "shared_documentdb_kms_key_policy" {
+  key_id = aws_kms_key.shared_documentdb_kms_key.id
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "Delegate permissions to IAM policies",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        },
+        "Action" : "kms:*",
+        "Resource" : "*"
+      },
+      {
+        "Sid" : "Allow access through RDS for all principals in the account that are authorized to use RDS",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : "*"
+        },
+        "Action" : [
+          "kms:ReEncrypt*",
+          "kms:ListGrants",
+          "kms:GenerateDataKey*",
+          "kms:Encrypt",
+          "kms:DescribeKey",
+          "kms:Decrypt",
+          "kms:CreateGrant"
+        ],
+        "Resource" : "*",
+        "Condition" : {
+          "StringEquals" : {
+            "kms:ViaService" : "rds.eu-west-1.amazonaws.com",
+            "kms:CallerAccount" : "${data.aws_caller_identity.current.account_id}"
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_docdb_cluster" "shared_cluster" {
   cluster_identifier              = "shared-documentdb-${var.govuk_environment}"
   availability_zones              = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
@@ -45,7 +108,7 @@ resource "aws_docdb_cluster" "shared_cluster" {
   storage_encrypted               = true
   backup_retention_period         = var.shared_documentdb_backup_retention_period
   db_cluster_parameter_group_name = aws_docdb_cluster_parameter_group.shared_parameter_group.name
-  kms_key_id                      = data.terraform_remote_state.infra_security.outputs.shared_documentdb_kms_key_arn
+  kms_key_id                      = aws_kms_key.shared_documentdb_kms_key.arn
   vpc_security_group_ids          = ["${data.terraform_remote_state.infra_security_groups.outputs.sg_shared_documentdb_id}"]
   enabled_cloudwatch_logs_exports = ["profiler"]
 }


### PR DESCRIPTION
## What?
This removes the usage of terraform_remote_state from the govuk-publishing-infrastructure TF Deployment.

There is one very glaring exception - Security Groups. These will likely need addressing in a separate PR because of complexity and risk.