### PR TITLE
Add `bedrock:ListFoundationModels` IAM permission for Chat Service

### DIFF
--- a/terraform/deployments/chat/bedrock_iam.tf
+++ b/terraform/deployments/chat/bedrock_iam.tf
@@ -30,7 +30,8 @@ data "aws_iam_policy_document" "bedrock_access" {
     sid = "BedrockAssumeRolePolicy"
     actions = [
       "bedrock:InvokeModel",
-      "bedrock:InvokeModelWithResponseStream"
+      "bedrock:InvokeModelWithResponseStream",
+      "bedrock:ListFoundationModels"
     ]
     effect    = "Allow"
     resources = ["*"]


### PR DESCRIPTION
## What

Add `bedrock:ListFoundationModels` permission to `govuk-chat-bedrock-access-role`

## Why

The Chat Service needs to be able to determine which Bedrock models it has access to