### PR TITLE
Import Web Banners Branch Protection

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -201,8 +201,8 @@ resource "github_repository" "govuk_repos" {
 }
 
 import {
-  to = github_repository.govuk_repos["govuk_web_banners"]
-  id = "govuk_web_banners"
+  to = github_branch_protection.govuk_repos["govuk_web_banners"]
+  id = "govuk_web_banners:main"
 }
 
 import {


### PR DESCRIPTION
## What?
This imports a missing branch protection for `govuk_web_banners`, hopefully unblocking our Github Terraform management.