### PR TITLE
Deploy kubernetes events shipper into cluster services

### DIFF
--- a/terraform/deployments/cluster-services/kubernetes-events-shipper.tf
+++ b/terraform/deployments/cluster-services/kubernetes-events-shipper.tf
@@ -1,0 +1,10 @@
+resource "helm_release" "kubernetes_events_shipper" {
+  depends_on = [helm_release.cluster_secrets]
+
+  chart      = "kubernetes-events-shipper"
+  name       = "kubernetes-events-shipper"
+  namespace  = local.services_ns
+  repository = "https://alphagov.github.io/govuk-helm-charts/"
+  version    = "1.0.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  timeout    = var.helm_timeout_seconds
+}


### PR DESCRIPTION
This chart ships kubernetes control plane events to logit, it depends on https://github.com/alphagov/govuk-infrastructure/pull/2500 which has been applied in integration, staging, and production.

When it comes to applying this, I'll apply integration and ensure everything is honky dory before doing any other envs

Requires https://github.com/alphagov/govuk-helm-charts/pull/3374 to be merged and a release to be done