### PR TITLE
Bump `kubernetes-event-shipper` Helm chart to 1.1.1

### DIFF
--- a/terraform/deployments/cluster-services/kubernetes-events-shipper.tf
+++ b/terraform/deployments/cluster-services/kubernetes-events-shipper.tf
@@ -7,6 +7,6 @@ resource "helm_release" "kubernetes_events_shipper" {
   name       = "kubernetes-events-shipper"
   namespace  = local.services_ns
   repository = "https://alphagov.github.io/govuk-helm-charts/"
-  version    = "1.1.0"
+  version    = "1.1.1"
   timeout    = var.helm_timeout_seconds
 }


### PR DESCRIPTION
Description:
- Bumps `kubernetes-event-shipper` Helm chart to 1.1.1
- See https://github.com/alphagov/govuk-helm-charts/pull/3626