### PR TITLE
Create encrypted snapshot of jfharden-test and disable deletion protection

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -162,6 +162,8 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Test"
         encryption_at_rest           = false
+        create_encrypted_snapshot    = true
+        deletion_protection          = false
       }
 
       account_api = {


### PR DESCRIPTION
Prepare for conversion of test db to encrypted:

1. Create an encrypted snapshot
2. Disable deletion protection on the db (since it will be destroyed and recreated in the next PR