### PR TITLE
Make it possible to isolate an RDS instance

### DIFF
--- a/terraform/deployments/rds/security_groups.tf
+++ b/terraform/deployments/rds/security_groups.tf
@@ -9,7 +9,10 @@ resource "aws_security_group" "rds" {
 }
 
 resource "aws_security_group_rule" "mysql" {
-  for_each          = { for name, data in var.databases : name => data if data.engine == "mysql" }
+  for_each = {
+    for name, data in var.databases : name => data
+    if data.engine == "mysql" && !try(data.isolate, false)
+  }
   security_group_id = aws_security_group.rds[each.key].id
   description       = "Access to MySQL database from EKS worker nodes"
 
@@ -22,7 +25,10 @@ resource "aws_security_group_rule" "mysql" {
 }
 
 resource "aws_security_group_rule" "postgres" {
-  for_each          = { for name, data in var.databases : name => data if data.engine == "postgres" }
+  for_each = {
+    for name, data in var.databases : name => data
+    if data.engine == "postgres" && !try(data.isolate, false)
+  }
   security_group_id = aws_security_group.rds[each.key].id
   description       = "Access to PostgreSQL database from EKS worker nodes"
 


### PR DESCRIPTION
For the database options you can pass the option `isolate = true` for any DB and the SG rule will be destroyed which allows inbound access from the cluster.

It would be required to reboot the database to sever already established connections after applying this.