### PR TITLE
BAU - Add IAM PassRole to `basic_lambda_role`

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -124,8 +124,11 @@ data "aws_iam_policy_document" "tfc_policy" {
     ]
   }
   statement {
-    actions   = ["iam:*Role"]
-    resources = ["arn:aws:iam::*:role/AWSLambdaRole-transition-executor"]
+    actions = ["iam:*Role"]
+    resources = [
+      "arn:aws:iam::*:role/AWSLambdaRole-transition-executor",
+      "arn:aws:iam::*:role/basic_lambda_role"
+    ]
   }
   statement {
     actions = ["iam:*User"]


### PR DESCRIPTION
Description:
- To fix https://app.terraform.io/app/govuk/workspaces/cloudfront-staging/runs/run-bbdJK2HLjgZrbWbF TFC needs to be able to do `iam:PassRole` onto https://github.com/alphagov/govuk-infrastructure/blob/8c80b1f752bf55db590219e15a11024b742305df/terraform/deployments/cloudfront/main.tf#L356