### PR TITLE
Replace links like [here] with useful link text

### DIFF
--- a/docs/prerequisite-secrets.md
+++ b/docs/prerequisite-secrets.md
@@ -1,8 +1,7 @@
 # Prerequisite Secrets
 
 The platform requires some prerequisite secrets in order to fully function.
-These secrets are stores in AWS Secret Manager, further info about the integration
-of the k8s platform platform with AWS Secret Manager is available [here](kubernetes-external-secrets.md)
+These secrets are stored in AWS Secret Manager, using the Kubernetes [External Secrets operator](kubernetes-external-secrets.md)
 
 The secrets listed here are either:
 1. externally generated in external systems and imported into our platform. E.g.
@@ -15,9 +14,8 @@ The secrets listed here are either:
    helm chart of the [govuk-helm-charts] GitHub repository. These are usually copied across from
    from [govuk-secrets](https://github.com/alphagov/govuk-secrets)
 
-The canonical source of all the platform secrets required are listed
-[here](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/cluster-secrets/templates)
-in the [govuk-helm-charts] GitHub repository.
+The canonical source of all the [platform secrets](https://github.com/alphagov/govuk-helm-charts/tree/main/charts/cluster-secrets/templates) 
+required are listed in the [govuk-helm-charts] GitHub repository.
 
 The purpose of this document is to provide information about:
 1. how these secrets are generated/obtained exactly

--- a/docs/setting-up-content-delivery-network.md
+++ b/docs/setting-up-content-delivery-network.md
@@ -10,8 +10,8 @@ To setup Fastly, log into the Fastly web management [portal](https://manage.fast
 
 1. Choose a domain that users will use to reach your GOV.UK environment, e.g.
    the GOV.UK EKS platform uses domain with format `www.eks.<environment>.govuk.digital`
-2. Create a Fastly/letsencrypt TLS certificate for your chosen domain and attach
-   it to the "govuk" TLS configuration. Further details are available [here](https://docs.fastly.com/en/guides/serving-https-traffic-using-fastly-managed-certificates)
+2. Create a Fastly/letsencrypt TLS certificate for your chosen domain and [attach it]((https://docs.fastly.com/en/guides/serving-https-traffic-using-fastly-managed-certificates))
+   to the "govuk" TLS configuration.
 3. You will be asked to create a CNAME to point to a specific given address, you should use
    this address as the value of the variable `www_dns_validation_rdata` in the `commons.yaml` file
    of the environment you are deploying, e.g. for integration it is located [here](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/variables/integration/common.tfvars)
@@ -21,7 +21,7 @@ To setup Fastly, log into the Fastly web management [portal](https://manage.fast
 
 1. In the Fastly portal, create a new CDN service, e.g. `<environment> GOV.UK EKS`.
    You should use the same domain that you have chosen above. Make a note of the new service ID.
-2. Create a pull request in the [GitHub repo](https://github.com/alphagov/govuk-cdn-config-secrets)
-   with a new service under `www-eks`. You can use this previous [pull request](https://github.com/alphagov/govuk-cdn-config-secrets/pull/151)
+2. Create a pull request in [the `govuk-cdn-config-secrets` GitHub repo](https://github.com/alphagov/govuk-cdn-config-secrets)
+   with a new service under `www-eks`. You can use this [previous pull request](https://github.com/alphagov/govuk-cdn-config-secrets/pull/151)
    as example.
 3. See [how to deploy Fastly](https://docs.publishing.service.gov.uk/manual/cdn.html#deploying-fastly).

--- a/terraform/docs/tagging-guide.md
+++ b/terraform/docs/tagging-guide.md
@@ -97,4 +97,4 @@ The following is a list of AWS resources that do NOT support tags :-
 - AWS::WAFRegional::WebACL
 
 # Reference content
-- For the definitive list of AWS resources that support tagging see [here](https://docs.aws.amazon.com/awsconsolehelpdocs/latest/gsg/supported-resources.html)
+- For the definitive list of AWS resources that support tagging see [AWS' guide to supported resources](https://docs.aws.amazon.com/awsconsolehelpdocs/latest/gsg/supported-resources.html)


### PR DESCRIPTION
The GOV.UK style guide explicitly says to avoid words like "here" as link text[1]. We should be using descriptive link text.

[1] https://www.gov.uk/guidance/content-design/links