### PR TITLE
Set up Cloudwatch logging for Bedrock

### DIFF
--- a/terraform/deployments/chat/bedrock_iam.tf
+++ b/terraform/deployments/chat/bedrock_iam.tf
@@ -36,6 +36,19 @@ data "aws_iam_policy_document" "bedrock_access" {
   }
 }
 
+data "aws_iam_policy_document" "bedrock_cloudwatch" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.bedrock_log_group.name}:log-stream:aws/bedrock/modelinvocations"
+    ]
+  }
+}
+
 resource "aws_iam_policy" "bedrock_access" {
   name   = "govuk-chat-bedrock-access-policy"
   policy = data.aws_iam_policy_document.bedrock_access.json
@@ -44,4 +57,14 @@ resource "aws_iam_policy" "bedrock_access" {
 resource "aws_iam_role_policy_attachment" "bedrock_access" {
   role       = aws_iam_role.bedrock_access.name
   policy_arn = aws_iam_policy.bedrock_access.arn
+}
+
+resource "aws_iam_policy" "bedrock_cloudwatch" {
+  name   = "govuk-chat-bedrock-cloudwatch-policy"
+  policy = data.aws_iam_policy_document.bedrock_cloudwatch.json
+}
+
+resource "aws_iam_role_policy_attachment" "bedrock_cloudwatch" {
+  role       = aws_iam_role.bedrock_access.name
+  policy_arn = aws_iam_policy.bedrock_cloudwatch.arn
 }

--- a/terraform/deployments/chat/bedrock_logging.tf
+++ b/terraform/deployments/chat/bedrock_logging.tf
@@ -1,0 +1,13 @@
+
+resource "aws_bedrock_model_invocation_logging_configuration" "bedrock_logging" {
+  logging_config {
+    embedding_data_delivery_enabled = true
+    text_data_delivery_enabled      = true
+
+    cloudwatch_config {
+      log_group_name = aws_cloudwatch_log_group.bedrock_log_group.name
+      role_arn       = aws_iam_role.bedrock_access.arn
+    }
+  }
+}
+

--- a/terraform/deployments/chat/cloudwatch.tf
+++ b/terraform/deployments/chat/cloudwatch.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "bedrock_log_group" {
+  name              = "/aws/bedrock"
+  retention_in_days = 30
+}


### PR DESCRIPTION
https://trello.com/c/V3Dnjlfl/2579

We want to track Bedrock usage (specifically token usage) for GOV.UK
Chat, so know how close to our quota we are.

To do this, we need to set up Bedrock to enable logging to CW. From
there we'll pull the data out and display it in a Grafana dashboard.

This sets up the following:

* Adds a log group to Cloudwatch for Bedrock logs
* Attaches an IAM policy to the existing Bedrock role which allows
  creating log streams and sending log events
* Turns on logging in Bedrock

See [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-invocation-logging.html)
