### PR TITLE
Setup logical replication parameters and create the green parameter group

### DIFF
--- a/terraform/deployments/rds/ckan_integration_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/ckan_integration_postgres_14_upgrade.tf
@@ -1,0 +1,25 @@
+resource "aws_db_parameter_group" "postgresql14_green_params" {
+
+  name_prefix = "${var.govuk_environment}-ckan-postgres-"
+  family      = "postgres14"
+
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_logical_replication_workers"
+    value        = "20"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_worker_processes"
+    value        = "25"
+    apply_method = "pending-reboot"
+  }
+
+  lifecycle { create_before_destroy = true }
+}

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -201,10 +201,15 @@ module "variable-set-rds-integration" {
         engine         = "postgres"
         engine_version = "13"
         engine_params = {
-          log_min_duration_statement = { value = 10000 }
-          log_statement              = { value = "all" }
-          deadlock_timeout           = { value = 2500 }
-          log_lock_waits             = { value = 1 }
+          log_min_duration_statement      = { value = 10000 }
+          log_statement                   = { value = "all" }
+          deadlock_timeout                = { value = 2500 }
+          log_lock_waits                  = { value = 1 }
+          "rds.logical_replication"       = { value = 1, apply_method = "pending-reboot" }
+          max_wal_senders                 = { value = 35, apply_method = "pending-reboot" }
+          max_logical_replication_workers = { value = 20, apply_method = "pending-reboot" }
+          max_worker_processes            = { value = 40, apply_method = "pending-reboot" }
+
         }
         engine_params_family         = "postgres13"
         name                         = "ckan"
@@ -212,6 +217,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         project                      = "GOV.UK - DGU"
+        backup_retention_period      = 1
       }
 
       collections_publisher = {


### PR DESCRIPTION
This pull request introduces configuration updates to support PostgreSQL logical replication and optimize database performance for CKAN integration. The changes involve creating a new parameter group for PostgreSQL 14 and updating parameters for an existing PostgreSQL 13 integration.

### PostgreSQL 14 Parameter Group Creation:
* [`terraform/deployments/rds/ckan_integration_postgres_14_upgrade.tf`](diffhunk://#diff-1af4deb3de37440e9e2cefd20aa3b1c48c1ca6e92a1874c91fa681d1f9a05c54R1-R25): Added a new `aws_db_parameter_group` resource named `postgresql14_green_params`, configured for PostgreSQL 14 with parameters enabling logical replication (`rds.logical_replication`) and tuning worker processes (`max_logical_replication_workers`, `max_worker_processes`). Lifecycle settings ensure safe updates.

### PostgreSQL 13 Integration Updates:
* [`terraform/deployments/tfc-configuration/variables-integration.tf`](diffhunk://#diff-798246f076378012ccfc28b19f3a3e39d964f47a06ac4426bc9677c95b8ee740R208-R220): Updated `module "variable-set-rds-integration"` to include logical replication parameters (`rds.logical_replication`, `max_wal_senders`, `max_logical_replication_workers`, `max_worker_processes`) and added a `backup_retention_period` setting for enhanced data protection.

This is in preparation for upgrading postgres to v14

https://github.com/alphagov/govuk-infrastructure/issues/2335