### PR TITLE
Comment out the RDS workspace from ephemeral deployments

### DIFF
--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -97,6 +97,9 @@ module "cluster_services" {
   depends_on = [module.cluster_infrastructure, tfe_project.project]
 }
 
+/*
+ * Commented out because it doesn't work, but the workspace it makes
+ * causes every RDS PR to show it is failing the build
 module "rds" {
   source               = "./ws"
   name                 = "rds"
@@ -105,6 +108,7 @@ module "rds" {
 
   depends_on = [module.cluster_infrastructure, module.vpc, tfe_project.project]
 }
+*/
 
 module "datagovuk_infrastructure" {
   source = "./ws"


### PR DESCRIPTION
The RDS workspace in ephemeral deployments doesn't work at all, we aren't likely to fix it soon ®️ and any ephemeral cluster being deployed makes every rds pr show as failing the build because the eph cluster plans fail