### PR TITLE
Search API v2 add permission to delete storage objects

### DIFF
--- a/terraform/deployments/search-api-v2/automated_evaluation.tf
+++ b/terraform/deployments/search-api-v2/automated_evaluation.tf
@@ -326,6 +326,7 @@ resource "google_project_iam_custom_role" "automated_evaluation_pipeline" {
   description = ""
   permissions = [
     "discoveryengine.servingConfigs.search",
+    "storage.objects.delete",
     "storage.objects.get",
     "storage.objects.list",
     "storage.objects.create",


### PR DESCRIPTION
A scheduled task failed to upload Search API v2 evaluation results because a bucket object with the same name already existed, and the task lacked permission to delete it before replacing it.

We would probably always want to replace an existing file anyway, so this commit grants the `storage.objects.delete` permission.

Note that permissions are granted at the project level, whereas granting them at the resource level would better meet the principle of least privilege. We intend to refactor this when we remove the redundant infrastructure of manual evaluations.