### PR TITLE
Convert chat RDS in staging to encrypted

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -226,9 +226,10 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         project                      = "GOV.UK - AI"
-        encryption_at_rest           = false
         create_encrypted_snapshot    = true
         deletion_protection          = false
+        snapshot_identifier          = "chat-postgres-post-encryption"
+        encryption_at_rest           = true
       }
 
       ckan = {


### PR DESCRIPTION
Enable encryption at rest for staging and restore from the encrypted snapshot. This will destroy and recreate the chat db in staging.