### PR TITLE
Add govuk-chat-gradio-prototype to repos.yml

### DIFF
--- a/terraform/deployments/github/import.tf
+++ b/terraform/deployments/github/import.tf
@@ -1,0 +1,4 @@
+import {
+  to = github_repository.govuk_repos["govuk-chat-gradio-prototype"]
+  id = "govuk-chat-gradio-prototype"
+}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -298,6 +298,17 @@ repos:
         - Format
         - Type checks
 
+  govuk-chat-gradio-prototype:
+    visibility: private
+    homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk-chat-gradio-prototype.html"
+    required_status_checks:
+      # standard security checks are disabled as not configured for a private repo
+      additional_contexts:
+        - Tests
+        - Lint
+        - Format
+        - Type checks
+
   govuk-content-api-docs:
     homepage_url: "https://content-api.publishing.service.gov.uk"
     need_production_access_to_merge: false


### PR DESCRIPTION
We've recently added this prototype to conduct rapid experiments for GOV.UK Chat using Gradio.