### PR TITLE
Add the Security Sensitive Vars to TF Config First

### DIFF
--- a/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
@@ -28,6 +28,7 @@ module "govuk-publishing-infrastructure-integration" {
     module.variable-set-common.id,
     module.variable-set-integration.id,
     module.variable-set-amazonmq-integration.id,
+    module.sensitive-variables.security_integration_id,
     module.sensitive-variables.waf_integration_id
   ]
 }
@@ -61,6 +62,7 @@ module "govuk-publishing-infrastructure-staging" {
     module.variable-set-common.id,
     module.variable-set-staging.id,
     module.variable-set-amazonmq-staging.id,
+    module.sensitive-variables.security_staging_id,
     module.sensitive-variables.waf_staging_id
   ]
 }
@@ -94,6 +96,7 @@ module "govuk-publishing-infrastructure-production" {
     module.variable-set-common.id,
     module.variable-set-production.id,
     module.variable-set-amazonmq-production.id,
+    module.sensitive-variables.security_production_id,
     module.sensitive-variables.waf_production_id
   ]
 }

--- a/terraform/deployments/tfc-configuration/variables-sensitive.tf
+++ b/terraform/deployments/tfc-configuration/variables-sensitive.tf
@@ -1,4 +1,4 @@
 module "sensitive-variables" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/variables"
-  version = "0.0.13"
+  version = "0.0.22"
 }


### PR DESCRIPTION
## What?
This updates TFC Config to use the Sensitive Security variables module - we should do this before we plan/apply the new Office IP vars in the other Deployments, else the lists will come out blank.

I have needed to update the module version too, as this was out of date.