### PR TITLE
Upgrade integration elasticsearch

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -774,7 +774,7 @@ module "variable-set-elasticsearch-integration" {
       throughput       = 250
       provisioned_iops = 3000
     }
-    engine_version         = "6.7"
+    engine_version         = "6.8"
     zone_awareness_enabled = true
 
     instance_count = 3


### PR DESCRIPTION
Upgrades AWS Elasticsearch from 6.7 to 6.8.

Summary of changes
------------------

There are [no breaking changes between 6.7 and 6.8](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.8.html)

There are [four "release highlights"](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-highlights.html) in this upgrade:
- two licensing changes (in 6.8.0)
- an OOM error fix for cross-cluster replication (which we don't use)
- a fix for retries in cross-cluster replication (which we don't use)

There are no changes that I've seen regarding to relevance in the [full release notes](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/es-release-notes.html).

There are several [security fixes including one for log4j](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.21.html).

Internal Process
----------------

There are some docs on what happens during minor version upgrades:
- https://aws.amazon.com/blogs/database/in-place-version-upgrades-for-amazon-elasticsearch-service/
- https://aws.amazon.com/opensearch-service/faqs/#topic-8
- https://aws.amazon.com/blogs/big-data/an-automated-approach-to-perform-an-in-place-engine-upgrade-in-amazon-opensearch-service/

Older docs say that minor versions are an inplace upgrade. Each node is removed from the cluster, upgraded and then re-added. Newer docs (which might be less relevant given the venerable age of our version) indicate that it might be a blue/green deployment. In either case, downtime for queries is not expected.

Our Process
-----------

1. Run the [preflight checks](https://docs.publishing.service.gov.uk/manual/reindex-elasticsearch.html#1-preflight-checks) to ensure that we don't have duplicate indices hanging around.

2. [Take a manual snapshot](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-snapshot-create.html) of the index. We will remove any old snapshots

4. Deploy this TF change to create a new cluster (blue/green) with the new version

5. Monitor the new cluster and switch over.

6. Consider [replaying content changes](https://docs.publishing.service.gov.uk/manual/fix-out-of-date-search-indices.html) that may have happened during the upgrade.

7. Remove the old cluster if all is ok.

Rollback
--------

Rollback involves switching back to the old cluster and replaying missing data.

Environment Sync
----------------

I don't expect this to affect the environment sync that occurs overnight.
