### PR TITLE
BAU - Fix TFC IAM AWS Bedrock permission

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -43,6 +43,7 @@ data "aws_iam_policy_document" "tfc_policy" {
       "apigateway:*",
       "athena:*",
       "autoscaling:*",
+      "bedrock:GetModelInvocationLoggingConfiguration",
       "bedrock:PutModelInvocationLoggingConfiguration",
       "cloudfront:*",
       "cloudwatch:*",


### PR DESCRIPTION
Description:
- TFC needs this permission to modify the Terraform
- Fixes https://app.terraform.io/app/govuk/workspaces/chat-integration/runs/run-jeqW3T2kzEkFPHyg as the error is: `is not authorized to perform: bedrock:GetModelInvocationLoggingConfiguration because no identity-based policy allows the bedrock:GetModelInvocationLoggingConfiguration action`