### PR TITLE
Configure explicit encryption in transit for Chat S3 buckets

### DIFF
--- a/terraform/deployments/chat/cloudfront.tf
+++ b/terraform/deployments/chat/cloudfront.tf
@@ -99,6 +99,11 @@ data "aws_iam_policy_document" "origin_service_disabled" {
       values   = ["${aws_cloudfront_distribution.chat_distribution[0].id}"]
       variable = "AWS:SourceArn"
     }
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["true"]
+    }
   }
 }
 

--- a/terraform/deployments/opensearch/s3.tf
+++ b/terraform/deployments/opensearch/s3.tf
@@ -63,5 +63,10 @@ data "aws_iam_policy_document" "opensearch_snapshot_bucket_policy" {
       aws_s3_bucket.opensearch_snapshot.arn,
       "${aws_s3_bucket.opensearch_snapshot.arn}/*",
     ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["true"]
+    }
   }
 }


### PR DESCRIPTION
## What

Add explicit encryption in transit in the bucket policy for Chat S3 buckets

## Why

This is to comply with the ITHC security recommendation that we ensure all access to the buckets are encrypted in transit