### PR TITLE
Search API V2: create bucket for automated evaluation output

### DIFF
--- a/terraform/deployments/search-api-v2/automated_evaluation.tf
+++ b/terraform/deployments/search-api-v2/automated_evaluation.tf
@@ -77,6 +77,12 @@ resource "google_storage_bucket" "automated_evaluation_output" {
   location = var.gcp_region
 }
 
+# bucket for output of VAIS (i.e. out-of-the-box) automated evaluation
+resource "google_storage_bucket" "vais_evaluation_output" {
+  name     = "${var.gcp_project_id}_vais_evaluation_output"
+  location = var.gcp_region
+}
+
 #
 resource "google_storage_bucket_object" "qrels_seed_file" {
   name   = "ts=1970-01-01T00:00:00/qc=0/rc=0/judgement_list=sample/qrels.csv"


### PR DESCRIPTION
Trello: https://trello.com/c/byVjO4ZU/876-surface-vais-evaluation-results-in-bq

The best name is already in use for the "old" evaluations. This is for the out-of-the-box evaluations now provided by Vertex AI, hence naming it `vais_evaluation_output` for "Vertex AI Search".

Steps to follow once data is available in the bucket:

1. Create a BigQuery dataset similar to https://github.com/alphagov/govuk-infrastructure/blob/eccb6203f57bf3b68e5fe2d601360ef1c4269ad4/terraform/deployments/search-api-v2/automated_evaluation.tf#L164
2. Create one or more BigQuery tables similar to https://github.com/alphagov/govuk-infrastructure/blob/eccb6203f57bf3b68e5fe2d601360ef1c4269ad4/terraform/deployments/search-api-v2/automated_evaluation.tf#L237
