### PR TITLE
Add synthetic test app repo

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -309,3 +309,8 @@ resource "github_actions_organization_secret_repositories" "slack_webhook_url" {
   secret_name             = "GOVUK_SLACK_WEBHOOK_URL" # pragma: allowlist secret
   selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
 }
+
+import {
+  to = github_repository.govuk_repos["govuk-synthetic-test-app"]
+  id = "govuk-synthetic-test-app"
+}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -917,6 +917,12 @@ repos:
       additional_contexts:
         - test
 
+  govuk-synthetic-test-app:
+    can_be_deployed: true
+    required_status_checks:
+      additional_contexts:
+        - Test
+
   govuk-user-reviewer:
     visibility: private
     homepage_url: "https://github.com/alphagov/govuk-rfcs/pull/75"


### PR DESCRIPTION
Adding the synthetic test app repo for a spike in running a synthetic test for the pipeline, I've imported it as it was originally forked from the govuk-replatform-test-app.

https://github.com/alphagov/govuk-infrastructure/issues/2598