### PR TITLE
Add a canary repo to be used by the synthetic test app

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -914,6 +914,7 @@ repos:
     required_status_checks:
       additional_contexts:
         - Test
+    standard_contexts: *standard_security_checks
 
   govuk-user-reviewer:
     visibility: private


### PR DESCRIPTION
This will be a very simple app that will work with the Ginkgo tests in the synthetic test app repo to check that the release pipeline is working.

https://github.com/alphagov/govuk-infrastructure/issues/2736