### PR TITLE
[WIP] [SCH-1418] Separate production and integration GCP access

### DIFF
--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
@@ -22,9 +22,9 @@ locals {
   display_name = title(var.name)
 }
 
-resource "google_project" "environment_project" {
-  name       = "Search API V2 ${local.display_name}"
-  project_id = "search-api-v2-${var.name}"
+resource "google_project" "production_environment_project" {
+  name       = "Search API V2 Production"
+  project_id = "search-api-v2-production"
 
   folder_id       = var.google_cloud_folder
   billing_account = var.google_cloud_billing_account
@@ -32,15 +32,57 @@ resource "google_project" "environment_project" {
   labels = {
     "programme"         = "govuk"
     "team"              = "govuk-search-improvement"
-    "govuk_environment" = var.name
+    "govuk_environment" = production
   }
 }
 
-resource "google_project_iam_member" "environment_project_owner" {
-  project = google_project.environment_project.project_id
+resource "google_project" "staging_environment_project" {
+  name       = "Search API V2 Staging"
+  project_id = "search-api-v2-staging"
+
+  folder_id       = var.google_cloud_folder
+  billing_account = var.google_cloud_billing_account
+
+  labels = {
+    "programme"         = "govuk"
+    "team"              = "govuk-search-improvement"
+    "govuk_environment" = staging
+  }
+}
+
+resource "google_project" "integration_environment_project" {
+  name       = "Search API V2 Integration"
+  project_id = "search-api-v2-integration"
+
+  folder_id       = var.google_cloud_folder
+  billing_account = var.google_cloud_billing_account
+
+  labels = {
+    "programme"         = "govuk"
+    "team"              = "govuk-search-improvement"
+    "govuk_environment" = integration
+  }
+}
+
+resource "google_project_iam_member" "production_environment_project_owner" {
+  project = google_project.production_environment_project.project_id
   role    = "roles/owner"
 
-  member = "group:govuk-gcp-access@digital.cabinet-office.gov.uk"
+  member = "group:govuk-gcp-access-production@digital.cabinet-office.gov.uk"
+}
+
+resource "google_project_iam_member" "staging_environment_project_owner" {
+  project = google_project.staging_environment_project.project_id
+  role    = "roles/owner"
+
+  member = "group:govuk-gcp-access-production@digital.cabinet-office.gov.uk"
+}
+
+resource "google_project_iam_member" "integration_environment_project_owner" {
+  project = google_project.integration_environment_project.project_id
+  role    = "roles/owner"
+
+  member = "group:govuk-gcp-access-integration@digital.cabinet-office.gov.uk"
 }
 
 resource "google_project_service" "api_service" {


### PR DESCRIPTION
At the moment the "govuk-gcp-access" google groups grants admin access to all three search api v2 gcp environments. This isn't ideal as on GOV.UK we have rules about when someone should be granted [production access].

The idea is to create two new google groups:

* govuk-gcp-access-production
* govuk-gcp-access-integration

govuk-gcp-access-production will be a copy of govuk-gcp-access, with members copied across. It will grant members admin access to the production and staging search api V2 projects on GCP.

govuk-gcp-access-integration will grant members admin access to the integration search api V2 project on GCP, but not staging and production. govuk-gcp-access-production will be a member of
govuk-gcp-access-integration so that members also have access to integration.

I'm not sure how the resources created here are associated with their respective modules (environment_production, environment_staging, environment_integration) in  "./modules/search-api-v2" and if anything else needs to be amended.

I'm not sure if this change is correct and will do what I expect.

If it is, there are still things to consider:

Is this the best way to manage access?
Should staging have its own group to manage access? Is there a way to dry this up?

[production access]: https://docs.publishing.service.gov.uk/manual/rules-for-getting-production-access.html#when-you-get-production-admin-access