### PR TITLE
Allow ITHC testers team to access monitoring & Argo services

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -29,6 +29,7 @@ locals {
     } : {
     "policy.csv" = <<-EOT
     g, ${var.github_read_only_team}, role:readonly
+    g, ${var.github_ithc_team}, role:readonly
     g, ${var.github_read_write_team}, role:admin
     EOT
   }

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -34,6 +34,12 @@ variable "github_read_only_team" {
   default     = "alphagov:gov-uk"
 }
 
+variable "github_ithc_team" {
+  type        = string
+  description = "Name of the GitHub team for ITHC testers to have read-only access to Dex SSO-enabled applications"
+  default     = "alphagov:gov-uk-ithc-and-penetration-testing"
+}
+
 variable "helm_timeout_seconds" {
   type        = number
   description = "Timeout for helm install/upgrade operations."

--- a/terraform/deployments/tfc-configuration/variables-common.tf
+++ b/terraform/deployments/tfc-configuration/variables-common.tf
@@ -6,7 +6,7 @@ module "variable-set-common" {
   tfvars = {
     dex_github_orgs_teams = [{
       name  = "alphagov"
-      teams = ["gov-uk", "gov-uk-production-deploy"]
+      teams = ["gov-uk", "gov-uk-production-deploy", "gov-uk-ithc-and-penetration-testing"]
     }]
   }
 }


### PR DESCRIPTION
This is necessary for allowing testers access to our monitoring stack and tools like ArgoCD and Argo Workflows

https://github.com/alphagov/govuk-infrastructure/issues/1973