### PR TITLE
Bump `locations-api` parameter group to Postgres 14

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -493,7 +493,7 @@ module "variable-set-rds-integration" {
 
       locations_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -516,7 +516,7 @@ module "variable-set-rds-integration" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "locations-api"
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"


### PR DESCRIPTION
Description:
- Bumps `locations-api` parameter group to Postgres 14
- https://github.com/alphagov/govuk-infrastructure/issues/3004