### PR TITLE
✨ Add default tagging options to tfc-aws-config terraform

### DIFF
--- a/terraform/deployments/tfc-aws-config/provider.tf
+++ b/terraform/deployments/tfc-aws-config/provider.tf
@@ -32,12 +32,13 @@ provider "aws" {
   region = "eu-west-1"
   default_tags {
     tags = {
-      Product              = "GOV.UK"
-      System               = "Terraform Cloud"
-      Environment          = var.govuk_environment
-      Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      product              = "govuk"
+      system               = "govuk-platform-engineering"
+      service              = "tfc-aws-config"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
       repository           = "govuk-infrastructure"
-      terraform_deployment = basename(abspath(path.root))
+      terraform-deployment = basename(abspath(path.root))
     }
   }
 }


### PR DESCRIPTION
## Summary
- Standardise AWS resource tagging in tfc-aws-config deployment
- Update tag structure with lowercase keys and govuk-specific values
- Add service tag for better resource identification

## Changes
- Change product tag from "GOV.UK" to "govuk"
- Change system tag from "Terraform Cloud" to "govuk-platform-engineering"
- Add service tag "tfc-aws-config"
- Convert tag keys to lowercase (environment, owner)
- Convert terraform_deployment to terraform-deployment (lowercase with hyphen)
- Maintain repository tag

## Test plan
- [ ] Verify terraform plan shows expected tag changes
- [ ] Confirm no breaking changes to existing resources
- [ ] Validate tags are applied correctly to new resources