### PR TITLE
Add GitHub Team for ITHC testers and code to grant this team access to repos

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -51,7 +51,7 @@ repos:
       additional_contexts:
         - Test
 
-  bulk-merger:
+  bulk-merger: {}
 
   collections:
     homepage_url: "https://docs.publishing.service.gov.uk/apps/collections.html"
@@ -627,7 +627,7 @@ repos:
   search-api-v2-dataform:
     homepage_url: "https://docs.publishing.service.gov.uk/repos/search-api-v2-dataform.html"
 
-  search-v2-evaluator:
+  search-v2-evaluator: {}
 
   select-with-search-component:
     homepage_url: "https://docs.publishing.service.gov.uk/repos/select-with-search-component.html"


### PR DESCRIPTION
By default, this new team has no access to any repositories. Access has to be explicitly configured for each repository, and defaults to read-only

https://github.com/alphagov/govuk-infrastructure/issues/1973