### PR TITLE
Archive `miller-columns-element`

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -602,6 +602,7 @@ repos:
       standard_contexts: *standard_security_checks
 
   miller-columns-element:
+    archived: true
     homepage_url: "https://alphagov.github.io/miller-columns-element/"
     required_status_checks:
       standard_contexts: *standard_security_checks


### PR DESCRIPTION
## What

Add `archive: true` to `miller-columns-element` within `repos.yml`.

## Why

Following the steps to [Retire a repo](https://docs.publishing.service.gov.uk/manual/retiring-a-repo.html). [miller-columns-element](https://github.com/alphagov/miller-columns-element) has [moved into Whitehall](https://github.com/alphagov/whitehall/pull/10567) and [has been retired](https://github.com/alphagov/miller-columns-element/pull/366).
