### PR TITLE
Update external-secrets to 0.17.0

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -17,7 +17,7 @@ resource "helm_release" "external_secrets" {
   name             = "external-secrets"
   repository       = "https://charts.external-secrets.io"
   chart            = "external-secrets"
-  version          = "0.16.2"
+  version          = "0.17.0"
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({

--- a/terraform/deployments/ephemeral/validate.sh
+++ b/terraform/deployments/ephemeral/validate.sh
@@ -46,7 +46,7 @@ aws secretsmanager create-secret \
   --secret-string '{"testSecretKey": "testSecretValueInitial"}' >> /dev/null # pragma: allowlist secret
 
 MANIFEST="$(cat <<EOF
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: ephemeral-cluster-validator


### PR DESCRIPTION
All external-secrets.io apiVersions in our github are now v1, they were already stored as v1 in kubernetes, so we should be safe to bump to 0.17.0 now.

To test this is safe:

* I've launched an ephemeral cluster against main (on external secrets 0.16.2)
* provisioned an external secret from secrets manager
* validated it was correctly provisioned as a secret
* updated to this branch (external secrets 0.17.0)
* updated the secret in secrets manager
* forced a resync of the secret (with `kubectl annotate externalsecrets.external-secrets.io <external-secret-name> force-sync="$(date +%s)" --overwrite`)
* validated the secret was correctly updated

Then after this I did a full run of the ephemeral cluster validator which does all the above from scratch (so also testing 0.17 correctly provisions a brand new secret)

All of this was successful