### PR TITLE
Don't update GitHub topics for archived repos

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -177,7 +177,7 @@ resource "github_repository" "govuk_repos" {
   name = each.key
 
   visibility = try(each.value.visibility, "public")
-  topics     = try(each.value.topics, ["govuk"])
+  topics     = try(each.value.archived, false) ? null : try(each.value.topics, ["govuk"])
 
   allow_squash_merge = true
   allow_merge_commit = false


### PR DESCRIPTION
This will only assign topics value to repos that are not archived.

Since the repos are archived we can't make changes to them but the API gives a successful response so the changes keep reappearing in the subsequent terraform plans.