### PR TITLE
Revert "Only use an env prefix for RDS identifiers for ephemeral clusters"

### DIFF
--- a/terraform/deployments/rds/notifications.tf
+++ b/terraform/deployments/rds/notifications.tf
@@ -1,11 +1,11 @@
 data "aws_secretsmanager_secret" "slack_channel" {
-  count = local.is_ephemeral ? 0 : 1
+  count = startswith(var.govuk_environment, "eph-") ? 0 : 1
 
   name = "govuk/slack/platform-support-email"
 }
 
 data "aws_secretsmanager_secret_version" "slack_channel" {
-  count = local.is_ephemeral ? 0 : 1
+  count = startswith(var.govuk_environment, "eph-") ? 0 : 1
 
   secret_id = data.aws_secretsmanager_secret.slack_channel[count.index].id
 }
@@ -16,7 +16,7 @@ resource "aws_sns_topic" "rds_alerts" {
 }
 
 resource "aws_sns_topic_subscription" "rds_alerts" {
-  count = local.is_ephemeral ? 0 : 1
+  count = startswith(var.govuk_environment, "eph-") ? 0 : 1
 
   topic_arn = aws_sns_topic.rds_alerts.arn
   protocol  = "email"

--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -1,8 +1,5 @@
 locals {
   rds_subnet_ids = compact([for name, id in data.tfe_outputs.vpc.nonsensitive_values.private_subnet_ids : startswith(name, "rds_") ? id : ""])
-
-  is_ephemeral      = startswith(var.govuk_environment, "eph-")
-  identifier_prefix = local.is_ephemeral ? "${var.govuk_environment}-" : ""
 }
 
 resource "random_string" "database_password" {
@@ -54,7 +51,7 @@ resource "aws_db_instance" "instance" {
   username                    = var.database_admin_username
   password                    = random_string.database_password[each.key].result
   instance_class              = each.value.instance_class
-  identifier                  = "${local.identifier_prefix}${each.value.name}-${each.value.engine}"
+  identifier                  = "${var.govuk_environment}-${each.value.name}-${each.value.engine}"
   db_subnet_group_name        = aws_db_subnet_group.subnet_group.name
   multi_az                    = var.multi_az
   parameter_group_name        = aws_db_parameter_group.engine_params[each.key].name
@@ -88,6 +85,8 @@ resource "aws_db_instance" "instance" {
   skip_final_snapshot       = var.skip_final_snapshot
 
   tags = { Name = "govuk-rds-${each.value.name}-${each.value.engine}", project = lookup(each.value, "project", "GOV.UK - Other") }
+
+  lifecycle { ignore_changes = [identifier] }
 }
 
 resource "aws_db_event_subscription" "subscription" {
@@ -137,7 +136,7 @@ resource "aws_db_instance" "replica" {
   }
 
   instance_class                        = each.value.instance_class
-  identifier                            = "${local.identifier_prefix}${each.value.name}-${each.value.engine}-replica"
+  identifier                            = "${var.govuk_environment}-${each.value.name}-${each.value.engine}-replica"
   replicate_source_db                   = aws_db_instance.instance[each.key].identifier
   performance_insights_enabled          = aws_db_instance.instance[each.key].performance_insights_enabled
   performance_insights_retention_period = aws_db_instance.instance[each.key].performance_insights_retention_period
@@ -145,6 +144,8 @@ resource "aws_db_instance" "replica" {
   skip_final_snapshot = true
 
   tags = { Name = "govuk-rds-${each.value.name}-${each.value.engine}-replica", project = lookup(each.value, "project", "GOV.UK - Other") }
+
+  lifecycle { ignore_changes = [identifier] }
 }
 
 resource "aws_route53_record" "replica_cname" {


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#2566

This is chagning the publishing_api replica name :( not just the publisher name