### PR TITLE
Remove logical replication from production transition postgres

### DIFF
--- a/terraform/deployments/rds/production_transition_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/production_transition_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["transition"]
-  id = "transition-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["transition"]
-  id = "production-transition-postgres-20250909102106888100000001"
-}

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -742,22 +742,6 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "transition"


### PR DESCRIPTION
Description:
- production transition postgres14 is imported into Terraform so the logical replication can be safely removed