### PR TITLE
Allow assumer in non-prod envs to assume other non-prod env accounts

### DIFF
--- a/terraform/deployments/release/assumer.tf
+++ b/terraform/deployments/release/assumer.tf
@@ -2,13 +2,14 @@ data "aws_caller_identity" "current" {}
 
 locals {
   # production can assume everywhere,
-  # other accounts can assume into themselves
-  account_ids = var.govuk_environment == "production" ? [
-    "172025368201", # production
+  # other accounts can assume into non-prod accounts
+  _account_ids = [
     "696911096973", # staging
     "210287912431", # integration
     "430354129336"  # test
-  ] : [data.aws_caller_identity.current.account_id]
+  ]
+  account_ids = (var.govuk_environment == "production" ?
+  "${concat(local._account_ids, ["172025368201"])}" : local._account_ids)
 
   assume_arns = [
     for id in local.account_ids : "arn:aws:iam::${id}:role/release-assumed"


### PR DESCRIPTION
Only allow non-production assumer role to assume accounts in other non-produstion environments.

This will limit the security risk if the permissions for the `release-assumed` role were to change in the future. 

https://github.com/alphagov/govuk-infrastructure/issues/2236