### PR TITLE
Remove `support-api` staging logical replication parameters

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -681,22 +681,6 @@ module "variable-set-rds-staging" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "support-api"


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2946 imported the Terraform
- Remove the logical replication parameters
- https://github.com/alphagov/govuk-infrastructure/issues/2907