### PR TITLE
Tidy up GitHub config

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -144,7 +144,6 @@ resource "github_team_repository" "govuk_production_deploy_repos" {
   permission = try(local.repositories[each.key].teams["govuk"], "push")
 }
 
-
 resource "github_team_repository" "co_platform_engineering_repos" {
   for_each   = toset(["govuk-dns-tf", "govuk-dns", "govuk-dns-config"])
   repository = each.key
@@ -170,11 +169,6 @@ data "github_repository_pull_requests" "govuk_repos_prs" {
   }
   base_repository = each.key
   state           = "open"
-}
-
-moved {
-  from = github_repository.govuk_repos["govuk-content-block-manager"]
-  to   = github_repository.govuk_repos["content-block-manager"]
 }
 
 resource "github_repository" "govuk_repos" {

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -158,13 +158,11 @@ repos:
   data-community-tech-docs:
     homepage_url: "https://docs.data-community.publishing.service.gov.uk/"
     need_production_access_to_merge: false
-    allow_squash_merge: true
     push_allowances: []
 
   datagovuk-tech-docs:
     homepage_url: "https://guidance.data.gov.uk/"
     need_production_access_to_merge: false
-    allow_squash_merge: true
     push_allowances: []
 
   email-alert-api:
@@ -335,7 +333,6 @@ repos:
   govuk-content-api-docs:
     homepage_url: "https://content-api.publishing.service.gov.uk"
     need_production_access_to_merge: false
-    allow_squash_merge: true
     push_allowances: []
 
   govuk-data-science-workshop:
@@ -353,14 +350,12 @@ repos:
         - Test
 
   govuk-developer-docs:
-    allow_squash_merge: true
     can_be_deployed: true
     homepage_url: "https://docs.publishing.service.gov.uk"
     need_production_access_to_merge: false
 
   govuk-display-screen:
     need_production_access_to_merge: false
-    allow_squash_merge: true
     standard_contexts: *standard_security_checks
     teams: {
       govuk: "maintain"
@@ -421,44 +416,34 @@ repos:
     up_to_date_branches: true
 
   govuk-mobile-android-app:
-    allow_squash_merge: true
     branch_protection: false
 
   govuk-mobile-android-homepage:
-    allow_squash_merge: true
     branch_protection: false
 
   govuk-mobile-android-onboarding:
-    allow_squash_merge: true
     branch_protection: false
 
   govuk-mobile-android-services:
-    allow_squash_merge: true
     branch_protection: false
 
   govuk-mobile-ios-app:
-    allow_squash_merge: true
     branch_protection: false
 
   govuk-mobile-ios-homepage:
-    allow_squash_merge: true
     branch_protection: false
 
   govuk-mobile-ios-onboarding:
-    allow_squash_merge: true
     branch_protection: false
 
   govuk-mobile-ios-services:
-    allow_squash_merge: true
     branch_protection: false
 
   govuk-mobile-ios-ui-components:
-    allow_squash_merge: true
     branch_protection: false
 
   govuk-reports-prototype:
     need_production_access_to_merge: false
-    allow_squash_merge: true
     branch_protection: false
 
   govuk-rota-generator:


### PR DESCRIPTION
Removes redundant bits (to off loading the main PR).
Plan shows no changes
<img width="760" height="192" alt="Screenshot 2025-10-03 at 16 53 35" src="https://github.com/user-attachments/assets/6ccd6e4c-a912-4a2d-a498-fa39038d5d5b" />
