### PR TITLE
ADR-0015 maintain a readonly role

### DIFF
--- a/.github/workflows/guardrail_adr_numbering.yml
+++ b/.github/workflows/guardrail_adr_numbering.yml
@@ -1,0 +1,37 @@
+name: "Guardrail: ADR numbering matches the title"
+
+on:
+  pull_request:
+    paths:
+      - "docs/architecture/decisions/*.md"
+
+jobs:
+  check-adr-numbering:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          show-progress: false
+
+      - name: "Check ADR file numbering matches title"
+        run: |
+          set -euo pipefail
+          EXIT_CODE=0
+  
+          while read -r ADR_FILE; do
+            ADR_NAME="$(basename "${ADR_FILE}")"
+          
+            ADR_FILE_NUMBER="$(echo "${ADR_NAME}" | cut -d'-' -f1 | sed -nE 's/0+([1-9]{1}[0-9]*|0)/\1/p')"
+            ADR_TITLE_NUMBER="$(sed -nE 's/^# ([0-9]+). .*/\1/p' "${ADR_FILE}")"
+          
+            echo -n "Checking ${ADR_FILE}..... "
+            if [[ "${ADR_FILE_NUMBER}" != "${ADR_TITLE_NUMBER}" ]]; then
+              echo "BAD"
+              printf "\tFile number: %s Title number: %s\n" "${ADR_FILE_NUMBER}" "${ADR_TITLE_NUMBER}"
+              EXIT_CODE=1
+            else
+              echo "OK"
+            fi
+          done < <(find docs/architecture/decisions -type f -maxdepth 1)
+          
+          exit $EXIT_CODE

--- a/docs/architecture/decisions/0000-TEMPLATE.md
+++ b/docs/architecture/decisions/0000-TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+Using this template:
+
+1. Clone this file and rename it with the next 4-digit number (leading zeroes included) and
+   a kebab-case title
+   e.g.
+   0099-believe-in-ghosts.md
+
+2. Change the H1 heading to include the new number without leading zeroes and a title
+   e.g.
+   # 99. Believe in ghosts
+
+3. Once the decision is approved, set the status to "Approved" and merge the changes.
+
+For guidance writing good ADRs read Michael Nygard's blog post:
+https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
+-->
+
+# 0. Template
+
+Date: <!-- Today's date -->
+
+## Status
+
+Pending
+
+## Context
+
+<!--
+  Describe the problem being solved.
+  Describe the context in which the decision is being made.
+  Describe any relevant research that was conducted.
+  Describe any other decisions that could have been made, and why we didn't make them.
+-->
+
+## Decision
+
+<!--
+  Describe the decision we have made.
+  Describe the justifications for making this decision.
+  Describe any trade-offs we've made.
+-->
+
+## Consequences
+
+<!--
+  Describe the impacts and side effects of the decision we have made.
+  Describe the impacts and side effects on both the team and the systems we operate.
+  Include both the good and the bad consequences.
+-->

--- a/docs/architecture/decisions/0015-maintain-a-readonly-role.md
+++ b/docs/architecture/decisions/0015-maintain-a-readonly-role.md
@@ -1,0 +1,54 @@
+# 15. Maintain a read-only IAM role
+
+Date: 2026-06-16
+
+## Status
+
+Pending
+
+## Context
+
+We aim to adhere to the principle of least privilege wherever we can. In the particular case of AWS and Kubernetes 
+cluster access we do this by providing IAM and Kubernetes roles which grant the kinds of permissions needed for developers 
+and platform engineers to do routine parts of their jobs, and separating out the permissions needed for more destructive
+or sensitive acts into more privileged roles which we more tightly gate access to.
+
+Prior to May 2025 we had four roles: `ReadOnly`, `User`, `PowerUser`, and `Admin`. We ran some research a developer survey 
+and discovered that most users were defaulting to using the `PowerUser` role because `ReadOnly` didn't them access to 
+everything they needed; crucially, it did not grant them access to Amazon Athena. Developers found friction in using the
+`ReadOnly` role for most of their work, only to find they needed to switch roles to use Athena. In the end, most developers
+had begun to assume the `PowerUser` role by default, which granted them additional permissions in excess of that they
+_required_ to do their work.
+
+In response to this, we elected to retire the `ReadOnly` role (because nobody used it), and the `User` and `PowerUser` 
+roles in favour of new roles whose granted permissions better reflected those needed by the developers: `Developer`.
+
+We noted that the `Developer` role granted its users the permission to update and delete Kubernetes `Deployment` resources, 
+making it possible to take running applications offline. `Developer` had become the lowest level of privilege available
+to its users, and we felt that the lowest level of privilege should not be capable of causing a production outage.
+However, the ability to mutate `Deployment` resources is a valid and useful permission for developers to have.
+
+In June 2025 we reconsidered the need for a `ReadOnly` role.
+
+## Decision
+
+We have decided to reintroduce the `ReadOnly` role in order to provide a fully read-only level of privilege in a number
+of scenarios:
+
+1. Developers wanting to just look about without changing anything,
+2. Junior/apprentice level roles needing access without the ability to accidentally change anything,
+3. External people, such as pen testers, needing access to our AWS accounts.
+
+We feel that the purpose of a read-only role is to provide a level of privilege which grants no greater a level of access
+than reading the source code would grant. For that reason, we have chosen to explicitly prevent the `ReadOnly` role from
+reading secret values from both AWS Secrets Manager and AWS SSM Parameter Store, as well as preventing it from reading 
+objects within Amazon S3.
+
+We will ensure the role can be assumed in the same way as our other roles; either via GDS CLI or using a predictable name
+in the console.
+
+## Consequences
+
+As a consequence of the decisions we've made, we will have an additional role to maintain over time. We believe this is
+a minimal burden, and by choosing to prevent its access to secrets and objects in S3 we feel we have further mitigated
+any risks it poses.


### PR DESCRIPTION
Introduces an ADR which documents why we've chosen to maintain a readonly role. It also introduces a new guardrail test to ensure the ADR numbering on the file matches the title.