### PR TITLE
cluster-access depends on cluster-services, not vice-versa

### DIFF
--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -80,7 +80,7 @@ module "cluster_access" {
     ship_kubernetes_events_to_logit = false
   }
 
-  depends_on = [module.cluster_infrastructure, tfe_project.project]
+  depends_on = [module.cluster_infrastructure, module.cluster_services, tfe_project.project]
 }
 
 module "cluster_services" {
@@ -94,7 +94,7 @@ module "cluster_services" {
     ship_kubernetes_events_to_logit = false
   }
 
-  depends_on = [module.cluster_access, tfe_project.project]
+  depends_on = [module.cluster_infrastructure, tfe_project.project]
 }
 
 module "rds" {


### PR DESCRIPTION
cluster-access requires the namespaces to have already been created, so it cannot be created prior to cluster-services (which creates the namespaces), otherwise you get errors as in [this ephemeral cluster creation run](https://app.terraform.io/app/govuk/workspaces/cluster-access-eph-jfharden-2025-09-01/runs/run-ZDxa6sKJr6sbyLcy)

```
Error: namespaces "datagovuk" not found
with kubernetes_role.developer["datagovuk"]
on eks_access.tf line 204, in resource "kubernetes_role" "developer":
resource "kubernetes_role" "developer" {
```

After this change, spinning up an ephemeral cluster works again