### PR TITLE
Allow TFC role to manage Bedrock access IAM role

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -117,7 +117,8 @@ data "aws_iam_policy_document" "tfc_policy" {
     actions = ["iam:PassRole"]
     resources = [
       "arn:aws:iam::*:role/rds-monitoring-role",
-      "arn:aws:iam::*:role/govuk-*-csp-reports-firehose-role"
+      "arn:aws:iam::*:role/govuk-*-csp-reports-firehose-role",
+      "arn:aws:iam::*:role/govuk-chat-bedrock-access-role"
     ]
   }
   statement {


### PR DESCRIPTION

Running TF results in the following error:

```
operation error Bedrock: PutModelInvocationLoggingConfiguration, https response error StatusCode: 403, User: arn:aws:sts::210287912431:assumed-role/terraform-cloud/terraform-run-h7rD1XcGWxHMDCG7 is not authorized to perform: iam:PassRole on resource: arn:aws:iam::210287912431:role/govuk-chat-bedrock-access-role because no identity-based policy allows the iam:PassRole action
```

See TF Run: https://app.terraform.io/app/govuk/workspaces/chat-integration/runs/run-h7rD1XcGWxHMDCG7