### PR TITLE
Update TFC Config for Integration support_api DB

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -665,7 +665,7 @@ module "variable-set-rds-integration" {
 
       support_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -688,7 +688,7 @@ module "variable-set-rds-integration" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "support-api"
         allocated_storage            = 200
         instance_class               = "db.t4g.medium"


### PR DESCRIPTION
## What?
This switches the Support API DB from Postgres 13 to 14 in Integration.