### PR TITLE
Create encrypted snapshot of chat in staging & disable deletion protection

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -227,6 +227,8 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         project                      = "GOV.UK - AI"
         encryption_at_rest           = false
+        create_encrypted_snapshot    = true
+        deletion_protection          = false
       }
 
       ckan = {


### PR DESCRIPTION
We can go ahead with the DB maintenance now, so this PR creates an encrypted snapshot and disables deletion protection (the next PR will recreate the DB)