### PR TITLE
Remove search-v2-evaluator from Sentry

### DIFF
--- a/terraform/deployments/sentry/locals.tf
+++ b/terraform/deployments/sentry/locals.tf
@@ -43,7 +43,6 @@ locals {
     "search-api",
     "search-api-v2",
     "search-api-v2-beta-features",
-    "search-v2-evaluator",
     "service-manual-publisher",
     "short-url-manager",
     "signon",


### PR DESCRIPTION
This repo has been archived, but the Sentry integration was not updated at the same time.

PR to remove repo from deployments: https://github.com/alphagov/govuk-infrastructure/pull/2933