### PR TITLE
Fix link-checker-api integration database spelling mistake

### DIFF
--- a/terraform/deployments/rds/link_checker_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/link_checker_api_postgres_14_upgrade.tf
@@ -1,6 +1,6 @@
 import {
   to = aws_db_instance.instance["link_checker_api"]
-  id = "linker-checker-api-postgres"
+  id = "link-checker-api-postgres"
 }
 
 import {


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2657 had it as `linker` when it should be `link`