### PR TITLE
Search API v2: Add `first_published_at` to schema

### DIFF
--- a/terraform/deployments/search-api-v2/datastore_schema.tf
+++ b/terraform/deployments/search-api-v2/datastore_schema.tf
@@ -70,6 +70,13 @@ resource "restapi_object" "google_discovery_engine_datastore_schema" {
           retrievable = true
           indexable   = true
         }
+        # RFC3339 timestamp of when this document was first published (for
+        # sorting/filtering/boosting)
+        first_published_at = {
+          type        = "datetime"
+          retrievable = true
+          indexable   = true
+        }
         # The source document type (for boosting)
         document_type = {
           type        = "string"


### PR DESCRIPTION
This adds a new field to the schema that will contain when a document was first published, allowing us to use that field for boosting purposes.