### PR TITLE
[SCH-1442] Add search-api-v2-beta-features repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -728,6 +728,13 @@ repos:
   search-api-v2-dataform:
     homepage_url: "https://docs.publishing.service.gov.uk/repos/search-api-v2-dataform.html"
 
+  search-api-v2-beta-features:
+    can_be_deployed: true
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Test Ruby / Run RSpec
+
   service-manual-publisher:
     can_be_deployed: true
     homepage_url: "https://docs.publishing.service.gov.uk/apps/service-manual-publisher.html"


### PR DESCRIPTION
search-api-v2-beta-features runs evaluations for [GOV.UK site search](https://www.gov.uk/search/all) using the Google Vertex AI Search evaluations framework