### PR TITLE
Fix brakeman alerting

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -32,11 +32,17 @@ jobs:
             --no-exit-on-warn --no-exit-on-error \
             -o brakeman.json -o brakeman.sarif
 
+      - name: Strip suppressed results from SARIF
+        run: |
+          ruby -rjson -e 's=JSON.parse(File.read("brakeman.sarif"));
+            s["runs"]&.each{|r| r["results"] = (r["results"]||[]).reject{|res| res["suppressions"] && !res["suppressions"].empty? }};
+            File.write("brakeman.filtered.sarif", JSON.pretty_generate(s))'
+
       - name: Upload SARIF to GitHub
         if: github.repository_visibility == 'public'
         uses: github/codeql-action/upload-sarif@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.10
         with:
-          sarif_file: brakeman.sarif
+          sarif_file: brakeman.filtered.sarif
           category: brakeman
 
       - name: Upload JSON results
@@ -45,8 +51,10 @@ jobs:
           name: brakeman-json
           path: brakeman.json
 
-      - name: Upload SARIF artifact
+      - name: Upload SARIF artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: brakeman-sarif
-          path: brakeman.sarif
+          path: |
+            brakeman.sarif
+            brakeman.filtered.sarif

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -37,6 +37,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.10
         with:
           sarif_file: brakeman.sarif
+          category: brakeman
 
       - name: Upload JSON results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -44,3 +44,9 @@ jobs:
         with:
           name: brakeman-json
           path: brakeman.json
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: brakeman-sarif
+          path: brakeman.sarif


### PR DESCRIPTION
We had a [Brakeman security scan alert](https://github.com/alphagov/specialist-publisher/security/code-scanning/30) for Specialist Publisher, which turned out to be a false positive. We [added it to the ignore list](https://github.com/alphagov/specialist-publisher/pull/3340). But the alert didn't auto-resolve.

This appears to be because GitHub doesn't honour 'suppressions' in the generated SARIF file. So instead, we add a pre-processing step whereby any detected issue that is also 'suppressed' is purged from the SARIF file prior to uploading.

Tested by pointing a [branch of Specialist Publisher](https://github.com/alphagov/specialist-publisher/pull/3348) to the new workflow. We can see that the alert is removed on the 'branch' version.

Before:

> <img width="680" height="304" alt="Screenshot 2025-08-21 at 13 22 50" src="https://github.com/user-attachments/assets/2c666605-dad6-4373-9969-4193b31738c7" />


After: 

> <img width="389" height="289" alt="Screenshot 2025-08-21 at 13 22 46" src="https://github.com/user-attachments/assets/74dda101-9321-4491-a9f8-2771538d6601" />
