### PR TITLE
Bump `locations-api` Postgres parameter group to 14.18

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -530,7 +530,7 @@ module "variable-set-rds-production" {
 
       locations_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -553,7 +553,7 @@ module "variable-set-rds-production" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "locations-api"
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"


### PR DESCRIPTION
Description:
- Bump `locations-api` Postgres parameter group to 14.18
- https://github.com/alphagov/govuk-infrastructure/issues/3004