### PR TITLE
Bump `cluster-secrets` to 0.12.0

### DIFF
--- a/terraform/deployments/cluster-services/external_secrets.tf
+++ b/terraform/deployments/cluster-services/external_secrets.tf
@@ -62,6 +62,6 @@ resource "helm_release" "cluster_secrets" {
   name       = "cluster-secrets"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
-  version    = "0.11.0"
+  version    = "0.12.0"
   timeout    = var.helm_timeout_seconds
 }


### PR DESCRIPTION
Description:
- Chart version is now at 0.12.0
- https://github.com/alphagov/govuk-infrastructure/issues/2803