### PR TITLE
Import prod `locations-api` Postgres 14 database into Terraform

### DIFF
--- a/terraform/deployments/rds/production_locations_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/production_locations_api_postgres_14_upgrade.tf
@@ -1,25 +1,9 @@
-resource "aws_db_parameter_group" "locations_api_postgresql_14_green_params" {
+import {
+  to = aws_db_instance.instance["locations_api"]
+  id = "locations-api-postgres"
+}
 
-  name_prefix = "${var.govuk_environment}-locations-api-postgres-"
-  family      = "postgres14"
-
-  parameter {
-    name         = "rds.logical_replication"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-
-  lifecycle { create_before_destroy = true }
+import {
+  to = aws_db_parameter_group.engine_params["locations_api"]
+  id = "production-locations-api-postgres-20250828115316247700000005"
 }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -536,22 +536,6 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "locations-api"


### PR DESCRIPTION
Description:
- Import prod `locations-api` Postgres 14 database into Terraform
- Remove `locations-api` logical rpelication parameters
- https://github.com/alphagov/govuk-infrastructure/issues/3004