### PR TITLE
Set and enable VPC Endpoints in Integration

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -87,6 +87,9 @@ module "variable-set-integration" {
     licensify_backup_retention_period         = 1
     shared_documentdb_instance_count          = 1
     shared_documentdb_backup_retention_period = 1
+
+    use_ecr_vpc_endpoints        = true
+    use_secretsmanager_endpoints = true
   }
 }
 


### PR DESCRIPTION
## What?
This is a follow-on from the previous PR - and sets the VPC Endpoints to "true" and creates them in Integration for ECR and Secrets Manager.

### Related

* https://github.com/alphagov/govuk-infrastructure/pull/2747