### PR TITLE
[SCH-1418] Separate production and integration GCP access

### DIFF
--- a/terraform/deployments/gcp-search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/main.tf
@@ -29,6 +29,7 @@ module "environment_integration" {
   google_cloud_folder          = var.google_cloud_folder
   tfc_project_name             = var.tfe_project_name
   environment_workspace_name   = "search-api-v2-integration"
+  access_group_name            = "govuk-gcp-access-integration"
 }
 
 module "environment_staging" {
@@ -40,6 +41,7 @@ module "environment_staging" {
   google_cloud_folder          = var.google_cloud_folder
   tfc_project_name             = var.tfe_project_name
   environment_workspace_name   = "search-api-v2-staging"
+  access_group_name            = "govuk-gcp-access"
 }
 
 module "environment_production" {
@@ -51,6 +53,7 @@ module "environment_production" {
   google_cloud_folder          = var.google_cloud_folder
   tfc_project_name             = var.tfe_project_name
   environment_workspace_name   = "search-api-v2-production"
+  access_group_name            = "govuk-gcp-access"
 
 
   # NOTE: There are limits on the Google side on how high we are permitted to set these quotas. If

--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
@@ -40,7 +40,7 @@ resource "google_project_iam_member" "environment_project_owner" {
   project = google_project.environment_project.project_id
   role    = "roles/owner"
 
-  member = "group:govuk-gcp-access@digital.cabinet-office.gov.uk"
+  member = "group:${var.access_group_name}@digital.cabinet-office.gov.uk"
 }
 
 resource "google_project_service" "api_service" {

--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/variables.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/variables.tf
@@ -79,3 +79,8 @@ variable "environment_workspace_name" {
   type        = string
   description = "Provisions search-api-v2 Discovery Engine resources for the environment"
 }
+
+variable "access_group_name" {
+  type        = string
+  description = "The google group that should be able to access the environment"
+}


### PR DESCRIPTION
At the moment the "govuk-gcp-access" google groups grants admin access to all three search api v2 gcp environments. This isn't ideal as on GOV.UK we have rules about when someone should be granted [production access].

A new google group has been created, `govuk-gcp-access-integration` that only gives members access to the Search API V2 integration project.

The existing `govuk-gcp-access` group has been made a member of `govuk-gcp-access-integration` so members of that group will still have access to integration.

These changes should mean that we can give new starters access to integration only whilst leaving the access for people with production access unchanged.

[production access]: https://docs.publishing.service.gov.uk/manual/rules-for-getting-production-access.html#when-you-get-production-admin-access