### PR TITLE
Implement freshness boost as a serving control

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -7,7 +7,6 @@ module "serving_config_global_variant" {
 
   boost_control_ids = [
     # specific to serving_config_global_variant
-    module.control_global_boost_demote_historic.id,
     module.control_global_boost_freshness_general.id,
 
     # identical to serving_config_global_default
@@ -16,9 +15,7 @@ module "serving_config_global_variant" {
     module.control_global_boost_demote_low.id,
     module.control_global_boost_demote_medium.id,
     module.control_global_boost_demote_pages.id,
-
-    # explicitly not included in serving_config_global_variant
-    # module.control_global_boost_demote_strong.id,
+    module.control_global_boost_demote_strong.id
   ]
   filter_control_ids = [
     # identical to serving_config_global_default
@@ -28,21 +25,6 @@ module "serving_config_global_variant" {
     # identical to serving_config_global_default
     module.control_global_synonym_hmrc.id,
   ]
-}
-
-module "control_global_boost_demote_historic" {
-  source = "./modules/control"
-
-  id           = "boost_demote_historic"
-  display_name = "Boost: Demote historic"
-  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
-  action = {
-    boostAction = {
-      filter     = "is_historic = 1",
-      fixedBoost = -0.25
-      dataStore  = google_discovery_engine_data_store.govuk_content.name
-    }
-  }
 }
 
 module "control_global_boost_freshness_general" {

--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -54,22 +54,27 @@ module "control_global_boost_freshness_general" {
   action = {
     boostAction = {
       dataStore = google_discovery_engine_data_store.govuk_content.name,
+      filter    = "content_purpose_supergroup: ANY(\"news_and_communications\")",
       interpolationBoostSpec = {
         fieldName         = "public_timestamp_datetime",
         attributeType     = "FRESHNESS",
         interpolationType = "LINEAR",
         controlPoints = [
           {
-            attributeValue = "0D",
-            boostAmount    = 0.4
+            attributeValue = "7D",
+            boostAmount    = 0.2
           },
           {
-            attributeValue = "30D",
-            boostAmount    = 0.1
+            attributeValue = "90D",
+            boostAmount    = 0.05
+          },
+          {
+            attributeValue = "365D",
+            boostAmount    = -0.5
           },
           {
             attributeValue = "1460D",
-            # boostAmount = 0 is the default, setting it explicitly causes state drift
+            boostAmount    = -0.75
           }
         ]
       }


### PR DESCRIPTION
We want to replace the existing freshness boost that we apply at query time[1] as a boost spec with a serving control. 

Tara would like to implement:

0.2 (decaying to 0.05), for the first 7 days
0.05 (decaying to 0), for 8 days to 90 days
0 (decaying to -0.5) for 91 days to 365 days
-0.5 (decaying to -0.75) for 366 days to 1460 days
-0.75 (fixed) for anything older than 1460 days

Hopefully that is what I have implemented here, if not please leave a comment! 

[1] = https://github.com/alphagov/search-api-v2/blob/main/app/services/discovery_engine/query/news_recency_boost.rb