### PR TITLE
Add secret for discovery engine default location

### DIFF
--- a/terraform/deployments/search-api-v2/discovery_engine.tf
+++ b/terraform/deployments/search-api-v2/discovery_engine.tf
@@ -1,7 +1,8 @@
 # TODO: These IDs/paths are semi-hardcoded here as there aren't first party resources/data sources
 # available for them yet.
 locals {
-  discovery_engine_default_collection_name = "projects/${var.gcp_project_id}/locations/${var.discovery_engine_location}/collections/default_collection"
+  discovery_engine_default_location_name   = "projects/${var.gcp_project_id}/locations/${var.discovery_engine_location}"
+  discovery_engine_default_collection_name = "${local.discovery_engine_default_location_name}/collections/default_collection"
 }
 
 resource "google_discovery_engine_data_store" "govuk_content" {

--- a/terraform/deployments/search-api-v2/outputs.tf
+++ b/terraform/deployments/search-api-v2/outputs.tf
@@ -7,3 +7,8 @@ output "google_cloud_discovery_engine_default_collection_name" {
   description = "The fully qualified name of the default collection on the GCP project"
   value       = local.discovery_engine_default_collection_name
 }
+
+output "google_cloud_discovery_engine_default_location_name" {
+  description = "The fully qualified name of the default location for the GCP project"
+  value       = local.discovery_engine_default_location_name
+}

--- a/terraform/deployments/search-api-v2/secrets.tf
+++ b/terraform/deployments/search-api-v2/secrets.tf
@@ -9,6 +9,7 @@ resource "aws_secretsmanager_secret_version" "discovery_engine_configuration" {
     "GOOGLE_CLOUD_CREDENTIALS"                 = base64decode(google_service_account_key.api.private_key)
     "GOOGLE_CLOUD_PROJECT_ID"                  = var.gcp_project_id
     "DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME" = local.discovery_engine_default_collection_name
+    "DISCOVERY_ENGINE_DEFAULT_LOCATION_NAME"   = local.discovery_engine_default_location_name
   })
 }
 


### PR DESCRIPTION
[Trello](https://trello.com/c/PUn43yi3)

This value will be used to populate a
DISCOVERY_ENGINE_DEFAULT_LOCATION_NAME env var that will be used to in the automated judgment list tasks.

See:
https://github.com/alphagov/search-api-v2/blob/fc7a362b80145c9a16c4d91c6f343eef382c6d7f/config/application.rb#L23C54-L23C113