### PR TITLE
Send `assets-govuk` CloudFront logs to CloudWatch using V2 logs

### DIFF
--- a/terraform/deployments/cloudfront/logging.tf
+++ b/terraform/deployments/cloudfront/logging.tf
@@ -27,7 +27,8 @@ data "aws_iam_policy_document" "cloudfront_cloudwatch" {
     ]
     effect = "Allow"
     resources = [
-      "arn:aws:logs:${data.aws_region.global.region}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.www_distribution_cloudfront_log_group.name}:*"
+      "arn:aws:logs:${data.aws_region.global.region}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.www_distribution_cloudfront_log_group.name}:*",
+      "arn:aws:logs:${data.aws_region.global.region}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.assets_distribution_cloudfront_log_group.name}:*",
     ]
   }
 }
@@ -49,11 +50,25 @@ resource "aws_cloudwatch_log_group" "www_distribution_cloudfront_log_group" {
   retention_in_days = 30
 }
 
+resource "aws_cloudwatch_log_group" "assets_distribution_cloudfront_log_group" {
+  name              = "/aws/cloudfront/assets-${var.govuk_environment}"
+  provider          = aws.global
+  region            = var.aws_region_global
+  retention_in_days = 30
+}
+
 resource "aws_cloudwatch_log_delivery_source" "www_distribution_cloudfront_log_delivery_source" {
   name         = "www_distribution_cloudfront"
   log_type     = "ACCESS_LOGS"
   provider     = aws.global
   resource_arn = aws_cloudfront_distribution.www_distribution.arn
+}
+
+resource "aws_cloudwatch_log_delivery_source" "assets_distribution_cloudfront_log_delivery_source" {
+  name         = "assets_distribution_cloudfront"
+  log_type     = "ACCESS_LOGS"
+  provider     = aws.global
+  resource_arn = aws_cloudfront_distribution.assets_distribution.arn
 }
 
 resource "aws_cloudwatch_log_delivery_destination" "www_distribution_cloudfront_log_delivery_destination" {
@@ -65,8 +80,23 @@ resource "aws_cloudwatch_log_delivery_destination" "www_distribution_cloudfront_
   }
 }
 
+resource "aws_cloudwatch_log_delivery_destination" "assets_distribution_cloudfront_log_delivery_destination" {
+  name     = "assets_distribution_cloudfront_log_group"
+  provider = aws.global
+
+  delivery_destination_configuration {
+    destination_resource_arn = aws_cloudwatch_log_group.assets_distribution_cloudfront_log_group.arn
+  }
+}
+
 resource "aws_cloudwatch_log_delivery" "www_distribution_cloudfront_log_delivery" {
   provider                 = aws.global
   delivery_source_name     = aws_cloudwatch_log_delivery_source.www_distribution_cloudfront_log_delivery_source.name
   delivery_destination_arn = aws_cloudwatch_log_delivery_destination.www_distribution_cloudfront_log_delivery_destination.arn
+}
+
+resource "aws_cloudwatch_log_delivery" "assets_distribution_cloudfront_log_delivery" {
+  provider                 = aws.global
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.assets_distribution_cloudfront_log_delivery_source.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.assets_distribution_cloudfront_log_delivery_destination.arn
 }


### PR DESCRIPTION
Description:
- Our current setup uses the legacy CloudFront logging but it is currently not working as we haven't configured the [S3 ACL](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging-legacy-s3.html#AccessLogsBucketAndFileOwnership) on `govuk-production-aws-logging`
- Switch to [V2 standard logging](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html) and deliver logs to CloudWatch
- Following the example in https://github.com/alphagov/govuk-infrastructure/pull/2622
- https://github.com/alphagov/govuk-infrastructure/issues/2522