### PR TITLE
Allow merge commits by default on new repos

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -180,7 +180,7 @@ resource "github_repository" "govuk_repos" {
   topics     = try(each.value.archived, false) ? null : try(each.value.topics, ["govuk"])
 
   allow_squash_merge = true
-  allow_merge_commit = false
+  allow_merge_commit = true
 
   has_downloads        = true
   vulnerability_alerts = !try(each.value.archived, false) # Archived repos cannot have vulnerability alerts


### PR DESCRIPTION
Allow merge commits (Add all commits from the head branch to the base branch with a merge commit) is enabled for all GOV.UK repos, which is what we want, despite this config stating otherwise.

When a new repo is created this value is set to false which engineers found confusing as there was no option to "Merge" the PR  but to "Squash and merge". They had to change the Pull Request setting in the UI. 
<kbd><img width="398" height="177" alt="Screenshot 2025-10-09 at 14 09 27" src="https://github.com/user-attachments/assets/1db7a2e6-97f8-419b-ab7c-07d48cfb3250" /></kbd>


Subsequent terraform apply runs don't appear to be changing this setting so it maybe something to look into later.


Tested by running TF plan on a new repo and this value is set correctly for a new repo:
```
  # github_repository.govuk_repos["new-repo"] will be created
  + resource "github_repository" "govuk_repos" {
      + allow_auto_merge            = false
      + allow_merge_commit          = true
      + allow_rebase_merge          = true
      + allow_squash_merge          = true
      ...
```

**TF Plan** shows no changes to this property.