### PR TITLE
Create encrypted snapshot for chat in production & disable deletion protection

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -238,6 +238,8 @@ module "variable-set-rds-production" {
         performance_insights_enabled = false
         project                      = "GOV.UK - AI"
         encryption_at_rest           = false
+        create_encrypted_snapshot    = true
+        deletion_protection          = false
       }
 
       ckan = {


### PR DESCRIPTION
Create encrypted snapshot for chat in production & disable deletion protection in preparation to convert to an encrypted RDS instance.