### PR TITLE
RDS Delete Protect default on, make configurable.

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -80,7 +80,7 @@ resource "aws_db_instance" "instance" {
     update = var.terraform_update_rds_timeout
   }
 
-  deletion_protection       = var.govuk_environment == "production"
+  deletion_protection       = try(each.value.deletion_protection, true)
   final_snapshot_identifier = "${each.value.name}-final-snapshot"
   skip_final_snapshot       = var.skip_final_snapshot
 


### PR DESCRIPTION
## What?
This changes the default settings for RDS Instances across all environments.

**Previously:**

* Deletion Protection was set to `true` in Production.

**Now:**

* Deletion Protection defaults to `true` in all environments, unless it is explicitly set to `false` on a per-instance, per-environment basis, configurable by setting this to `false` in the TF Vars.