### PR TITLE
Upgrade the Kubernetes cluster to 1.32 in staging

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -6,7 +6,7 @@ module "variable-set-staging" {
     govuk_aws_state_bucket              = "govuk-terraform-steppingstone-staging"
     cluster_infrastructure_state_bucket = "govuk-terraform-staging"
 
-    cluster_version               = "1.31"
+    cluster_version               = "1.32"
     cluster_log_retention_in_days = 7
 
     vpc_cidr = "10.12.0.0/16"


### PR DESCRIPTION
We've verified that there no advisories from AWS or changes in 1.32 requiring our attention.

Unlike previous upgrades, the cluster has not been upgraded in the console and Terraform made to match. Instead, we allow Terraform and AWS EKS to direct the upgrade process.