### PR TITLE
Demote hmrc manuals

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_default.tf
@@ -6,13 +6,13 @@ module "serving_config_global_default" {
   engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
 
   boost_control_ids = [
-    module.control_global_boost_demote_low.id,
-    module.control_global_boost_demote_medium.id,
-    module.control_global_boost_demote_low_pages.id,
-    module.control_global_boost_demote_pages.id,
-    module.control_global_boost_demote_strong.id,
     module.control_global_boost_promote_low.id,
+    module.control_global_boost_demote_low.id,
+    module.control_global_boost_demote_low_pages.id,
     module.control_global_boost_promote_medium.id,
+    module.control_global_boost_demote_medium.id,
+    module.control_global_boost_demote_strong.id,
+    module.control_global_boost_demote_strong_pages.id,
   ]
   filter_control_ids = [
     module.control_global_filter_temporary_exclusions.id,
@@ -20,21 +20,6 @@ module "serving_config_global_default" {
   synonyms_control_ids = [
     module.control_global_synonym_hmrc.id,
   ]
-}
-
-module "control_global_boost_promote_medium" {
-  source = "./modules/control"
-
-  id           = "boost_promote_medium"
-  display_name = "Boost: Promote medium"
-  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
-  action = {
-    boostAction = {
-      filter     = "content_purpose_supergroup: ANY(\"services\") OR document_type: ANY(\"calendar\", \"detailed_guide\", \"document_collection\", \"external_content\", \"organisation\")",
-      fixedBoost = 0.2
-      dataStore  = google_discovery_engine_data_store.govuk_content.name
-    }
-  }
 }
 
 module "control_global_boost_promote_low" {
@@ -94,6 +79,21 @@ module "control_global_boost_demote_low_pages" {
   }
 }
 
+module "control_global_boost_promote_medium" {
+  source = "./modules/control"
+
+  id           = "boost_promote_medium"
+  display_name = "Boost: Promote medium"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      filter     = "content_purpose_supergroup: ANY(\"services\") OR document_type: ANY(\"calendar\", \"detailed_guide\", \"document_collection\", \"external_content\", \"organisation\")",
+      fixedBoost = 0.2
+      dataStore  = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
 module "control_global_boost_demote_medium" {
   source = "./modules/control"
 
@@ -124,7 +124,7 @@ module "control_global_boost_demote_strong" {
   }
 }
 
-module "control_global_boost_demote_pages" {
+module "control_global_boost_demote_strong_pages" {
   source = "./modules/control"
 
   id           = "boost_demote_pages"

--- a/terraform/deployments/search-api-v2/serving_config_global_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_default.tf
@@ -8,6 +8,7 @@ module "serving_config_global_default" {
   boost_control_ids = [
     module.control_global_boost_demote_low.id,
     module.control_global_boost_demote_medium.id,
+    module.control_global_boost_demote_low_pages.id,
     module.control_global_boost_demote_pages.id,
     module.control_global_boost_demote_strong.id,
     module.control_global_boost_promote_low.id,
@@ -60,6 +61,33 @@ module "control_global_boost_demote_low" {
   action = {
     boostAction = {
       filter     = "document_type: ANY(\"about\", \"taxon\", \"world_news_story\")",
+      fixedBoost = -0.25
+      dataStore  = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
+locals {
+  # Pages to demote by 0.25
+  demote_pages_low = [
+    "/hmrc-internal-manuals/tax-credits-manual/tcm1000248",
+    "/hmrc-internal-manuals/tax-credits-manual/tcm1000267",
+    "/hmrc-internal-manuals/tax-credits-manual/tcm1000541",
+    "/hmrc-internal-manuals/tax-credits-manual/tcm1000659",
+    "/hmrc-internal-manuals/tax-credits-manual/tcm1000398"
+  ]
+  demote_pages_low_expr = join(",", [for page in local.demote_pages_low : "\"${page}\""])
+}
+
+module "control_global_boost_demote_low_pages" {
+  source = "./modules/control"
+
+  id           = "boost_demote_pages_low"
+  display_name = "Boost: Demote specific pages low"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      filter     = "link: ANY(${local.demote_pages_low_expr})",
       fixedBoost = -0.25
       dataStore  = google_discovery_engine_data_store.govuk_content.name
     }

--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -13,6 +13,7 @@ module "serving_config_global_variant" {
     module.control_global_boost_promote_medium.id,
     module.control_global_boost_promote_low.id,
     module.control_global_boost_demote_low.id,
+    module.control_global_boost_demote_low_pages.id,
     module.control_global_boost_demote_medium.id,
     module.control_global_boost_demote_pages.id,
     module.control_global_boost_demote_strong.id,

--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -10,13 +10,13 @@ module "serving_config_global_variant" {
     module.control_global_boost_freshness_general.id,
 
     # identical to serving_config_global_default
-    module.control_global_boost_promote_medium.id,
     module.control_global_boost_promote_low.id,
     module.control_global_boost_demote_low.id,
     module.control_global_boost_demote_low_pages.id,
+    module.control_global_boost_promote_medium.id,
     module.control_global_boost_demote_medium.id,
-    module.control_global_boost_demote_pages.id,
     module.control_global_boost_demote_strong.id,
+    module.control_global_boost_demote_strong_pages.id,
   ]
   filter_control_ids = [
     # identical to serving_config_global_default


### PR DESCRIPTION
Demote relevance of 5 HMRC manual pages by 0.25 in search-api-v2

These pages appear in certain user queries that are not useful for
end users

Jira: https://gov-uk.atlassian.net/browse/SCH-1462