### PR TITLE
✨ Add default tagging options to cluster-infrastructure, cluster-services and csp-reporter terraform deployments 

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -119,13 +119,13 @@ provider "aws" {
   region = "eu-west-1"
   default_tags {
     tags = {
-      Product              = "GOV.UK"
-      System               = "EKS cluster infrastructure"
-      Environment          = var.govuk_environment
-      Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
-      cluster              = var.cluster_name
+      product              = "govuk"
+      system               = "govuk-platform-engineering"
+      service              = "eks"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
       repository           = "govuk-infrastructure"
-      terraform_deployment = basename(abspath(path.root))
+      terraform-deployment = basename(abspath(path.root))
     }
   }
 }

--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -41,13 +41,13 @@ provider "aws" {
   region = "eu-west-1"
   default_tags {
     tags = {
-      Product              = "GOV.UK"
-      System               = "EKS cluster services"
-      Environment          = var.govuk_environment
-      Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
-      cluster              = "govuk"
+      product              = "govuk"
+      system               = "govuk-platform-engineering"
+      service              = "eks-cluster-services"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
       repository           = "govuk-infrastructure"
-      terraform_deployment = basename(abspath(path.root))
+      terraform-deployment = basename(abspath(path.root))
     }
   }
 }

--- a/terraform/deployments/csp-reporter/main.tf
+++ b/terraform/deployments/csp-reporter/main.tf
@@ -19,13 +19,13 @@ provider "aws" {
   region = var.aws_region
   default_tags {
     tags = {
-      Product              = "GOV.UK"
-      System               = "CSP Reporter"
-      Environment          = var.govuk_environment
-      Owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      product              = "govuk"
+      system               = "govuk-csp-reporter"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
       cluster              = "govuk"
       repository           = "govuk-infrastructure"
-      terraform_deployment = basename(abspath(path.root))
+      terraform-deployment = basename(abspath(path.root))
     }
   }
 }


### PR DESCRIPTION
## Summary
- Standardise AWS resource tagging across cluster-infrastructure, cluster-services and csp-reporter deployments
- Update tag structure with lowercase keys and govuk-specific values
- Add service tags for better resource identification where applicable

## Changes

### Cluster-infrastructure deployment
- Change product tag from "GOV.UK" to "govuk"
- Change system tag from "EKS cluster infrastructure" to "govuk-platform-engineering"
- Add service tag "eks"
- Convert tag keys to lowercase and standardise format
- Remove cluster tag

### Cluster-services deployment
- Change product tag from "GOV.UK" to "govuk"
- Change system tag from "EKS cluster services" to "govuk-platform-engineering"
- Add service tag "eks-cluster-services"
- Convert tag keys to lowercase and standardise format
- Remove cluster tag

### CSP-reporter deployment
- Change product tag from "GOV.UK" to "govuk"
- Change system tag from "CSP Reporter" to "govuk-csp-reporter"
- Convert tag keys to lowercase and standardise format


## Test plan
- [ ] Verify terraform plan shows expected tag changes for all three deployments
- [ ] Confirm no breaking changes to existing resources
- [ ] Validate tags are applied correctly to new resources across all deployments