### PR TITLE
We don't need to declare the group here, my bad.

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -100,12 +100,6 @@ resource "github_team" "govuk_ithc" {
   description = "To grant temporary access to our GitHub repositories and services that require GitHub authentication to ITHC testers"
 }
 
-resource "github_team" "govuk_publishing_devs" {
-  name        = "GOV.UK Publishing Developers"
-  privacy     = "closed"
-  description = "To enable finer access for merge permissions in publishing apps"
-}
-
 import {
   to = github_team.govuk_production_deploy
   id = "gov-uk-production-deploy"


### PR DESCRIPTION
## What?
As this team is declared in govuk-user-reviewer, we don't need to put it here as well.