### PR TITLE
Re-Import Recovered DocDB Instance for Prod

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -31,6 +31,12 @@ variable "licensify_backup_retention_period" {
   description = "Number of days to keep Licensify DocumentDB backups for"
 }
 
+variable "shared_documentdb_identifier_suffix" {
+  type        = string
+  default     = ""
+  description = "Identifier suffix for shared DocumentDB instances"
+}
+
 variable "shared_documentdb_instance_count" {
   type        = number
   default     = 3

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -70,6 +70,8 @@ module "variable-set-production" {
     frontend_memcached_node_type = "cache.r6g.large"
 
     ckan_s3_organogram_bucket = "datagovuk-production-ckan-organogram"
+
+    shared_documentdb_identifier_suffix = "-1"
   }
 }
 


### PR DESCRIPTION
## What?
This helps to square-off the DocumentDB related issues we had yesterday.

We have manually removed the State from Terraform and this will re-import the recovered cluster into the state file.