### PR TITLE
Encrypt jfharden-test rds instance

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -161,7 +161,8 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         project                      = "GOV.UK - Test"
-        encryption_at_rest           = false
+        encryption_at_rest           = true
+        snapshot_identifier          = "jfharden-test-postgres-post-encryption"
         create_encrypted_snapshot    = true
         deletion_protection          = false
       }


### PR DESCRIPTION
This should trigger a destroy and recreate, with the new instance encrypted and restored from the snapshot we took earlier.