### PR TITLE
Spin down old Node Group and name it green

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -88,14 +88,14 @@ locals {
   }
 
   # This will be a "Green" Node Group once Blue has become primary
-  arm_managed_node_group = {
+  arm_managed_node_group_green = {
     arm = {
       ami_type              = "AL2023_ARM_64_STANDARD"
-      name_prefix           = var.cluster_name
-      desired_size          = var.arm_workers_size_desired
-      max_size              = var.arm_workers_size_max
-      min_size              = var.arm_workers_size_min
-      instance_types        = var.arm_workers_instance_types
+      name_prefix           = "${var.cluster_name}-green"
+      desired_size          = var.arm_workers_green_size_desired
+      max_size              = var.arm_workers_green_size_max
+      min_size              = var.arm_workers_green_size_min
+      instance_types        = var.arm_workers_green_instance_types
       update_config         = { max_unavailable = 1 }
       block_device_mappings = local.default_block_device_mappings
       additional_tags = {

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -106,7 +106,7 @@ locals {
   }
 
 
-  eks_managed_node_groups = merge(var.enable_x86_workers ? local.x86_managed_node_group : {}, var.enable_arm_workers_blue ? local.arm_managed_node_group_blue : {}, var.enable_arm_workers ? local.arm_managed_node_group : {})
+  eks_managed_node_groups = merge(var.enable_x86_workers ? local.x86_managed_node_group : {}, var.enable_arm_workers_blue ? local.arm_managed_node_group_blue : {}, var.enable_arm_workers_green ? local.arm_managed_node_group_green : {})
 }
 
 provider "aws" {

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -57,22 +57,16 @@ variable "enable_kube_state_metrics" {
   default     = false
 }
 
-variable "enable_arm_workers" {
-  type        = bool
-  description = "Whether to enable the ARM/Graviton-based Managed Node Group"
-  default     = false
-}
-
 variable "enable_arm_workers_blue" {
   type        = bool
   description = "Whether to enable the 'blue' ARM/Graviton-based Managed Node Group"
   default     = false
 }
 
-variable "arm_workers_instance_types" {
-  type        = list(string)
-  description = "List of ARM-based instance types for the managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
-  default     = ["m7g.4xlarge", "m6g.4xlarge"]
+variable "enable_arm_workers_green" {
+  type        = bool
+  description = "Whether to enable the 'green' ARM/Graviton-based Managed Node Group"
+  default     = false
 }
 
 variable "arm_workers_blue_instance_types" {
@@ -81,51 +75,57 @@ variable "arm_workers_blue_instance_types" {
   default     = ["m7g.4xlarge", "m6g.4xlarge"]
 }
 
-variable "arm_workers_default_capacity_type" {
-  type        = string
-  description = "Default capacity type for ARM-based managed node groups: SPOT or ON_DEMAND."
-  default     = "ON_DEMAND"
+variable "arm_workers_green_instance_types" {
+  type        = list(string)
+  description = "List of ARM-based instance types for the 'green managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
+  default     = ["m7g.4xlarge", "m6g.4xlarge"]
 }
 
 variable "arm_workers_blue_default_capacity_type" {
   type        = string
-  description = "Default capacity type for ARM-based managed node groups: SPOT or ON_DEMAND."
+  description = "Default capacity type for ARM-based 'blue' managed node groups: SPOT or ON_DEMAND."
   default     = "ON_DEMAND"
 }
 
-variable "arm_workers_size_desired" {
-  type        = number
-  description = "Desired capacity of ARM-based managed node autoscale group."
-  default     = 6
+variable "arm_workers_green_default_capacity_type" {
+  type        = string
+  description = "Default capacity type for ARM-based 'green' managed node groups: SPOT or ON_DEMAND."
+  default     = "ON_DEMAND"
 }
 
 variable "arm_workers_blue_size_desired" {
   type        = number
-  description = "Desired capacity of ARM-based managed node autoscale group."
+  description = "Desired capacity of ARM-based 'blue' managed node autoscale group."
   default     = 6
 }
 
-variable "arm_workers_size_min" {
+variable "arm_workers_green_size_desired" {
   type        = number
-  description = "Min capacity of ARM-based managed node autoscale group."
-  default     = 3
+  description = "Desired capacity of ARM-based 'green' managed node autoscale group."
+  default     = 6
 }
 
 variable "arm_workers_blue_size_min" {
   type        = number
-  description = "Min capacity of ARM-based managed node autoscale group."
+  description = "Min capacity of ARM-based 'blue' managed node autoscale group."
   default     = 3
 }
 
-variable "arm_workers_size_max" {
+variable "arm_workers_green_size_min" {
   type        = number
-  description = "Max capacity of ARM-based managed node autoscale group."
-  default     = 12
+  description = "Min capacity of ARM-based 'green' managed node autoscale group."
+  default     = 3
 }
 
 variable "arm_workers_blue_size_max" {
   type        = number
-  description = "Max capacity of ARM-based managed node autoscale group."
+  description = "Max capacity of ARM-based 'blue' managed node autoscale group."
+  default     = 12
+}
+
+variable "arm_workers_green_size_max" {
+  type        = number
+  description = "Max capacity of ARM-based 'green' managed node autoscale group."
   default     = 12
 }
 

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -52,9 +52,9 @@ module "variable-set-integration" {
 
     enable_kube_state_metrics = true
 
-    enable_arm_workers      = true
-    enable_arm_workers_blue = true
-    enable_x86_workers      = true
+    enable_arm_workers_blue  = true
+    enable_arm_workers_green = false
+    enable_x86_workers       = true
 
     publishing_service_domain = "integration.publishing.service.gov.uk"
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -51,15 +51,15 @@ module "variable-set-production" {
 
     enable_kube_state_metrics = false
 
-    enable_arm_workers      = true
-    enable_arm_workers_blue = true
-    enable_x86_workers      = true
+    enable_arm_workers_blue  = true
+    enable_arm_workers_green = false
+    enable_x86_workers       = true
 
     publishing_service_domain = "publishing.service.gov.uk"
 
-    arm_workers_instance_types      = ["r8g.4xlarge", "r7g.4xlarge", "m7g.8xlarge", "m6g.8xlarge"]
-    arm_workers_blue_instance_types = ["r8g.2xlarge"]
-    x86_workers_instance_types      = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
+    arm_workers_blue_instance_types  = ["r8g.2xlarge"]
+    arm_workers_green_instance_types = ["r8g.2xlarge"]
+    x86_workers_instance_types       = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
 
     frontend_memcached_node_type = "cache.r6g.large"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -51,9 +51,9 @@ module "variable-set-staging" {
 
     enable_kube_state_metrics = false
 
-    enable_arm_workers      = true
-    enable_arm_workers_blue = true
-    enable_x86_workers      = true
+    enable_arm_workers_blue  = true
+    enable_arm_workers_green = false
+    enable_x86_workers       = true
 
     publishing_service_domain = "staging.publishing.service.gov.uk"
 


### PR DESCRIPTION
## What?
This is the "final" step of the Node Group changes - the old Node Group has been set to "false" so it is currently wound-down and I have also renamed the old group to "green" to make it easier to swap between the two Node Groups in the future.

I am hoping in the future that we will be able to update the Launch Templates in a newer version of the EKS Module without having to go through this tick-tock process of needing to swap between "blue" and "green" Node Groups to change things gracefully.

### Related
* https://github.com/alphagov/govuk-infrastructure/issues/2862