### PR TITLE
Remove the ckan_integration_postgres_14.tf file

### DIFF
--- a/terraform/deployments/rds/ckan_integration_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/ckan_integration_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["ckan"]
-  id = "ckan-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["ckan"]
-  id = "integration-ckan-postgres-20250714155750732300000001"
-}


### PR DESCRIPTION
This is part of the clean up process after the upgrade to postgres 14 

https://github.com/alphagov/govuk-infrastructure/issues/2335

