### PR TITLE
Remove CKAN PostgreSQL 13 imports

### DIFF
--- a/terraform/deployments/rds/import.tf
+++ b/terraform/deployments/rds/import.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["ckan"]
-  id = "ckan-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["ckan"]
-  id = "integration-ckan-postgres-20250305112304940000000016"
-}


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2366 imported CKAN PostgreSQL 13 and the parameter group so now we can remove the imports
- https://github.com/alphagov/govuk-infrastructure/issues/2326