### PR TITLE
Give search-api-v2 additional permissions

### DIFF
--- a/terraform/deployments/search-api-v2/service_accounts.tf
+++ b/terraform/deployments/search-api-v2/service_accounts.tf
@@ -26,6 +26,7 @@ resource "google_project_iam_custom_role" "api" {
     "discoveryengine.documents.update",
     "discoveryengine.evaluations.create",
     "discoveryengine.evaluations.get",
+    "discoveryengine.evaluations.list",
     "discoveryengine.operations.get",
     "discoveryengine.sampleQueries.import",
     "discoveryengine.sampleQuerySets.create",


### PR DESCRIPTION
Jira: https://gov-uk.atlassian.net/browse/SCH-1490
( prior art: https://trello.com/c/3CcdDw99/847-evaluations-add-required-permissions-to-search-api-v2-service-account)

Grant permission to Search-api-v2 to request the discoveryengine.evaluations.list endpoint. 
Related work in Search-api-v2: https://github.com/alphagov/search-api-v2/pull/564