### PR TITLE
Set aws_cloudwatch_log_delivery to `us-east-1`

### DIFF
--- a/terraform/deployments/cloudfront/logging.tf
+++ b/terraform/deployments/cloudfront/logging.tf
@@ -65,6 +65,7 @@ resource "aws_cloudwatch_log_delivery_destination" "www_distribution_cloudfront_
 }
 
 resource "aws_cloudwatch_log_delivery" "www_distribution_cloudfront_log_delivery" {
+  provider                 = aws.global
   delivery_source_name     = aws_cloudwatch_log_delivery_source.www_distribution_cloudfront_log_delivery_source.name
   delivery_destination_arn = aws_cloudwatch_log_delivery_destination.www_distribution_cloudfront_log_delivery_destination.arn
 }


### PR DESCRIPTION
Description:
- Needs to be set to `us-east-1` as CloudFront is in that region
- https://github.com/alphagov/govuk-infrastructure/issues/2522