### PR TITLE
Create cluster-access workspaces for ephemeral clusters

### DIFF
--- a/terraform/deployments/ephemeral/shutdown.sh
+++ b/terraform/deployments/ephemeral/shutdown.sh
@@ -225,5 +225,6 @@ helm_shutdown
 retry 2 tfc_do_destroy "datagovuk-infrastructure"
 retry 2 tfc_do_destroy "rds"
 retry 2 tfc_do_destroy "cluster-services"
+retry 2 tfc_do_destroy "cluster-access"
 retry 2 tfc_do_destroy "cluster-infrastructure"
 retry 2 tfc_do_destroy "vpc"

--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -69,6 +69,20 @@ module "cluster_infrastructure" {
   depends_on = [module.vpc, tfe_project.project]
 }
 
+module "cluster_access" {
+  source = "./ws"
+
+  name                 = "cluster-access"
+  ephemeral_cluster_id = var.ephemeral_cluster_id
+  variable_set_id      = module.var_set.id
+
+  tfvars = {
+    ship_kubernetes_events_to_logit = false
+  }
+
+  depends_on = [module.cluster_infrastructure, tfe_project.project]
+}
+
 module "cluster_services" {
   source = "./ws"
 
@@ -80,7 +94,7 @@ module "cluster_services" {
     ship_kubernetes_events_to_logit = false
   }
 
-  depends_on = [module.cluster_infrastructure, tfe_project.project]
+  depends_on = [module.cluster_access, tfe_project.project]
 }
 
 module "rds" {


### PR DESCRIPTION
EKS user access now exists in this new root instead of cluster-services

https://github.com/alphagov/govuk-infrastructure/issues/2644