### PR TITLE
(CM-416) Provision Postgres DBs for Content Block Manager

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -247,6 +247,24 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
       }
 
+      content_block_manager = {
+        engine                      = "postgres"
+        engine_version              = "17"
+        allow_major_version_upgrade = true
+        engine_params = {
+          log_min_duration_statement = { value = 10000 }
+          log_statement              = { value = "all" }
+          deadlock_timeout           = { value = 2500 }
+          log_lock_waits             = { value = 1 }
+        }
+        engine_params_family         = "postgres17"
+        name                         = "content_block_manager"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
+        performance_insights_enabled = true
+        project                      = "GOV.UK - Publishing"
+      }
+
       content_data_admin = {
         engine         = "postgres"
         engine_version = "14.18"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -268,6 +268,24 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
       }
 
+      content_block_manager = {
+        engine                      = "postgres"
+        engine_version              = "17"
+        allow_major_version_upgrade = true
+        engine_params = {
+          log_min_duration_statement = { value = 10000 }
+          log_statement              = { value = "all" }
+          deadlock_timeout           = { value = 2500 }
+          log_lock_waits             = { value = 1 }
+        }
+        engine_params_family         = "postgres17"
+        name                         = "content_block_manager"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
+        performance_insights_enabled = true
+        project                      = "GOV.UK - Publishing"
+      }
+
       content_data_admin = {
         engine         = "postgres"
         engine_version = "14.18"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -257,6 +257,24 @@ module "variable-set-rds-staging" {
         project                      = "GOV.UK - Publishing"
       }
 
+      content_block_manager = {
+        engine                      = "postgres"
+        engine_version              = "17"
+        allow_major_version_upgrade = true
+        engine_params = {
+          log_min_duration_statement = { value = 10000 }
+          log_statement              = { value = "all" }
+          deadlock_timeout           = { value = 2500 }
+          log_lock_waits             = { value = 1 }
+        }
+        engine_params_family         = "postgres17"
+        name                         = "content_block_manager"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
+        performance_insights_enabled = true
+        project                      = "GOV.UK - Publishing"
+      }
+
       content_data_admin = {
         engine         = "postgres"
         engine_version = "14.18"


### PR DESCRIPTION
We are in the process of moving Content Block Manager to its own application, so need to provision some new DBs. I’ve taken the barebones config from Publisher, which seems to be enough for our purposes for now.