### PR TITLE
Remove logical replication params for service_manual_publisher staging DB

### DIFF
--- a/terraform/deployments/rds/staging_service_manual_publisher_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/staging_service_manual_publisher_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["service_manual_publisher"]
-  id = "service-manual-publisher-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["service_manual_publisher"]
-  id = "staging-service-manual-publisher-postgres-20250916122007110200000001"
-}

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -679,30 +679,13 @@ module "variable-set-rds-staging" {
       }
 
       service_manual_publisher = {
-        engine                  = "postgres"
-        engine_version          = "14.18"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "service-manual-publisher"


### PR DESCRIPTION
Those params were only needed for blue/green deployment to upgrade Postgres. We don't normally have replication enabled in integration and staging.

https://github.com/alphagov/govuk-infrastructure/issues/2802