### PR TITLE
Add "archived" option to Github Repo YAML.

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -208,8 +208,16 @@ resource "github_repository" "govuk_repos" {
     ]
 
     precondition {
-      condition =  !try(each.value.archived, false) || length(data.github_repository_pull_requests.govuk_repos_prs[each.key].results) == 0
+      condition     = !try(each.value.archived, false) || length(data.github_repository_pull_requests.govuk_repos_prs[each.key].results) == 0
       error_message = "You cannot archive a Repo with open PRs. Review and close the PRs first."
+    }
+
+    precondition {
+      condition = (
+        !try(each.value.archived, false) ||
+        try(length(data.github_repository.govuk[format("alphagov/%s", each.key)].pages), 0) == 0
+      )
+      error_message = "You cannot archive a Repo with an active GitHub Pages Configuration. Remove this first."
     }
   }
 }


### PR DESCRIPTION
## What?
This change should start allowing us to archive Repositories while also keeping them managed within our YAML file so they remain in IaC.

### Example
This is what happens if you try to archive a Repo which has PRs open (in case someone skips a step in the instructions):
```
╷
│ Error: Resource precondition failed
│ 
│   on main.tf line 211, in resource "github_repository" "govuk_repos":
│  211:       condition =  !try(each.value.archived, false) || length(data.github_repository_pull_requests.govuk_repos_prs[each.key].results) == 0
│     ├────────────────
│     │ data.github_repository_pull_requests.govuk_repos_prs is object with 134 attributes
│     │ each.key is "govuk-replatform-test-app"
│     │ each.value.archived is true
│ 
│ You cannot archive a Repo with open PRs. Review and close the PRs first.
```

A similar failure should also happen if GitHub pages are still configured.