### PR TITLE
Remove demote historic module

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -27,21 +27,6 @@ module "serving_config_global_variant" {
   ]
 }
 
-module "control_global_boost_demote_historic" {
-  source = "./modules/control"
-
-  id           = "boost_demote_historic"
-  display_name = "Boost: Demote historic"
-  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
-  action = {
-    boostAction = {
-      filter     = "is_historic = 1",
-      fixedBoost = -0.25
-      dataStore  = google_discovery_engine_data_store.govuk_content.name
-    }
-  }
-}
-
 module "control_global_boost_freshness_general" {
   source = "./modules/control"
 


### PR DESCRIPTION
This module is no longer being used. [1]
We are using the value from the default serving config instead.

[1]: https://github.com/alphagov/govuk-infrastructure/pull/2412