### PR TITLE
Add govuk-chat-evaluation as a managed repo

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -210,6 +210,11 @@ import {
   id = "govuk_chat_private"
 }
 
+import {
+  to = github_repository.govuk_repos["govuk-chat-evaluation"]
+  id = "govuk-chat-evaluation"
+}
+
 resource "github_branch_protection" "govuk_repos" {
   for_each = { for repo_name, repo_details in local.repositories : repo_name => repo_details if try(repo_details["branch_protection"], true) }
 

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -288,6 +288,16 @@ repos:
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
 
+  govuk-chat-evaluation:
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/govuk-chat-evaluation.html"
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - Tests
+        - Lint
+        - Format
+        - Type checks
+
   govuk-content-api-docs:
     homepage_url: "https://content-api.publishing.service.gov.uk"
     need_production_access_to_merge: false


### PR DESCRIPTION
I didn't previously add this repo so it has lacked consistent management.

As this is a Python project it doesn't reuse the same actions as other repos, hence the less conventional additional_contexts names.