### PR TITLE
Set up "Blue" Node Groups in all envs

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -52,10 +52,9 @@ module "variable-set-integration" {
 
     enable_kube_state_metrics = true
 
-    enable_arm_workers = true
-    enable_x86_workers = true
-
-    main_workers_instance_types = ["m6i.4xlarge", "m6a.4xlarge", "m6i.2xlarge", "m6a.2xlarge"]
+    enable_arm_workers      = true
+    enable_arm_workers_blue = true
+    enable_x86_workers      = true
 
     publishing_service_domain = "integration.publishing.service.gov.uk"
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -51,14 +51,15 @@ module "variable-set-production" {
 
     enable_kube_state_metrics = false
 
-    enable_arm_workers = true
-    enable_x86_workers = true
+    enable_arm_workers      = true
+    enable_arm_workers_blue = true
+    enable_x86_workers      = true
 
     publishing_service_domain = "publishing.service.gov.uk"
 
-    arm_workers_instance_types  = ["r8g.4xlarge", "r7g.4xlarge", "m7g.8xlarge", "m6g.8xlarge"]
-    main_workers_instance_types = ["m6i.8xlarge", "m6a.8xlarge"]
-    x86_workers_instance_types  = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
+    arm_workers_instance_types      = ["r8g.4xlarge", "r7g.4xlarge", "m7g.8xlarge", "m6g.8xlarge"]
+    arm_workers_blue_instance_types = ["r8g.2xlarge"]
+    x86_workers_instance_types      = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
 
     frontend_memcached_node_type = "cache.r6g.large"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -51,10 +51,9 @@ module "variable-set-staging" {
 
     enable_kube_state_metrics = false
 
-    enable_arm_workers = true
-    enable_x86_workers = true
-
-    main_workers_instance_types = ["m6i.4xlarge", "m6a.4xlarge", "m6i.2xlarge", "m6a.2xlarge"]
+    enable_arm_workers      = true
+    enable_arm_workers_blue = true
+    enable_x86_workers      = true
 
     publishing_service_domain = "staging.publishing.service.gov.uk"
 


### PR DESCRIPTION
## What?
This is the next step in fixing the NodeGroup config - add the "blue" Node Group to all environments.

I should have added as well that in Production I want to launch the new Node Group with `r8g.2xlarge` size to try and right-size the Nodes for our current workloads.

The following PR will be to gracefully cycle down the old NodeGroup and rename that to "green" once "blue" has spun up. Any subsequent updates or changes to NodeGroups should be a fair bit easier after this is done.