### PR TITLE
Add govuk_chat_private as a repo

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -205,6 +205,11 @@ import {
   id = "govuk_web_banners"
 }
 
+import {
+  to = github_repository.govuk_repos["govuk_chat_private"]
+  id = "govuk_chat_private"
+}
+
 resource "github_branch_protection" "govuk_repos" {
   for_each = { for repo_name, repo_details in local.repositories : repo_name => repo_details if try(repo_details["branch_protection"], true) }
 

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -429,6 +429,19 @@ repos:
       additional_contexts:
         - test
 
+  govuk_chat_private:
+    homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk_chat_private.html"
+    visibility: private
+    # This utility is a gem that isn't pushed to Rubygems, but we need to set
+    # this to true for the appropriate CI token to be set
+    publishes_gem: true
+    required_status_checks:
+      # standard security checks are disabled as not configured for a private repo
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
+        - Run RSpec
+        - Test GOV.UK Chat / Run RSpec
+
   govuk_document_types:
     homepage_url: "https://docs.publishing.service.gov.uk/document-types.html"
     publishes_gem: true


### PR DESCRIPTION
This adds the repo checks. The regular standard security checks CodeQL doesn't work for a private repo and the dependency-review one seems to require additional set-up beyond what a GitHub admin can do. So both are disabled.