### PR TITLE
Output Private Subnet Route Table IDs, and...

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -89,6 +89,7 @@ module "variable-set-integration" {
     shared_documentdb_backup_retention_period = 1
 
     use_ecr_vpc_endpoints        = true
+    use_s3_vpc_endpoints         = true
     use_secretsmanager_endpoints = true
   }
 }

--- a/terraform/deployments/vpc/outputs.tf
+++ b/terraform/deployments/vpc/outputs.tf
@@ -1,5 +1,9 @@
 output "id" { value = aws_vpc.vpc.id }
 
+output "private_subnet_route_table_ids" {
+  value = [for rt in aws_route_table.private_subnet : rt.id]
+}
+
 output "private_subnet_ids" {
   description = "A map of private subnet names to IDs"
   value       = { for name, subnet in var.legacy_private_subnets : name => aws_subnet.private_subnet[name].id }

--- a/terraform/deployments/vpc/vpc.tf
+++ b/terraform/deployments/vpc/vpc.tf
@@ -29,7 +29,10 @@ removed {
   }
 }
 
-resource "aws_vpc_endpoint" "s3" {
-  vpc_id       = aws_vpc.vpc.id
-  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
+# S3 Gateway Endpoint: Moved to cluster-infrastructure module
+removed {
+  from = aws_vpc_endpoint.s3
+  lifecycle {
+    destroy = false
+  }
 }


### PR DESCRIPTION
## What?
This allows us to move the S3 Gateway Endpoint resource out of the VPC deployment and into the cluster-infrastructure deployment along with the rest of our Endpoint configurations. This also outputs the Private Subnet Route Table IDs so we can use those if necessary.