### PR TITLE
(CM-416) Rename Content Block Manager repo

### DIFF
--- a/terraform/deployments/github/import.tf
+++ b/terraform/deployments/github/import.tf
@@ -1,4 +1,0 @@
-import {
-  to = github_repository.govuk_repos["govuk-content-block-manager"]
-  id = "govuk-content-block-manager"
-}

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -174,6 +174,11 @@ data "github_repository_pull_requests" "govuk_repos_prs" {
   state           = "open"
 }
 
+moved {
+  from = github_repository.govuk_repos["govuk-content-block-manager"]
+  to   = github_repository.govuk_repos["content-block-manager"]
+}
+
 resource "github_repository" "govuk_repos" {
   for_each = local.repositories
 

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -91,6 +91,12 @@ repos:
         - Playwright / Run Tests
         - Vitest / Run Tests
 
+  content-block-manager:
+    can_be_deployed: true
+    homepage_url: "https://docs.publishing.service.gov.uk/apps/content-block-manager.html"
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+
   content-data-admin:
     can_be_deployed: true
     homepage_url: "https://docs.publishing.service.gov.uk/apps/content-data-admin.html"
@@ -314,12 +320,6 @@ repos:
     need_production_access_to_merge: false
     allow_squash_merge: true
     push_allowances: []
-
-  govuk-content-block-manager:
-    can_be_deployed: true
-    homepage_url: "https://docs.publishing.service.gov.uk/apps/govuk-content-block-manager.html"
-    required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
 
   govuk-dependabot-merger:
     required_status_checks:


### PR DESCRIPTION
We’ve now changed this to remove the prefix (which is only relevant to gems), as having to type `govuk-` each time would get tedious, and it’s not consistent with any of the other apps.