### PR TITLE
Add staging support-api postgres14 params

### DIFF
--- a/terraform/deployments/rds/integration_support_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/integration_support_api_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["support_api"]
-  id = "support-api-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["support_api"]
-  id = "integration-support-api-postgres-20250826151928116600000002"
-}

--- a/terraform/deployments/rds/staging_support_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/staging_support_api_postgres_14_upgrade.tf
@@ -1,0 +1,25 @@
+resource "aws_db_parameter_group" "support_api_postgresql_14_green_params" {
+
+  name_prefix = "${var.govuk_environment}-support-api-postgres-"
+  family      = "postgres14"
+
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_logical_replication_workers"
+    value        = "20"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_worker_processes"
+    value        = "25"
+    apply_method = "pending-reboot"
+  }
+
+  lifecycle { create_before_destroy = true }
+}

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -671,22 +671,6 @@ module "variable-set-rds-integration" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "support-api"


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2913 imported the support-api Postgres 14 database so now we can remove the logical replication parameters
- Add the staging support-api postgres14 parameter group
- https://github.com/alphagov/govuk-infrastructure/issues/2907