### PR TITLE
Update our versioned charts for external secrets CRD v1

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -169,7 +169,7 @@ resource "helm_release" "argo_bootstrap" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
-  version          = "0.3.4" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.4.0"
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since
@@ -203,7 +203,7 @@ resource "helm_release" "argo_bootstrap_ephemeral" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
-  version          = "0.1.1"
+  version          = "0.2.0"
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     awsAccountId     = data.aws_caller_identity.current.account_id
@@ -232,7 +232,7 @@ resource "helm_release" "argo_workflows" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "0.45.22" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version          = "0.45.22"
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     controller = {

--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -44,7 +44,7 @@ resource "helm_release" "cluster_secret_store" {
   name       = "cluster-secret-store"
   repository = "https://alphagov.github.io/govuk-helm-charts/"
   chart      = "cluster-secret-store"
-  version    = "0.2.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "0.3.0"
   namespace  = local.services_ns
   timeout    = var.helm_timeout_seconds
   values = [yamlencode({
@@ -62,6 +62,6 @@ resource "helm_release" "cluster_secrets" {
   name       = "cluster-secrets"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
-  version    = "0.10.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "0.11.0"
   timeout    = var.helm_timeout_seconds
 }

--- a/terraform/deployments/cluster-services/kubernetes-events-shipper.tf
+++ b/terraform/deployments/cluster-services/kubernetes-events-shipper.tf
@@ -7,6 +7,6 @@ resource "helm_release" "kubernetes_events_shipper" {
   name       = "kubernetes-events-shipper"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
-  version    = "1.0.0" # TODO: Dependabot or equivalent so this doesn't get neglected.
+  version    = "1.1.0"
   timeout    = var.helm_timeout_seconds
 }


### PR DESCRIPTION
We've merged charts which convert us from v1beta1 apiVersion of external secrets to v1.

This PR just bumps those versioned charts to the newest (as well as removing the comments about dependabot since these are covered by renov8)