### PR TITLE
Production: upgrade and import PostgreSQL 14 content-data-admin database

### DIFF
--- a/terraform/deployments/rds/content_data_admin_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/content_data_admin_postgres_14_upgrade.tf
@@ -1,25 +1,9 @@
-resource "aws_db_parameter_group" "content_data_admin_postgresql_14_green_params" {
+import {
+  to = aws_db_instance.instance["content_data_admin"]
+  id = "content-data-admin-postgres"
+}
 
-  name_prefix = "${var.govuk_environment}-content-data-admin-postgres-"
-  family      = "postgres14"
-
-  parameter {
-    name         = "rds.logical_replication"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-
-  lifecycle { create_before_destroy = true }
+import {
+  to = aws_db_parameter_group.engine_params["content_data_admin"]
+  id = "production-content-data-admin-postgres-20250819094634183300000001"
 }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -254,7 +254,7 @@ module "variable-set-rds-production" {
 
       content_data_admin = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -274,7 +274,7 @@ module "variable-set-rds-production" {
           }
 
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "content-data-admin"
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"


### PR DESCRIPTION
This PR does 2 things:

1. Upgrades content-data-admin to pg14 in production in code
2. Imports the upgraded pg14 database into Terraform state