### PR TITLE
Bump `support-api` prod params to PostgreSQL 14

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -683,7 +683,7 @@ module "variable-set-rds-production" {
 
       support_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -702,7 +702,7 @@ module "variable-set-rds-production" {
             value = 40, apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "support-api"
         allocated_storage            = 200
         instance_class               = "db.t4g.medium"


### PR DESCRIPTION
Description:
- Bump parameter group to 14
- https://github.com/alphagov/govuk-infrastructure/issues/2907