### PR TITLE
♻️ Change the k8s serviceaccount name

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
@@ -390,7 +390,7 @@ module "govuk_mirror_sync_iam_role" {
   role_description = "Role for govuk-mirror-sync to access S3. Corresponds to govuk-mirror-sync k8s ServiceAccount."
 
   cluster_service_accounts = {
-    "${local.cluster_name}" = ["apps:govuk-mirror-sync"]
+    "${local.cluster_name}" = ["apps:mirror"]
   }
 
   role_policy_arns = {


### PR DESCRIPTION
Mirror has had a little environment refactor. This change reflects a change in serviceaccount that needs to be kept in sync with the role that's created for it.
