### PR TITLE
Add govuk-chat-gradio-user-research repo to terraform

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -315,6 +315,17 @@ repos:
         - Format
         - Type checks
 
+  govuk-chat-gradio-user-research:
+    visibility: private
+    homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk-chat-gradio-user-research.html"
+    required_status_checks:
+      # standard security checks are disabled as not configured for a private repo
+      additional_contexts:
+        - Tests
+        - Lint
+        - Format
+        - Type checks
+
   govuk-content-api-docs:
     homepage_url: "https://content-api.publishing.service.gov.uk"
     need_production_access_to_merge: false


### PR DESCRIPTION
## Description

This is a new repo that will be used to build repid prototypes for user research sessions.

I've copied the config from the existing govuk-chat-gradio-prototype repo as we will be using the same CI actions etc.

## Trello card

https://trello.com/c/lYX0DFvQ/2713-create-prototypes-for-research-on-response-latency