### PR TITLE
Tell CodeQL to set up same version of Ruby as upstream app

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,11 @@ jobs:
       with:
         show-progress: false
 
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.10
       with:


### PR DESCRIPTION
We're seeing some [file parsing errors in the CodeQL SAST scan](https://github.com/alphagov/whitehall/actions/runs/17075395186/job/48415312255) job:

>   [2025-08-19 16:12:30] [build-stdout] [2025-08-19 16:12:30] [build-stdout]  WARN /home/runner/work/whitehall/whitehall/app/views/admin/shared/_featurable_editions.html.erb:12: A parse error occurred. Check the syntax of the file. If the file is invalid, correct the error or exclude the file from analysis.

That corresponds to this line of code in Whitehall:

```
<%= render "admin/featurable_editions/search_results", featurable_editions:, paginator:, anchor:, feature_path: %>
```

It appears that CodeQL's Ruby/ERB extractor is behind on Ruby syntax. The `foo:, bar:` shorthand only became valid in Ruby 3.1.

Forcing CodeQL to use a newer Ruby should fix the parsing issues.
