### PR TITLE
BAU - Archive fastly exporter and router-api

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -312,8 +312,3 @@ resource "github_actions_organization_secret_repositories" "slack_webhook_url" {
   secret_name             = "GOVUK_SLACK_WEBHOOK_URL" # pragma: allowlist secret
   selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
 }
-
-import {
-  to = github_branch_protection.govuk_repos["router-api"]
-  id = "router-api:main"
-}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -197,7 +197,7 @@ repos:
         - Test Ruby / Run RSpec
 
   fastly-exporter:
-    standard_contexts: *standard_security_checks
+    archived: true
 
   feedback:
     can_be_deployed: true
@@ -719,7 +719,7 @@ repos:
         - Test Go
 
   router-api:
-    standard_contexts: *standard_security_checks
+    archived: true
 
   rubocop-govuk:
     publishes_gem: true


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2766 has created the branch protections so both repos can be archived