### PR TITLE
Remove access to content-data-admin CSVs bucket from node role

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/reports_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/reports_s3.tf
@@ -32,7 +32,6 @@ data "aws_iam_policy_document" "write_reports_to_s3" {
     actions = ["s3:GetBucketLocation", "s3:ListBucket"]
     resources = [
       aws_s3_bucket.publisher_csvs.arn,
-      "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-csvs",
       "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-siteimprove-sitemaps",
       "arn:aws:s3:::govuk-${var.govuk_environment}-specialist-publisher-csvs",
       "arn:aws:s3:::govuk-${var.govuk_environment}-support-api-csvs",
@@ -51,7 +50,6 @@ data "aws_iam_policy_document" "write_reports_to_s3" {
     ]
     resources = [
       "${aws_s3_bucket.publisher_csvs.arn}/*",
-      "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-csvs/*",
       "arn:aws:s3:::govuk-${var.govuk_environment}-content-data-siteimprove-sitemaps/*",
       "arn:aws:s3:::govuk-${var.govuk_environment}-specialist-publisher-csvs/*",
       "arn:aws:s3:::govuk-${var.govuk_environment}-support-api-csvs/*",


### PR DESCRIPTION
This has been replaced with a pod IAM role

https://github.com/alphagov/govuk-infrastructure/issues/2171