### PR TITLE
Bump `locations-api` staging postgres to 14.18

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -519,7 +519,7 @@ module "variable-set-rds-staging" {
 
       locations_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -542,7 +542,7 @@ module "variable-set-rds-staging" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "locations-api"
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"


### PR DESCRIPTION
Description:
- Bump the `locations-api` staging Postgres parameter group to `14.18`
- https://github.com/alphagov/govuk-infrastructure/issues/3004