### PR TITLE
Give `terraform-cloud` role PassRole permission for `bedrock_cloudwatch`

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -118,7 +118,8 @@ data "aws_iam_policy_document" "tfc_policy" {
     resources = [
       "arn:aws:iam::*:role/rds-monitoring-role",
       "arn:aws:iam::*:role/govuk-*-csp-reports-firehose-role",
-      "arn:aws:iam::*:role/govuk-chat-bedrock-access-role"
+      "arn:aws:iam::*:role/govuk-chat-bedrock-access-role",
+      "arn:aws:iam::*:role/govuk-chat-bedrock-cloudwatch-role"
     ]
   }
   statement {


### PR DESCRIPTION
## What

Give permission to allow `terraform-cloud` role to perform iam:PassRole on new resource

## Why

This is to allow the new resource to be deployed successfully