### PR TITLE
Add analytics bucket access to Fastly Svc Role

### DIFF
--- a/terraform/deployments/security/iam_service_roles.tf
+++ b/terraform/deployments/security/iam_service_roles.tf
@@ -36,10 +36,16 @@ data "aws_iam_policy_document" "govuk_fastly_s3_access" {
       "s3:PutObject",
       "s3:AbortMultipartUpload"
     ]
-    resources = [
-      data.tfe_outputs.fastly_logs.nonsensitive_values.govuk_fastly_logs_s3_bucket_arn,
-      "${data.tfe_outputs.fastly_logs.nonsensitive_values.govuk_fastly_logs_s3_bucket_arn}/*"
-    ]
+    resources = concat(
+      [
+        data.tfe_outputs.fastly_logs.nonsensitive_values.govuk_fastly_logs_s3_bucket_arn,
+        "${data.tfe_outputs.fastly_logs.nonsensitive_values.govuk_fastly_logs_s3_bucket_arn}/*"
+      ],
+      var.govuk_environment == "production" ? [
+        "arn:aws:s3:::govuk-analytics-logs-production",
+        "arn:aws:s3:::govuk-analytics-logs-production/*"
+      ] : []
+    )
   }
 }
 


### PR DESCRIPTION
## What?
This updates the IAM Policy for the Fastly Service Role so that Fastly can also use the new Service Role to write to the analytics bucket (that is only used in Production).

This will continue to reduce our reliance on legacy IAM Access keys.