### PR TITLE
Remove logical replication params for link_checker_api staging and production

### DIFF
--- a/terraform/deployments/rds/imports.tf
+++ b/terraform/deployments/rds/imports.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["link_checker_api"]
-  id = "link-checker-api-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["link_checker_api"]
-  id = "staging-link-checker-api-postgres-20250827092600496900000002"
-}

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -500,22 +500,6 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "link-checker-api"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -486,30 +486,13 @@ module "variable-set-rds-staging" {
       }
 
       link_checker_api = {
-        engine                  = "postgres"
-        engine_version          = "14.18"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "link-checker-api"


### PR DESCRIPTION
Description:
- `link-checker-api` is imported in staging and production into Terraform so we can remove logical replication (staging and prod) and turn off backups (staging)