### PR TITLE
Import integration link-checker-api postgres14 database into Terraform

### DIFF
--- a/terraform/deployments/rds/link_checker_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/link_checker_api_postgres_14_upgrade.tf
@@ -1,25 +1,9 @@
-resource "aws_db_parameter_group" "link_checker_api_postgresql_14_green_params" {
+import {
+  to = aws_db_instance.instance["link_checker_api"]
+  id = "linker-checker-api-postgres"
+}
 
-  name_prefix = "${var.govuk_environment}-link-checker-api-postgres-"
-  family      = "postgres14"
-
-  parameter {
-    name         = "rds.logical_replication"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-
-  lifecycle { create_before_destroy = true }
+import {
+  to = aws_db_parameter_group.engine_params["link_checker_api"]
+  id = "integration-link-checker-api-postgres-20250826130107426000000001"
 }

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -459,7 +459,7 @@ module "variable-set-rds-integration" {
 
       link_checker_api = {
         engine                  = "postgres"
-        engine_version          = "13"
+        engine_version          = "14.18"
         backup_retention_period = 1
         engine_params = {
           log_min_duration_statement = { value = 10000 }
@@ -483,7 +483,7 @@ module "variable-set-rds-integration" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "link-checker-api"
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"


### PR DESCRIPTION
Description:
- Imports the link-checker-api postgres14 RDS instance and postgres14 parameter group into Terraform
- Bumps the engine version to 14.18 in integration in code