### PR TITLE
Remove archived `search-v2-evaluator` repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -762,9 +762,6 @@ repos:
   search-api-v2-dataform:
     homepage_url: "https://docs.publishing.service.gov.uk/repos/search-api-v2-dataform.html"
 
-  search-v2-evaluator:
-    can_be_deployed: true
-
   service-manual-publisher:
     can_be_deployed: true
     homepage_url: "https://docs.publishing.service.gov.uk/apps/service-manual-publisher.html"


### PR DESCRIPTION
This repo was retired a year ago but not archived. Manually removed from terraform state.

Plan is showing no change:
<img width="762" height="257" alt="Screenshot 2025-10-06 at 12 39 49" src="https://github.com/user-attachments/assets/ebeb7cbc-c651-473b-8140-62d9c714e90d" />
