### PR TITLE
Add govuk-synthetic-test-app to extra_repo

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -58,6 +58,7 @@ locals {
     "govuk-e2e-tests",
     "govuk-fastly-diff-generator",
     "govuk-replatform-test-app",
+    "govuk-synthetic-test-app",
     "imminence",
     "licensify-backend",
     "licensify-feed",


### PR DESCRIPTION
Adding the govuk-synthetic-test-app repo to the extra_repositories block because it isn't being picked up possibly because when it was imported into the github terraform state the `govuk` topic wasn't set.

https://github.com/alphagov/govuk-infrastructure/issues/2598