### PR TITLE
Correct assignment of IAM Policy to the correct Role

### DIFF
--- a/terraform/deployments/chat/bedrock_iam.tf
+++ b/terraform/deployments/chat/bedrock_iam.tf
@@ -82,6 +82,6 @@ resource "aws_iam_policy" "bedrock_cloudwatch" {
 }
 
 resource "aws_iam_role_policy_attachment" "bedrock_cloudwatch" {
-  role       = aws_iam_role.bedrock_access.name
+  role       = aws_iam_role.bedrock_cloudwatch.name
   policy_arn = aws_iam_policy.bedrock_cloudwatch.arn
 }


### PR DESCRIPTION
## What

Change assignment of IAM Policy `govuk-chat-bedrock-cloudwatch-policy` from `govuk-chat-bedrock-access-role` to `govuk-chat-bedrock-cloudwatch-role`

## Why

The policy is currently assigned to the wrong role