### PR TITLE
Import `support-api` prod params in postgres 14

### DIFF
--- a/terraform/deployments/rds/production_support_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/production_support_api_postgres_14_upgrade.tf
@@ -1,25 +1,9 @@
-resource "aws_db_parameter_group" "support_api_postgresql_14_green_params" {
+import {
+  to = aws_db_instance.instance["support_api"]
+  id = "support-api-postgres"
+}
 
-  name_prefix = "${var.govuk_environment}-support-api-postgres-"
-  family      = "postgres14"
-
-  parameter {
-    name         = "rds.logical_replication"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-
-  lifecycle { create_before_destroy = true }
+import {
+  to = aws_db_parameter_group.engine_params["support_api"]
+  id = "production-support-api-postgres-20250828115316247400000003"
 }


### PR DESCRIPTION
Description:
- Import `support-api` into Terraform
- https://github.com/alphagov/govuk-infrastructure/issues/2907