### PR TITLE
Set apply to pending reboot for postgres14 green params

### DIFF
--- a/terraform/deployments/rds/temp_file_postgres_upgrade.tf
+++ b/terraform/deployments/rds/temp_file_postgres_upgrade.tf
@@ -4,18 +4,21 @@ resource "aws_db_parameter_group" "postgresql14_green_params" {
   family      = "postgres14"
 
   parameter {
-    name  = "rds.logical_replication"
-    value = "1"
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
   }
 
   parameter {
-    name  = "max_logical_replication_workers"
-    value = "20"
+    name         = "max_logical_replication_workers"
+    value        = "20"
+    apply_method = "pending-reboot"
   }
 
   parameter {
-    name  = "max_worker_processes"
-    value = "25"
+    name         = "max_worker_processes"
+    value        = "25"
+    apply_method = "pending-reboot"
   }
 
   lifecycle { create_before_destroy = true }


### PR DESCRIPTION
Description:
- Terraform sets `apply_method` to `apply immediately` which won't work for static parameters which require a DB reboot
- This is to satisfy the API as at this moment the DB parameter group is created not the green RDS instance
- https://github.com/alphagov/govuk-infrastructure/issues/2326