### PR TITLE
Small typo fix before green gets applied.

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -89,7 +89,7 @@ locals {
 
   # This will be a "Green" Node Group once Blue has become primary
   arm_managed_node_group_green = {
-    arm = {
+    arm_green = {
       ami_type              = "AL2023_ARM_64_STANDARD"
       name_prefix           = "${var.cluster_name}-green"
       desired_size          = var.arm_workers_green_size_desired


### PR DESCRIPTION
## What?
A tiny consistency fix before I go to lunch - make sure the node group naming is consistent across blue and green groups.