### PR TITLE
Add configuration for elasticsearch6 in integration

### DIFF
--- a/terraform/deployments/elasticsearch/README.md
+++ b/terraform/deployments/elasticsearch/README.md
@@ -1,0 +1,82 @@
+# Elasticsearch cluster
+
+Managed Elasticsearch 6 cluster
+
+The snapshot repository configuration is not currently done via Terraform;
+see register-snapshot-repository.py.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.10 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | 0.67.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.opensearch_error_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.opensearch_index_slow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.opensearch_search_slow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_resource_policy.opensearch_log_publishing_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
+| [aws_elasticsearch_domain.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain) | resource |
+| [aws_iam_policy.can_configure_es_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.manual_snapshot_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.manual_snapshot_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.manual_snapshot_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_service_linked_role.es_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
+| [aws_route53_record.service_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_s3_bucket.manual_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_logging.manual_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_policy.manual_snapshots_cross_account_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_acm_certificate.govuk_internal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.can_configure_es_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.domain_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.es_can_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.manual_snapshot_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.manual_snapshots_cross_account_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.opensearch_log_publishing_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [tfe_outputs.cluster_infrastructure](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/outputs) | data source |
+| [tfe_outputs.logging](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/outputs) | data source |
+| [tfe_outputs.root_dns](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/outputs) | data source |
+| [tfe_outputs.security](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/outputs) | data source |
+| [tfe_outputs.vpc](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/outputs) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"eu-west-1"` | no |
+| <a name="input_dedicated_master"></a> [dedicated\_master](#input\_dedicated\_master) | Dedicated master settings, leave null to disable dedicated master | <pre>object({<br>    instance_count = number<br>    instance_type = string<br>  })</pre> | `null` | no |
+| <a name="input_ebs"></a> [ebs](#input\_ebs) | EBS configuration, leave null to disable EBS | <pre>object({<br>    volume_size      = number<br>    volume_type      = string<br>    throughput       = number<br>    provisioned_iops = number<br>  })</pre> | `null` | no |
+| <a name="input_elasticsearch6_manual_snapshot_bucket_arns"></a> [elasticsearch6\_manual\_snapshot\_bucket\_arns](#input\_elasticsearch6\_manual\_snapshot\_bucket\_arns) | A list of S3 Bucket ARNS that the manual snapshot role should be able to access | `list(string)` | n/a | yes |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version of the opensearch cluster | `string` | n/a | yes |
+| <a name="input_govuk_environment"></a> [govuk\_environment](#input\_govuk\_environment) | Acceptable values are test, integration, staging, production | `string` | n/a | yes |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | n/a | `number` | n/a | yes |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | `string` | n/a | yes |
+| <a name="input_stackname"></a> [stackname](#input\_stackname) | Name of the stack, valid options are 'blue' and 'green' | `string` | n/a | yes |
+| <a name="input_tls_security_policy"></a> [tls\_security\_policy](#input\_tls\_security\_policy) | The pre-canned AWS security policy to enforce for connections to opensearch | `string` | n/a | yes |
+| <a name="input_zone_awareness_enabled"></a> [zone\_awareness\_enabled](#input\_zone\_awareness\_enabled) | n/a | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_domain_configuration_policy_arn"></a> [domain\_configuration\_policy\_arn](#output\_domain\_configuration\_policy\_arn) | ARN of the policy used to configure the elasticsearch domain |
+| <a name="output_manual_snapshots_bucket_arn"></a> [manual\_snapshots\_bucket\_arn](#output\_manual\_snapshots\_bucket\_arn) | ARN of the bucket to store manual snapshots |
+| <a name="output_service_dns_name"></a> [service\_dns\_name](#output\_service\_dns\_name) | DNS name to access the Elasticsearch internal service |
+| <a name="output_service_endpoint"></a> [service\_endpoint](#output\_service\_endpoint) | Endpoint to submit index, search, and upload requests |

--- a/terraform/deployments/elasticsearch/data.tf
+++ b/terraform/deployments/elasticsearch/data.tf
@@ -1,0 +1,33 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {
+  name = var.aws_region
+}
+data "tfe_outputs" "cluster_infrastructure" {
+  organization = "govuk"
+  workspace    = "cluster-infrastructure-${var.govuk_environment}"
+}
+
+data "tfe_outputs" "security" {
+  organization = "govuk"
+  workspace    = "security-${var.govuk_environment}"
+}
+
+data "tfe_outputs" "vpc" {
+  organization = "govuk"
+  workspace    = "vpc-${var.govuk_environment}"
+}
+
+data "tfe_outputs" "root_dns" {
+  organization = "govuk"
+  workspace    = "root-dns-${var.govuk_environment}"
+}
+
+data "tfe_outputs" "logging" {
+  organization = "govuk"
+  workspace    = "logging-${var.govuk_environment}"
+}
+
+data "aws_acm_certificate" "govuk_internal" {
+  domain   = "*.${var.govuk_environment}.govuk-internal.digital"
+  statuses = ["ISSUED"]
+}

--- a/terraform/deployments/elasticsearch/iam.tf
+++ b/terraform/deployments/elasticsearch/iam.tf
@@ -1,0 +1,83 @@
+import {
+  to = aws_iam_role.manual_snapshot_role
+  id = "${var.stackname}-elasticsearch6-manual-snapshot-role"
+}
+
+resource "aws_iam_role" "manual_snapshot_role" {
+  name               = "${var.stackname}-elasticsearch6-manual-snapshot-role"
+  assume_role_policy = data.aws_iam_policy_document.es_can_assume_role.json
+}
+
+data "aws_iam_policy_document" "es_can_assume_role" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["es.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+import {
+  to = aws_iam_policy.manual_snapshot_bucket_policy
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/govuk-${var.govuk_environment}-elasticsearch6-manual-snapshot-bucket-policy"
+}
+
+resource "aws_iam_policy" "manual_snapshot_bucket_policy" {
+  name   = "govuk-${var.govuk_environment}-elasticsearch6-manual-snapshot-bucket-policy"
+  policy = data.aws_iam_policy_document.manual_snapshot_bucket_policy.json
+}
+
+data "aws_iam_policy_document" "manual_snapshot_bucket_policy" {
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = var.elasticsearch6_manual_snapshot_bucket_arns
+  }
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = formatlist("%s/*", var.elasticsearch6_manual_snapshot_bucket_arns)
+  }
+}
+
+import {
+  to = aws_iam_role_policy_attachment.manual_snapshot_role_policy
+  id = "${aws_iam_role.manual_snapshot_role.name}/${aws_iam_policy.manual_snapshot_bucket_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "manual_snapshot_role_policy" {
+  role       = aws_iam_role.manual_snapshot_role.name
+  policy_arn = aws_iam_policy.manual_snapshot_bucket_policy.arn
+
+}
+
+import {
+  to = aws_iam_policy.can_configure_es_snapshots
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/govuk-${var.govuk_environment}-elasticsearch6-manual-snapshot-domain-configuration-policy"
+}
+
+resource "aws_iam_policy" "can_configure_es_snapshots" {
+  name        = "govuk-${var.govuk_environment}-elasticsearch6-manual-snapshot-domain-configuration-policy"
+  description = "Human operator permissions for initial setup of the snapshot bucket for the ES domain. https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html#es-managedomains-snapshot-prerequisites"
+  policy      = data.aws_iam_policy_document.can_configure_es_snapshots.json
+
+  lifecycle {
+    ignore_changes = [
+      description # Inexplicably immutable in AWS.
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "can_configure_es_snapshots" {
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.manual_snapshot_role.arn]
+  }
+  statement {
+    actions   = ["es:ESHttpPut"]
+    resources = ["${aws_elasticsearch_domain.opensearch.arn}/*"]
+  }
+}

--- a/terraform/deployments/elasticsearch/main.tf
+++ b/terraform/deployments/elasticsearch/main.tf
@@ -1,0 +1,229 @@
+/***
+ * # Elasticsearch cluster
+ *
+ * Managed Elasticsearch 6 cluster
+ *
+ * The snapshot repository configuration is not currently done via Terraform;
+ * see register-snapshot-repository.py.
+ */
+
+terraform {
+  cloud {
+    organization = "govuk"
+    workspaces {
+      tags = ["elasticsearch", "aws"]
+    }
+  }
+  required_version = "~> 1.10"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      aws_environment      = var.govuk_environment
+      project              = "GOV.UK - Search"
+      terraform_deployment = "app-elasticsearch6"
+    }
+  }
+}
+
+locals {
+  domain = "${var.stackname}-elasticsearch6-domain"
+  subnet_ids = [
+    data.tfe_outputs.vpc.nonsensitive_values.private_subnet_ids["elasticsearch_a"],
+    data.tfe_outputs.vpc.nonsensitive_values.private_subnet_ids["elasticsearch_b"],
+    data.tfe_outputs.vpc.nonsensitive_values.private_subnet_ids["elasticsearch_c"],
+  ]
+  // master_user = "${var.service}-masteruser"
+}
+
+/*
+resource "random_password" "password" {
+  length  = 32
+  special = true
+}
+*/
+
+import {
+  to = aws_cloudwatch_log_group.opensearch_search_slow_logs
+  id = "/aws/aes/domains/${local.domain}/es6-search-logs"
+}
+
+resource "aws_cloudwatch_log_group" "opensearch_search_slow_logs" {
+  name              = "/aws/aes/domains/${local.domain}/es6-search-logs"
+  retention_in_days = 3
+}
+
+import {
+  to = aws_cloudwatch_log_group.opensearch_index_slow_logs
+  id = "/aws/aes/domains/${local.domain}/es6-index-logs"
+}
+
+resource "aws_cloudwatch_log_group" "opensearch_index_slow_logs" {
+  name              = "/aws/aes/domains/${local.domain}/es6-index-logs"
+  retention_in_days = 3
+}
+
+import {
+  to = aws_cloudwatch_log_group.opensearch_error_logs
+  id = "/aws/aes/domains/${local.domain}/es6-application-logs"
+}
+
+resource "aws_cloudwatch_log_group" "opensearch_error_logs" {
+  name              = "/aws/aes/domains/${local.domain}/es6-application-logs"
+  retention_in_days = 3
+}
+
+data "aws_iam_policy_document" "opensearch_log_publishing_policy" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["es.amazonaws.com"]
+    }
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+    ]
+
+    resources = [
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/aes/domains/${local.domain}/*"
+    ]
+  }
+}
+
+import {
+  to = aws_cloudwatch_log_resource_policy.opensearch_log_publishing_policy
+  id = "elasticsearch6_log_resource_policy"
+}
+
+resource "aws_cloudwatch_log_resource_policy" "opensearch_log_publishing_policy" {
+  policy_name = "elasticsearch6_log_resource_policy"
+
+  policy_document = data.aws_iam_policy_document.opensearch_log_publishing_policy.json
+}
+
+import {
+  to = aws_iam_service_linked_role.es_role
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/es.amazonaws.com/AWSServiceRoleForAmazonElasticsearchService"
+}
+
+resource "aws_iam_service_linked_role" "es_role" {
+  aws_service_name = "es.amazonaws.com"
+}
+
+import {
+  to = aws_elasticsearch_domain.opensearch
+  id = local.domain
+}
+
+resource "aws_elasticsearch_domain" "opensearch" {
+  depends_on = [aws_iam_service_linked_role.es_role]
+
+  domain_name           = local.domain
+  elasticsearch_version = var.engine_version
+
+  cluster_config {
+    dedicated_master_enabled = var.dedicated_master != null
+    dedicated_master_count   = var.dedicated_master == null ? 0 : var.dedicated_master.instance_count
+    dedicated_master_type    = var.dedicated_master == null ? null : var.dedicated_master.instance_type
+    instance_count           = var.instance_count
+    instance_type            = var.instance_type
+    zone_awareness_enabled   = var.zone_awareness_enabled
+    zone_awareness_config {
+      availability_zone_count = var.zone_awareness_enabled ? length(local.subnet_ids) : null
+    }
+  }
+
+  advanced_security_options {
+    enabled = false
+  }
+
+  encrypt_at_rest {
+    enabled = false
+  }
+
+  domain_endpoint_options {
+    enforce_https                   = false
+    tls_security_policy             = var.tls_security_policy
+    custom_endpoint_enabled         = true
+    custom_endpoint                 = "elasticsearch6.${var.govuk_environment}.govuk-internal.digital"
+    custom_endpoint_certificate_arn = data.aws_acm_certificate.govuk_internal.arn
+  }
+
+  dynamic "ebs_options" {
+    for_each = var.ebs[*]
+
+    content {
+      ebs_enabled = true
+      volume_size = ebs_options.value.volume_size
+      volume_type = ebs_options.value.volume_type
+      throughput  = ebs_options.value.throughput
+      iops        = ebs_options.value.provisioned_iops
+    }
+  }
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.opensearch_index_slow_logs.arn
+    log_type                 = "INDEX_SLOW_LOGS"
+  }
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.opensearch_search_slow_logs.arn
+    log_type                 = "SEARCH_SLOW_LOGS"
+  }
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.opensearch_error_logs.arn
+    log_type                 = "ES_APPLICATION_LOGS"
+  }
+
+  node_to_node_encryption {
+    enabled = false
+  }
+
+  vpc_options {
+    subnet_ids         = local.subnet_ids
+    security_group_ids = [data.tfe_outputs.security.nonsensitive_values.govuk_elasticsearch6_access_sg_id]
+  }
+
+  access_policies = data.aws_iam_policy_document.domain_access_policy.json
+
+  tags = {
+    Name          = "${var.stackname}-elasticsearch6"
+    Project       = "${var.stackname}"
+    aws_stackname = "${var.stackname}"
+  }
+}
+
+data "aws_iam_policy_document" "domain_access_policy" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions   = ["es:*"]
+    resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.domain}/*"]
+  }
+}
+
+import {
+  to = aws_route53_record.service_record
+  id = "${data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_id}_elasticsearch6.${var.stackname}.${data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_name}_CNAME"
+}
+
+resource "aws_route53_record" "service_record" {
+  zone_id = data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_id
+  name    = "elasticsearch6.${var.stackname}.${data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_name}"
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_elasticsearch_domain.opensearch.endpoint]
+}

--- a/terraform/deployments/elasticsearch/outputs.tf
+++ b/terraform/deployments/elasticsearch/outputs.tf
@@ -1,0 +1,19 @@
+output "service_endpoint" {
+  value       = aws_elasticsearch_domain.opensearch.endpoint
+  description = "Endpoint to submit index, search, and upload requests"
+}
+
+output "service_dns_name" {
+  value       = aws_route53_record.service_record.fqdn
+  description = "DNS name to access the Elasticsearch internal service"
+}
+
+output "domain_configuration_policy_arn" {
+  value       = aws_iam_policy.can_configure_es_snapshots.arn
+  description = "ARN of the policy used to configure the elasticsearch domain"
+}
+
+output "manual_snapshots_bucket_arn" {
+  value       = aws_s3_bucket.manual_snapshots.arn
+  description = "ARN of the bucket to store manual snapshots"
+}

--- a/terraform/deployments/elasticsearch/register-snapshot-repository.py
+++ b/terraform/deployments/elasticsearch/register-snapshot-repository.py
@@ -1,0 +1,76 @@
+"""
+WARNING: This script was munged together between a very old one which wasn't updated
+for running in EKS, and one that chat wrote for initialising their opensearch cluster
+neither the instructions, nor the code, has been tested in anger
+
+https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-snapshots.html
+This script has been copied from:
+https://raw.githubusercontent.com/alphagov/govuk-aws/main/terraform/projects/app-elasticsearch6/register-snapshot-repository.py
+and is to be used to register the required S3 buckets as repositories for the Elasticsearch backup jobs,
+in Integration, Staging and Production environments, which are run by EKS as cronjobs.
+
+Instructions for running this script:
+$ eval $(gds aws govuk-[test|integration|staging|production]-fulladmin -e -art 8h)
+$ OPENSEARCH_URL=$(aws opensearch describe-domain --domain-name blue-elasticsearch6-domain  | jq -r '.DomainStatus.Endpoints.vpc')
+$ kubectl relay host/$OPENSEARCH_URL 4443:443
+Open https://localhost:4443/_dashboards in a browser and log in
+Map your AWS Role using instructions in Step 1 of https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-snapshots.html#managedomains-snapshot-registerdirectory
+$ virtualenv venv
+$ source venv/bin/activate
+$ pip install boto3 requests requests-aws4auth
+$ python register-snapshot-repository.py [integration|staging|production]
+"""
+
+import os
+import sys
+import boto3
+import requests
+from requests_aws4auth import AWS4Auth
+
+host = 'https://localhost:4443/'
+region = 'eu-west-1'
+service = 'es'
+credentials = boto3.Session().get_credentials()
+awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+
+def register_repository(name, role_arn, delete_first=False, read_only=False):
+    print(name)
+
+    url = host + '_snapshot/' + name
+
+    if delete_first:
+        r = requests.delete(url)
+        r.raise_for_status()
+        print(r.text)
+
+    payload = {
+        "type": "s3",
+        "settings": {
+            "bucket": name + '-elasticsearch6-manual-snapshots',
+            "region": region,
+            "role_arn": role_arn,
+            "readonly": read_only
+        }
+    }
+
+    headers = {"Content-Type": "application/json"}
+
+    r = requests.put(url, auth=awsauth, json=payload, headers=headers, verify=False)
+    r.raise_for_status()
+    print(r.text)
+
+delete_first = 'DELETE_FIRST' in os.environ
+
+if sys.argv[1] == 'integration':
+    role_arn = 'arn:aws:iam::210287912431:role/blue-elasticsearch6-manual-snapshot-role'
+    register_repository('govuk-integration', role_arn, delete_first=delete_first)
+    register_repository('govuk-staging', role_arn, delete_first=delete_first, read_only=True)
+elif sys.argv[1] == 'staging':
+    role_arn = 'arn:aws:iam::696911096973:role/blue-elasticsearch6-manual-snapshot-role'
+    register_repository('govuk-staging', role_arn, delete_first=delete_first)
+    register_repository('govuk-production', role_arn, delete_first=delete_first, read_only=True)
+elif sys.argv[1] == 'production':
+    role_arn = 'arn:aws:iam::172025368201:role/blue-elasticsearch6-manual-snapshot-role'
+    register_repository('govuk-production', role_arn, delete_first=delete_first)
+else:
+    print('expected one of [integration|staging|production]')

--- a/terraform/deployments/elasticsearch/s3.tf
+++ b/terraform/deployments/elasticsearch/s3.tf
@@ -1,0 +1,64 @@
+locals {
+  bucket_name = "govuk-${var.govuk_environment}-elasticsearch6-manual-snapshots"
+}
+
+import {
+  to = aws_s3_bucket.manual_snapshots
+  id = local.bucket_name
+}
+
+resource "aws_s3_bucket" "manual_snapshots" {
+  bucket = local.bucket_name
+  tags = {
+    Name = local.bucket_name
+  }
+}
+
+import {
+  to = aws_s3_bucket_logging.manual_snapshots
+  id = local.bucket_name
+}
+
+resource "aws_s3_bucket_logging" "manual_snapshots" {
+  bucket        = aws_s3_bucket.manual_snapshots.id
+  target_bucket = data.tfe_outputs.logging.nonsensitive_values.aws_logging_bucket_id
+  target_prefix = "s3/${local.bucket_name}/"
+}
+
+import {
+  to = aws_s3_bucket_policy.manual_snapshots_cross_account_access
+  id = local.bucket_name
+}
+
+resource "aws_s3_bucket_policy" "manual_snapshots_cross_account_access" {
+  bucket = aws_s3_bucket.manual_snapshots.id
+  policy = data.aws_iam_policy_document.manual_snapshots_cross_account_access.json
+}
+
+data "aws_iam_policy_document" "manual_snapshots_cross_account_access" {
+  statement {
+    sid = "CrossAccountAccess"
+    principals {
+      type = "AWS"
+      identifiers = [
+        "172025368201", # Production
+        "696911096973", # Staging
+        "210287912431", # Integration
+      ]
+    }
+    # This bucket is only for copying the indices from prod to
+    # staging/integration. Backup snapshots of prod are stored separately, so
+    # the (required) put/delete permissions here don't represent a problem.
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:PutObjectAcl",
+    ]
+    resources = [
+      aws_s3_bucket.manual_snapshots.arn,
+      "${aws_s3_bucket.manual_snapshots.arn}/*",
+    ]
+  }
+}

--- a/terraform/deployments/elasticsearch/variables.tf
+++ b/terraform/deployments/elasticsearch/variables.tf
@@ -1,0 +1,63 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "govuk_environment" {
+  type        = string
+  description = "Acceptable values are test, integration, staging, production"
+}
+
+variable "stackname" {
+  type        = string
+  description = "Name of the stack, valid options are 'blue' and 'green'"
+
+  validation {
+    condition     = var.stackname == "blue" || var.stackname == "green"
+    error_message = "stackname must be one of 'blue' or 'green'"
+  }
+}
+
+variable "engine_version" {
+  type        = string
+  description = "The engine version of the opensearch cluster"
+}
+
+variable "instance_type" { type = string }
+variable "instance_count" { type = number }
+
+variable "dedicated_master" {
+  type = object({
+    instance_count = number
+    instance_type  = string
+  })
+  description = "Dedicated master settings, leave null to disable dedicated master"
+  default     = null
+}
+
+variable "ebs" {
+  type = object({
+    volume_size      = number
+    volume_type      = string
+    throughput       = number
+    provisioned_iops = number
+  })
+  description = "EBS configuration, leave null to disable EBS"
+  default     = null
+}
+
+variable "tls_security_policy" {
+  type        = string
+  description = "The pre-canned AWS security policy to enforce for connections to opensearch"
+}
+
+variable "zone_awareness_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "elasticsearch6_manual_snapshot_bucket_arns" {
+  type        = list(string)
+  description = "A list of S3 Bucket ARNS that the manual snapshot role should be able to access"
+}

--- a/terraform/deployments/tfc-configuration/elasticsearch.tf
+++ b/terraform/deployments/tfc-configuration/elasticsearch.tf
@@ -1,0 +1,32 @@
+module "elasticsearch-integration" {
+  source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
+
+  organization      = var.organization
+  workspace_name    = "elasticsearch-integration"
+  workspace_desc    = "This module manages AWS resources for creating an Elasticsearch cluster."
+  workspace_tags    = ["integration", "elasticsearch", "aws"]
+  terraform_version = var.terraform_version
+  execution_mode    = "remote"
+  working_directory = "/terraform/deployments/elasticsearch/"
+  trigger_patterns  = ["/terraform/deployments/elasticsearch/**/*"]
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production (r/o)" = "write"
+    "GOV.UK Production"           = "write"
+  }
+
+  variable_set_ids = [
+    local.aws_credentials["integration"],
+    module.variable-set-common.id,
+    module.variable-set-integration.id,
+    module.variable-set-elasticsearch-integration.id
+  ]
+}
+

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -636,3 +636,38 @@ module "variable-set-elasticache-integration" {
     }
   }
 }
+
+module "variable-set-elasticsearch-integration" {
+  source = "./variable-set"
+
+  name = "elasticsearch-integration"
+
+  tfvars = {
+    ebs = {
+      volume_size      = 314
+      volume_type      = "gp3"
+      throughput       = 250
+      provisioned_iops = 3000
+    }
+    govuk_environment      = "integration"
+    engine_version         = "6.7"
+    zone_awareness_enabled = true
+
+    instance_count = 3
+    instance_type  = "r7i.xlarge.elasticsearch"
+
+    dedicated_master = {
+      instance_count = 3
+      instance_type  = "c7i.xlarge.elasticsearch"
+    }
+
+    tls_security_policy = "Policy-Min-TLS-1-0-2019-07"
+
+    stackname = "blue"
+
+    elasticsearch6_manual_snapshot_bucket_arns = [
+      "arn:aws:s3:::govuk-staging-elasticsearch6-manual-snapshots",
+      "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots"
+    ]
+  }
+}


### PR DESCRIPTION
This imports (when tested locally using local state, not in TFC) elasticsearch6 in integration

I am unsure about the TFC configuration (and especially the tags on the terraform cloud config block, and on the variable set and workspace.

with a local plan with the following tfvars file:

```tf
ebs = {
  volume_size      = 314
  volume_type      = "gp3"
  throughput       = 250
  provisioned_iops = 3000
}
govuk_environment      = "integration"
engine_version         = "6.7"
zone_awareness_enabled = true

instance_count = 3
instance_type  = "r7i.xlarge.elasticsearch"

dedicated_master = {
  instance_count = 3
  instance_type  = "c7i.xlarge.elasticsearch"
}

tls_security_policy = "Policy-Min-TLS-1-0-2019-07"

stackname = "blue"

elasticsearch6_manual_snapshot_bucket_arns = [
  "arn:aws:s3:::govuk-staging-elasticsearch6-manual-snapshots",
  "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots"
]
```
<details><summary>Terraform plan when planning for a local state</summary>


```tf
Terraform will perform the following actions:

  # aws_cloudwatch_log_group.opensearch_error_logs will be imported
    resource "aws_cloudwatch_log_group" "opensearch_error_logs" {
        arn               = "arn:aws:logs:eu-west-1:210287912431:log-group:/aws/aes/domains/blue-elasticsearch6-domain/es6-application-logs"
        id                = "/aws/aes/domains/blue-elasticsearch6-domain/es6-application-logs"
        kms_key_id        = null
        log_group_class   = "STANDARD"
        name              = "/aws/aes/domains/blue-elasticsearch6-domain/es6-application-logs"
        name_prefix       = null
        retention_in_days = 3
        skip_destroy      = false
        tags              = {}
        tags_all          = {
            "aws_environment"      = "integration"
            "project"              = "GOV.UK - Search"
            "terraform_deployment" = "app-elasticsearch6"
        }
    }

  # aws_cloudwatch_log_group.opensearch_index_slow_logs will be imported
    resource "aws_cloudwatch_log_group" "opensearch_index_slow_logs" {
        arn               = "arn:aws:logs:eu-west-1:210287912431:log-group:/aws/aes/domains/blue-elasticsearch6-domain/es6-index-logs"
        id                = "/aws/aes/domains/blue-elasticsearch6-domain/es6-index-logs"
        kms_key_id        = null
        log_group_class   = "STANDARD"
        name              = "/aws/aes/domains/blue-elasticsearch6-domain/es6-index-logs"
        name_prefix       = null
        retention_in_days = 3
        skip_destroy      = false
        tags              = {}
        tags_all          = {
            "aws_environment"      = "integration"
            "project"              = "GOV.UK - Search"
            "terraform_deployment" = "app-elasticsearch6"
        }
    }

  # aws_cloudwatch_log_group.opensearch_search_slow_logs will be imported
    resource "aws_cloudwatch_log_group" "opensearch_search_slow_logs" {
        arn               = "arn:aws:logs:eu-west-1:210287912431:log-group:/aws/aes/domains/blue-elasticsearch6-domain/es6-search-logs"
        id                = "/aws/aes/domains/blue-elasticsearch6-domain/es6-search-logs"
        kms_key_id        = null
        log_group_class   = "STANDARD"
        name              = "/aws/aes/domains/blue-elasticsearch6-domain/es6-search-logs"
        name_prefix       = null
        retention_in_days = 3
        skip_destroy      = false
        tags              = {}
        tags_all          = {
            "aws_environment"      = "integration"
            "project"              = "GOV.UK - Search"
            "terraform_deployment" = "app-elasticsearch6"
        }
    }

  # aws_cloudwatch_log_resource_policy.opensearch_log_publishing_policy will be imported
    resource "aws_cloudwatch_log_resource_policy" "opensearch_log_publishing_policy" {
        id              = "elasticsearch6_log_resource_policy"
        policy_document = jsonencode(
            {
                Statement = [
                    {
                        Action    = [
                            "logs:PutLogEventsBatch",
                            "logs:PutLogEvents",
                            "logs:CreateLogStream",
                        ]
                        Effect    = "Allow"
                        Principal = {
                            Service = "es.amazonaws.com"
                        }
                        Resource  = "arn:aws:logs:eu-west-1:210287912431:log-group:/aws/aes/domains/blue-elasticsearch6-domain/*"
                        Sid       = ""
                    },
                ]
                Version   = "2012-10-17"
            }
        )
        policy_name     = "elasticsearch6_log_resource_policy"
    }

  # aws_elasticsearch_domain.opensearch will be imported
    resource "aws_elasticsearch_domain" "opensearch" {
        access_policies       = jsonencode(
            {
                Statement = [
                    {
                        Action    = "es:*"
                        Effect    = "Allow"
                        Principal = {
                            AWS = "*"
                        }
                        Resource  = "arn:aws:es:eu-west-1:210287912431:domain/blue-elasticsearch6-domain/*"
                    },
                ]
                Version   = "2012-10-17"
            }
        )
        advanced_options      = {
            "override_main_response_version" = "true"
        }
        arn                   = "arn:aws:es:eu-west-1:210287912431:domain/blue-elasticsearch6-domain"
        domain_id             = "210287912431/blue-elasticsearch6-domain"
        domain_name           = "blue-elasticsearch6-domain"
        elasticsearch_version = "6.7"
        endpoint              = "vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com"
        id                    = "arn:aws:es:eu-west-1:210287912431:domain/blue-elasticsearch6-domain"
        kibana_endpoint       = "vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com/_plugin/kibana/"
        tags                  = {
            "Name"          = "blue-elasticsearch6"
            "Project"       = "blue"
            "aws_stackname" = "blue"
        }
        tags_all              = {
            "Name"                 = "blue-elasticsearch6"
            "Project"              = "blue"
            "aws_environment"      = "integration"
            "aws_stackname"        = "blue"
            "project"              = "GOV.UK - Search"
            "terraform_deployment" = "app-elasticsearch6"
        }

        advanced_security_options {
            enabled                        = false
            internal_user_database_enabled = false
        }

        auto_tune_options {
            desired_state       = "ENABLED"
            rollback_on_disable = "NO_ROLLBACK"
        }

        cluster_config {
            dedicated_master_count   = 3
            dedicated_master_enabled = true
            dedicated_master_type    = "c7i.xlarge.elasticsearch"
            instance_count           = 3
            instance_type            = "r7i.xlarge.elasticsearch"
            warm_count               = 0
            warm_enabled             = false
            warm_type                = null
            zone_awareness_enabled   = true

            cold_storage_options {
                enabled = false
            }

            zone_awareness_config {
                availability_zone_count = 3
            }
        }

        cognito_options {
            enabled          = false
            identity_pool_id = null
            role_arn         = null
            user_pool_id     = null
        }

        domain_endpoint_options {
            custom_endpoint                 = "elasticsearch6.integration.govuk-internal.digital"
            custom_endpoint_certificate_arn = "arn:aws:acm:eu-west-1:210287912431:certificate/59fc6f82-fc01-43b1-89d0-6ad1abf01b73"
            custom_endpoint_enabled         = true
            enforce_https                   = false
            tls_security_policy             = "Policy-Min-TLS-1-0-2019-07"
        }

        ebs_options {
            ebs_enabled = true
            iops        = 3000
            throughput  = 250
            volume_size = 314
            volume_type = "gp3"
        }

        encrypt_at_rest {
            enabled    = false
            kms_key_id = null
        }

        log_publishing_options {
            cloudwatch_log_group_arn = "arn:aws:logs:eu-west-1:210287912431:log-group:/aws/aes/domains/blue-elasticsearch6-domain/es6-application-logs"
            enabled                  = true
            log_type                 = "ES_APPLICATION_LOGS"
        }
        log_publishing_options {
            cloudwatch_log_group_arn = "arn:aws:logs:eu-west-1:210287912431:log-group:/aws/aes/domains/blue-elasticsearch6-domain/es6-index-logs"
            enabled                  = true
            log_type                 = "INDEX_SLOW_LOGS"
        }
        log_publishing_options {
            cloudwatch_log_group_arn = "arn:aws:logs:eu-west-1:210287912431:log-group:/aws/aes/domains/blue-elasticsearch6-domain/es6-search-logs"
            enabled                  = true
            log_type                 = "SEARCH_SLOW_LOGS"
        }

        node_to_node_encryption {
            enabled = false
        }

        snapshot_options {
            automated_snapshot_start_hour = 1
        }

        vpc_options {
            availability_zones = [
                "eu-west-1a",
                "eu-west-1b",
                "eu-west-1c",
            ]
            security_group_ids = [
                "sg-0fb159fc94f25ecf2",
            ]
            subnet_ids         = [
                "subnet-04e4078da0b0f5a06",
                "subnet-05c26f21cd3778a73",
                "subnet-0c40dd5ad1677fec6",
            ]
            vpc_id             = "vpc-53cd2235"
        }
    }

  # aws_iam_policy.can_configure_es_snapshots will be imported
    resource "aws_iam_policy" "can_configure_es_snapshots" {
        arn              = "arn:aws:iam::210287912431:policy/govuk-integration-elasticsearch6-manual-snapshot-domain-configuration-policy"
        attachment_count = 0
        description      = "Human operator permissions for initial setup of the snapshot bucket for the ES domain. https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html#es-managedomains-snapshot-prerequisites"
        id               = "arn:aws:iam::210287912431:policy/govuk-integration-elasticsearch6-manual-snapshot-domain-configuration-policy"
        name             = "govuk-integration-elasticsearch6-manual-snapshot-domain-configuration-policy"
        name_prefix      = null
        path             = "/"
        policy           = jsonencode(
            {
                Statement = [
                    {
                        Action   = "iam:PassRole"
                        Effect   = "Allow"
                        Resource = "arn:aws:iam::210287912431:role/blue-elasticsearch6-manual-snapshot-role"
                    },
                    {
                        Action   = "es:ESHttpPut"
                        Effect   = "Allow"
                        Resource = "arn:aws:es:eu-west-1:210287912431:domain/blue-elasticsearch6-domain/*"
                    },
                ]
                Version   = "2012-10-17"
            }
        )
        policy_id        = "ANPATB5RC4XXUBSCLSRIB"
        tags             = {}
        tags_all         = {
            "aws_environment"      = "integration"
            "project"              = "GOV.UK - Search"
            "terraform_deployment" = "app-elasticsearch6"
        }
    }

  # aws_iam_policy.manual_snapshot_bucket_policy will be imported
    resource "aws_iam_policy" "manual_snapshot_bucket_policy" {
        arn              = "arn:aws:iam::210287912431:policy/govuk-integration-elasticsearch6-manual-snapshot-bucket-policy"
        attachment_count = 1
        description      = null
        id               = "arn:aws:iam::210287912431:policy/govuk-integration-elasticsearch6-manual-snapshot-bucket-policy"
        name             = "govuk-integration-elasticsearch6-manual-snapshot-bucket-policy"
        name_prefix      = null
        path             = "/"
        policy           = jsonencode(
            {
                Statement = [
                    {
                        Action   = "s3:ListBucket"
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::govuk-staging-elasticsearch6-manual-snapshots",
                            "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots",
                        ]
                        Sid      = ""
                    },
                    {
                        Action   = [
                            "s3:PutObject",
                            "s3:GetObject",
                            "s3:DeleteObject",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:s3:::govuk-staging-elasticsearch6-manual-snapshots/*",
                            "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots/*",
                        ]
                        Sid      = ""
                    },
                ]
                Version   = "2012-10-17"
            }
        )
        policy_id        = "ANPATB5RC4XXYZFDRMRZK"
        tags             = {}
        tags_all         = {
            "aws_environment"      = "integration"
            "project"              = "GOV.UK - Search"
            "terraform_deployment" = "app-elasticsearch6"
        }
    }

  # aws_iam_role.manual_snapshot_role will be imported
    resource "aws_iam_role" "manual_snapshot_role" {
        arn                   = "arn:aws:iam::210287912431:role/blue-elasticsearch6-manual-snapshot-role"
        assume_role_policy    = jsonencode(
            {
                Statement = [
                    {
                        Action    = "sts:AssumeRole"
                        Effect    = "Allow"
                        Principal = {
                            Service = "es.amazonaws.com"
                        }
                        Sid       = ""
                    },
                ]
                Version   = "2012-10-17"
            }
        )
        create_date           = "2019-05-31T11:17:43Z"
        description           = null
        force_detach_policies = false
        id                    = "blue-elasticsearch6-manual-snapshot-role"
        managed_policy_arns   = [
            "arn:aws:iam::210287912431:policy/govuk-integration-elasticsearch6-manual-snapshot-bucket-policy",
        ]
        max_session_duration  = 3600
        name                  = "blue-elasticsearch6-manual-snapshot-role"
        name_prefix           = null
        path                  = "/"
        permissions_boundary  = null
        tags                  = {}
        tags_all              = {
            "aws_environment"      = "integration"
            "project"              = "GOV.UK - Search"
            "terraform_deployment" = "app-elasticsearch6"
        }
        unique_id             = "AROATB5RC4XXQ6IIIRYVM"
    }

  # aws_iam_role_policy_attachment.manual_snapshot_role_policy will be imported
    resource "aws_iam_role_policy_attachment" "manual_snapshot_role_policy" {
        id         = "blue-elasticsearch6-manual-snapshot-role-arn:aws:iam::210287912431:policy/govuk-integration-elasticsearch6-manual-snapshot-bucket-policy"
        policy_arn = "arn:aws:iam::210287912431:policy/govuk-integration-elasticsearch6-manual-snapshot-bucket-policy"
        role       = "blue-elasticsearch6-manual-snapshot-role"
    }

  # aws_iam_service_linked_role.es_role will be imported
    resource "aws_iam_service_linked_role" "es_role" {
        arn              = "arn:aws:iam::210287912431:role/aws-service-role/es.amazonaws.com/AWSServiceRoleForAmazonElasticsearchService"
        aws_service_name = "es.amazonaws.com"
        create_date      = "2019-02-14T09:46:06Z"
        custom_suffix    = null
        description      = null
        id               = "arn:aws:iam::210287912431:role/aws-service-role/es.amazonaws.com/AWSServiceRoleForAmazonElasticsearchService"
        name             = "AWSServiceRoleForAmazonElasticsearchService"
        path             = "/aws-service-role/es.amazonaws.com/"
        tags             = {}
        tags_all         = {
            "aws_environment"      = "integration"
            "project"              = "GOV.UK - Search"
            "terraform_deployment" = "app-elasticsearch6"
        }
        unique_id        = "AROAIJKGOSAZNPWGAZJTQ"
    }

  # aws_route53_record.service_record will be imported
    resource "aws_route53_record" "service_record" {
        fqdn                             = "elasticsearch6.blue.integration.govuk-internal.digital"
        health_check_id                  = null
        id                               = "Z15X3KXNVBQPDX_elasticsearch6.blue.integration.govuk-internal.digital_CNAME"
        multivalue_answer_routing_policy = false
        name                             = "elasticsearch6.blue.integration.govuk-internal.digital"
        records                          = [
            "vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com",
        ]
        set_identifier                   = null
        ttl                              = 300
        type                             = "CNAME"
        zone_id                          = "Z15X3KXNVBQPDX"
    }

  # aws_s3_bucket.manual_snapshots will be imported
    resource "aws_s3_bucket" "manual_snapshots" {
        acceleration_status         = null
        arn                         = "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots"
        bucket                      = "govuk-integration-elasticsearch6-manual-snapshots"
        bucket_domain_name          = "govuk-integration-elasticsearch6-manual-snapshots.s3.amazonaws.com"
        bucket_prefix               = null
        bucket_regional_domain_name = "govuk-integration-elasticsearch6-manual-snapshots.s3.eu-west-1.amazonaws.com"
        hosted_zone_id              = "Z1BKCTXD74EZPE"
        id                          = "govuk-integration-elasticsearch6-manual-snapshots"
        object_lock_enabled         = false
        policy                      = jsonencode(
            {
                Statement = [
                    {
                        Action    = [
                            "s3:PutObjectAcl",
                            "s3:PutObject",
                            "s3:ListBucket",
                            "s3:GetObject",
                            "s3:DeleteObject",
                        ]
                        Effect    = "Allow"
                        Principal = {
                            AWS = [
                                "arn:aws:iam::210287912431:root",
                                "arn:aws:iam::696911096973:root",
                                "arn:aws:iam::172025368201:root",
                            ]
                        }
                        Resource  = [
                            "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots/*",
                            "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots",
                        ]
                        Sid       = "CrossAccountAccess"
                    },
                ]
                Version   = "2012-10-17"
            }
        )
        region                      = "eu-west-1"
        request_payer               = "BucketOwner"
        tags                        = {
            "Name" = "govuk-integration-elasticsearch6-manual-snapshots"
        }
        tags_all                    = {
            "Name"                 = "govuk-integration-elasticsearch6-manual-snapshots"
            "aws_environment"      = "integration"
            "project"              = "GOV.UK - Search"
            "terraform_deployment" = "app-elasticsearch6"
        }

        grant {
            id          = "eb8fd7f05ccdef24b9f7210965a589f901b6e3fa2de6075de1ac2ccf86321df6"
            permissions = [
                "FULL_CONTROL",
            ]
            type        = "CanonicalUser"
            uri         = null
        }

        logging {
            target_bucket = "govuk-integration-aws-logging"
            target_prefix = "s3/govuk-integration-elasticsearch6-manual-snapshots/"
        }

        server_side_encryption_configuration {
            rule {
                bucket_key_enabled = false

                apply_server_side_encryption_by_default {
                    kms_master_key_id = null
                    sse_algorithm     = "AES256"
                }
            }
        }

        versioning {
            enabled    = false
            mfa_delete = false
        }
    }

  # aws_s3_bucket_logging.manual_snapshots will be imported
    resource "aws_s3_bucket_logging" "manual_snapshots" {
        bucket                = "govuk-integration-elasticsearch6-manual-snapshots"
        expected_bucket_owner = null
        id                    = "govuk-integration-elasticsearch6-manual-snapshots"
        target_bucket         = "govuk-integration-aws-logging"
        target_prefix         = "s3/govuk-integration-elasticsearch6-manual-snapshots/"
    }

  # aws_s3_bucket_policy.manual_snapshots_cross_account_access will be imported
    resource "aws_s3_bucket_policy" "manual_snapshots_cross_account_access" {
        bucket = "govuk-integration-elasticsearch6-manual-snapshots"
        id     = "govuk-integration-elasticsearch6-manual-snapshots"
        policy = jsonencode(
            {
                Statement = [
                    {
                        Action    = [
                            "s3:PutObjectAcl",
                            "s3:PutObject",
                            "s3:ListBucket",
                            "s3:GetObject",
                            "s3:DeleteObject",
                        ]
                        Effect    = "Allow"
                        Principal = {
                            AWS = [
                                "arn:aws:iam::210287912431:root",
                                "arn:aws:iam::696911096973:root",
                                "arn:aws:iam::172025368201:root",
                            ]
                        }
                        Resource  = [
                            "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots/*",
                            "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots",
                        ]
                        Sid       = "CrossAccountAccess"
                    },
                ]
                Version   = "2012-10-17"
            }
        )
    }

Plan: 14 to import, 0 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + domain_configuration_policy_arn = "arn:aws:iam::210287912431:policy/govuk-integration-elasticsearch6-manual-snapshot-domain-configuration-policy"
  + manual_snapshots_bucket_arn     = "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots"
  + service_dns_name                = "elasticsearch6.blue.integration.govuk-internal.digital"
  + service_endpoint                = "vpc-blue-elasticsearch6-domain-uolbxqjhkiqmg5w3gg7gio5sty.eu-west-1.es.amazonaws.com"

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```
</details>