### PR TITLE
Update service name in release_assumer_assume policy document

### DIFF
--- a/terraform/deployments/release/assumer.tf
+++ b/terraform/deployments/release/assumer.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "release_assumer_assume" {
     condition {
       test     = "StringEquals"
       variable = "${replace(data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_oidc_provider_arn, "/^(.*provider/)/", "")}:sub"
-      values   = ["system:serviceaccount:apps:release"]
+      values   = ["system:serviceaccount:apps:release-assumer"]
     }
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
Release couldn't make request to STS (to assume a release-assumed role in an AWS account).  We were getting `Not authorized to perform sts:AssumeRoleWithWebIdentity (Aws::STS::Errors::AccessDenied)` error.

This is because the value for service account didn't match the value in the charts: https://github.com/alphagov/govuk-helm-charts/blob/336702d/charts/release/templates/assumer_serviceaccount.yaml#L4

https://github.com/alphagov/govuk-infrastructure/issues/2236