### PR TITLE
Set the correct var to pending-reboot

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -317,8 +317,8 @@ module "variable-set-rds-production" {
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
           maintenance_work_mem                 = { value = "GREATEST({DBInstanceClassMemory/${1024 * 3}},65536)" }
           "rds.force_autovacuum_logging_level" = { value = "log" }
-          log_autovacuum_min_duration          = { value = 10000 }
-          log_min_duration_statement           = { value = "10000", apply_method = "pending-reboot" }
+          log_autovacuum_min_duration          = { value = 10000, apply_method = "pending-reboot" }
+          log_min_duration_statement           = { value = "10000" }
           log_statement                        = { value = "all" }
           deadlock_timeout                     = { value = 2500 }
           log_lock_waits                       = { value = 1 }


### PR DESCRIPTION
I accidentally set log_min_duration_statement to pending-reboot instead of log_autovacuum_min_duration in prod. This PR fixes that.