### PR TITLE
Enable RDS performance insights on replicas

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -134,9 +134,11 @@ resource "aws_db_instance" "replica" {
     if lookup(value, "has_read_replica", false)
   }
 
-  instance_class      = each.value.instance_class
-  identifier          = "${var.govuk_environment}-${each.value.name}-${each.value.engine}-replica"
-  replicate_source_db = aws_db_instance.instance[each.key].identifier
+  instance_class                        = each.value.instance_class
+  identifier                            = "${var.govuk_environment}-${each.value.name}-${each.value.engine}-replica"
+  replicate_source_db                   = aws_db_instance.instance[each.key].identifier
+  performance_insights_enabled          = aws_db_instance.instance[each.key].performance_insights_enabled
+  performance_insights_retention_period = aws_db_instance.instance[each.key].performance_insights_retention_period
 
   skip_final_snapshot = true
 


### PR DESCRIPTION
It would be good to have query level performance data on publishing-api's read replica, as part of the graphql work. In general, it seems sensible to enable performance insights on any replica if the primary has it enabled.

[According to the docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Enabling.html) "Turning Performance Insights on and off doesn't cause downtime, a reboot, or a failover."

The docs also say that Performance Insights is being deprecated, and that [we should switch to some CloudWatch thing which is the new hotness](https://repost.aws/articles/AR6gPnT__dQdq81Md6Q_A1mA/transitioning-from-rds-performance-insights-to-cloudwatch-database-insights). I think that's a bigger change than I want to make here though, so I'll take platform engineering's advice on that.