### PR TITLE
(CM-416) Add Sentry project for `content-block-manager`

### DIFF
--- a/terraform/deployments/sentry/locals.tf
+++ b/terraform/deployments/sentry/locals.tf
@@ -9,6 +9,7 @@ locals {
     "ckanext-datagovuk",
     "collections",
     "collections-publisher",
+    "content-block-manager",
     "content-data-admin",
     "content-data-api",
     "content-publisher",


### PR DESCRIPTION
This follows on from https://github.com/alphagov/govuk-infrastructure/pull/2665, and will allow us to start the process of getting Content Block Manager deployed as a seperate app.