### PR TITLE
Switch to m8g.4xlarge for "Green" ARM Nodes

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -72,13 +72,13 @@ variable "enable_arm_workers_green" {
 variable "arm_workers_blue_instance_types" {
   type        = list(string)
   description = "List of ARM-based instance types for the 'blue' managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
-  default     = ["m7g.4xlarge", "m6g.4xlarge"]
+  default     = ["m7g.4xlarge"]
 }
 
 variable "arm_workers_green_instance_types" {
   type        = list(string)
   description = "List of ARM-based instance types for the 'green managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
-  default     = ["m7g.4xlarge", "m6g.4xlarge"]
+  default     = ["m8g.4xlarge"]
 }
 
 variable "arm_workers_blue_default_capacity_type" {

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -53,7 +53,7 @@ module "variable-set-integration" {
     enable_kube_state_metrics = true
 
     enable_arm_workers_blue  = true
-    enable_arm_workers_green = false
+    enable_arm_workers_green = true
     enable_x86_workers       = false
 
     publishing_service_domain = "integration.publishing.service.gov.uk"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -52,14 +52,14 @@ module "variable-set-production" {
     enable_kube_state_metrics = false
 
     enable_arm_workers_blue  = true
-    enable_arm_workers_green = false
+    enable_arm_workers_green = true
     enable_x86_workers       = false
 
     publishing_service_domain = "publishing.service.gov.uk"
 
-    arm_workers_blue_instance_types  = ["r8g.2xlarge"]
-    arm_workers_green_instance_types = ["r8g.2xlarge"]
-    x86_workers_instance_types       = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
+    arm_workers_blue_instance_types = ["r8g.2xlarge"]
+    # arm_workers_green_instance_types = ["m8g.4xlarge"]
+    x86_workers_instance_types = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
 
     frontend_memcached_node_type = "cache.r6g.large"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -52,7 +52,7 @@ module "variable-set-staging" {
     enable_kube_state_metrics = false
 
     enable_arm_workers_blue  = true
-    enable_arm_workers_green = false
+    enable_arm_workers_green = true
     enable_x86_workers       = false
 
     publishing_service_domain = "staging.publishing.service.gov.uk"


### PR DESCRIPTION
## What?
We're going straight to the "green" Node Group as it seems that AWS have changed their Pod density calculations to be more conservative since updates to AWS CNI and EKS 1.33. This means when we dropped to `r8g.2xlarge` from `r8g.4xlarge`, our Pods-per-Node count dropped again, resulting in poor node density. Switching to `m8g.4xlarge` should get us back to a better node density with the updated CNI versions.