### PR TITLE
Fix CloudWatch log source to `us-east-1`

### DIFF
--- a/terraform/deployments/cloudfront/logging.tf
+++ b/terraform/deployments/cloudfront/logging.tf
@@ -50,6 +50,7 @@ resource "aws_cloudwatch_log_group" "www_distribution_cloudfront_log_group" {
 resource "aws_cloudwatch_log_delivery_source" "www_distribution_cloudfront_log_delivery_source" {
   name         = "www_distribution_cloudfront"
   log_type     = "ACCESS_LOGS"
+  provider     = aws.global
   resource_arn = aws_cloudfront_distribution.www_distribution.arn
 }
 


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2622 configured V2 logging but it is erroring as the log source needs to be in `us-east-1` as CloudFront is managed from that region
- https://github.com/alphagov/govuk-infrastructure/issues/2522