### PR TITLE
Delete replication params from Transition integration

### DIFF
--- a/terraform/deployments/rds/imports.tf
+++ b/terraform/deployments/rds/imports.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["transition"]
-  id = "transition-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["transition"]
-  id = "integration-transition-postgres-20250826151928116600000001"
-}

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -733,30 +733,13 @@ module "variable-set-rds-integration" {
       }
 
       transition = {
-        engine                  = "postgres"
-        engine_version          = "14.18"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "transition"


### PR DESCRIPTION
Those params were only needed for blue/green deployment to upgrade Postgres.
We don't normally have replication enabled in integration and staging.