### PR TITLE
Delete test db

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -146,27 +146,6 @@ module "variable-set-rds-integration" {
     multi_az                = false
 
     databases = {
-      jfharden_test = {
-        engine         = "postgres"
-        engine_version = "16"
-        engine_params = {
-          log_min_duration_statement = { value = 10000 }
-          log_statement              = { value = "all" }
-          deadlock_timeout           = { value = 2500 }
-          log_lock_waits             = { value = 1 }
-        }
-        engine_params_family         = "postgres16"
-        name                         = "jfharden-test"
-        allocated_storage            = 100
-        instance_class               = "db.t4g.small"
-        performance_insights_enabled = false
-        project                      = "GOV.UK - Test"
-        encryption_at_rest           = true
-        snapshot_identifier          = "jfharden-test-postgres-post-encryption"
-        create_encrypted_snapshot    = true
-        deletion_protection          = false
-      }
-
       account_api = {
         engine                  = "postgres"
         engine_version          = "13"


### PR DESCRIPTION
This test db was used for testing the database encryption process, it is no longer needed.