### PR TITLE
chore: 🤖 default value for amazonmq_engine_version removed

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -76,7 +76,6 @@ variable "search_api_rate_limit" {
 
 variable "amazonmq_engine_version" {
   type        = string
-  default     = "3.11.28"
   description = "Engine version for publishing AmazonMQ cluster"
 }
 


### PR DESCRIPTION
- variable default value removed (noop)

✅ Closes: [#2420](https://github.com/alphagov/govuk-infrastructure/issues/2420)