### PR TITLE
Create encrypted snapshot of chat in staging & disable deletion protection

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -227,6 +227,8 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         project                      = "GOV.UK - AI"
         encryption_at_rest           = false
+        create_encrypted_snapshot    = true
+        deletion_protection          = false
       }
 
       ckan = {


### PR DESCRIPTION
Take an encrypted snapshot of chat in staging and disable deletion protection to enable recreating chat RDS in staging as encrypted in a follow on PR