### PR TITLE
Update cluster-secrets helm chart version

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -62,6 +62,6 @@ resource "helm_release" "cluster_secrets" {
   name       = "cluster-secrets"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
-  version    = "0.9.5" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "0.10.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
   timeout    = var.helm_timeout_seconds
 }


### PR DESCRIPTION
Update to the new version of cluster-secrets which includes the logit opensearch secrets needed for the lubernetes events shipper