### PR TITLE
Create a DNS zone for a subdomain of publishing.service.gov.uk in each environment

### DIFF
--- a/terraform/deployments/root-dns/root_dns_zones.tf
+++ b/terraform/deployments/root-dns/root_dns_zones.tf
@@ -1,3 +1,6 @@
+locals {
+  publishing_subdomain = var.govuk_environment == "production" ? "" : "${var.govuk_environment}."
+}
 resource "aws_route53_zone" "internal_zone" {
   name = "${var.govuk_environment}.govuk-internal.digital."
 
@@ -8,4 +11,8 @@ resource "aws_route53_zone" "internal_zone" {
 
 resource "aws_route53_zone" "external_zone" {
   name = "${var.govuk_environment}.govuk.digital."
+}
+
+resource "aws_route53_zone" "publishing_subdomain" {
+  name = "${local.publishing_subdomain}publishing.service.gov.uk"
 }


### PR DESCRIPTION
## What
We want to delegate control of these subdomains to other pieces of Terraform. Subsequent commits in `govuk-dns-tf` will set the `NS` and `SOA` records on the `publishing.service.gov.uk` domain for delegation.

Part of #1601 