### PR TITLE
Introduce subdomain DNS record management to govuk-publishing-infrastructure

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/subdomain_dns.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/subdomain_dns.tf
@@ -1,0 +1,16 @@
+data "aws_route53_zone" "publishing_subdomain" {
+  zone_id = data.tfe_outputs.root_dns.nonsensitive_values.publishing_subdomain_zone_id
+}
+
+resource "aws_route53_record" "additional_dns_records" {
+  # this could be a simple foreach, but Terraform would think the order matters then
+  # instead transform the list into a name => object pair so that each resource has
+  # a stable name
+  for_each = { for _, v in var.subdomain_dns_records : v.name => v }
+
+  zone_id = data.aws_route53_zone.publishing_subdomain.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = each.value.value
+  ttl     = each.value.ttl
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -169,3 +169,15 @@ variable "office_ips" {
   description = "List of CIDRs from which we consider Office IPs."
   default     = []
 }
+
+variable "subdomain_dns_records" {
+  type = list(object({
+    type  = string
+    name  = string
+    value = list(string)
+    ttl   = number
+  }))
+
+  description = "List of arbitrary DNS records that should be present in the the publishing subdomain's hosted zone"
+  default     = []
+}


### PR DESCRIPTION
We plan to delegate subdomains of `publishing.service.gov.uk` to their own hosted zones in each environment so that they can more easily manage their own DNS.

In `govuk-dns-tf` there are already a number of additional static DNS records that exist on each subdomain. Before we can switch over to using the new, delegated zones we'll need to replicate those DNS records.

This commit introduces a mechanism for adding arbitrary DNS records to the subdomain. Future commits will populate those records.

Subsequent PRs will populate these variables with the correct values for each environment.