### PR TITLE
Update 'Report GitHub workflow run failure to Slack' README

### DIFF
--- a/.github/actions/report-run-failure/README.md
+++ b/.github/actions/report-run-failure/README.md
@@ -2,12 +2,14 @@
 
 This GitHub Action sends a notification to a nominated Slack channel when a GitHub workflow run fails. The action is typically used to notify a team about critical CI failures on the main branch. It helps to ensure that key issues are addressed quickly by sending relevant information including a direct link to the build logs.
 
+The Slack message includes "The https://github.com/alphagov/repo-name failed on main." text and a "Check the build logs" button with a link to the logs.
+
 ## Notes on using this action
 
 - It is configured with the following inputs:
   -  `slack_webhook_url`: (required) The Slack webhook URL used to send notifications to a specific Slack channel. It's stored as a GitHub secret (GOVUK_SLACK_WEBHOOK_URL), which is added to all GOV.UK repositories as an organisation secret in the [GOV.UK GitHub Infrastructure configuration](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/main.tf).
   - `channel`: (required) The name of the Slack channel (excluding `#`) where the failure notifications will be sent. 
-  - `message`: (optional) A custom message that can be included in the notification to provide additional context. It could include a link to a runbook or documentation.
+  - `message`: (optional) A custom message that can be included in the notification to provide additional context. It could include a link to a runbook or documentation. Note that the default message will appear above this one.
 
 - To minimise noise, the slack message is only sent out for failures on the main branch.
 


### PR DESCRIPTION
- Mention the default Slack message – It's not clear without looking into the code what message will be posted in Slack. This should ensure that the information is not duplicated in the additional message.
- Add usage example for workflow with multiple jobs - the `secrets` context is not available within the context of `jobs`