### PR TITLE
Remove moved block now terraform has been applied

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -255,8 +255,3 @@ resource "aws_kms_key" "eks" {
   deletion_window_in_days = 7
   enable_key_rotation     = true
 }
-
-moved {
-  from = module.eks.aws_iam_role_policy_attachment.this["AmazonEKSVPCResourceController"]
-  to   = module.eks.aws_iam_role_policy_attachment.additional["AmazonEKSVPCResourceController"]
-}


### PR DESCRIPTION
This terraform has now been applied so we can remove the moved block.

The failing terraform is Kens ephemeral cluster which can be ignored