### PR TITLE
Remove Bedrock Cloudwatch policy

### DIFF
--- a/terraform/deployments/chat/bedrock_iam.tf
+++ b/terraform/deployments/chat/bedrock_iam.tf
@@ -36,19 +36,6 @@ data "aws_iam_policy_document" "bedrock_access" {
   }
 }
 
-data "aws_iam_policy_document" "bedrock_cloudwatch" {
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-    effect = "Allow"
-    resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.bedrock_log_group.name}:log-stream:aws/bedrock/modelinvocations"
-    ]
-  }
-}
-
 resource "aws_iam_policy" "bedrock_access" {
   name   = "govuk-chat-bedrock-access-policy"
   policy = data.aws_iam_policy_document.bedrock_access.json
@@ -57,14 +44,4 @@ resource "aws_iam_policy" "bedrock_access" {
 resource "aws_iam_role_policy_attachment" "bedrock_access" {
   role       = aws_iam_role.bedrock_access.name
   policy_arn = aws_iam_policy.bedrock_access.arn
-}
-
-resource "aws_iam_policy" "bedrock_cloudwatch" {
-  name   = "govuk-chat-bedrock-cloudwatch-policy"
-  policy = data.aws_iam_policy_document.bedrock_cloudwatch.json
-}
-
-resource "aws_iam_role_policy_attachment" "bedrock_cloudwatch" {
-  role       = aws_iam_role.bedrock_access.name
-  policy_arn = aws_iam_policy.bedrock_cloudwatch.arn
 }


### PR DESCRIPTION

This policy was added to the `govuk-chat-bedrock-access-role` role which isn't
good practise. This removes the policy from that role, we'll create a
separate role for it later.
