### PR TITLE
BAU - Temporarily unarchive router-api and fastly-exporter to allow branch permissions

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -312,13 +312,3 @@ resource "github_actions_organization_secret_repositories" "slack_webhook_url" {
   secret_name             = "GOVUK_SLACK_WEBHOOK_URL" # pragma: allowlist secret
   selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
 }
-
-import {
-  to = github_repository.govuk_repos["router-api"]
-  id = "router-api"
-}
-
-import {
-  to = github_repository.govuk_repos["fastly-exporter"]
-  id = "fastly-exporter"
-}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -197,7 +197,7 @@ repos:
         - Test Ruby / Run RSpec
 
   fastly-exporter:
-    archived: true
+    standard_contexts: *standard_security_checks
 
   feedback:
     can_be_deployed: true
@@ -719,7 +719,7 @@ repos:
         - Test Go
 
   router-api:
-    archived: true
+    standard_contexts: *standard_security_checks
 
   rubocop-govuk:
     publishes_gem: true


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2764 imported both `router-api` and `fastly-exporter` but archived them both however the TF failed as it couldn't create the branch protections as the repos were archived
- Temporarily unarchive them to create the branch permissions then a subsequent PR will archive them again