### PR TITLE
✨ Add default tagging options to datagovuk-infrastructure terraform

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/main.tf
+++ b/terraform/deployments/datagovuk-infrastructure/main.tf
@@ -31,21 +31,20 @@ locals {
   cluster_id    = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id
   services_ns   = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_services_namespace
   oidc_provider = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_oidc_provider
-
-  default_tags = {
-    Product              = "DATA.GOV.UK"
-    System               = "DATA.GOV.UK"
-    Environment          = var.govuk_environment
-    Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
-    project              = "replatforming"
-    repository           = "govuk-infrastructure"
-    terraform_deployment = basename(abspath(path.root))
-  }
 }
 
 provider "aws" {
   region = "eu-west-1"
-  default_tags { tags = local.default_tags }
+  default_tags {
+    tags = {
+      product              = "govuk"
+      system               = "govuk-dgu"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      repository           = "govuk-infrastructure"
+      terraform-deployment = basename(abspath(path.root))
+    }
+  }
 }
 
 data "aws_eks_cluster_auth" "cluster_token" {


### PR DESCRIPTION
## Summary
- Standardize AWS resource tagging by moving from local variable to inline provider configuration
- Update tag structure with lowercase keys and govuk-specific values
- Remove unused project tag while maintaining core tags (environment, owner, repository)

## Changes
- Move default_tags from local variable to inline provider configuration
- Change product tag from "DATA.GOV.UK" to "govuk"
- Change system tag from "DATA.GOV.UK" to "govuk-dgu" 
- Convert terraform_deployment to terraform-deployment (lowercase with hyphen)
- Remove project tag

## Test plan
- [ ] Verify terraform plan shows expected tag changes
- [ ] Confirm no breaking changes to existing resources
- [ ] Validate tags are applied correctly to new resources

🤖 Generated with [Claude Code](https://claude.ai/code)