### PR TITLE
Remove the no longer required snapshots enable deletion protection

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -236,8 +236,6 @@ module "variable-set-rds-integration" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         project                      = "GOV.UK - AI"
-        create_encrypted_snapshot    = true
-        deletion_protection          = false
         encryption_at_rest           = true
         snapshot_identifier          = "chat-postgres-post-encryption"
       }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -226,8 +226,6 @@ module "variable-set-rds-staging" {
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false
         project                      = "GOV.UK - AI"
-        create_encrypted_snapshot    = true
-        deletion_protection          = false
         snapshot_identifier          = "chat-postgres-post-encryption"
         encryption_at_rest           = true
       }


### PR DESCRIPTION
We can now remove the snapshots and re-enabled deletion protection for chat in integration and staging