### PR TITLE
Enable create_encrypted_snapshot for content-data-admin in integration

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -283,6 +283,7 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
+        create_encrypted_snapshot    = true
       }
 
       content_data_api = {


### PR DESCRIPTION
See https://github.com/alphagov/govuk-infrastructure/pull/2780

I want to be able to test that the above PR works, so this PR will enable creating an encrypted snapshot for content data admin in integration.

With this PR merged I can re-run the plan in the above PR for integration and it should show the creation of a snapshot, and an encrypted snapshot copy