### PR TITLE
Search API v2: Fix boost control drift

### DIFF
--- a/terraform/deployments/search-api-v2/modules/control/main.tf
+++ b/terraform/deployments/search-api-v2/modules/control/main.tf
@@ -51,5 +51,8 @@ resource "restapi_object" "control" {
   ignore_changes_to = [
     "associatedServingConfigIds",
     "name",
+    # legacy field that still comes through in the API response even for boost controls that use the
+    # new `fixedBoost` property
+    "boostAction.boost"
   ]
 }


### PR DESCRIPTION
The VAIS API seems to return the deprecated `boost` property on controls with a `boostAction`, even when they have been created with the new `fixedBoost` property.

This ignores the field so Terraform doesn't detect false positive drift on these controls.