### PR TITLE
Set CloudFront logging log group to `us-east-1`

### DIFF
--- a/terraform/deployments/cloudfront/logging.tf
+++ b/terraform/deployments/cloudfront/logging.tf
@@ -3,8 +3,8 @@ resource "aws_iam_role" "cloudfront_cloudwatch" {
   assume_role_policy = data.aws_iam_policy_document.cloudfront_cloudwatch_assume_role.json
 }
 
-data "aws_region" "current" {
-  region = var.aws_region
+data "aws_region" "global" {
+  region = "us-east-1"
 }
 
 data "aws_caller_identity" "current" {}
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "cloudfront_cloudwatch" {
     ]
     effect = "Allow"
     resources = [
-      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.www_distribution_cloudfront_log_group.name}:*"
+      "arn:aws:logs:${data.aws_region.global.region}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.www_distribution_cloudfront_log_group.name}:*"
     ]
   }
 }
@@ -44,6 +44,7 @@ resource "aws_iam_role_policy_attachment" "cloudfront_cloudwatch" {
 
 resource "aws_cloudwatch_log_group" "www_distribution_cloudfront_log_group" {
   name              = "/aws/cloudfront/www-${var.govuk_environment}"
+  provider          = aws.global
   retention_in_days = 30
 }
 


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2624 fixed the logging destination but it also requires the log group to be in `us-east-1`
- https://github.com/alphagov/govuk-infrastructure/issues/2522