### PR TITLE
Allow `govuk-production-admin` and `govuk-production-deploy` to push to branch

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -273,7 +273,6 @@ repos:
     homepage_url: "https://docs.publishing.service.gov.uk"
     need_production_access_to_merge: false
     allow_squash_merge: true
-    push_allowances: []
 
   govuk-display-screen:
     need_production_access_to_merge: false


### PR DESCRIPTION
Description:
- Currently only `govuk-production-admin` can push to `main` so only individuals there can merge PRs
- Change allows it so that `govuk-production-deploy` can also merge in PRs as this requires `push` access to `main`