### PR TITLE
fix: update erblint call to erb_lint

### DIFF
--- a/.github/workflows/erblint.yml
+++ b/.github/workflows/erblint.yml
@@ -24,4 +24,4 @@ jobs:
           BUNDLE_GITHUB__COM: "x-access-token:${{ secrets.BUNDLER_GITHUB_TOKEN }}"
 
       - name: Run ErbLint
-        run: bundle exec erblint --lint-all
+        run: bundle exec erb_lint --lint-all


### PR DESCRIPTION
- calls to erblint have been deprecated for about a year https://github.com/Shopify/erb_lint/pull/360