### PR TITLE
Default to encrypted at rest RDS databases

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -90,7 +90,7 @@ resource "aws_db_instance" "instance" {
   skip_final_snapshot       = var.skip_final_snapshot
 
   storage_encrypted = try(each.value.encryption_at_rest, true)
-  kms_key_id        = try(each.value.encryption_at_rest, true) ? aws_kms_alias.rds.name : null
+  kms_key_id        = try(each.value.encryption_at_rest, true) ? aws_kms_key.rds.arn : null
 
   tags = { Name = "govuk-rds-${each.value.name}-${each.value.engine}", project = lookup(each.value, "project", "GOV.UK - Other") }
 }


### PR DESCRIPTION
~DO NOT MERGE until after https://github.com/alphagov/govuk-infrastructure/pull/2788~

This sets the default for all new databases to be encrypted at rest.
The plan for prod with it enabled was helpful to show me I can't use the alias, so I've also update the kms key id to use the full arn of the key.

~Right now the plan in prod will show destroy and recreate all databases. But hopefully the plan in int and staging shows no changes.~ Should now show no changes (beyond the perpetual one waiting for the maintenance window)