### PR TITLE
Set -eu in shutdown script

### DIFF
--- a/terraform/deployments/ephemeral/shutdown.sh
+++ b/terraform/deployments/ephemeral/shutdown.sh
@@ -176,8 +176,7 @@ function retry {
     if [ "${i}" != "1" ]; then
       echo "retrying '$*' attempt ${i}/${RETRY_COUNT}"
     fi
-    ($@)
-    if [ "$?" = "0" ]; then
+    if "$@"; then
       return 0
     fi
   done

--- a/terraform/deployments/ephemeral/shutdown.sh
+++ b/terraform/deployments/ephemeral/shutdown.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eu
+
 CLUSTER_ID="${1}"
 
 if [ "${CLUSTER_ID:0:4}" != "eph-" ] && [ "${IGNORE_BAD_CLUSTER_ID}" != "true" ]; then
@@ -145,13 +147,12 @@ function tfc_wait_for_run {
   
   while true; do
     RUN_STATUS=$(tfc_run_status "${RUN_ID}")
-    echo "${RUN_STATUS}" | grep -E '(applied|planned_and_finished)' > /dev/null
-    if [ "$?" = "0" ]; then
+
+    if [[ "${RUN_STATUS}" =~ (applied|planned_and_finished) ]]; then
       echo "Run ID ${RUN_ID} finished: ${RUN_STATUS}"
       return 0
     fi
-    echo "${RUN_STATUS}" | grep -E '(errored|canceled|force_canceled|discarded)' > /dev/null
-    if [ "$?" = "0" ]; then
+    if [[ "${RUN_STATUS}" =~ (errored|canceled|force_canceled|discarded) ]]; then
       echo "Run ID ${RUN_ID} failed: ${RUN_STATUS}"
       return 1
     fi


### PR DESCRIPTION
This script didn't have `set -e` set, instead attempting to handle errors manually.

Unfortunately, this led to a situation where a command failed (`aws eks update-kubeconfig --name "${CLUSTER_ID}"`), but we didn't check `$?` afterwards so the script continued running (while targetting the wrong kubeconfig).

There are a couple of other changes to the script required to use `set -e` without breaking the manual error handling, but they all look like unambiguous improvements to me. This change also gets the script to pass [shellcheck](https://www.shellcheck.net/) (which as a separate task, we should probably integrate with CI)