### PR TITLE
Add govuk-synthetic-test-app as extra_repository for ecr

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -57,6 +57,7 @@ locals {
     "clamav",
     "govuk-fastly-diff-generator",
     "govuk-replatform-test-app",
+    "govuk-synthetic-test-app",
     "imminence",
     "licensify-backend",
     "licensify-feed",


### PR DESCRIPTION
The govuk-synthetic-test-app image not currently being pulled through and will soon be just a cronjob running the ginkgo tests and not a deployable app, so it will need to be explicitly defined to be pulled through to ECR.

https://github.com/alphagov/govuk-infrastructure/issues/2736