### PR TITLE
✨ Add a govuk-reports role to allow cost and rds scraping

### DIFF
--- a/terraform/deployments/govuk-reports/iam.tf
+++ b/terraform/deployments/govuk-reports/iam.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "govuk_reports_permissions" {
     sid = "CostExplorerAccess"
     actions = [
       "ce:GetCostAndUsage",
-      "ce:GetDimensionValues", 
+      "ce:GetDimensionValues",
       "ce:GetRightsizingRecommendation",
       "ce:ListCostCategoryDefinitions"
     ]
@@ -83,3 +83,4 @@ module "govuk_reports_iam_role" {
     application = "govuk-reports"
   }
 }
+

--- a/terraform/deployments/govuk-reports/iam.tf
+++ b/terraform/deployments/govuk-reports/iam.tf
@@ -1,0 +1,85 @@
+# IAM role for govuk-reports application with access to Cost Explorer, RDS, and tagging APIs
+
+locals {
+  govuk_reports_service_account_name = "govuk-reports"
+}
+
+# IAM policy document for govuk-reports permissions
+data "aws_iam_policy_document" "govuk_reports_permissions" {
+  # Cost Explorer permissions
+  statement {
+    sid = "CostExplorerAccess"
+    actions = [
+      "ce:GetCostAndUsage",
+      "ce:GetDimensionValues", 
+      "ce:GetRightsizingRecommendation",
+      "ce:ListCostCategoryDefinitions"
+    ]
+    resources = ["*"]
+  }
+
+  # RDS permissions
+  statement {
+    sid = "RDSAccess"
+    actions = [
+      "rds:DescribeDBInstances",
+      "rds:DescribeDBEngineVersions",
+      "rds:ListTagsForResource",
+      "rds:DescribeDBSubnetGroups",
+      "rds:DescribeDBParameterGroups"
+    ]
+    resources = ["*"]
+  }
+
+  # EC2 and tagging permissions
+  statement {
+    sid = "EC2AndTaggingAccess"
+    actions = [
+      "ec2:DescribeSecurityGroups",
+      "tag:GetResources",
+      "tag:GetTagKeys",
+      "tag:GetTagValues"
+    ]
+    resources = ["*"]
+  }
+}
+
+# IAM policy for govuk-reports
+resource "aws_iam_policy" "govuk_reports" {
+  name        = "govuk-${var.govuk_environment}-reports-policy"
+  description = "Policy for govuk-reports application with access to Cost Explorer, RDS, and tagging APIs"
+  policy      = data.aws_iam_policy_document.govuk_reports_permissions.json
+
+  tags = {
+    system      = "reports"
+    environment = var.govuk_environment
+    application = "govuk-reports"
+  }
+}
+
+# IRSA role for govuk-reports service account
+module "govuk_reports_iam_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.20"
+
+  role_name            = "${local.govuk_reports_service_account_name}-${data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id}"
+  role_description     = "Role for govuk-reports application. Corresponds to ${local.govuk_reports_service_account_name} k8s ServiceAccount."
+  max_session_duration = 28800
+
+  role_policy_arns = {
+    govuk_reports_policy = aws_iam_policy.govuk_reports.arn
+  }
+
+  oidc_providers = {
+    main = {
+      provider_arn               = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_oidc_provider_arn
+      namespace_service_accounts = ["apps:${local.govuk_reports_service_account_name}"]
+    }
+  }
+
+  tags = {
+    system      = "reports"
+    environment = var.govuk_environment
+    application = "govuk-reports"
+  }
+}

--- a/terraform/deployments/govuk-reports/main.tf
+++ b/terraform/deployments/govuk-reports/main.tf
@@ -30,3 +30,4 @@ provider "aws" {
     }
   }
 }
+

--- a/terraform/deployments/govuk-reports/main.tf
+++ b/terraform/deployments/govuk-reports/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  cloud {
+    organization = "govuk"
+    workspaces {
+      tags = ["aws", "govuk-reports"]
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  required_version = "~> 1.5"
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      product              = "govuk"
+      system               = "reports"
+      environment          = var.govuk_environment
+      managed-by           = "terraform"
+      repository           = "govuk-infrastructure"
+      terraform-deployment = "govuk-reports"
+    }
+  }
+}

--- a/terraform/deployments/govuk-reports/remote.tf
+++ b/terraform/deployments/govuk-reports/remote.tf
@@ -1,0 +1,4 @@
+data "tfe_outputs" "cluster_infrastructure" {
+  organization = "govuk"
+  workspace    = "cluster-infrastructure-${var.govuk_environment}"
+}

--- a/terraform/deployments/govuk-reports/variables.tf
+++ b/terraform/deployments/govuk-reports/variables.tf
@@ -1,0 +1,4 @@
+variable "govuk_environment" {
+  type        = string
+  description = "GOV.UK environment where resources are being deployed"
+}

--- a/terraform/deployments/tfc-configuration/govuk-reports.tf
+++ b/terraform/deployments/tfc-configuration/govuk-reports.tf
@@ -1,0 +1,32 @@
+module "govuk-reports-integration" {
+  source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
+
+  organization        = var.organization
+  workspace_name      = "govuk-reports-integration"
+  workspace_desc      = "This module manages the IAM resources needed for the govuk-reports prototype application"
+  workspace_tags      = ["integration", "govuk-reports", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/govuk-reports/"
+  trigger_patterns    = ["/terraform/deployments/govuk-reports/**/*"]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production (r/o)" = "write"
+    "GOV.UK Production"           = "write"
+  }
+
+  variable_set_ids = [
+    local.aws_credentials["integration"],
+    module.variable-set-common.id,
+    module.variable-set-integration.id
+  ]
+}
+


### PR DESCRIPTION
## 👀 Purpose

  - Add IAM role infrastructure for the govuk-reports prototype application (https://github.com/alphagov/govuk-reports-prototype)
  - Enable the prototype to access AWS Cost Explorer, RDS metadata, and resource tagging APIs for cost and infrastructure reporting

## ♻️ What's changed

  - Created new terraform/deployments/govuk-reports/ directory with Terraform configuration
  - Added IRSA (IAM Roles for Service Accounts) role govuk-reports-{cluster-id} with minimal required permissions:
    - Cost Explorer API access (ce:GetCostAndUsage, ce:GetDimensionValues, etc.)
    - RDS metadata access (rds:DescribeDBInstances, rds:ListTagsForResource, etc.)
    - EC2 security group and resource tagging permissions (ec2:DescribeSecurityGroups, tag:GetResources, etc.)

## 📝 Notes

- This supports the govuk-reports prototype for cost reporting and RDS infrastructure analysis
- Uses modern IRSA pattern following existing conventions in the repository
- Role will be available to the govuk-reports service account in the apps namespace
- All permissions follow principle of least privilege for the specific reporting use cases