### PR TITLE
Update GitHub Deploy Docs and Add ADR

### DIFF
--- a/docs/architecture/decisions/0017-retire-use-of-github-topics-for-config-management.md
+++ b/docs/architecture/decisions/0017-retire-use-of-github-topics-for-config-management.md
@@ -1,0 +1,33 @@
+# 17. Retire Use of GitHub Topics for Config Management
+
+Date: 2026-08-06
+
+## Status
+
+Accepted
+
+## Context
+
+Historically, GOV.UK has used GitHub Topic Tags (like labels) in order to select and configure multiple Repositories for things such as enforcing standard configurations or granting variables (including secrets) to sets of Repositories.
+
+This has been highlighted as an issue for several reasons, including:
+
+* Use of Topics is not access-controlled or restricted - they can be assigned by anyone who has access to a Repository, making it possible to accidentally (or intentionally) bring an unexpected or undesired repo into configuration scope.
+* GitHub incidents have resulted in the GitHub Search API returning unexpected (or no) results, negatively impacting Terraform runs and resulting in the undesired removal of ECR Repositories or CodeCommit mirrors.
+
+## Decision
+
+We have decided to stop using GitHub Topics as selectors or identifiers for our automation scripts (including Terraform). As a consequence, we must now configure our GitHub Repositories using configuration files or in code, explicitly rather than implicitly through remotely-managed tags or labels.
+
+The changes spurred from this decision have been documented in the [GOV.UK Developer Docs](https://github.com/alphagov/govuk-developer-docs/pull/5187) and predominantly affect the 
+[Github Terraform Deployment](https://github.com/alphagov/govuk-infrastructure/tree/main/terraform/deployments/github).
+
+Topics can still be set by Repository owners for the purpose of making Repositories easier to filter, search or organise, however, must no longer be used as selectors for automations or scripts.
+
+## Consequences
+
+As a result of this decision:
+
+* We will need to remember to update any Repository configuration changes in code.
+* Topics will no longer be able to grant Deployment Secrets to Repositories without oversight.
+* Issues affecting the GitHub Search API will no longer risk breaking our Terraform in a way that is unsafe.

--- a/terraform/deployments/github/README.md
+++ b/terraform/deployments/github/README.md
@@ -3,18 +3,17 @@
 > **Note**: Currently this module can only be applied by an alphagov GitHub
 Organisation Admin.
 
-This module configures GitHub resources (currently just GitHub Action Organisation
-Secret Repositories) so that the platform can automatically give permissions to
-repositories with specific tags.
+This module configures GitHub resources so that the platform can automatically give permissions to
+repositories with specific properties in the included YAML file.
 
-We anticipate that teams will add GitHub tags to their repositories (similar to
-annotations on Kubernetes resources) to enable platform functionality.
-For instance creating an ECR registry and giving permissions to push to the
-registry might be enabled with the repo tag `container`.
+We no longer use GitHub topics (tags) on repositories (similar to
+annotations on Kubernetes resources) to configure or enable platform functionality.
+
+Instead, creating an ECR registry and giving permissions to push to the
+registry might be enabled by setting `can_be_deployed` to `true` in the YAML file.
 
 This module configures repositories with sensible defaults such as
-protecting the `main` branch and ensuring the repository is compatible with
-our old EC2-based platform (such as checking Jenkins config).
+protecting the `main` branch.
 
 ## Applying Terraform
 


### PR DESCRIPTION
## What?
This creates a new ADR explaining the "retirement" of GitHub Topics for Configuration Management purposes.

This also updates the included README in the GitHub TF Deployment folder to stop referring to the use of Topics.