### PR TITLE
Remove default code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# Production access required by default
-* @alphagov/gov-uk-production-deploy
+# Anyone with write access can merge by default
+*
 
 # Platform Engineering review required
 # Reusable GitHub Actions workflows and repo config


### PR DESCRIPTION
This will stop every dev in GOV.UK from being notified whenever a PR is opened in this repo for a file that doesn't have platform engineering as a code owner.

https://github.com/alphagov/govuk-infrastructure/issues/2170