### PR TITLE
Upgrade Kubernetes cluster to 1.33 in staging

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -6,7 +6,7 @@ module "variable-set-staging" {
     govuk_aws_state_bucket              = "govuk-terraform-steppingstone-staging"
     cluster_infrastructure_state_bucket = "govuk-terraform-staging"
 
-    cluster_version               = "1.32"
+    cluster_version               = "1.33"
     cluster_log_retention_in_days = 7
 
     vpc_cidr = "10.12.0.0/16"


### PR DESCRIPTION
Upgrades from 1.32 to the latest version, 1.33.