### PR TITLE
Green is live, turn down blue Workers

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -72,7 +72,7 @@ variable "enable_arm_workers_green" {
 variable "arm_workers_blue_instance_types" {
   type        = list(string)
   description = "List of ARM-based instance types for the 'blue' managed node group, in order of preference. The second and subsequent preferences are only relevant when using spot instances."
-  default     = ["m7g.4xlarge", "m6g.4xlarge"]
+  default     = ["m8g.4xlarge"]
 }
 
 variable "arm_workers_green_instance_types" {

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -52,7 +52,7 @@ module "variable-set-integration" {
 
     enable_kube_state_metrics = true
 
-    enable_arm_workers_blue  = true
+    enable_arm_workers_blue  = false
     enable_arm_workers_green = true
     enable_x86_workers       = false
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -51,15 +51,12 @@ module "variable-set-production" {
 
     enable_kube_state_metrics = false
 
-    enable_arm_workers_blue  = true
+    enable_arm_workers_blue  = false
     enable_arm_workers_green = true
     enable_x86_workers       = false
 
     publishing_service_domain = "publishing.service.gov.uk"
 
-    arm_workers_blue_instance_types = ["r8g.2xlarge"]
-    # arm_workers_green_instance_types = ["m8g.4xlarge"]
-    x86_workers_instance_types = ["r7i.large", "r7a.large", "m7i-flex.xlarge", "m6a.xlarge", "m6i.xlarge"]
 
     frontend_memcached_node_type = "cache.r6g.large"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -51,7 +51,7 @@ module "variable-set-staging" {
 
     enable_kube_state_metrics = false
 
-    enable_arm_workers_blue  = true
+    enable_arm_workers_blue  = false
     enable_arm_workers_green = true
     enable_x86_workers       = false
 


### PR DESCRIPTION
## What?
The new instance types are now live, so we can now turn down the "blue" Node Group again.