### PR TITLE
IA-1319: update GA4 BigQuery access custom roles

### DIFF
--- a/terraform/deployments/ga4-analytics/project_iam_custom_roles.tf
+++ b/terraform/deployments/ga4-analytics/project_iam_custom_roles.tf
@@ -2,6 +2,7 @@ resource "google_project_iam_custom_role" "gds_bigquery_read_access" {
   description = "Permissions to read BigQuery datasets and tables"
   permissions = [
     "bigquery.datasets.get",
+    "bigquery.datasets.getIamPolicy",
     "bigquery.tables.get",
     "bigquery.tables.getData"
   ]
@@ -90,6 +91,7 @@ resource "google_project_iam_custom_role" "gds_bigquery_editor" {
     "bigquery.datasets.create",
     "bigquery.datasets.get",
     "bigquery.datasets.getIamPolicy",
+    "bigquery.datasets.setIamPolicy",
     "bigquery.datasets.update",
     "bigquery.datasets.updateTag",
     "bigquery.jobs.create",


### PR DESCRIPTION
Custom roles with `bigquery.datasets.get` and `bigquery.datasets.update` now need additional permissions `bigquery.datasets.getIamPolicy` and `bigquery.datasets.setIamPolicy` defined respectively. This will ensure existing behaviour will continue unaffected once Google make the planned changes linked and described in Jira ticket [IA-1319](https://gov-uk.atlassian.net/browse/IA-1319).

[IA-1319]: https://gov-uk.atlassian.net/browse/IA-1319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ