### PR TITLE
KMS - Fix Wrong Key Target

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb.tf
@@ -57,7 +57,7 @@ resource "aws_kms_key" "licensify_documentdb_kms_key" {
 
 resource "aws_kms_alias" "licensify_documentdb_kms_alias" {
   name          = "alias/documentdb/licensify-documentdb-kms-key"
-  target_key_id = aws_kms_key.shared_documentdb_kms_key.id
+  target_key_id = aws_kms_key.licensify_documentdb_kms_key.id
 }
 
 resource "aws_kms_key_policy" "licensify_documentdb_kms_key_policy" {


### PR DESCRIPTION
## What?
This corrects the key target for the licensify KMS Key Alias. Because I copy-pasta'd.