### PR TITLE
Set region explicitly on CloudWatch log group

### DIFF
--- a/terraform/deployments/cloudfront/logging.tf
+++ b/terraform/deployments/cloudfront/logging.tf
@@ -4,7 +4,7 @@ resource "aws_iam_role" "cloudfront_cloudwatch" {
 }
 
 data "aws_region" "global" {
-  region = "us-east-1"
+  region = var.aws_region_global
 }
 
 data "aws_caller_identity" "current" {}
@@ -45,6 +45,7 @@ resource "aws_iam_role_policy_attachment" "cloudfront_cloudwatch" {
 resource "aws_cloudwatch_log_group" "www_distribution_cloudfront_log_group" {
   name              = "/aws/cloudfront/www-${var.govuk_environment}"
   provider          = aws.global
+  region            = var.aws_region_global
   retention_in_days = 30
 }
 

--- a/terraform/deployments/cloudfront/main.tf
+++ b/terraform/deployments/cloudfront/main.tf
@@ -37,11 +37,6 @@ provider "aws" {
   region = "us-east-1"
 }
 
-provider "aws" {
-  alias  = "eu_west_2"
-  region = "eu-west-2"
-}
-
 provider "archive" {}
 
 resource "aws_cloudfront_cache_policy" "no-cookies" {

--- a/terraform/deployments/cloudfront/variables.tf
+++ b/terraform/deployments/cloudfront/variables.tf
@@ -3,6 +3,11 @@ variable "aws_region" {
   default = "eu-west-1"
 }
 
+variable "aws_region_global" {
+  type    = string
+  default = "us-east-1"
+}
+
 variable "govuk_environment" {
   type        = string
   description = "Name of the environment (AWS account) being deployed to."


### PR DESCRIPTION
Description:
- CloudWatch CloudFront log group is still set to `eu-west-1` despite use of the `provider` meta-argument
- Pass in the region explicitly to `us-east-1`
- https://github.com/alphagov/govuk-infrastructure/issues/2522