### PR TITLE
Set `max_logical_replication_workers` to 20 for ckan postgres in integration

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -201,12 +201,13 @@ module "variable-set-rds-integration" {
         engine         = "postgres"
         engine_version = "13"
         engine_params = {
-          log_min_duration_statement = { value = 10000 }
-          log_statement              = { value = "all" }
-          deadlock_timeout           = { value = 2500 }
-          log_lock_waits             = { value = 1 }
-          "rds.logical_replication"  = { value = 1, apply_method = "pending-reboot" }
-          max_wal_senders            = { value = 35, apply_method = "pending-reboot" }
+          log_min_duration_statement      = { value = 10000 }
+          log_statement                   = { value = "all" }
+          deadlock_timeout                = { value = 2500 }
+          log_lock_waits                  = { value = 1 }
+          "rds.logical_replication"       = { value = 1, apply_method = "pending-reboot" }
+          max_wal_senders                 = { value = 35, apply_method = "pending-reboot" }
+          max_logical_replication_workers = { value = 20, apply_method = "pending-reboot" }
         }
         backup_retention_period      = 1
         engine_params_family         = "postgres13"


### PR DESCRIPTION
Description:
- Default replication slots is 20 so this needs to be explicitly set to match it
- https://github.com/alphagov/govuk-infrastructure/issues/2326