### PR TITLE
Remove logical replication parameters for ckan integration postgresql14

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -201,16 +201,11 @@ module "variable-set-rds-integration" {
         engine         = "postgres"
         engine_version = "14.18"
         engine_params = {
-          log_min_duration_statement      = { value = 10000 }
-          log_statement                   = { value = "all" }
-          deadlock_timeout                = { value = 2500 }
-          log_lock_waits                  = { value = 1 }
-          "rds.logical_replication"       = { value = 1, apply_method = "pending-reboot" }
-          max_wal_senders                 = { value = 35, apply_method = "pending-reboot" }
-          max_logical_replication_workers = { value = 20, apply_method = "pending-reboot" }
-          max_worker_processes            = { value = 40, apply_method = "pending-reboot" }
+          log_min_duration_statement = { value = 10000 }
+          log_statement              = { value = "all" }
+          deadlock_timeout           = { value = 2500 }
+          log_lock_waits             = { value = 1 }
         }
-        backup_retention_period = 1
 
         engine_params_family         = "postgres14"
         name                         = "ckan"


### PR DESCRIPTION
Part of clearing down some of the migration steps for the [Postgres upgrade](https://docs.google.com/document/d/1j-Hhh2k-HyPuCjVgI5QbUq9U1JuQNC4AcWmk6zwY2wQ/edit?tab=t.0) 

https://github.com/alphagov/govuk-infrastructure/issues/2335