### PR TITLE
Fix ephemeral clusters

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -67,6 +67,11 @@ variable "enable_arm_workers_green" {
   type        = bool
   description = "Whether to enable the 'green' ARM/Graviton-based Managed Node Group"
   default     = false
+
+  validation {
+    condition     = var.enable_arm_workers_blue == true || var.enable_arm_workers_green == true
+    error_message = "Either enable_arm_workers_blue or enable_arm_workers_green must be true"
+  }
 }
 
 variable "arm_workers_blue_instance_types" {

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -69,8 +69,8 @@ variable "enable_arm_workers_green" {
   default     = false
 
   validation {
-    condition     = var.enable_arm_workers_blue == true || var.enable_arm_workers_green == true
-    error_message = "Either enable_arm_workers_blue or enable_arm_workers_green must be true"
+    condition     = var.enable_arm_workers_blue || var.enable_arm_workers_green || var.enable_x86_workers
+    error_message = "At least one of enable_arm_workers_blue, enable_arm_workers_green, or enable_x86_workers must be true"
   }
 }
 

--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -19,7 +19,8 @@ module "var_set" {
     govuk_aws_state_bucket    = ""
     publishing_service_domain = "${var.ephemeral_cluster_id}.publishing.service.gov.uk"
 
-    enable_arm_workers         = true
+    enable_arm_workers_blue    = true
+    enable_arm_workers_green   = false
     enable_x86_workers         = false
     arm_workers_instance_types = ["m7g.2xlarge"]
 


### PR DESCRIPTION
At least one node group must be enabled, otherwise the cluster addons cannot be created, this is currently breaking the ephemeral cluster creation since the variables haven't been updated to the new names. So this PR

* Adds a variable condition so that at least one node group type must be enabled
* Corrects the variables for the ephmeral cluster node groups so that arm workers blue is enabled.

The error in terraform plans is for Kens ephemeral cluster which can be ignored