### PR TITLE
Upgrade Integration Kubernetes cluster to 1.33

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -6,7 +6,7 @@ module "variable-set-integration" {
     govuk_aws_state_bucket              = "govuk-terraform-steppingstone-integration"
     cluster_infrastructure_state_bucket = "govuk-terraform-integration"
 
-    cluster_version               = "1.31"
+    cluster_version               = "1.33"
     cluster_log_retention_in_days = 7
 
     vpc_cidr = "10.1.0.0/16"


### PR DESCRIPTION
The cluster has been upgraded in the console. This change brings the Terraform configuration into line.