### PR TITLE
(CM-416) Rename Content Block Manager Database

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -258,7 +258,7 @@ module "variable-set-rds-integration" {
           log_lock_waits             = { value = 1 }
         }
         engine_params_family         = "postgres17"
-        name                         = "content_block_manager"
+        name                         = "content-block-manager"
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = true

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -279,7 +279,7 @@ module "variable-set-rds-production" {
           log_lock_waits             = { value = 1 }
         }
         engine_params_family         = "postgres17"
-        name                         = "content_block_manager"
+        name                         = "content-block-manager"
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = true

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -268,7 +268,7 @@ module "variable-set-rds-staging" {
           log_lock_waits             = { value = 1 }
         }
         engine_params_family         = "postgres17"
-        name                         = "content_block_manager"
+        name                         = "content-block-manager"
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = true


### PR DESCRIPTION
RDS doesn’t like underscores, so we have a [failed run at the mo](https://app.terraform.io/app/govuk/workspaces/rds-integration/runs/run-R2yD6QNwSs3hnmUj)