### PR TITLE
Set `max_worker_processes` on CKAN integration postgres

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -208,6 +208,7 @@ module "variable-set-rds-integration" {
           "rds.logical_replication"       = { value = 1, apply_method = "pending-reboot" }
           max_wal_senders                 = { value = 35, apply_method = "pending-reboot" }
           max_logical_replication_workers = { value = 20, apply_method = "pending-reboot" }
+          max_worker_processes            = { value = 40, apply_method = "pending-reboot" }
         }
         backup_retention_period      = 1
         engine_params_family         = "postgres13"


### PR DESCRIPTION
Description:
- `max_worker_processes` > 21 is required. Setting it to 40 will give enough overhead for logical replication workers and wal senders and other background processes
- https://github.com/alphagov/govuk-infrastructure/issues/2326