### PR TITLE
Update deprecated attribute for "aws_region" in Chat

### DIFF
--- a/terraform/deployments/chat/bedrock_iam.tf
+++ b/terraform/deployments/chat/bedrock_iam.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "bedrock_cloudwatch" {
     ]
     effect = "Allow"
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.bedrock_log_group.name}:log-stream:aws/bedrock/modelinvocations"
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.bedrock_log_group.name}:log-stream:aws/bedrock/modelinvocations"
     ]
   }
 }

--- a/terraform/deployments/chat/data.tf
+++ b/terraform/deployments/chat/data.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {
-  name = var.aws_region
+  region = var.aws_region
 }
 
 data "tfe_outputs" "cluster_infrastructure" {


### PR DESCRIPTION
## What

Update "name" attribute to "region" for data "aws_region" lookup

## Why

The "name" attribute has been deprecated and is generating warnings in TFC