### PR TITLE
Grant TFC role access to Bedrock logging config

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -43,6 +43,7 @@ data "aws_iam_policy_document" "tfc_policy" {
       "apigateway:*",
       "athena:*",
       "autoscaling:*",
+      "bedrock:PutModelInvocationLoggingConfiguration",
       "cloudfront:*",
       "cloudwatch:*",
       "ec2:*",


### PR DESCRIPTION

Allows the TFC role to enable Bedrock logging to Cloudwatch.
