### PR TITLE
Add service health alerts to Chat Slack channel

### DIFF
--- a/terraform/deployments/chat/eventbridge.tf
+++ b/terraform/deployments/chat/eventbridge.tf
@@ -1,0 +1,18 @@
+resource "aws_cloudwatch_event_rule" "aws_service_health_alert" {
+  name        = "chat-aws-service-health-alert"
+  description = "Rule to monitor AWS Service Health Events for Chat application"
+  event_pattern = jsonencode({
+    "source" : ["aws.health"],
+    "detail-type" : ["AWS Health Event"],
+    "detail" : {
+      "service" : ["BEDROCK", "EKS", "ELASTICACHE", "ES", "RDS"],
+      "eventTypeCategory" : ["issue"]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "aws_service_health_alert" {
+  rule      = aws_cloudwatch_event_rule.aws_service_health_alert.name
+  arn       = aws_sns_topic.chat_alerts.arn
+  target_id = "chat-aws-service-health-alert-target"
+}


### PR DESCRIPTION
## What

Add AWS Service status alerts for Bedrock, EKS, Elasticache, Opensearch & RDS to go to the Chat Slack channel `#dev-notifications-ai-govuk`

## Why

The Chat Team would like to be actively notified when there is an issue with any of the services they depend upon