### PR TITLE
✨ Add default tagging options to opensearch terraform

### DIFF
--- a/terraform/deployments/opensearch/main.tf
+++ b/terraform/deployments/opensearch/main.tf
@@ -16,6 +16,17 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
+  default_tags {
+    tags = {
+      product              = "govuk"
+      system               = "govuk-chat"
+      service              = "opensearch"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      repository           = "govuk-infrastructure"
+      terraform-deployment = basename(abspath(path.root))
+    }
+  }
 }
 
 locals {


### PR DESCRIPTION
The default options are described in further details by the aws way definition: https://gds-way.digital.cabinet-office.gov.uk/manuals/aws-tagging.html#tagging-aws-resources
