### PR TITLE
Update external-secrets to 0.18.2

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -17,7 +17,7 @@ resource "helm_release" "external_secrets" {
   name             = "external-secrets"
   repository       = "https://charts.external-secrets.io"
   chart            = "external-secrets"
-  version          = "0.17.0"
+  version          = "0.18.2"
   namespace        = local.services_ns
   create_namespace = true
   values = [yamlencode({


### PR DESCRIPTION
All external-secrets.io apiVersions in our github are now v1 and external-secrets is deployed as 0.17 everywhere.

To test this is safe:

* I've launched an ephemeral cluster against main (on external secrets 0.17.0)
* provisioned an external secret from secrets manager
* validated it was correctly provisioned as a secret
* updated to this branch (external secrets 0.18.2)
* updated the secret in secrets manager
* forced a resync of the secret (with `kubectl annotate externalsecrets.external-secrets.io <external-secret-name> force-sync="$(date +%s)" --overwrite`)
* validated the secret was correctly updated

Then after this I did a full run of the ephemeral cluster validator which does all the above from scratch (so also testing 0.18.2) correctly provisions a brand new secret)

All of this was successful