### PR TITLE
Set log_autovauum_min_duration to pending_reboot apply method to stop continual drift

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -296,7 +296,7 @@ module "variable-set-rds-integration" {
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
           maintenance_work_mem                 = { value = "GREATEST({DBInstanceClassMemory/${1024 * 3}},65536)" }
           "rds.force_autovacuum_logging_level" = { value = "log" }
-          log_autovacuum_min_duration          = { value = 10000 }
+          log_autovacuum_min_duration          = { value = 10000, apply_method = "pending-reboot" }
           log_min_duration_statement           = { value = "10000" }
           log_statement                        = { value = "all" }
           deadlock_timeout                     = { value = 2500 }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -318,7 +318,7 @@ module "variable-set-rds-production" {
           maintenance_work_mem                 = { value = "GREATEST({DBInstanceClassMemory/${1024 * 3}},65536)" }
           "rds.force_autovacuum_logging_level" = { value = "log" }
           log_autovacuum_min_duration          = { value = 10000 }
-          log_min_duration_statement           = { value = "10000" }
+          log_min_duration_statement           = { value = "10000", apply_method = "pending-reboot" }
           log_statement                        = { value = "all" }
           deadlock_timeout                     = { value = 2500 }
           log_lock_waits                       = { value = 1 }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -306,7 +306,7 @@ module "variable-set-rds-staging" {
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
           maintenance_work_mem                 = { value = "GREATEST({DBInstanceClassMemory/${1024 * 3}},65536)" }
           "rds.force_autovacuum_logging_level" = { value = "log" }
-          log_autovacuum_min_duration          = { value = 10000 }
+          log_autovacuum_min_duration          = { value = 10000, apply_method = "pending-reboot" }
           log_min_duration_statement           = { value = "10000" }
           log_statement                        = { value = "all" }
           deadlock_timeout                     = { value = 2500 }


### PR DESCRIPTION
Every terraform plan for this parameter setting is trying to change it from `pending_reboot` to `immediate`, to lets set the terraform to reflect the reality and stop seeing `1 change` on every single terraform plan for all RDS workspaces.