### PR TITLE
BAU - Set `apply_immediately` for non-prod environments in RDS

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -63,7 +63,7 @@ resource "aws_db_instance" "instance" {
   monitoring_role_arn     = data.tfe_outputs.logging.nonsensitive_values.rds_enhanced_monitoring_role_arn
   vpc_security_group_ids  = [aws_security_group.rds[each.key].id]
   ca_cert_identifier      = "rds-ca-rsa2048-g1"
-  apply_immediately       = true # var.govuk_environment != "production"
+  apply_immediately       = var.govuk_environment != "production"
 
   performance_insights_enabled          = each.value.performance_insights_enabled
   performance_insights_retention_period = each.value.performance_insights_enabled ? 7 : 0


### PR DESCRIPTION
Description:
- Currently `apply_immediately` is set to true for all environments but this should only be the case for non-prod environments
- Cleans up https://github.com/alphagov/govuk-infrastructure/pull/1752