### PR TITLE
Use the correct EKS SG ID Output

### DIFF
--- a/terraform/deployments/security/main.tf
+++ b/terraform/deployments/security/main.tf
@@ -49,7 +49,7 @@ resource "aws_security_group" "govuk_content-data-api-postgresql-primary_access"
 }
 
 import {
-  id = data.terraform_remote_state.infra_security_groups.outputs.govuk_elasticsearch6_id
+  id = data.terraform_remote_state.infra_security_groups.outputs.sg_elasticsearch6_id
   to = aws_security_group.govuk_elasticsearch6_access
 }
 

--- a/terraform/deployments/security/main.tf
+++ b/terraform/deployments/security/main.tf
@@ -1,5 +1,5 @@
 data "aws_security_group" "eks_cluster_primary_sg" {
-  id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_primary_security_group_id
+  id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.control_plane_security_group_id
 }
 
 import {

--- a/terraform/deployments/tfc-configuration/security.tf
+++ b/terraform/deployments/tfc-configuration/security.tf
@@ -26,8 +26,7 @@ module "security-integration" {
   variable_set_ids = [
     local.aws_credentials["integration"],
     module.variable-set-common.id,
-    module.variable-set-integration.id,
-    module.variable-set-rds-integration.id
+    module.variable-set-integration.id
   ]
 }
 
@@ -58,8 +57,7 @@ module "security-staging" {
   variable_set_ids = [
     local.aws_credentials["staging"],
     module.variable-set-common.id,
-    module.variable-set-integration.id,
-    module.variable-set-rds-integration.id
+    module.variable-set-staging.id
   ]
 }
 
@@ -90,7 +88,6 @@ module "security-production" {
   variable_set_ids = [
     local.aws_credentials["production"],
     module.variable-set-common.id,
-    module.variable-set-integration.id,
-    module.variable-set-rds-integration.id
+    module.variable-set-production.id
   ]
 }


### PR DESCRIPTION
## What?
So upon trying to plan and apply the Security Group imports, I discovered that the output name for the Control Plane SG ID was wrong (I was going by the documentation, not what it was actually set to)