### PR TITLE
Remove integration link-checker-api logical replication params

### DIFF
--- a/terraform/deployments/rds/link_checker_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/link_checker_api_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["link_checker_api"]
-  id = "link-checker-api-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["link_checker_api"]
-  id = "integration-link-checker-api-postgres-20250826130107426000000001"
-}

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -458,30 +458,13 @@ module "variable-set-rds-integration" {
       }
 
       link_checker_api = {
-        engine                  = "postgres"
-        engine_version          = "14.18"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "link-checker-api"


### PR DESCRIPTION
Description:
- link-checker-api is now imported into Terraform and upgraded to postgres14 so we can remove the logical replication params and turn off backups