### PR TITLE
Import `local-links-manager` integration Postgres14 into Terraform and remove logical replication parameters

### DIFF
--- a/terraform/deployments/rds/integration_local_links_manager_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/integration_local_links_manager_postgres_14_upgrade.tf
@@ -1,25 +1,9 @@
-resource "aws_db_parameter_group" "local_links_manager_postgresql_14_green_params" {
+import {
+  to = aws_db_instance.instance["local_links_manager"]
+  id = "local-links-manager-postgres"
+}
 
-  name_prefix = "${var.govuk_environment}-local-links-manager-postgres-"
-  family      = "postgres14"
-
-  parameter {
-    name         = "rds.logical_replication"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-
-  lifecycle { create_before_destroy = true }
+import {
+  to = aws_db_parameter_group.engine_params["local_links_manager"]
+  id = "integration-local-links-manager-postgres-20250828113749103100000002"
 }

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -481,22 +481,6 @@ module "variable-set-rds-integration" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "local-links-manager"


### PR DESCRIPTION
Description:
- Import `local-links-manager` into Postgres14 and remove the logical replication parameters at the same time
- https://github.com/alphagov/govuk-infrastructure/issues/2918