### PR TITLE
Search API v2: Rename new global serving configs

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_default.tf
@@ -1,7 +1,7 @@
 module "serving_config_global_default" {
   source = "./modules/serving_config"
 
-  id           = "default_search"
+  id           = "default"
   display_name = "Default (used by live Search API v2)"
   engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
 

--- a/terraform/deployments/search-api-v2/serving_config_global_raw.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_raw.tf
@@ -1,7 +1,7 @@
 module "serving_config_global_raw" {
   source = "./modules/serving_config"
 
-  id           = "raw_search"
+  id           = "raw"
   display_name = "Raw (without any attached controls, used for internal testing)"
   engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
 }

--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -1,7 +1,7 @@
 module "serving_config_global_variant" {
   source = "./modules/serving_config"
 
-  id           = "variant_search"
+  id           = "variant"
   display_name = "Variant (used as the 'B' variant when AB testing live Search API v2)"
   engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
 


### PR DESCRIPTION
VAIS isn't happy with the names of these, as apparently they need to be unique across the entire collection (not just the engine).

This renames the new serving configs to have unique names, by dropping the `_search` suffix we use on the existing engine.