### PR TITLE
Search API v2: Add explicit scopes for GDrive access

### DIFF
--- a/terraform/deployments/search-api-v2/main.tf
+++ b/terraform/deployments/search-api-v2/main.tf
@@ -34,6 +34,13 @@ terraform {
 provider "google" {
   project = var.gcp_project_id
   region  = var.gcp_region
+  scopes = [
+    # Default scopes requested by Terraform Google provider
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+    # Needed for `google_bigquery_table` to use Google Drive as source
+    "https://www.googleapis.com/auth/drive.readonly",
+  ]
 }
 
 provider "aws" {


### PR DESCRIPTION
This adds the `drive.readonly` scope to the OAuth scopes requested by the Terraform provider, which also requires us to explicitly include the default values that would normally be implicit.

This will allow us to use the `google_bigquery_table` resource with a Google Sheet as an external source.

See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table.html#source_format-1