### PR TITLE
Add 2h timeouts for snapshot creation

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -104,6 +104,10 @@ resource "aws_db_snapshot" "unencrypted_snapshot" {
   # aws_db_instance gets destroyed.
   db_instance_identifier = "${local.identifier_prefix}${each.value.name}-${each.value.engine}"
   db_snapshot_identifier = "${local.identifier_prefix}${each.value.name}-${each.value.engine}-pre-encryption"
+
+  timeouts {
+    create = "2h"
+  }
 }
 
 resource "aws_db_snapshot_copy" "encrypted_snapshot" {
@@ -114,6 +118,10 @@ resource "aws_db_snapshot_copy" "encrypted_snapshot" {
   source_db_snapshot_identifier = aws_db_snapshot.unencrypted_snapshot[each.key].db_snapshot_arn
   target_db_snapshot_identifier = "${local.identifier_prefix}${each.value.name}-${each.value.engine}-post-encryption"
   kms_key_id                    = aws_kms_key.rds.arn
+
+  timeouts {
+    create = "2h"
+  }
 }
 
 resource "aws_db_event_subscription" "subscription" {


### PR DESCRIPTION
We need to give the snapshots a long timeout to create, this is because in staging and integration we don't have automated snapshots enabled so it takes ages to make a snapshot 