### PR TITLE
Create `govuk-toolbox-image` GitHub repository

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -974,3 +974,6 @@ repos:
       govuk: "maintain"
     }
   }
+
+  govuk-toolbox-image:
+    can_be_deployed: true


### PR DESCRIPTION
Description:
- As part of migrating the `toolbox` image away from `govuk-infrastructure` we create a new repository to house it
- https://github.com/alphagov/govuk-infrastructure/issues/2592