### PR TITLE
Archived repos cannot have vulnerability reports

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -188,7 +188,7 @@ resource "github_repository" "govuk_repos" {
   allow_merge_commit = false
 
   has_downloads        = true
-  vulnerability_alerts = true
+  vulnerability_alerts = !try(each.value.archived, false) # Archived repos cannot have vulnerability alerts
 
   delete_branch_on_merge = true
 


### PR DESCRIPTION
Since archived repos cannot have vulnerability reports, and having it set to true causes perpetual changes in the terraform, if a repo is archived then set vulnerability reports to false