### PR TITLE
Output publishing subdomain zone id from root-dns TF root

### DIFF
--- a/terraform/deployments/root-dns/outputs.tf
+++ b/terraform/deployments/root-dns/outputs.tf
@@ -17,3 +17,8 @@ output "external_root_zone_name" {
   description = "Name of the external Route53 DNS zone"
   value       = aws_route53_zone.external_zone.name
 }
+
+output "publishing_subdomain_zone_id" {
+  description = "ID of the Route53 DNS zone for the publishing subdomain"
+  value       = aws_route53_zone.publishing_subdomain.id
+}


### PR DESCRIPTION
The subdomain's zone ID is necessary for the govuk-publishing-infrastructure root to add DNS records in subsequent commits