### PR TITLE
Dont deploy k8s events shipper in eph clusters

### DIFF
--- a/terraform/deployments/cluster-services/kubernetes-events-shipper.tf
+++ b/terraform/deployments/cluster-services/kubernetes-events-shipper.tf
@@ -1,4 +1,6 @@
 resource "helm_release" "kubernetes_events_shipper" {
+  count = var.ship_kubernetes_events_to_logit ? 1 : 0
+
   depends_on = [helm_release.cluster_secrets]
 
   chart      = "kubernetes-events-shipper"

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -79,3 +79,9 @@ variable "force_destroy" {
   description = "Setting for force_destroy on resources such as Route53 zones. For use in non-production environments to allow for automated tear-down."
   default     = false
 }
+
+variable "ship_kubernetes_events_to_logit" {
+  type        = bool
+  description = "Whether to deploy the kubernetes-events-shipper helm chart which ships kubernetes events to logit"
+  default     = true
+}

--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -76,6 +76,10 @@ module "cluster_services" {
   ephemeral_cluster_id = var.ephemeral_cluster_id
   variable_set_id      = module.var_set.id
 
+  tfvars = {
+    ship_kubernetes_events_to_logit = false
+  }
+
   depends_on = [module.cluster_infrastructure, tfe_project.project]
 }
 

--- a/terraform/deployments/ephemeral/ws/variables.tf
+++ b/terraform/deployments/ephemeral/ws/variables.tf
@@ -20,6 +20,12 @@ variable "variable_set_id" {
   type = string
 }
 
+variable "git_branch" {
+  type        = string
+  description = "The branch of the source repo to deploy"
+  default     = "main"
+}
+
 variable "tfvars" {
   type        = map(any)
   description = "Additional tfvars to set on the workspace"

--- a/terraform/deployments/ephemeral/ws/variables.tf
+++ b/terraform/deployments/ephemeral/ws/variables.tf
@@ -19,3 +19,9 @@ variable "terraform_version" {
 variable "variable_set_id" {
   type = string
 }
+
+variable "tfvars" {
+  type        = map(any)
+  description = "Additional tfvars to set on the workspace"
+  default     = {}
+}

--- a/terraform/deployments/ephemeral/ws/workspace.tf
+++ b/terraform/deployments/ephemeral/ws/workspace.tf
@@ -30,6 +30,8 @@ module "workspace" {
     "common",
     "common-ephemeral"
   ]
+
+  tfvars = var.tfvars
 }
 
 resource "tfe_workspace_run" "run" {

--- a/terraform/deployments/ephemeral/ws/workspace.tf
+++ b/terraform/deployments/ephemeral/ws/workspace.tf
@@ -15,7 +15,7 @@ module "workspace" {
   project_name = var.ephemeral_cluster_id
   vcs_repo = {
     identifier     = "alphagov/govuk-infrastructure"
-    branch         = "main"
+    branch         = var.git_branch
     oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
   }
 


### PR DESCRIPTION
The kubernetes-events-shipper shouldn't be deployed to ephemeral clusters, so this PR:

* Adds a feature flag to cluster-services (defaulted to on) for deploying the kubernetes-events-shipper
* Updates the ephemeral workspace module to allow passing tfvars to the workspace
* Updates the ephemeral cluster-services ephemeral workspace to set the feature flag for shipping events to false

However, epemeral clusters are hardcoded to run the main branch of govuk-infrastructure. Given a big need for them is for us to test cluster terraform changes, I also:

* Add a variable in the ephemeral workspace module to allow deploying a non-default branch of govuk-infrastructure

This allowed me locally to set it to this branch, and apply in my ephemeral cluster, which then [correctly didn't try and deploy the helm chart for kubernetes-events-shipper](https://app.terraform.io/app/govuk/workspaces/cluster-services-eph-jfharden-2025-08-05/runs/run-D9T1XmmaSiL346P2)