### PR TITLE
Manage publisher team

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -100,6 +100,12 @@ resource "github_team" "govuk_ithc" {
   description = "To grant temporary access to our GitHub repositories and services that require GitHub authentication to ITHC testers"
 }
 
+resource "github_team" "govuk_publishing_devs" {
+  name        = "GOV.UK Publishing Developers"
+  privacy     = "closed"
+  description = "To enable finer access for merge permissions in publishing apps"
+}
+
 import {
   to = github_team.govuk_production_deploy
   id = "gov-uk-production-deploy"

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -541,6 +541,8 @@ repos:
 
   publisher:
     homepage_url: "https://docs.publishing.service.gov.uk/apps/publisher.html"
+    required_pull_request_reviews:
+      require_code_owner_reviews: true
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:


### PR DESCRIPTION
Two commits:

- Creates a new publishing team for better handling of repo permissions
- Forces a codeowner check for Publisher.

Once completed, merge https://github.com/alphagov/govuk-user-reviewer/pull/1628