### PR TITLE
Add test path to filtered_pages

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_default.tf
@@ -114,6 +114,8 @@ module "control_global_boost_demote_pages" {
 locals {
   # Pages to temporarily exclude from search results
   filtered_pages = [
+    # It is unclear how terraform will handle an empty filtered_pages array, so this dummy path should not be deleted
+    "/example/link/dont-delete-me",
     # GOV.UK app beta (note double appearance of HTML publications)
     "/government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data",
     "/government/publications/govuk-app-testing-privacy-notice-how-we-use-your-data/govuk-app-testing-privacy-notice-how-we-use-your-data",


### PR DESCRIPTION
There are only two remaining pages being filtered from search results. If a request is made to remove them, we are unclear how an empty array will be parsed by terraform and so would at that point remove the whole block.

Removing the block will make it less easy for non-team members to implement filters in the future. So the most pragmatic thing to do is probably to ensure that a placeholder is always present.

This code is a prime candidate for tooling in search admin.