### PR TITLE
Revert "BAU - Set engine version to 14 in integration"

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -205,7 +205,7 @@ module "variable-set-rds-integration" {
 
       ckan = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -258,7 +258,7 @@ module "variable-set-rds-integration" {
 
       content_data_admin = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -276,7 +276,7 @@ module "variable-set-rds-integration" {
 
       content_data_api = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.18"
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
@@ -456,7 +456,7 @@ module "variable-set-rds-integration" {
 
       link_checker_api = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -475,7 +475,7 @@ module "variable-set-rds-integration" {
 
       local_links_manager = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -616,7 +616,7 @@ module "variable-set-rds-integration" {
 
       service_manual_publisher = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -649,7 +649,7 @@ module "variable-set-rds-integration" {
 
       support_api = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -667,7 +667,7 @@ module "variable-set-rds-integration" {
 
       transition = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#2952

From the AWS Docs, "The version number of the database engine to upgrade to. Changing this parameter results in an outage and the change is applied during the next maintenance window unless the ApplyImmediately parameter is enabled for this request."

The Terraform provider seems to want to downgrade to `14.17.`