### PR TITLE
Remove content-data-admin encrypted snapshots

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -283,7 +283,6 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.micro"
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
-        create_encrypted_snapshot    = true
       }
 
       content_data_api = {


### PR DESCRIPTION
The encrytped snapshot creation was successful. I want to remove it again now to test this works.

A follow on PR will be done which uses our own KMS keys instead of the default