### PR TITLE
Upgrade Kubernetes in production to 1.32

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -6,7 +6,7 @@ module "variable-set-production" {
     govuk_aws_state_bucket              = "govuk-terraform-steppingstone-production"
     cluster_infrastructure_state_bucket = "govuk-terraform-production"
 
-    cluster_version               = "1.31"
+    cluster_version               = "1.32"
     cluster_log_retention_in_days = 7
 
     vpc_cidr = "10.13.0.0/16"


### PR DESCRIPTION
A subsequent PR will upgrade to 1.33.