### PR TITLE
Remove quotes from `generate_release_notes`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,6 @@ jobs:
               tag_name: newTag,
               name: newTag,
               target_commitish: '${{ github.event.workflow_run.head_commit.id}}',
-              generate_release_notes: '${{ inputs.generate_release_notes }}',
+              generate_release_notes: ${{ inputs.generate_release_notes }},
               make_latest: "legacy",
             });


### PR DESCRIPTION
This was introduced in https://github.com/alphagov/govuk-infrastructure/pull/2797m with the boolean erroneously enclosed in quotes, which is causing builds to break.