### PR TITLE
Set all int and staging dbs for 1 day automated backups

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -141,15 +141,14 @@ module "variable-set-rds-integration" {
   name = "rds-integration"
 
   tfvars = {
-    backup_retention_period = 0
+    backup_retention_period = 1
     skip_final_snapshot     = true
     multi_az                = false
 
     databases = {
       account_api = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -291,9 +290,8 @@ module "variable-set-rds-integration" {
       }
 
       content_data_api = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
@@ -331,9 +329,8 @@ module "variable-set-rds-integration" {
       }
 
       content_publisher = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -384,9 +381,8 @@ module "variable-set-rds-integration" {
       }
 
       content_tagger = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -437,9 +433,8 @@ module "variable-set-rds-integration" {
       }
 
       email_alert_api = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -510,9 +505,8 @@ module "variable-set-rds-integration" {
       }
 
       local_links_manager = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -545,9 +539,8 @@ module "variable-set-rds-integration" {
       }
 
       locations_api = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -615,7 +608,6 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
-        backup_retention_period      = 1
         has_read_replica             = true
         encryption_at_rest           = false
       }
@@ -703,9 +695,8 @@ module "variable-set-rds-integration" {
       }
 
       support_api = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -152,15 +152,14 @@ module "variable-set-rds-staging" {
 
   name = "rds-staging"
   tfvars = {
-    backup_retention_period = 0
+    backup_retention_period = 1
     skip_final_snapshot     = true
     multi_az                = false
 
     databases = {
       account_api = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -301,9 +300,8 @@ module "variable-set-rds-staging" {
       }
 
       content_data_api = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
@@ -341,9 +339,8 @@ module "variable-set-rds-staging" {
       }
 
       content_publisher = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -394,9 +391,8 @@ module "variable-set-rds-staging" {
       }
 
       content_tagger = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -447,9 +443,8 @@ module "variable-set-rds-staging" {
       }
 
       email_alert_api = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -520,9 +515,8 @@ module "variable-set-rds-staging" {
       }
 
       local_links_manager = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -555,9 +549,8 @@ module "variable-set-rds-staging" {
       }
 
       locations_api = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -625,7 +618,6 @@ module "variable-set-rds-staging" {
         instance_class               = "db.m7g.2xlarge"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
-        backup_retention_period      = 1
         has_read_replica             = true
         encryption_at_rest           = false
       }
@@ -713,9 +705,8 @@ module "variable-set-rds-staging" {
       }
 
       support_api = {
-        engine                  = "postgres"
-        engine_version          = "13"
-        backup_retention_period = 1
+        engine         = "postgres"
+        engine_version = "13"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }


### PR DESCRIPTION
Enable 1 day automated backups for all RDS instances in integration and staging.

This is really to make maintenance work much quicker rather than to provide for disaster recovery. This works since manual snapshots will be be incremental and take a couple of minutes instead of multiple hours.

For RDS instances where this changes from 0 to 1 it will cause a reboot of the databases meaning a brief outage.