### PR TITLE
✨ Add default tagging options to release, root-dns and security terraform deployments

### DIFF
--- a/terraform/deployments/release/main.tf
+++ b/terraform/deployments/release/main.tf
@@ -23,13 +23,13 @@ provider "aws" {
   region = "eu-west-1"
   default_tags {
     tags = {
-      Product              = "GOV.UK"
-      System               = "EKS release assumer"
-      Environment          = var.govuk_environment
-      Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      product              = "govuk"
+      system               = "govuk-release"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
       cluster              = "govuk"
       repository           = "govuk-infrastructure"
-      terraform_deployment = basename(abspath(path.root))
+      terraform-deployment = basename(abspath(path.root))
     }
   }
 }

--- a/terraform/deployments/root-dns/main.tf
+++ b/terraform/deployments/root-dns/main.tf
@@ -18,12 +18,13 @@ provider "aws" {
   region = var.aws_region
   default_tags {
     tags = {
-      Product              = "GOV.UK"
-      System               = "DNS"
-      Environment          = var.govuk_environment
-      Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      product              = "govuk"
+      system               = "govuk-platform-engineering"
+      service              = "dns"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
       repository           = "govuk-infrastructure"
-      terraform_deployment = basename(abspath(path.root))
+      terraform-deployment = basename(abspath(path.root))
     }
   }
 }

--- a/terraform/deployments/security/provider.tf
+++ b/terraform/deployments/security/provider.tf
@@ -18,12 +18,13 @@ provider "aws" {
   region = "eu-west-1"
   default_tags {
     tags = {
-      Product              = "GOV.UK"
-      System               = "Security"
-      Environment          = var.govuk_environment
-      Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      product              = "govuk"
+      system               = "govuk-platform-engineering"
+      service              = "security"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
       repository           = "govuk-infrastructure"
-      terraform_deployment = basename(abspath(path.root))
+      terraform-deployment = basename(abspath(path.root))
     }
   }
 }


### PR DESCRIPTION
## Summary
- Standardise AWS resource tagging across release, root-dns and security deployments
- Update tag structure with lowercase keys and govuk-specific values
- Add service tags for better resource identification where applicable

## Changes

### Release deployment
- Change product tag from "GOV.UK" to "govuk"
- Change system tag from "EKS release assumer" to "govuk-release"
- Convert tag keys to lowercase and standardise format

### Root-DNS deployment
- Change product tag from "GOV.UK" to "govuk"
- Change system tag from "DNS" to "govuk-platform-engineering"
- Add service tag "dns"
- Convert tag keys to lowercase and standardise format

### Security deployment
- Change product tag from "GOV.UK" to "govuk"
- Change system tag from "Security" to "govuk-platform-engineering"
- Add service tag "security"
- Convert tag keys to lowercase and standardise format

## Test plan
- [ ] Verify terraform plan shows expected tag changes for all three deployments
- [ ] Confirm no breaking changes to existing resources
- [ ] Validate tags are applied correctly to new resources across all deployments