### PR TITLE
Default to using VPC Endpoints in all envs

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -209,7 +209,7 @@ variable "authentication_mode" {
 variable "use_ecr_vpc_endpoints" {
   type        = bool
   description = "If true, create VPC endpoints for ECR and ECR Docker, to avoid using the NAT gateway for this traffic."
-  default     = false
+  default     = true
 }
 
 variable "use_s3_vpc_endpoints" {
@@ -221,5 +221,5 @@ variable "use_s3_vpc_endpoints" {
 variable "use_secretsmanager_endpoints" {
   type        = bool
   description = "If true, create VPC endpoints for Secrets Manager, to avoid using the NAT gateway for this traffic."
-  default     = false
+  default     = true
 }

--- a/terraform/deployments/cluster-infrastructure/vpc_endpoints.tf
+++ b/terraform/deployments/cluster-infrastructure/vpc_endpoints.tf
@@ -1,11 +1,3 @@
-locals {
-  s3_endpoint_ids = {
-    integration = "vpce-08b2cec62e7f7e212"
-    staging     = "vpce-012731b6ddd9675d2"
-    production  = "vpce-0146b3689d80a6848"
-  }
-}
-
 resource "aws_security_group" "vpc_endpoints" {
   name        = "vpc-endpoints-${var.govuk_environment}"
   description = "Allow ingress from VPC on port 443"
@@ -54,11 +46,6 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   tags = {
     Name = "ecr-dkr-endpoint-${var.govuk_environment}"
   }
-}
-
-import {
-  id = local.s3_endpoint_ids[var.govuk_environment]
-  to = aws_vpc_endpoint.s3[0]
 }
 
 resource "aws_vpc_endpoint" "s3" {

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -87,10 +87,6 @@ module "variable-set-integration" {
     licensify_backup_retention_period         = 1
     shared_documentdb_instance_count          = 1
     shared_documentdb_backup_retention_period = 1
-
-    use_ecr_vpc_endpoints        = true
-    use_s3_vpc_endpoints         = true
-    use_secretsmanager_endpoints = true
   }
 }
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -76,9 +76,6 @@ module "variable-set-staging" {
     licensify_backup_retention_period         = 1
     shared_documentdb_instance_count          = 1
     shared_documentdb_backup_retention_period = 1
-
-    use_ecr_vpc_endpoints        = true
-    use_secretsmanager_endpoints = true
   }
 }
 

--- a/terraform/deployments/vpc/vpc.tf
+++ b/terraform/deployments/vpc/vpc.tf
@@ -28,11 +28,3 @@ removed {
     destroy = false
   }
 }
-
-# S3 Gateway Endpoint: Moved to cluster-infrastructure module
-removed {
-  from = aws_vpc_endpoint.s3
-  lifecycle {
-    destroy = false
-  }
-}


### PR DESCRIPTION
## What?
This does a few things surrounding VPC Endpoints:

* Adds the S3 Endpoint Routes to the EKS Private Subnets in Production (matching Integration and Staging)
* Removes the migration changes now the S3 Endpoints are managed in `cluster-infrastructure`.
* Defaults the variables for all environments to "true" to use the ECR, S3 and SecretsManager Endpoints.