### PR TITLE
Removed unused Valkey instancse from integration and staging

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -614,21 +614,7 @@ module "variable-set-elasticache-integration" {
   #   }
 
   tfvars = {
-    caches = {
-      publishing-api = {
-        name        = "publishing-api-valkey"
-        description = "Publishing API Valkey Instance"
-        node_type   = "cache.m7g.large"
-      }
-      search-api = {
-        name        = "search-api-valkey"
-        description = "Search API Valkey Instance"
-      }
-      whitehall-admin = {
-        name        = "whitehall-admin-valkey"
-        description = "Whitehall Admin Valkey Instance"
-      }
-    }
+    caches = {}
   }
 }
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -626,20 +626,7 @@ module "variable-set-elasticache-staging" {
   #   }
 
   tfvars = {
-    caches = {
-      publishing-api = {
-        name        = "publishing-api-valkey"
-        description = "Publishing API Valkey Instance"
-      }
-      search-api = {
-        name        = "search-api-valkey"
-        description = "Search API Valkey Instance"
-      }
-      whitehall-admin = {
-        name        = "whitehall-admin-valkey"
-        description = "Whitehall Admin Valkey Instance"
-      }
-    }
+    caches = {}
   }
 }
 


### PR DESCRIPTION
The applications that use Redis in integration and staging have been moved back to using in-cluster Redis so that everything is consistent. These Valkey instances are no longer used and can be terminated.