### PR TITLE
Allow duplicate DNS record names in publishing infrastructure

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/subdomain_dns.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/subdomain_dns.tf
@@ -6,7 +6,7 @@ resource "aws_route53_record" "additional_dns_records" {
   # this could be a simple foreach, but Terraform would think the order matters then
   # instead transform the list into a name => object pair so that each resource has
   # a stable name
-  for_each = { for _, v in var.subdomain_dns_records : v.name => v }
+  for_each = { for _, v in var.subdomain_dns_records : "${v.name} (${v.type})" => v }
 
   zone_id = data.aws_route53_zone.publishing_subdomain.zone_id
   name = (


### PR DESCRIPTION
Previously we used the record name as the key for the record in Terraform, but this has the side effect of not allowing duplicate names, which exist when we have >1 type of record for a name (such as an A record and a TXT record).

To work around that, we include the record type in the key. The combination of name and type will always be unique.

This will make Terraform destroy and recreate the records, which is OK because this zone isn't in use yet.