### PR TITLE
Turn on logical replication for postgres 13 databases in production

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -177,6 +177,22 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "account-api"
@@ -282,6 +298,22 @@ module "variable-set-rds-production" {
           log_statement                        = { value = "all" }
           deadlock_timeout                     = { value = 2500 }
           log_lock_waits                       = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "blue-content-data-api-postgresql-primary"
@@ -299,6 +331,22 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "content-publisher"
@@ -333,6 +381,22 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "content-tagger"
@@ -367,6 +431,22 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "email-alert-api"
@@ -402,6 +482,22 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "link-checker-api"
@@ -420,6 +516,22 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "local-links-manager"
@@ -437,6 +549,22 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "locations-api"
@@ -454,6 +582,22 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "publishing-api"
@@ -520,6 +664,22 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "service-manual-publisher"
@@ -551,6 +711,18 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value = 1, apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value = 35, apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value = 20, apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value = 40, apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "support-api"
@@ -568,6 +740,22 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
+          "rds.logical_replication" = {
+            value        = 1,
+            apply_method = "pending-reboot"
+          }
+          max_wal_senders = {
+            value        = 35,
+            apply_method = "pending-reboot"
+          }
+          max_logical_replication_workers = {
+            value        = 20,
+            apply_method = "pending-reboot"
+          }
+          max_worker_processes = {
+            value        = 40,
+            apply_method = "pending-reboot"
+          }
         }
         engine_params_family         = "postgres13"
         name                         = "transition"


### PR DESCRIPTION
Description:
- Turn on logical replication for

- [x] account-api
- [x] content-data-api
- [x] content-publisher
- [x] content-tagger
- [x] email-alert-api
- [x] link-checker-api
- [x] local-links-manager
- [x] locations-api
- [x] publishing-api
- [x] service-manual-publisher
- [x] support-api
- [x] transition