### PR TITLE
Upgrade to terraform aws eks v21

### DIFF
--- a/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "external_secrets" {
     ]
 
     resources = [
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${local.secrets_prefix}/*",
+      "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:${local.secrets_prefix}/*",
     ]
   }
 }

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -61,6 +61,9 @@ locals {
     enable_monitoring              = true
     enable_efa_only                = false
     use_latest_ami_release_version = false
+    metadata_options = {
+      http_put_response_hop_limit = 2
+    }
   }
 
   x86_managed_node_group = {

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -255,3 +255,8 @@ resource "aws_kms_key" "eks" {
   deletion_window_in_days = 7
   enable_key_rotation     = true
 }
+
+moved {
+  from = module.eks.aws_iam_role_policy_attachment.this["AmazonEKSVPCResourceController"]
+  to   = module.eks.aws_iam_role_policy_attachment.additional["AmazonEKSVPCResourceController"]
+}

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.13.1"
+      version = "< 6.15.0"
     }
   }
 }

--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -244,6 +244,10 @@ module "eks" {
   enable_cluster_creator_admin_permissions = true
 
   eks_managed_node_groups = local.eks_managed_node_groups
+
+  iam_role_additional_policies = {
+    AmazonEKSVPCResourceController = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+  }
 }
 
 resource "aws_kms_key" "eks" {

--- a/terraform/deployments/cluster-infrastructure/vpc_endpoints.tf
+++ b/terraform/deployments/cluster-infrastructure/vpc_endpoints.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "vpc_endpoints" {
 resource "aws_vpc_endpoint" "ecr_api" {
   count               = var.use_ecr_vpc_endpoints ? 1 : 0
   vpc_id              = data.tfe_outputs.vpc.nonsensitive_values.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ecr.api"
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
   security_group_ids  = [aws_security_group.vpc_endpoints.id]
@@ -37,7 +37,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
 resource "aws_vpc_endpoint" "ecr_dkr" {
   count               = var.use_ecr_vpc_endpoints ? 1 : 0
   vpc_id              = data.tfe_outputs.vpc.nonsensitive_values.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.dkr"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ecr.dkr"
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
   security_group_ids  = [aws_security_group.vpc_endpoints.id]
@@ -51,7 +51,7 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
 resource "aws_vpc_endpoint" "s3" {
   count             = var.use_s3_vpc_endpoints ? 1 : 0
   vpc_id            = data.tfe_outputs.vpc.nonsensitive_values.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.s3"
   vpc_endpoint_type = "Gateway"
 
   route_table_ids = concat(
@@ -68,7 +68,7 @@ resource "aws_vpc_endpoint" "s3" {
 resource "aws_vpc_endpoint" "secretsmanager" {
   count               = var.use_secretsmanager_endpoints ? 1 : 0
   vpc_id              = data.tfe_outputs.vpc.nonsensitive_values.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.secretsmanager"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.secretsmanager"
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
   security_group_ids  = [aws_security_group.vpc_endpoints.id]


### PR DESCRIPTION
* Resolve deprecation notice for aws_region data source (the name attribute is deprecated in favour of the region attribute)
* Upgrade terraform-aws-modules/aws/eks to v21. I've added a bunch of attributes since the defaults are changing, and hopefully this should get us very close to a clean plan.

The build error is for an ephermeral cluster launched by @kentsanggds and can be ignored.

Notes on this change:

* There is [a bug with the module](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3516) which means this can't be applied, but [a simple workaround](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3516#issuecomment-3364499919) which I've done in an ephemeral cluster and works fine:
  * Apply the terraform which removes the custom policy required for auto mode. This apply will then error
  * Manually clickops enable EKS auto mode, it saves and applies, but auto mode doesn't work since the cluster IAM policy doesn't have the required permissions
  * Apply the terraform again which this time will work, and will turn auto mode off again
* A lot of variables have been renamed
* The node group defaults has been removed completely, so I've reimplemented this in our own terraform by merging defaults into each node group config
* An IAM policy is being removed (`module.eks.aws_iam_policy.custom[0]`) which is the policy that would be required for auto mode, but the terraform module update now doesn't include the policy unless it's required.
* The change you can see in the eks cluster itself is bring in config which disables auto mode
* The additional policy was going to be deleted and recreated since the module changed how adding policies works, so I've added a moved block so it just moves in the state and doesn't delete and recreate.

I've launched an eph cluster from main, then run through the upgrade. After the upgrade I changed the node group size to check it could still control the autoscaling group, this worked fine. I also ran the cluster validator which proves the following things still work:

* external dns
* external secrets
* the CNI controller
* the EBS controller