### PR TITLE
Rollback ckan integration to PostgreSQL 13

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -199,14 +199,14 @@ module "variable-set-rds-integration" {
       }
       ckan = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
         }
-        engine_params_family         = "postgres14"
+        engine_params_family         = "postgres13"
         name                         = "ckan"
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"


### PR DESCRIPTION
This is to ensure ckan integration is in its original state to ensure other SREs/developers can verify the migration guidance Follow up PR will do the Terraform state surgery to re-import PostgreSQL 13 instance and PostgreSQL parameter groups

https://github.com/alphagov/govuk-infrastructure/issues/2335