### PR TITLE
Fix role ARN for Bedrock Cloudwatch logging

### DIFF
--- a/terraform/deployments/chat/bedrock_logging.tf
+++ b/terraform/deployments/chat/bedrock_logging.tf
@@ -6,7 +6,7 @@ resource "aws_bedrock_model_invocation_logging_configuration" "bedrock_logging" 
 
     cloudwatch_config {
       log_group_name = aws_cloudwatch_log_group.bedrock_log_group.name
-      role_arn       = aws_iam_role.bedrock_access.arn
+      role_arn       = aws_iam_role.bedrock_cloudwatch.arn
     }
   }
 }


### PR DESCRIPTION

This role should be the one that has access to the Cloudwatch log group,
but it's currently set to the role that allows access to Bedrock itself.

Failed run: https://app.terraform.io/app/govuk/workspaces/chat-integration/runs/run-LUk3u2WQHujteoEY

Error:

```
operation error Bedrock: PutModelInvocationLoggingConfiguration
https response error StatusCode: 400
ValidationException: Failed to validate permissions for log group: /aws/bedrock, with role: arn:aws:iam::210287912431:role/govuk-chat-bedrock-access-role.
Verify the IAM role permissions are correct.
```

I'm _pretty_ sure this is the problem, but not 100%.

