### PR TITLE
Use Security "Common" TFvars in Sec Deployment

### DIFF
--- a/terraform/deployments/tfc-configuration/security.tf
+++ b/terraform/deployments/tfc-configuration/security.tf
@@ -26,7 +26,8 @@ module "security-integration" {
   variable_set_ids = [
     local.aws_credentials["integration"],
     module.variable-set-common.id,
-    module.variable-set-integration.id
+    module.variable-set-integration.id,
+    module.sensitive-variables.security_common_id
   ]
 }
 
@@ -57,7 +58,8 @@ module "security-staging" {
   variable_set_ids = [
     local.aws_credentials["staging"],
     module.variable-set-common.id,
-    module.variable-set-staging.id
+    module.variable-set-staging.id,
+    module.sensitive-variables.security_common_id
   ]
 }
 
@@ -88,6 +90,7 @@ module "security-production" {
   variable_set_ids = [
     local.aws_credentials["production"],
     module.variable-set-common.id,
-    module.variable-set-production.id
+    module.variable-set-production.id,
+    module.sensitive-variables.security_common_id
   ]
 }

--- a/terraform/deployments/tfc-configuration/variables-sensitive.tf
+++ b/terraform/deployments/tfc-configuration/variables-sensitive.tf
@@ -1,4 +1,4 @@
 module "sensitive-variables" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/variables"
-  version = "0.0.22"
+  version = "0.0.23"
 }


### PR DESCRIPTION
### What?
This "consumes" the new Security "Common" TF Vars that are now available in the latest Sensitive TF Module, published as version 0.0.23.