### PR TITLE
Optionally generate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_call:
+    inputs:
+      generate_release_notes:
+        required: false
+        type: boolean
+        default: false
     secrets:
       GH_TOKEN:
         required: true
@@ -80,5 +85,6 @@ jobs:
               tag_name: newTag,
               name: newTag,
               target_commitish: '${{ github.event.workflow_run.head_commit.id}}',
+              generate_release_notes: '${{ inputs.generate_release_notes }}',
               make_latest: "legacy",
             });


### PR DESCRIPTION
This adds an input to the Release workflow to automatically generate release notes (see https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).

While we practice continuous delivery, so one PR usually results in one release, this could still be useful to link releases to PRs. For now, I’ve made it optional with a default of true, but I’m happy to set it to `true` for our project and see how we go.

I did this manually for one of our releases, and this is how it looks - https://github.com/alphagov/content-block-manager/releases/tag/v37