### PR TITLE
Add "Service: govuk-chat" tag to Chat resources

### DIFF
--- a/terraform/deployments/chat/main.tf
+++ b/terraform/deployments/chat/main.tf
@@ -24,6 +24,7 @@ provider "aws" {
       owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
       repository           = "govuk-infrastructure"
       terraform-deployment = basename(abspath(path.root))
+      Service              = "govuk-chat"
     }
   }
 }

--- a/terraform/deployments/opensearch/main.tf
+++ b/terraform/deployments/opensearch/main.tf
@@ -25,6 +25,7 @@ provider "aws" {
       owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
       repository           = "govuk-infrastructure"
       terraform-deployment = basename(abspath(path.root))
+      Service              = "govuk-chat"
     }
   }
 }


### PR DESCRIPTION
## What

Add `Service: govuk-chat` tag to Chat resources

## Why

So Cost Allocation can be applied specifically to Chat resources