### PR TITLE
Import Support_API RDS in Integration for TF State

### DIFF
--- a/terraform/deployments/rds/integration_support_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/integration_support_api_postgres_14_upgrade.tf
@@ -1,25 +1,9 @@
-resource "aws_db_parameter_group" "support_api_postgresql_14_green_params" {
+import {
+  to = aws_db_instance.instance["support_api"]
+  id = "support-api-postgres"
+}
 
-  name_prefix = "${var.govuk_environment}-support-api-postgres-"
-  family      = "postgres14"
-
-  parameter {
-    name         = "rds.logical_replication"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-
-  lifecycle { create_before_destroy = true }
+import {
+  to = aws_db_parameter_group.engine_params["support_api"]
+  id = "integration-support-api-postgres-20250826151928116600000002"
 }

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -665,7 +665,7 @@ module "variable-set-rds-integration" {
 
       support_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -688,7 +688,7 @@ module "variable-set-rds-integration" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "support-api"
         allocated_storage            = 200
         instance_class               = "db.t4g.medium"


### PR DESCRIPTION
## What?
This re-imports the Support API DB for Integration once the v13 DB is removed from State.