### PR TITLE
Add feature-flagged VPC Endpoints

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -205,3 +205,15 @@ variable "authentication_mode" {
   default     = "API"
   description = "Authentication mode to use for the cluster"
 }
+
+variable "use_ecr_vpc_endpoints" {
+  type        = bool
+  description = "If true, create VPC endpoints for ECR and ECR Docker, to avoid using the NAT gateway for this traffic."
+  default     = false
+}
+
+variable "use_secretsmanager_endpoints" {
+  type        = bool
+  description = "If true, create VPC endpoints for Secrets Manager, to avoid using the NAT gateway for this traffic."
+  default     = false
+}

--- a/terraform/deployments/cluster-infrastructure/vpc_endpoints.tf
+++ b/terraform/deployments/cluster-infrastructure/vpc_endpoints.tf
@@ -1,0 +1,63 @@
+resource "aws_security_group" "vpc_endpoints" {
+  name        = "vpc-endpoints-${var.govuk_environment}"
+  description = "Allow ingress from VPC on port 443"
+  vpc_id      = data.tfe_outputs.vpc.nonsensitive_values.id
+
+  ingress {
+    description = "Port 443 from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [for subnet in var.eks_private_subnets : subnet.cidr]
+  }
+
+  egress {
+    description = "Port 443 to VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  count               = var.use_ecr_vpc_endpoints ? 1 : 0
+  vpc_id              = data.tfe_outputs.vpc.nonsensitive_values.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  subnet_ids          = [for subnet in aws_subnet.eks_private : subnet.id]
+
+  tags = {
+    Name = "ecr-api-endpoint-${var.govuk_environment}"
+  }
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  count               = var.use_ecr_vpc_endpoints ? 1 : 0
+  vpc_id              = data.tfe_outputs.vpc.nonsensitive_values.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  subnet_ids          = [for subnet in aws_subnet.eks_private : subnet.id]
+
+  tags = {
+    Name = "ecr-dkr-endpoint-${var.govuk_environment}"
+  }
+}
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  count               = var.use_secretsmanager_endpoints ? 1 : 0
+  vpc_id              = data.tfe_outputs.vpc.nonsensitive_values.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.secretsmanager"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  subnet_ids          = [for subnet in aws_subnet.eks_private : subnet.id]
+
+  tags = {
+    Name = "secretsmanager-endpoint-${var.govuk_environment}"
+  }
+}


### PR DESCRIPTION
## What?
This adds VPC Endpoint Resources for the following:

* ECR API
* ECR DKR (Docker)
* Secrets Manager

This will be off by default but can be enabled per-environment by using the following variables:

* use_ecr_vpc_endpoints
* use_secretsmanager_endpoints