### PR TITLE
Remove logical replication parameters for `support-api` in production

### DIFF
--- a/terraform/deployments/rds/production_support_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/production_support_api_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["support_api"]
-  id = "support-api-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["support_api"]
-  id = "production-support-api-postgres-20250828115316247400000003"
-}

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -689,18 +689,6 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value = 1, apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value = 35, apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value = 20, apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value = 40, apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "support-api"


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2958 imported `support-api` PostgreSQL 14 into Terraform
- Remove the logical replication parameters
- https://github.com/alphagov/govuk-infrastructure/issues/2907