### PR TITLE
Always install the current LTS version of NodeJS in GitHub Actions

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
-        node-version: 18
+        node-version: lts/*
         cache: 'yarn'
 
     - name: Install JavaScript dependencies


### PR DESCRIPTION
Our GitHub Actions workflows install NodeJS in two reusable workflows:
- `setup-node` (n.b. this is NOT the standard GHA action, but our wrapper around it)
- `publish-npm-package` (this DOES use the standard GHA actions/setup-node action)

The latter already installed the latest NodeJS LTS version using the supported `lts/*` syntax. This commit makes our `actions/setup-node` reusable workflow do the same thing.

This should mean we don't need to change the version in future. We should continue to get the LTS versions as they're released.