### PR TITLE
Use Office IP Vars for govuk-publishing-infra

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
@@ -125,7 +125,7 @@ data "aws_iam_policy_document" "s3_mirror_read_policy" {
     condition {
       test     = "IpAddress"
       variable = "aws:SourceIp"
-      values   = data.terraform_remote_state.infra_security_groups.outputs.office_ips
+      values   = var.office_ips
     }
 
     principals {
@@ -190,7 +190,7 @@ data "aws_iam_policy_document" "s3_mirror_replica_read_policy" {
     condition {
       test     = "IpAddress"
       variable = "aws:SourceIp"
-      values   = data.terraform_remote_state.infra_security_groups.outputs.office_ips
+      values   = var.office_ips
     }
 
     principals {

--- a/terraform/deployments/govuk-publishing-infrastructure/security.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/security.tf
@@ -144,7 +144,7 @@ resource "aws_security_group_rule" "eks_ingress_www_origin_from_office_and_fastl
   from_port         = 80
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = concat(data.terraform_remote_state.infra_security_groups.outputs.office_ips, data.fastly_ip_ranges.fastly.cidr_blocks)
+  cidr_blocks       = concat(var.office_ips, data.fastly_ip_ranges.fastly.cidr_blocks)
   security_group_id = aws_security_group.eks_ingress_www_origin.id
 }
 

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -164,3 +164,8 @@ variable "fastly_rate_limit_token" {
   default     = "test"
 }
 
+variable "office_ips" {
+  type        = list(string)
+  description = "List of CIDRs from which we consider Office IPs."
+  default     = []
+}


### PR DESCRIPTION
### PR Dependency
Merge these first:

* https://github.com/alphagov/govuk-infrastructure/pull/2273

## What?
This switches the use of the office_ips vars to use the `tfset` ones from the sensitive module.