### PR TITLE
Differentiate names for Bedrock alerts

### DIFF
--- a/terraform/deployments/chat/cloudwatch_alarms.tf
+++ b/terraform/deployments/chat/cloudwatch_alarms.tf
@@ -7,7 +7,7 @@ locals {
 
 # Bedrock token usage over 50% alarm
 resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50" {
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold"
+  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-50"
   alarm_description   = "WARNING - The current ${var.govuk_environment} Bedrock token usage > 50%"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = 50
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50" {
 
 # Bedrock token usage over 100% alarm
 resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100" {
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold"
+  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-100"
   alarm_description   = "CRITICAL - The current ${var.govuk_environment} Bedrock token usage > 100%"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = 100


### PR DESCRIPTION
## What

Add the percentage value to the name of each Bedrock alert

## Why

To be able to differentiate between the 2 alerts