### PR TITLE
Provide option to point CNAMES to old or new RDS instances

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -245,7 +245,9 @@ resource "aws_route53_record" "instance_cname" {
   type    = "CNAME"
   ttl     = 300
   records = [
-    lookup(each.value, "launch_new_db", false) ? aws_db_instance.normalised_instance[each.key].address : aws_db_instance.instance[each.key].address
+    lookup(each.value, "cname_point_to_new_instance", false) && lookup(each.value, "launch_new_db", false) ?
+    aws_db_instance.normalised_instance[each.key].address :
+    aws_db_instance.instance[each.key].address
   ]
 }
 
@@ -306,7 +308,9 @@ resource "aws_route53_record" "replica_cname" {
   type    = "CNAME"
   ttl     = 300
   records = [
-    lookup(each.value, "launch_new_db", false) && lookup(each.value, "launch_new_replica", false) ?
+    lookup(each.value, "cname_point_to_new_instance", false) &&
+    lookup(each.value, "launch_new_db", false) &&
+    lookup(each.value, "launch_new_replica", false) ?
     aws_db_instance.normalised_replica[each.key].address :
     aws_db_instance.replica[each.key].address
   ]

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -165,6 +165,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       authenticating_proxy = {
@@ -186,6 +187,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       chat = {
@@ -207,6 +209,7 @@ module "variable-set-rds-integration" {
         snapshot_identifier          = "chat-postgres-post-encryption"
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       ckan = {
@@ -228,6 +231,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       collections_publisher = {
@@ -245,6 +249,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_block_manager = {
@@ -266,6 +271,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_data_admin = {
@@ -286,6 +292,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_data_api = {
@@ -312,6 +319,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_publisher = {
@@ -348,6 +356,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_store = {
@@ -368,6 +377,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_tagger = {
@@ -404,6 +414,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       draft_content_store = {
@@ -424,6 +435,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       email_alert_api = {
@@ -460,6 +472,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       imminence = {
@@ -482,6 +495,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       link_checker_api = {
@@ -503,6 +517,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       local_links_manager = {
@@ -523,6 +538,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       locations_api = {
@@ -543,6 +559,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       publishing_api = {
@@ -586,6 +603,7 @@ module "variable-set-rds-integration" {
         launch_new_db                = false
         launch_new_replica           = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       publisher = {
@@ -607,6 +625,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       release = {
@@ -624,6 +643,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       search_admin = {
@@ -641,6 +661,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       service_manual_publisher = {
@@ -661,6 +682,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       signon = {
@@ -678,6 +700,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       support_api = {
@@ -698,6 +721,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       transition = {
@@ -718,6 +742,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       whitehall = {
@@ -735,6 +760,7 @@ module "variable-set-rds-integration" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
     }
   }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -187,6 +187,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       authenticating_proxy = {
@@ -208,6 +209,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       chat = {
@@ -229,6 +231,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = true
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       ckan = {
@@ -249,6 +252,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       collections_publisher = {
@@ -266,6 +270,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_block_manager = {
@@ -287,6 +292,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_data_admin = {
@@ -307,6 +313,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_data_api = {
@@ -333,6 +340,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_publisher = {
@@ -369,6 +377,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_store = {
@@ -389,6 +398,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_tagger = {
@@ -425,6 +435,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       draft_content_store = {
@@ -445,6 +456,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       email_alert_api = {
@@ -481,6 +493,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       imminence = {
@@ -503,6 +516,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       link_checker_api = {
@@ -524,6 +538,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       local_links_manager = {
@@ -560,6 +575,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       locations_api = {
@@ -580,6 +596,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       publishing_api = {
@@ -620,6 +637,7 @@ module "variable-set-rds-production" {
         launch_new_db                = false
         launch_new_replica           = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       publisher = {
@@ -641,6 +659,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       release = {
@@ -658,6 +677,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       search_admin = {
@@ -675,6 +695,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       service_manual_publisher = {
@@ -695,6 +716,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       signon = {
@@ -712,6 +734,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       support_api = {
@@ -732,6 +755,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       transition = {
@@ -752,6 +776,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       whitehall = {
@@ -769,6 +794,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
     }
   }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -176,6 +176,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       authenticating_proxy = {
@@ -197,6 +198,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       chat = {
@@ -218,6 +220,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = true
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       ckan = {
@@ -238,6 +241,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       collections_publisher = {
@@ -255,6 +259,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_block_manager = {
@@ -276,6 +281,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_data_admin = {
@@ -296,6 +302,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_data_api = {
@@ -322,6 +329,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_publisher = {
@@ -358,6 +366,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_store = {
@@ -378,6 +387,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       content_tagger = {
@@ -414,6 +424,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       draft_content_store = {
@@ -434,6 +445,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       email_alert_api = {
@@ -470,6 +482,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       imminence = {
@@ -492,6 +505,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       link_checker_api = {
@@ -513,6 +527,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       local_links_manager = {
@@ -549,6 +564,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       locations_api = {
@@ -569,6 +585,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       publishing_api = {
@@ -612,6 +629,7 @@ module "variable-set-rds-staging" {
         launch_new_db                = false
         launch_new_replica           = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       publisher = {
@@ -633,6 +651,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       release = {
@@ -650,6 +669,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       search_admin = {
@@ -667,6 +687,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       service_manual_publisher = {
@@ -687,6 +708,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       signon = {
@@ -704,6 +726,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       support_api = {
@@ -724,6 +747,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       transition = {
@@ -744,6 +768,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
 
       whitehall = {
@@ -761,6 +786,7 @@ module "variable-set-rds-staging" {
         encryption_at_rest           = false
         launch_new_db                = false
         isolate                      = false
+        cname_point_to_new_instance  = false
       }
     }
   }


### PR DESCRIPTION
To allow for easy testing, and easy rollback, provide the option per instance of pointing the cnames to either the original instance and replica, or the new instance and replica.

Default it to false, and also set it on every DB