### PR TITLE
Allow to create an encrypted snapshot of an unencrypted database

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -102,9 +102,11 @@ resource "aws_db_snapshot" "unencrypted_snapshot" {
 }
 
 resource "aws_db_snapshot_copy" "encrypted_snapshot" {
-  for_each = aws_db_snapshot.unencrypted_snapshot
+  for_each = {
+    for db_name, db in var.databases : db_name => db if try(db.create_encrypted_snapshot, false)
+  }
 
-  source_db_snapshot_identifier = each.value.db_snapshot_identifier
+  source_db_snapshot_identifier = aws_db_snapshot.unencrypted_snapshot[each.key].db_snapshot_identifier
   target_db_snapshot_identifier = "${local.identifier_prefix}${each.value.name}-${each.value.engine}-post-encryption"
   kms_key_id                    = "alias/aws/rds"
 }


### PR DESCRIPTION
This PR enables you to add a `create_encrypted_snapshot = true` attribute to an RDS database and have terraform create a snapshot, and then in turn create an encrypted copy of that snapshot.

In https://github.com/alphagov/govuk-infrastructure/pull/2781 I've enabled create_encrypted_snapshot for content-data-admin in integration, and now you can see on the plan for integration it's going to create the unencrypted snapshot, and the copy of it.

I will apply this now, then I will do a follow on to delete the snapshot again since I just want to test the terraform in this case, and not keep the snapshots around. This will also let me start building a baseline for how long it's going to take

A note on the terraform plans:

* Work is currently ongoing to migrate some databases to a newer version of postgres so some of those changes are visibile in the plans, and unrelated to my chage
* The eph-cluster erroring can be ignored

