### PR TITLE
Remove logical replication and backups for staging transition

### DIFF
--- a/terraform/deployments/rds/staging_transition_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/staging_transition_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["transition"]
-  id = "transition-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["transition"]
-  id = "staging-transition-postgres-20250908163308605600000001"
-}

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -743,30 +743,13 @@ module "variable-set-rds-staging" {
       }
 
       transition = {
-        engine                  = "postgres"
-        engine_version          = "14.18"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "transition"


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2757 imported staging transition into Terraform
- Remove logical replication as it's no longer required
- Turn off backups as they are no longer required