### PR TITLE
Remove Legacy NATs and Public Subnets

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -29,12 +29,6 @@ module "variable-set-integration" {
       c = { az = "eu-west-1c", cidr = "10.1.32.0/22" }
     }
 
-    legacy_public_subnets = {
-      a = { az = "eu-west-1a", cidr = "10.1.1.0/24" }
-      b = { az = "eu-west-1b", cidr = "10.1.2.0/24" }
-      c = { az = "eu-west-1c", cidr = "10.1.3.0/24" }
-    }
-
     legacy_private_subnets = {
       a = { az = "eu-west-1a", cidr = "10.1.4.0/24", nat = true }
       b = { az = "eu-west-1b", cidr = "10.1.5.0/24", nat = true }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -29,12 +29,6 @@ module "variable-set-production" {
       c = { az = "eu-west-1c", cidr = "10.13.32.0/22" }
     }
 
-    legacy_public_subnets = {
-      a = { az = "eu-west-1a", cidr = "10.13.1.0/24" }
-      b = { az = "eu-west-1b", cidr = "10.13.2.0/24" }
-      c = { az = "eu-west-1c", cidr = "10.13.3.0/24" }
-    }
-
     legacy_private_subnets = {
       a = { az = "eu-west-1a", cidr = "10.13.4.0/24", nat = true }
       b = { az = "eu-west-1b", cidr = "10.13.5.0/24", nat = true }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -29,12 +29,6 @@ module "variable-set-staging" {
       c = { az = "eu-west-1c", cidr = "10.12.32.0/22" }
     }
 
-    legacy_public_subnets = {
-      a = { az = "eu-west-1a", cidr = "10.12.1.0/24" }
-      b = { az = "eu-west-1b", cidr = "10.12.2.0/24" }
-      c = { az = "eu-west-1c", cidr = "10.12.3.0/24" }
-    }
-
     legacy_private_subnets = {
       a = { az = "eu-west-1a", cidr = "10.12.4.0/24", nat = true }
       b = { az = "eu-west-1b", cidr = "10.12.5.0/24", nat = true }

--- a/terraform/deployments/tfc-configuration/variables-test.tf
+++ b/terraform/deployments/tfc-configuration/variables-test.tf
@@ -27,8 +27,6 @@ module "variable-set-ephemeral" {
       c = { az = "eu-west-1c", cidr = "10.10.96.0/19" }
     }
 
-    legacy_public_subnets = {}
-
     legacy_private_subnets = {}
 
     govuk_environment = "ephemeral"

--- a/terraform/deployments/vpc/outputs.tf
+++ b/terraform/deployments/vpc/outputs.tf
@@ -9,11 +9,6 @@ output "private_subnet_ids" {
   value       = { for name, subnet in var.legacy_private_subnets : name => aws_subnet.private_subnet[name].id }
 }
 
-output "public_subnet_ids" {
-  description = "A map of public subnet names to IDs"
-  value       = { for name, subnet in var.legacy_public_subnets : name => aws_subnet.public_subnet[name].id }
-}
-
 output "internet_gateway_id" {
   value = aws_internet_gateway.public.id
 }

--- a/terraform/deployments/vpc/subnets.tf
+++ b/terraform/deployments/vpc/subnets.tf
@@ -1,9 +1,26 @@
 locals {
-  azs                        = { for name, subnet in var.legacy_public_subnets : subnet.az => name }
-  nat_legacy_private_subnets = { for name, subnet in var.legacy_private_subnets : name => subnet if subnet["nat"] }
+  azs = [
+    "eu-west-1a",
+    "eu-west-1b",
+    "eu-west-1c"
+  ]
 }
 
 # Private subnets
+
+# Preserve EIPs from Legacy Subnets/NATs
+resource "aws_eip" "private_subnet_nat" {
+  for_each = toset(local.azs)
+  domain   = "vpc"
+  tags = {
+    Name    = "${each.key}-nat"
+    Purpose = "EIP Retained for Legacy ELMS Endpoints"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
 resource "aws_subnet" "private_subnet" {
   for_each          = var.legacy_private_subnets
@@ -11,19 +28,6 @@ resource "aws_subnet" "private_subnet" {
   cidr_block        = each.value.cidr
   availability_zone = each.value.az
   tags              = { Name = "govuk_private_${each.key}" }
-}
-
-# we want one NAT gateway per AZ
-resource "aws_eip" "private_subnet_nat" {
-  for_each = local.azs
-  domain   = "vpc"
-  tags     = { Name = "${each.key}-nat" }
-}
-
-resource "aws_nat_gateway" "private_subnet" {
-  for_each      = local.azs
-  allocation_id = aws_eip.private_subnet_nat[each.key].id
-  subnet_id     = aws_subnet.public_subnet[each.value].id
 }
 
 resource "aws_route_table" "private_subnet" {
@@ -38,32 +42,9 @@ resource "aws_route_table_association" "private_subnet" {
   route_table_id = aws_route_table.private_subnet[each.key].id
 }
 
-resource "aws_route" "private_subnet_nat" {
-  for_each               = local.nat_legacy_private_subnets
-  route_table_id         = aws_route_table.private_subnet[each.key].id
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.private_subnet[each.value.az].id
-}
-
-# Public subnets
-
-resource "aws_subnet" "public_subnet" {
-  for_each          = var.legacy_public_subnets
-  vpc_id            = aws_vpc.vpc.id
-  cidr_block        = each.value.cidr
-  availability_zone = each.value.az
-  tags              = { Name = "govuk_public_${each.key}" }
-}
-
 resource "aws_route_table" "public_subnet" {
   vpc_id = aws_vpc.vpc.id
   tags   = { Name = "govuk_public" }
-}
-
-resource "aws_route_table_association" "public_subnet" {
-  for_each       = var.legacy_public_subnets
-  subnet_id      = aws_subnet.public_subnet[each.key].id
-  route_table_id = aws_route_table.public_subnet.id
 }
 
 resource "aws_route" "public_subnet_igw" {

--- a/terraform/deployments/vpc/variables.tf
+++ b/terraform/deployments/vpc/variables.tf
@@ -41,8 +41,3 @@ variable "legacy_private_subnets" {
   type        = map(object({ az = string, cidr = string, nat = bool }))
   description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the private subnets for legacy resources"
 }
-
-variable "legacy_public_subnets" {
-  type        = map(object({ az = string, cidr = string }))
-  description = "Map of {subnet_name: {az=<az>, cidr=<cidr>}} for the public subnets for legacy resources"
-}

--- a/terraform/deployments/vpc/vpc.tf
+++ b/terraform/deployments/vpc/vpc.tf
@@ -6,7 +6,7 @@ resource "aws_vpc" "vpc" {
   enable_dns_hostnames = true
 
   tags = {
-    Name = "govuk-${var.govuk_environment}"
+    Name = "govuk-vpc-${var.govuk_environment}"
   }
 
   lifecycle {
@@ -18,7 +18,7 @@ resource "aws_internet_gateway" "public" {
   vpc_id = aws_vpc.vpc.id
 
   tags = {
-    Name = "govuk-${var.govuk_environment}"
+    Name = "govuk-ig-${var.govuk_environment}"
   }
 }
 


### PR DESCRIPTION
## What?
This PR makes the following changes:

* Removes Pre-Kubernetes "Legacy" NAT Gateways
* Removes Pre-Kubernetes "Legacy" Public Subnets
* Removes any redundant "local" variables, hard-code local "AZs" variable.
* Remove unused TF outputs
* Make the VPC and IG "Name" tags more verbose, for easier identification in AWS Console

### Not in Scope
I have left the "Private Subnets" largely alone as these are used by RDS, ElastiCache and ElasticSearch and could/should be refactored in future into their respective Deployments/Modules.

### TF Plan

[Plan can be reviewed here](https://app.terraform.io/app/govuk/vpc-integration/runs/run-sW7yEBBiFgXVoiZD)