### PR TITLE
Import `link_checker_api` postgres14 database production

### DIFF
--- a/terraform/deployments/rds/imports.tf
+++ b/terraform/deployments/rds/imports.tf
@@ -12,3 +12,13 @@ import {
   to = aws_db_parameter_group.transition_postgresql_14_green_params
   id = "production-transition-postgres-20250828115316248400000008"
 }
+
+import {
+  to = aws_db_instance.instance["link_checker_api"]
+  id = "link-checker-api-postgres"
+}
+
+import {
+  to = aws_db_parameter_group.engine_params["link_checker_api"]
+  id = "production-link-checker-api-postgres-20250828115316248100000007"
+}

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -494,7 +494,7 @@ module "variable-set-rds-production" {
 
       link_checker_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -517,7 +517,7 @@ module "variable-set-rds-production" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "link-checker-api"
         allocated_storage            = 100
         instance_class               = "db.t4g.large"


### PR DESCRIPTION
Description:
- Bump the parameter group to postgres14
- Import `link_checker_api` postgres14 database into Terraform