### PR TITLE
Try to address replacement of Search LTR SG

### DIFF
--- a/terraform/deployments/security/main.tf
+++ b/terraform/deployments/security/main.tf
@@ -108,6 +108,8 @@ resource "aws_security_group" "search-ltr-generation_access" {
   }
 
   lifecycle {
+    # SGs cannot have their Descriptions changed for some reason, so ignore it.
+    ignore_changes  = [description]
     prevent_destroy = true
   }
 }


### PR DESCRIPTION
## What?
Terraform wants to blow away and replace one of the SGs. I don't want it to. Let's try and fix the name and add "prevent_destroy" to stop this from happening.