### PR TITLE
Fix IAM role policy attachment error for Chat Service

### DIFF
--- a/terraform/deployments/chat/eventbridge.tf
+++ b/terraform/deployments/chat/eventbridge.tf
@@ -47,6 +47,6 @@ resource "aws_iam_policy" "aws_service_health_alert" {
 }
 
 resource "aws_iam_role_policy_attachment" "aws_service_health_alert" {
-  role       = aws_iam_role.aws_service_health_alert.arn
+  role       = aws_iam_role.aws_service_health_alert.name
   policy_arn = aws_iam_policy.aws_service_health_alert.arn
 }


### PR DESCRIPTION
## What

Fix a configuration error for an IAM Role Policy Attachment

## Why

The role had been configured with ARN instead of Name