### PR TITLE
Require codeowner reviews for more repos

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -367,6 +367,8 @@ repos:
     visibility: private
     strict: true
     up_to_date_branches: true
+    required_pull_request_reviews:
+      require_code_owner_reviews: true
     required_status_checks:
       additional_contexts:
         - test
@@ -384,11 +386,15 @@ repos:
     can_be_deployed: true
     strict: true
     up_to_date_branches: true
+    required_pull_request_reviews:
+      require_code_owner_reviews: true
 
   govuk-fastly-secrets:
     visibility: private
     strict: true
     up_to_date_branches: true
+    required_pull_request_reviews:
+      require_code_owner_reviews: true
 
   govuk-graphql:
     branch_protection: false
@@ -404,6 +410,8 @@ repos:
     visibility: private
     strict: true
     up_to_date_branches: true
+    required_pull_request_reviews:
+      require_code_owner_reviews: true
 
   terraform-govuk-tfe-workspacer:
     strict: true


### PR DESCRIPTION
Relates to https://github.com/alphagov/govuk-platform-internal/issues/61

Require code owner reviews for:

* govuk-dns-tf
* govuk-fastly
* govuk-fastly-secrets
* terraform-govuk-infrastructure-sensitive