### PR TITLE
Provision new Postgres DBs for Publisher

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -464,6 +464,23 @@ module "variable-set-rds-production" {
         has_read_replica             = true
       }
 
+      publisher = {
+        engine         = "postgres"
+        engine_version = "17"
+        engine_params = {
+          log_min_duration_statement = { value = 10000 }
+          log_statement              = { value = "all" }
+          deadlock_timeout           = { value = 2500 }
+          log_lock_waits             = { value = 1 }
+        }
+        engine_params_family         = "postgres17"
+        name                         = "publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.medium"
+        performance_insights_enabled = true
+        project                      = "GOV.UK - Publishing"
+      }
+
       release = {
         engine         = "mysql"
         engine_version = "8.0"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -458,6 +458,23 @@ module "variable-set-rds-staging" {
         has_read_replica             = true
       }
 
+      publisher = {
+        engine         = "postgres"
+        engine_version = "17"
+        engine_params = {
+          log_min_duration_statement = { value = 10000 }
+          log_statement              = { value = "all" }
+          deadlock_timeout           = { value = 2500 }
+          log_lock_waits             = { value = 1 }
+        }
+        engine_params_family         = "postgres17"
+        name                         = "publisher"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.micro"
+        performance_insights_enabled = false
+        project                      = "GOV.UK - Publishing"
+      }
+
       release = {
         engine         = "mysql"
         engine_version = "8.0"


### PR DESCRIPTION
We are migrating Publisher to run on Postgres 14 from Mongo. The integration database was provisioned in January but now we are ready to look towards delivery we need these available in staging and production.

The actual settings are based on service-manuals-publisher.