### PR TITLE
Remove TODOs from code

### DIFF
--- a/terraform/deployments/chat/redis.tf
+++ b/terraform/deployments/chat/redis.tf
@@ -50,7 +50,6 @@ resource "aws_elasticache_replication_group" "chat_redis_cluster" {
 
 resource "aws_route53_record" "chat_redis_cluster" {
   zone_id = local.internal_dns_zone_id
-  # TODO: consider removing EKS suffix once the old EC2 environments are gone.
   name    = "${local.chat_redis_name}.eks"
   type    = "CNAME"
   ttl     = 300

--- a/terraform/deployments/cluster-infrastructure/grafana.tf
+++ b/terraform/deployments/cluster-infrastructure/grafana.tf
@@ -146,7 +146,6 @@ resource "aws_route53_record" "grafana_db" {
   count = startswith(var.govuk_environment, "eph-") ? 0 : 1
 
   zone_id = data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_id
-  # TODO: consider removing EKS suffix once the old EC2 environments are gone.
   name    = "${local.grafana_db_name}-db.eks"
   type    = "CNAME"
   ttl     = 300

--- a/terraform/deployments/govuk-publishing-infrastructure/frontend_memcache.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/frontend_memcache.tf
@@ -37,7 +37,6 @@ resource "aws_elasticache_cluster" "frontend_memcached" {
 
 resource "aws_route53_record" "frontend_memcached" {
   zone_id = local.internal_dns_zone_id
-  # TODO: consider removing EKS suffix once the old EC2 environments are gone.
   name    = "frontend-memcached-${local.cluster_name}.eks"
   type    = "CNAME"
   ttl     = 300

--- a/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb.tf
@@ -99,7 +99,6 @@ resource "aws_docdb_cluster_instance" "licensify_cluster_instances" {
   count              = var.licensify_documentdb_instance_count
   identifier         = "licensify-documentdb-${count.index}"
   cluster_identifier = aws_docdb_cluster.licensify_cluster.id
-  # TODO: make sure this is the right DB instance size
-  instance_class = "db.r5.large"
-  tags           = aws_docdb_cluster.licensify_cluster.tags
+  instance_class     = "db.r5.large"
+  tags               = aws_docdb_cluster.licensify_cluster.tags
 }


### PR DESCRIPTION
This removes various TODOs from the code:

- TODOs about instance sizes can be covered in general rightsizing work
- TODOs about removing the .eks suffix covered by this issue https://github.com/alphagov/govuk-infrastructure/issues/2302 