### PR TITLE
Remove lifecycle rule from private subnet NAT EIPs

### DIFF
--- a/terraform/deployments/vpc/subnets.tf
+++ b/terraform/deployments/vpc/subnets.tf
@@ -16,10 +16,6 @@ resource "aws_eip" "private_subnet_nat" {
     Name    = "${each.key}-nat"
     Purpose = "EIP Retained for Legacy ELMS Endpoints"
   }
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_subnet" "private_subnet" {


### PR DESCRIPTION
In a previous commit we added a lifecycle rule that prevented deletion of the elastic IP addresses associated with NAT gateways in private subnets. The effect of this has been to make it impossible to cleanly delete an ephemeral environment.

We remove the lifecycle rule so that ephemeral environments can come up and down cleanly. The other effect of this change is that these EIPs can be deleted in other environments too. However we have other mitigations in place to prevent their accidental deletion:

* if deletion is intended, we will be OK with it
* code review will catch erroneous removal
* this part of the code changes with very little frequency, so there should be fewer chances for mistakes

Overall, the positives outweigh the negatives when the mitigations are taken into account.