### PR TITLE
Update usage instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,16 @@ Configuration of CDN services is stored in [alphagov/govuk-fastly](https://githu
 
 ## Usage
 
-To install the [currently-used version of Terraform](terraform/.terraform-version):
+To install the compatible version of Terraform:
 
 ```shell
 brew install tfenv
 cd terraform/
-tfenv install
+tfenv install latest
+tfenv use latest
 ```
+
+We set the constraints with minor version precision. However when using this Terraform version manager, you need to specify the patch version, e.g. `tfenv install 1.10.5`.
 
 ## Pre-commit hooks
 


### PR DESCRIPTION
The `terraform/.terraform-version` file was removed in https://github.com/alphagov/govuk-infrastructure/commit/4947720d544a7572e429c49853b0692643784681 so the instructions in the README no longer work and users are getting version mismatch errors. It wasn’t obvious to me at first that I need to specify patch version to use hence the line on this.