### PR TITLE
Remove reference to accessible autocomplete multiselect

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -849,7 +849,6 @@ repos:
         - "Dependency Review scan / dependency-review-pr"
         - "test"
 
-  accessible-autocomplete-multiselect: {}
   ckan-mock-harvest-sources: {}
   govuk-chat: {}
   govuk-data-science-workshop: {}


### PR DESCRIPTION
## What
Remove reference to `accessible-autocomplete-multiselect` repo.
https://github.com/alphagov/accessible-autocomplete-multiselect

## Why
The `accessible-autocomplete-multiselect` repo has now been retired/archived and is no longer required.