### PR TITLE
Remove `locations-api` production imports

### DIFF
--- a/terraform/deployments/rds/production_locations_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/production_locations_api_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["locations_api"]
-  id = "locations-api-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["locations_api"]
-  id = "production-locations-api-postgres-20250828115316247700000005"
-}


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/3032 imported `locations-api` production into Terraform
- https://github.com/alphagov/govuk-infrastructure/issues/3004