### PR TITLE
Bump `support-api` staging parameter group to PostgreSQL 14

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -675,7 +675,7 @@ module "variable-set-rds-staging" {
 
       support_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -698,7 +698,7 @@ module "variable-set-rds-staging" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "support-api"
         allocated_storage            = 200
         instance_class               = "db.t4g.medium"


### PR DESCRIPTION
Description:
- Bump the parameter group to PostgreSQL 14
- https://github.com/alphagov/govuk-infrastructure/issues/2907