### PR TITLE
Fix markdown in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -1,17 +1,17 @@
 <!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
 ## :eyes: Purpose
 
-•
+*
 
 <!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
 ## :recycle: What's Changed
 
-•
+*
 
 <!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
 ## :memo: Notes
 
-•
+*
 
 ---
 <!-- Optionally, check you've completed the following actions before submitting the PR -->


### PR DESCRIPTION
When using the PR template, I noticed the markdown didn't use valid github markdown bullet point characters. Instead of * or - it used a unicode • which is U+2022 : BULLET {black small circle}

You can see in the example below that using this character doesn't create HTML `<ul>` items, and so isn't semantically a valid list

• fake bullet point 1
• fake bullet point 2

* Real bullet point 1
* Real bullet point 1

This PR just swaps the U+2022 characters for *