### PR TITLE
Add serving configuration name to schema for search evaluation list results

### DIFF
--- a/terraform/deployments/search-api-v2/files/evaluation-list-results-schema.json
+++ b/terraform/deployments/search-api-v2/files/evaluation-list-results-schema.json
@@ -4,6 +4,10 @@
     "type": "STRING",
     "mode": "REQUIRED"
   },
+  { "name": "serving_configuration_name",   
+    "type": "STRING",  
+    "mode": "NULLABLE" 
+  },
   {
     "name": "evaluation_results",
     "type": "RECORD",


### PR DESCRIPTION
This schema defines the format of the Big Query table for evaluation results. We want to track the serving configuration with the results for more informed analysis.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1455