### PR TITLE
Create 2 databases to be used for testing a new process

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -297,6 +297,32 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
       }
 
+      content_data_api = {
+        engine         = "postgres"
+        engine_version = "14.18"
+        engine_params = {
+          work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
+          autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
+          maintenance_work_mem                 = { value = "GREATEST({DBInstanceClassMemory/${1024 * 3}},65536)" }
+          "rds.force_autovacuum_logging_level" = { value = "log" }
+          log_autovacuum_min_duration          = { value = 10000 }
+          log_min_duration_statement           = { value = "10000" }
+          log_statement                        = { value = "all" }
+          deadlock_timeout                     = { value = 2500 }
+          log_lock_waits                       = { value = 1 }
+        }
+        engine_params_family         = "postgres14"
+        name                         = "jfharden-test-content-data-api-001"
+        allocated_storage            = 500
+        instance_class               = "db.m6g.large"
+        performance_insights_enabled = false
+        project                      = "GOV.UK - Publishing"
+        encryption_at_rest           = false
+        snapshot_identifier          = "jfharden-test-content-data-api-001"
+        multi_az                     = true
+        skip_final_snapshot          = true
+      }
+
       content_publisher = {
         engine         = "postgres"
         engine_version = "13"
@@ -697,6 +723,25 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
       }
+
+      whitehall = {
+        engine         = "mysql"
+        engine_version = "8.0.42"
+        engine_params = {
+          max_allowed_packet = { value = 1073741824 }
+        }
+        engine_params_family         = "mysql8.0"
+        name                         = "jfharden-test-whitehall-001"
+        allocated_storage            = 400
+        instance_class               = "db.m7g.xlarge"
+        performance_insights_enabled = true
+        project                      = "GOV.UK - Publishing"
+        encryption_at_rest           = false
+        snapshot_identifier          = "jfharden-test-whitehall-001"
+        multi_az                     = true
+        skip_final_snapshot          = true
+      }
+
     }
   }
 }


### PR DESCRIPTION
I need a couple of RDS instances for testing and the easiest way to create them so they are provisioned correctly is to add them in the terraform, then in a follow on PR remove them and remove them from the state with a removed block.

Note I'm doing performance testing so to keep the same characteristics as prod these are the same size, and also multi-az just like prod.