### PR TITLE
Disable x86 Node Groups

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -54,7 +54,7 @@ module "variable-set-integration" {
 
     enable_arm_workers_blue  = true
     enable_arm_workers_green = false
-    enable_x86_workers       = true
+    enable_x86_workers       = false
 
     publishing_service_domain = "integration.publishing.service.gov.uk"
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -53,7 +53,7 @@ module "variable-set-production" {
 
     enable_arm_workers_blue  = true
     enable_arm_workers_green = false
-    enable_x86_workers       = true
+    enable_x86_workers       = false
 
     publishing_service_domain = "publishing.service.gov.uk"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -53,7 +53,7 @@ module "variable-set-staging" {
 
     enable_arm_workers_blue  = true
     enable_arm_workers_green = false
-    enable_x86_workers       = true
+    enable_x86_workers       = false
 
     publishing_service_domain = "staging.publishing.service.gov.uk"
 


### PR DESCRIPTION
## What?
A question was asked about the x86 Node Groups:
> [@david.mays](https://gds.slack.com/team/U016Z01S5A5) This question was born of reviewing your node group PRs. Do we need the x86 node group enabled now?
> I ask because there's this:
> ``` 
>     enable_arm_workers_blue  = true
>     enable_arm_workers_green = false
>     enable_x86_workers       = true
> ```
> Couldn't we false the x86?

The answer is "We could" - and I agree. So this sets them to false.