### PR TITLE
Remove logical replication parameters for ckan production postgresql14

### DIFF
--- a/terraform/deployments/rds/ckan_production_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/ckan_production_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["ckan"]
-  id = "ckan-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["ckan"]
-  id = "production-ckan-postgres-20250721153103318500000001"
-}

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -223,15 +223,10 @@ module "variable-set-rds-production" {
         engine         = "postgres"
         engine_version = "14.18"
         engine_params = {
-          log_min_duration_statement      = { value = 10000 }
-          log_statement                   = { value = "all" }
-          deadlock_timeout                = { value = 2500 }
-          log_lock_waits                  = { value = 1 }
-          "rds.logical_replication"       = { value = 1, apply_method = "pending-reboot" }
-          max_wal_senders                 = { value = 35, apply_method = "pending-reboot" }
-          max_logical_replication_workers = { value = 20, apply_method = "pending-reboot" }
-          max_worker_processes            = { value = 40, apply_method = "pending-reboot" }
-
+          log_min_duration_statement = { value = 10000 }
+          log_statement              = { value = "all" }
+          deadlock_timeout           = { value = 2500 }
+          log_lock_waits             = { value = 1 }
         }
         engine_params_family         = "postgres14"
         name                         = "ckan"


### PR DESCRIPTION
Now that the databases have been switched over and the postgres14 database imported into Terraform we can remove the logical replication parameters and turn off backups

https://github.com/alphagov/govuk-infrastructure/issues/2335