### PR TITLE
Search API v2: Delete legacy `govuk` engine

### DIFF
--- a/terraform/deployments/search-api-v2/discovery_engine.tf
+++ b/terraform/deployments/search-api-v2/discovery_engine.tf
@@ -23,29 +23,6 @@ resource "google_discovery_engine_data_store" "govuk_content" {
   }
 }
 
-resource "google_discovery_engine_search_engine" "govuk" {
-  engine_id    = "govuk"
-  display_name = "GOV.UK Site Search"
-
-  location      = google_discovery_engine_data_store.govuk_content.location
-  collection_id = "default_collection"
-
-  # TODO: The engine was originally created before this field existed. It now defaults to "GENERIC",
-  # but setting that explicitly causes it to be replaced. This is a workaround to avoid that.
-  industry_vertical = ""
-
-  data_store_ids = [google_discovery_engine_data_store.govuk_content.data_store_id]
-
-  search_engine_config {
-    search_tier    = "SEARCH_TIER_STANDARD"
-    search_add_ons = []
-  }
-
-  common_config {
-    company_name = "GOV.UK"
-  }
-}
-
 resource "google_discovery_engine_search_engine" "govuk_global" {
   engine_id    = "govuk_global"
   display_name = "GOV.UK Site Search for Global Search"

--- a/terraform/deployments/search-api-v2/serving_config_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_default.tf
@@ -1,8 +1,0 @@
-# TODO: This was created implicitly on the `govuk` engine when it was first created, so
-# we're just removing it from state in case explicitly deleting it has weird side effects.
-removed {
-  from = module.serving_config_default
-  lifecycle {
-    destroy = false
-  }
-}


### PR DESCRIPTION
This engine is now no longer used, and can be deleted (including its default serving config that has already been removed from state).