### PR TITLE
Prevent the readonly role from getting secret values in the cluster

### DIFF
--- a/terraform/deployments/cluster-services/eks_access.tf
+++ b/terraform/deployments/cluster-services/eks_access.tf
@@ -304,8 +304,14 @@ resource "kubernetes_cluster_role" "readonly" {
 
   rule {
     api_groups = [""]
-    resources  = ["namespaces", "pods", "pods/logs", "services", "configmaps", "secrets", "endpoints", "events"]
+    resources  = ["namespaces", "pods", "pods/logs", "services", "configmaps", "endpoints", "events"]
     verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["list"]
   }
 
   rule {


### PR DESCRIPTION
The readonly IAM role assigned to humans prevents them from reading secret values, but the equivalent Kubernetes role did not. We use the external secrets operator, so being able to read inside k8s is equivalent to being able to read in AWS.

The readonly role is now limited to listing which secrets exist, but not reading their values, within the cluster.