### PR TITLE
Fix CloudWatch delivery source to `us-east-1`

### DIFF
--- a/terraform/deployments/cloudfront/logging.tf
+++ b/terraform/deployments/cloudfront/logging.tf
@@ -55,7 +55,8 @@ resource "aws_cloudwatch_log_delivery_source" "www_distribution_cloudfront_log_d
 }
 
 resource "aws_cloudwatch_log_delivery_destination" "www_distribution_cloudfront_log_delivery_destination" {
-  name = "www_distribution_cloudfront_log_group"
+  name     = "www_distribution_cloudfront_log_group"
+  provider = aws.global
 
   delivery_destination_configuration {
     destination_resource_arn = aws_cloudwatch_log_group.www_distribution_cloudfront_log_group.arn


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2624 set the delivery destination to `us-east-1` so this also needs to be set to `us-east-1`
- https://github.com/alphagov/govuk-infrastructure/issues/2522