### PR TITLE
Allow govuk-fastly-diff-generator to be pulled by ECR

### DIFF
--- a/terraform/deployments/ecr/ecr-pull.tf
+++ b/terraform/deployments/ecr/ecr-pull.tf
@@ -1,4 +1,10 @@
+locals {
+  ecr_repos = toset([for repo in local.repositories : aws_ecr_repository.github_repositories[repo].name])
+}
+
 data "aws_iam_policy_document" "allow_cross_account_pull_from_ecr" {
+  for_each = local.ecr_repos
+
   statement {
     sid    = "AllowCrossAccountPull"
     effect = "Allow"
@@ -13,12 +19,31 @@ data "aws_iam_policy_document" "allow_cross_account_pull_from_ecr" {
       type        = "AWS"
     }
   }
+
+  dynamic "statement" {
+    for_each = contains(local.allow_lambda_pull, each.key) ? [each.key] : []
+
+    content {
+      sid    = "AllowLambdaToPull"
+      effect = "Allow"
+
+      principals {
+        type        = "Service"
+        identifiers = ["lambda.amazonaws.com"]
+      }
+
+      actions = [
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer"
+      ]
+    }
+  }
 }
 
 resource "aws_ecr_repository_policy" "pull_from_ecr" {
-  for_each   = toset([for repo in local.repositories : aws_ecr_repository.github_repositories[repo].name])
+  for_each   = local.ecr_repos
   repository = each.key
-  policy     = data.aws_iam_policy_document.allow_cross_account_pull_from_ecr.json
+  policy     = data.aws_iam_policy_document.allow_cross_account_pull_from_ecr[each.key].json
 }
 
 data "aws_iam_policy_document" "assume_pull_from_ecr_role" {

--- a/terraform/deployments/ecr/ecr-pull.tf
+++ b/terraform/deployments/ecr/ecr-pull.tf
@@ -1,5 +1,5 @@
 locals {
-  ecr_repos = toset([for repo in local.repositories : aws_ecr_repository.github_repositories[repo].name])
+  ecr_repos = { for repo in local.repositories : aws_ecr_repository.github_repositories[repo].name => repo }
 }
 
 data "aws_iam_policy_document" "allow_cross_account_pull_from_ecr" {
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "allow_cross_account_pull_from_ecr" {
   }
 
   dynamic "statement" {
-    for_each = contains(local.allow_lambda_pull, each.key) ? [each.key] : []
+    for_each = contains(local.allow_lambda_pull, each.value) ? [each.key] : []
 
     content {
       sid    = "AllowLambdaToPull"

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -67,6 +67,11 @@ locals {
     "search-api-learn-to-rank",
     "toolbox",
   ]
+
+  // Add repos to this list if you want lambda to have permission to pull the image
+  allow_lambda_pull = [
+    "govuk-fastly-diff-generator"
+  ]
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -55,7 +55,6 @@ locals {
 
   extra_repositories = [
     "clamav",
-    "govuk-e2e-tests",
     "govuk-fastly-diff-generator",
     "govuk-replatform-test-app",
     "imminence",


### PR DESCRIPTION
The diff generator needs to be pulled by lambda, so the ecr repo policy needs to allow lambda to pull it!

This solution is a generalised approach which means any repo can be added to the list which can be pulled by lambda.