### PR TITLE
Turn on logical replication for ckan integration

### DIFF
--- a/terraform/deployments/rds/temp_file_postgres_upgrade.tf
+++ b/terraform/deployments/rds/temp_file_postgres_upgrade.tf
@@ -1,0 +1,23 @@
+resource "aws_db_parameter_group" "postgresql14_green_params" {
+
+  name_prefix = "${var.govuk_environment}-ckan-postgres-"
+  family      = "postgres14"
+
+  parameter {
+    name  = "rds.logical_replication"
+    value = "1"
+  }
+
+  parameter {
+    name  = "max_logical_replication_workers"
+    value = "20"
+  }
+
+  parameter {
+    name  = "max_worker_processes"
+    value = "25"
+  }
+
+  lifecycle { create_before_destroy = true }
+
+}

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -205,7 +205,10 @@ module "variable-set-rds-integration" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication"  = { value = 1, apply_method = "pending-reboot" }
+          max_wal_senders            = { value = 35, apply_method = "pending-reboot" }
         }
+        backup_retention_period      = 1
         engine_params_family         = "postgres13"
         name                         = "ckan"
         allocated_storage            = 1000


### PR DESCRIPTION
Description:
- Set up green parameter group for Postgres14 upgrade
- Turn on logical replication to enable blue-green deployments
- https://github.com/alphagov/govuk-infrastructure/issues/2326