### PR TITLE
Add outputs from sec Deployment for use elsewhrere

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -20,6 +20,11 @@ data "tfe_outputs" "vpc" {
   workspace    = "vpc-${var.govuk_environment}"
 }
 
+data "tfe_outputs" "security" {
+  organization = "govuk"
+  workspace    = "security-${var.govuk_environment}"
+}
+
 data "terraform_remote_state" "infra_networking" {
   backend = "s3"
   config = {

--- a/terraform/deployments/security/outputs.tf
+++ b/terraform/deployments/security/outputs.tf
@@ -1,0 +1,29 @@
+output "govuk_asset-master-efs_access_sg_id" {
+  description = "Security Group ID for GOV.UK asset-master EFS Access"
+  value       = aws_security_group.govuk_asset-master-efs_access.id
+}
+
+output "govuk_content-data-api-postgresql-primary_access_sg_id" {
+  description = "Security Group ID for GOV.UK content-data-api Primary Postgres DB Access"
+  value       = aws_security_group.govuk_content-data-api-postgresql-primary_access.id
+}
+
+output "govuk_elasticsearch6_access_sg_id" {
+  description = "Security Group ID for GOV.UK Elasticsearch 6 Access"
+  value       = aws_security_group.govuk_elasticsearch6_access.id
+}
+
+output "search-ltr-generation_access_sg_id" {
+  description = "Security Group ID for GOV.UK Search LTR Generation Access"
+  value       = aws_security_group.search-ltr-generation_access.id
+}
+
+output "govuk_licensify-documentdb_access_sg_id" {
+  description = "Security Group ID for GOV.UK Licensify DocumentDB Access"
+  value       = aws_security_group.govuk_licensify-documentdb_access.id
+}
+
+output "govuk_shared_documentdb_access_sg_id" {
+  description = "Security Group ID for GOV.UK Shared DocumentDB Access"
+  value       = aws_security_group.govuk_shared_documentdb_access.id
+}


### PR DESCRIPTION
## What?
I need to explicitly define the outputs from the Security Deployments that will be used by the resources in the other deployments such as the govuk-publishing-infrastructure Deployment.

The next PR will actually consume these outputs to reduce our usage of legacy statefile outputs.