### PR TITLE
Send `govuk-chat` CloudFront logs to CloudWatch instead of S3 using CloudFront V2 logging

### DIFF
--- a/terraform/deployments/chat/cloudfront.tf
+++ b/terraform/deployments/chat/cloudfront.tf
@@ -37,12 +37,6 @@ resource "aws_cloudfront_distribution" "chat_distribution" {
   is_ipv6_enabled = true
   comment         = "Chat"
 
-  logging_config {
-    include_cookies = false
-    bucket          = "govuk-${var.govuk_environment}-aws-logging.s3.amazonaws.com"
-    prefix          = "cloudfront/"
-  }
-
   default_cache_behavior {
     allowed_methods          = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
     cached_methods           = ["GET", "HEAD"]

--- a/terraform/deployments/chat/cloudwatch.tf
+++ b/terraform/deployments/chat/cloudwatch.tf
@@ -2,3 +2,40 @@ resource "aws_cloudwatch_log_group" "bedrock_log_group" {
   name              = "/aws/bedrock"
   retention_in_days = 30
 }
+
+resource "aws_cloudwatch_log_group" "chat_distribution_cloudfront_log_group" {
+  count = var.cloudfront_create ? 1 : 0
+
+  name              = "/aws/cloudfront/govuk-chat-${var.govuk_environment}"
+  provider          = aws.global
+  region            = var.aws_region_global
+  retention_in_days = 30
+}
+
+resource "aws_cloudwatch_log_delivery_source" "chat_distribution_cloudfront_log_delivery_source" {
+  count = var.cloudfront_create ? 1 : 0
+
+  name         = "chat_distribution_cloudfront"
+  log_type     = "ACCESS_LOGS"
+  provider     = aws.global
+  resource_arn = aws_cloudfront_distribution.chat_distribution[count.index].arn
+}
+
+resource "aws_cloudwatch_log_delivery_destination" "chat_distribution_cloudfront_log_delivery_destination" {
+  count = var.cloudfront_create ? 1 : 0
+
+  name     = "chat_distribution_cloudfront_log_group"
+  provider = aws.global
+
+  delivery_destination_configuration {
+    destination_resource_arn = aws_cloudwatch_log_group.chat_distribution_cloudfront_log_group[count.index].arn
+  }
+}
+
+resource "aws_cloudwatch_log_delivery" "chat_distribution_cloudfront_log_delivery" {
+  count = var.cloudfront_create ? 1 : 0
+
+  provider                 = aws.global
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.chat_distribution_cloudfront_log_delivery_source[count.index].name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.chat_distribution_cloudfront_log_delivery_destination[count.index].arn
+}

--- a/terraform/deployments/chat/main.tf
+++ b/terraform/deployments/chat/main.tf
@@ -28,6 +28,11 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias  = "global"
+  region = "us-east-1"
+}
+
 locals {
   internal_dns_zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
 }

--- a/terraform/deployments/chat/variables.tf
+++ b/terraform/deployments/chat/variables.tf
@@ -3,6 +3,10 @@ variable "aws_region" {
   description = "AWS region"
   default     = "eu-west-1"
 }
+variable "aws_region_global" {
+  type    = string
+  default = "us-east-1"
+}
 variable "govuk_aws_state_bucket" {
   type        = string
   description = "Bucket where govuk-aws state is stored"


### PR DESCRIPTION
Description:
- Our current setup uses the legacy CloudFront logging but it is currently not working as we haven't configured the [S3 ACL](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging-legacy-s3.html#AccessLogsBucketAndFileOwnership) on `govuk-production-aws-logging`
- Switch to [V2 standard logging](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html) and deliver logs to CloudWatch
- Following prior art https://github.com/alphagov/govuk-infrastructure/pull/2622
- https://github.com/alphagov/govuk-infrastructure/issues/2522