### PR TITLE
Pull ECR Repository Config via Github Deployment Data

### DIFF
--- a/terraform/deployments/ecr/data.tf
+++ b/terraform/deployments/ecr/data.tf
@@ -44,3 +44,8 @@ data "aws_iam_policy_document" "topic-policy-ecr-sns" {
     sid       = "TrustCWEToPublishEventsToMyTopic"
   }
 }
+
+data "tfe_outputs" "github" {
+  organization = "govuk"
+  workspace    = "Github"
+}

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -53,17 +53,18 @@ locals {
   )
 
   extra_repositories = [
-    "mongodb",
-    "imminence",
-    "toolbox",
     "clamav",
-    "search-api-learn-to-rank",
+    "govuk-e2e-tests",
+    "govuk-fastly-diff-generator",
+    "govuk-replatform-test-app",
+    "imminence",
     "licensify-backend",
     "licensify-feed",
     "licensify-frontend",
-    "govuk-fastly-diff-generator",
-    "govuk-e2e-tests",
-    "publisher-on-pg"
+    "mongodb",
+    "publisher-on-pg",
+    "search-api-learn-to-rank",
+    "toolbox",
   ]
 }
 
@@ -77,8 +78,8 @@ resource "aws_ecr_repository" "github_repositories" {
   image_scanning_configuration { scan_on_push = true }
 
   lifecycle {
-   prevent_destroy = true
- }
+    prevent_destroy = true
+  }
 }
 
 resource "aws_ecr_pull_through_cache_rule" "github" {

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -46,14 +46,10 @@ provider "github" {
   token = data.aws_secretsmanager_secret_version.github-token.secret_string
 }
 
-data "github_repositories" "govuk" {
-  query = "org:alphagov topic:container topic:govuk fork:false archived:false"
-}
-
 locals {
   repositories = concat(
     local.extra_repositories,
-    data.github_repositories.govuk.names
+    data.tfe_outputs.github.nonsensitive_values.deployable_repo_names
   )
 
   extra_repositories = [
@@ -79,6 +75,10 @@ resource "aws_ecr_repository" "github_repositories" {
   name                 = "github/alphagov/govuk/${each.key}"
   image_tag_mutability = "MUTABLE" # To support a movable `latest` for developer convenience.
   image_scanning_configuration { scan_on_push = true }
+
+  lifecycle {
+   prevent_destroy = true
+ }
 }
 
 resource "aws_ecr_pull_through_cache_rule" "github" {

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -200,11 +200,6 @@ resource "github_repository" "govuk_repos" {
   }
 }
 
-import {
-  to = github_branch_protection.govuk_repos["govuk_chat_private"]
-  id = "govuk_chat_private:main"
-}
-
 resource "github_branch_protection" "govuk_repos" {
   for_each = { for repo_name, repo_details in local.repositories : repo_name => repo_details if try(repo_details["branch_protection"], true) }
 


### PR DESCRIPTION
## What?
This switches the ECR Deployment to use the explicit list of Github Repositories instead of using the Github API via Topic Selectors.

I have also thrown in a lifecycle rule to prevent accidental destruction of ECR Repos.