### PR TITLE
Configure GitHub topics and add docs for adding new repos

### DIFF
--- a/terraform/deployments/github/README.md
+++ b/terraform/deployments/github/README.md
@@ -33,31 +33,11 @@ protecting the `main` branch.
   ```shell
   GITHUB_TOKEN=<token> gds aws govuk-production-poweruser -- terraform apply
   ```
-## Adding existing repositories
 
-To manage an existing repository using the GOV.UK GitHub Infrastructure configuration, it needs to be imported into terraform state. Otherwise terraform apply will fail attempting to create a repository that already exists. 
+## Creating and configuring a new repository
 
-To import the resource, use an import block:
-```
-import {
-  to = github_repository.govuk_repos["govuk-existing-repo-name"]
-  id = "govuk-existing-repo-name"
-}
-```
-
-[Example commit of importing an existing repository](https://github.com/alphagov/govuk-infrastructure/commit/c6774a7d42ca2eb9b0987a51cde8b57e13e0577f). Note that the code only has to run once so it's ok to remove old entries.
-
-### Private repositories 
-
-Private repositiores should be treated as exceptions. We should [make new source code open](https://www.gov.uk/service-manual/service-standard/point-12-make-new-source-code-open) in accordance with [point 3 of the Technology Code of Practice](https://www.gov.uk/guidance/the-technology-code-of-practice). Only create a private repository if there are legitimate [grounds for keeping the code closed](https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed). 
-
-To configure a `private` or `internal` repository, set the `visibility` explicitly: 
-```
-  visibility: private
-```
-
-Note: Private repositories can't use GitHub Actions workflows that upload SARIF files, and therefore can't use the predefined standard security checks.
-
+To create and configure a **new** repository, you will need to raise a Pull Requests to add it to [repos.yml](/terraform/deployments/github/repos.yml) file and apply terraform changes in Terraform Cloud.
+You can use the existing repository configurations as examples. For detailed property definitions, refer to the [associated JSON schema](/terraform/deployments/github/schemas/repos.schema.json).
 
 ### Configuring required status checks
 
@@ -86,10 +66,45 @@ Example configuration:
 
 Note that private repositories can't use the predefined `standard_govuk_rails_checks` or `standard_security_checks`. In such cases, include a comment: `# standard security checks are disabled as not configured for a private repo`. You should define equivalent jobs in your repository’s CI workflow and reference them in the `additional_contexts` section of the required status checks.
 
+### Private repositories
+
+Private repositories should be treated as exceptions. We should [make new source code open](https://www.gov.uk/service-manual/service-standard/point-12-make-new-source-code-open) in accordance with [point 3 of the Technology Code of Practice](https://www.gov.uk/guidance/the-technology-code-of-practice). Only create a private repository if there are legitimate [grounds for keeping the code closed](https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed). 
+
+To configure a `private` or `internal` repository, set the `visibility` explicitly: 
+```
+  visibility: private
+```
+
+Note: Private repositories can't use GitHub Actions workflows that upload SARIF files, and therefore can't use the predefined standard security checks.
+
+### Adding existing repositories 
+
+> Skip this step if you are creating a new repository.
+
+To manage an **existing** repository using the GOV.UK GitHub Infrastructure configuration, it needs to be imported into terraform state. Otherwise terraform apply will fail attempting to create a repository that already exists. 
+
+To import the resource, use an import block:
+```
+import {
+  to = github_repository.govuk_repos["govuk-existing-repo-name"]
+  id = "govuk-existing-repo-name"
+}
+```
+
+[Example commit of importing an existing repository](https://github.com/alphagov/govuk-infrastructure/commit/c6774a7d42ca2eb9b0987a51cde8b57e13e0577f). Note that the code only has to run once so it's ok to remove old entries.
+
+If you've manually configured branch protection rules, you'll need to import them using the block below. Alternatively, you can delete the existing rules via the GitHub UI and allow Terraform to recreate them.
+```
+import {
+  to = github_branch_protection.govuk_repos["govuk-existing-repo-name"]
+  id = "govuk-existing-repo-name:main"
+}
+```
+
 ### Apply terraform changes
 
 Before merging your Pull Request, review the Terraform plan carefully. 
-After the PR is merged, remember to review it again and to apply the Terraform changes. 
+After the PR is merged, remember to review it again and to apply changes in [Terraform Cloud GitHub workspace](https://app.terraform.io/app/govuk/workspaces/GitHub/runs).
 
 
 ## Archiving repositories

--- a/terraform/deployments/github/README.md
+++ b/terraform/deployments/github/README.md
@@ -1,16 +1,30 @@
 # GOV.UK GitHub Infrastructure configuration
 
-This module configures GitHub resources so that the platform can automatically give permissions to
-repositories with specific properties in the included YAML file.
+This module configures GitHub resources to automatically assign permissions to repositories based on properties defined in a YAML file. For example, setting `can_be_deployed: true` enables features like creating an ECR registry and granting push permissions.
 
-We no longer use GitHub topics (tags) on repositories (similar to
-annotations on Kubernetes resources) to configure or enable platform functionality.
+This module:
 
-Instead, creating an ECR registry and giving permissions to push to the
-registry might be enabled by setting `can_be_deployed` to `true` in the YAML file.
+🧰 Ensures all repositories are configured consistently:
+- Visibility, topics, merge settings, branch deletion on merge etc.
+- Enables security features like vulnerability alerts
+- Prevents archiving if there are open PRs or GitHub Pages are active
 
-This module configures repositories with sensible defaults such as
-protecting the `main` branch.
+🔐 Applies branch protection to the `main` branch for applicable repositories:
+- Requires PR reviews
+- Supports status checks and code owner reviews
+- Defines standard status checks
+- Restricts who can push to the `main` branch in line with [GOV.UK Production access rules](https://docs.publishing.service.gov.uk/manual/rules-for-getting-production-access.html).
+
+👥 Manages team access:
+- Manages GitHub teams access such as: `GOV.UK`, `GOV.UK CI Bots`, `GOV.UK Production Admin`, `GOV.UK Production Deploy` and `GOV.UK ITHC and Penetration Testing`
+- Grants team-based repository access
+- Adds access for the CO Platform Engineering team to specific DNS repos
+
+🔑 Grants repositories access to pre-existing organisation-level secrets based on their roles:
+- Deployable repos → Argo & CI secrets
+- Pact publishers → Pact Broker credentials
+- Gem publishers → govuk-ci GitHub API token
+- All repos → Slack webhook URL
 
 ## Applying Terraform
 

--- a/terraform/deployments/github/README.md
+++ b/terraform/deployments/github/README.md
@@ -1,8 +1,5 @@
 # GOV.UK GitHub Infrastructure configuration
 
-> **Note**: Currently this module can only be applied by an alphagov GitHub
-Organisation Admin.
-
 This module configures GitHub resources so that the platform can automatically give permissions to
 repositories with specific properties in the included YAML file.
 

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -177,6 +177,7 @@ resource "github_repository" "govuk_repos" {
   name = each.key
 
   visibility = try(each.value.visibility, "public")
+  topics     = try(each.value.topics, ["govuk"])
 
   allow_squash_merge = true
   allow_merge_commit = false

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -257,7 +257,7 @@ resource "github_branch_protection" "govuk_repos" {
   }
 
   required_status_checks {
-    strict = try(each.value.strict, false)
+    strict = try(each.value.up_to_date_branches, false)
 
     contexts = concat(
       try(each.value["required_status_checks"]["standard_contexts"], []),

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -363,7 +363,6 @@ repos:
 
   govuk-dns-tf:
     visibility: private
-    strict: true
     up_to_date_branches: true
     required_pull_request_reviews:
       require_code_owner_reviews: true
@@ -382,14 +381,12 @@ repos:
 
   govuk-fastly:
     can_be_deployed: true
-    strict: true
     up_to_date_branches: true
     required_pull_request_reviews:
       require_code_owner_reviews: true
 
   govuk-fastly-secrets:
     visibility: private
-    strict: true
     up_to_date_branches: true
     required_pull_request_reviews:
       require_code_owner_reviews: true
@@ -399,20 +396,17 @@ repos:
     can_be_deployed: true
 
   govuk-infrastructure:
-    strict: true
     up_to_date_branches: true
     required_pull_request_reviews:
       require_code_owner_reviews: true
 
   terraform-govuk-infrastructure-sensitive:
     visibility: private
-    strict: true
     up_to_date_branches: true
     required_pull_request_reviews:
       require_code_owner_reviews: true
 
   terraform-govuk-tfe-workspacer:
-    strict: true
     up_to_date_branches: true
 
   govuk-mobile-android-app:

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -417,30 +417,39 @@ repos:
 
   govuk-mobile-android-app:
     branch_protection: false
+    topics: []
 
   govuk-mobile-android-homepage:
     branch_protection: false
+    topics: []
 
   govuk-mobile-android-onboarding:
     branch_protection: false
+    topics: []
 
   govuk-mobile-android-services:
     branch_protection: false
+    topics: []
 
   govuk-mobile-ios-app:
     branch_protection: false
+    topics: []
 
   govuk-mobile-ios-homepage:
     branch_protection: false
+    topics: []
 
   govuk-mobile-ios-onboarding:
     branch_protection: false
+    topics: []
 
   govuk-mobile-ios-services:
     branch_protection: false
+    topics: []
 
   govuk-mobile-ios-ui-components:
     branch_protection: false
+    topics: []
 
   govuk-reports-prototype:
     need_production_access_to_merge: false

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -757,7 +757,6 @@ repos:
   search-api-v2:
     can_be_deployed: true
     required_status_checks:
-      ignore_jenkins: true
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Test Ruby

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -813,7 +813,6 @@ repos:
   smart-answers:
     can_be_deployed: true
     homepage_url: "https://docs.publishing.service.gov.uk/apps/smart-answers.html"
-    allow_squash_merge: true
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:

--- a/terraform/deployments/github/schemas/repos.schema.json
+++ b/terraform/deployments/github/schemas/repos.schema.json
@@ -88,8 +88,7 @@
                 "additional_contexts": {
                   "type": "array",
                   "items": { "type": "string" }
-                },
-                "ignore_jenkins": { "type": "boolean" }
+                }
               },
               "additionalProperties": true
             }

--- a/terraform/deployments/github/schemas/repos.schema.json
+++ b/terraform/deployments/github/schemas/repos.schema.json
@@ -45,6 +45,11 @@
               "type": "object",
               "additionalProperties": { "type": "string" }
             },
+            "topics": {
+              "description": "The list of topics of the repository. If omitted, defaults to ['govuk']",
+              "type": "array",
+               "items": { "type": "string", "enum": ["govuk"]}
+            },
             "required_status_checks": {
               "type": "object",
               "properties": {

--- a/terraform/deployments/github/schemas/repos.schema.json
+++ b/terraform/deployments/github/schemas/repos.schema.json
@@ -16,23 +16,46 @@
         "^[a-zA-Z0-9._-]+$": {
           "type": "object",
           "properties": {
-            "can_be_deployed": { "type": "boolean" },
-            "pact_publisher": { "type": "boolean" },
-            "publishes_gem": { "type": "boolean" },
+            "can_be_deployed": {
+              "description": "Sets up the necessary secrets for deployment and create an Elastic Container Registry repository with the same name. If omitted, defaults to false",
+              "type": "boolean" 
+            },
+            "pact_publisher": {
+              "description": "Sets up Pact broker credentials for contract testing. If omitted, defaults to false",
+              "type": "boolean" 
+            },
+            "publishes_gem": {
+              "description": "Sets up the necessary secrets for releasing Ruby gems. If omitted, defaults to false",
+              "type": "boolean" 
+            },
             "homepage_url": { "type": "string" },
             "visibility": { "type": "string", "enum": ["public", "private", "internal"] },
-            "branch_protection": { "type": "boolean" },
-            "allow_squash_merge": { "type": "boolean" },
-            "need_production_access_to_merge": { "type": "boolean" },
+            "branch_protection": {
+              "description": "Enforces configurable branch protection rules for the main branch. If omitted, defaults to true",
+              "type": "boolean" 
+            },
+            "allow_squash_merge": { 
+              "description": "If omitted, defaults to true",
+              "type": "boolean" 
+            },
+            "need_production_access_to_merge": { 
+              "description": "If omitted, defaults to true",
+              "type": "boolean" 
+            },
             "up_to_date_branches": { 
               "description": "Determines whether the branch is required to be up to date with the base branch before merging. If omitted, defaults to false",
               "type": "boolean" 
             },
             "required_pull_request_reviews": {
+              "description": "Enforce restrictions for pull request reviews. Requires at least 1 approval by default",
               "type": "object",
               "properties": {
-                "require_code_owner_reviews": { "type": "boolean" },
+                "require_code_owner_reviews": {
+                  "description": "Require an approved review in pull requests including files with a designated code owner. If omitted, defaults to false",
+                  "type": "boolean" 
+                },
                 "pull_request_bypassers": {
+                  "description": "The list of actor Names/IDs that are allowed to bypass pull request requirements. If omitted, defaults to null",
                   "type": "array",
                   "items": { "type": "string" }
                 }
@@ -40,10 +63,12 @@
               "additionalProperties": true
             },
             "push_allowances": {
+              "description": "A list of actor Names/IDs that may push to the main branch. If omitted, defaults to GOV.UK Production Admin and GOV.UK Production Deploy GitHub teams.",
               "type": "array",
               "items": { "type": "string" }
             },
             "teams": {
+              "description": "Sets up repository access permissions. If omitted defaults access in line with GOV.UK's production access rules", 
               "type": "object",
               "additionalProperties": { "type": "string" }
             },
@@ -53,6 +78,7 @@
                "items": { "type": "string", "enum": ["govuk"]}
             },
             "required_status_checks": {
+              "description": "Configures what status checks must pass before you can merge your branch into the protected main branch",
               "type": "object",
               "properties": {
                 "standard_contexts": {

--- a/terraform/deployments/github/schemas/repos.schema.json
+++ b/terraform/deployments/github/schemas/repos.schema.json
@@ -24,8 +24,10 @@
             "branch_protection": { "type": "boolean" },
             "allow_squash_merge": { "type": "boolean" },
             "need_production_access_to_merge": { "type": "boolean" },
-            "strict": { "type": "boolean" },
-            "up_to_date_branches": { "type": "boolean" },
+            "up_to_date_branches": { 
+              "description": "Determines whether the branch is required to be up to date with the base branch before merging. If omitted, defaults to false",
+              "type": "boolean" 
+            },
             "required_pull_request_reviews": {
               "type": "object",
               "properties": {


### PR DESCRIPTION
The process changed and TF plan errors when users follow the manual because of dependencies/tasks order. 
This will allow engineers add repos independently and efficiently.

Also includes some refactoring to simplify the config. See individual commits for details.

https://github.com/alphagov/govuk-infrastructure/issues/2904