### PR TITLE
Add `locations-api` Postgres 14 parameter group for production

### DIFF
--- a/terraform/deployments/rds/production_locations_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/production_locations_api_postgres_14_upgrade.tf
@@ -1,0 +1,25 @@
+resource "aws_db_parameter_group" "locations_api_postgresql_14_green_params" {
+
+  name_prefix = "${var.govuk_environment}-locations-api-postgres-"
+  family      = "postgres14"
+
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_logical_replication_workers"
+    value        = "20"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_worker_processes"
+    value        = "25"
+    apply_method = "pending-reboot"
+  }
+
+  lifecycle { create_before_destroy = true }
+}

--- a/terraform/deployments/rds/staging_locations_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/staging_locations_api_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["locations_api"]
-  id = "locations-api-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["locations_api"]
-  id = "staging-locations-api-postgres-20250828115303735800000005"
-}


### PR DESCRIPTION
Description:
- Add `locations-api` Postgres 14 parameter group for production
- https://github.com/alphagov/govuk-infrastructure/issues/3004