### PR TITLE
Revert "Launch new RDS instances (without changing cnames)"

### DIFF
--- a/terraform/deployments/tfc-configuration/rds.tf
+++ b/terraform/deployments/tfc-configuration/rds.tf
@@ -23,11 +23,6 @@ module "rds-integration" {
     "GOV.UK Production"           = "write"
   }
 
-  envvars = {
-    TF_CLI_ARGS_plan  = "-parallelism=30"
-    TF_CLI_ARGS_apply = "-parallelism=30"
-  }
-
   variable_set_ids = [
     local.aws_credentials["integration"],
     module.variable-set-common.id,

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -163,7 +163,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -185,7 +185,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -229,7 +229,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - DGU"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -247,7 +247,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -269,7 +269,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -290,7 +290,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -317,7 +317,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -354,7 +354,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -375,7 +375,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -412,7 +412,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -433,7 +433,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -470,7 +470,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -493,7 +493,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -515,7 +515,7 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -536,7 +536,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -557,7 +557,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -600,7 +600,7 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
         has_read_replica             = true
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         launch_new_replica           = false
         isolate                      = false
         cname_point_to_new_instance  = false
@@ -623,7 +623,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -641,7 +641,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Infrastructure"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -659,7 +659,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Search"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -680,7 +680,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -698,7 +698,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -719,7 +719,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -740,7 +740,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -758,7 +758,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#3046

We hit the globally set terraform cloud timeout (we can adjust this) but it caused this apply to error, so lets revert it for now, I can adjust the settings, then we can go again later.