### PR TITLE
Disable deletion protection for publisher postgres db in staging and production

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -481,6 +481,7 @@ module "variable-set-rds-production" {
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
+        deletion_protection          = false
       }
 
       release = {

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -473,6 +473,7 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
+        deletion_protection          = false
       }
 
       release = {


### PR DESCRIPTION
These 2 databases (publisher postgres in staging and prod) are not yet in use and are inconsistently named.

With permission from the team we are destroying and recreating these currently empty databases. First I need to disable deletion protection.

In a follow on PR I will change the naming so they are consistent