### PR TITLE
Allow results about the App to show in internal search

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_default.tf
@@ -115,16 +115,8 @@ locals {
   # Pages to temporarily exclude from search results
   filtered_pages = [
     # GOV.UK app beta (note double appearance of HTML publications)
-    "/government/publications/govuk-app-terms-and-conditions",
-    "/government/publications/govuk-app-terms-and-conditions/govuk-app-terms-and-conditions",
-    "/government/publications/govuk-app-privacy-notice-how-we-use-your-data",
-    "/government/publications/govuk-app-privacy-notice-how-we-use-your-data/govuk-app-privacy-notice-how-we-use-your-data",
     "/government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data",
     "/government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data/govuk-app-testing-privacy-notice-how-we-use-your-data",
-    "/government/publications/accessibility-statement-for-the-govuk-app",
-    "/government/publications/accessibility-statement-for-the-govuk-app/accessibility-statement-for-the-govuk-app",
-    "/sign-up-test-govuk-app",
-    "/contact/govuk-app-support",
   ]
   filtered_pages_expr = join(",", [for page in local.filtered_pages : "\"${page}\""])
 }


### PR DESCRIPTION
Now that the app is live we only need to filter out the following two pages:

"/government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data", "/government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data/govuk-app-testing-privacy-notice-how-we-use-your-data",