### PR TITLE
Stop ignoring WAF rule changes

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -29,12 +29,6 @@ resource "aws_wafv2_web_acl" "default" {
     allow {}
   }
 
-  lifecycle {
-    ignore_changes = [
-      rule
-    ]
-  }
-
   rule {
     name     = "x-always-block_web_acl_rule"
     priority = 1
@@ -142,12 +136,6 @@ resource "aws_wafv2_web_acl" "backend_public" {
 
   default_action {
     allow {}
-  }
-
-  lifecycle {
-    ignore_changes = [
-      rule
-    ]
   }
 
   # this rule matches any request that contains the header X-Always-Block: true
@@ -361,12 +349,6 @@ resource "aws_wafv2_web_acl" "bouncer_public" {
 
   default_action {
     allow {}
-  }
-
-  lifecycle {
-    ignore_changes = [
-      rule
-    ]
   }
 
   # this rule matches any request that contains the header X-Always-Block: true


### PR DESCRIPTION
Following on from https://github.com/alphagov/govuk-infrastructure/pull/2723 this removes the ignores for WAF ACL rule changes.

The diffs are a little annoying, but the amount to:

* Changing the rule order numbers (but not reordering them, just changing the priority values, the order remains the same after the change)
* Removing the special header in int to bypass the rate limit

Notably staging does not have any changes