### PR TITLE
Search API V2: move evaluation id/name into JSON

### DIFF
--- a/terraform/deployments/search-api-v2/automated_evaluation.tf
+++ b/terraform/deployments/search-api-v2/automated_evaluation.tf
@@ -295,7 +295,7 @@ resource "google_bigquery_table" "vais_results" {
     ]
     hive_partitioning_options {
       mode              = "CUSTOM"
-      source_uri_prefix = join("", [google_storage_bucket.vais_evaluation_output.url, "/{judgement_list:STRING}/{partition_date:DATE}/{create_time:TIMESTAMP}/{evaluation_id:STRING}"])
+      source_uri_prefix = join("", [google_storage_bucket.vais_evaluation_output.url, "/{judgement_list:STRING}/{partition_date:DATE}/{create_time:TIMESTAMP}"])
     }
   }
 }

--- a/terraform/deployments/search-api-v2/files/evaluation-list-results-schema.json
+++ b/terraform/deployments/search-api-v2/files/evaluation-list-results-schema.json
@@ -1,21 +1,6 @@
 [
   {
-    "name": "judgement_list",
-    "type": "STRING",
-    "mode": "REQUIRED"
-  },
-  {
-    "name": "partition_date",
-    "type": "DATE",
-    "mode": "REQUIRED"
-  },
-  {
-    "name": "create_time",
-    "type": "TIMESTAMP",
-    "mode": "REQUIRED"
-  },
-  {
-    "name": "evaluation_id",
+    "name": "evaluation_name",
     "type": "STRING",
     "mode": "REQUIRED"
   },


### PR DESCRIPTION
1. Remove the `evaluation_id` (a UUID) from the name of the bucket object, where it is currently used as a hive partition
2. Put the full `evaluation_name` into the JSON of the object itself.

Advantages: It will be easier to join the table to a separate table of evaluations via the full name than via the UUID alone. The full `evaluation_name` contains `/`, which would be difficult to use as part of an object name.

Disadvantages: Less efficient queries, because of not partitioning by evaluation id/name. Less easy to find the bucket object that relates to a particular evaluation (though it can still be done because the `create_time` will be unique to an evaluation).

3. Remove the hive partition columns from the table schema. Fixes error during `terraform apply`:

```
Error: googleapi: Error 400: Field, judgement_list, is present in both Table Schema and Hive-Partition key., invalid
```
