### PR TITLE
Add `PassRole` permission to `terraform-cloud` role for `govuk-chat-eventbridge-health-alert`

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -122,7 +122,8 @@ data "aws_iam_policy_document" "tfc_policy" {
       "arn:aws:iam::*:role/rds-monitoring-role",
       "arn:aws:iam::*:role/govuk-*-csp-reports-firehose-role",
       "arn:aws:iam::*:role/govuk-chat-bedrock-access-role",
-      "arn:aws:iam::*:role/govuk-chat-bedrock-cloudwatch-role"
+      "arn:aws:iam::*:role/govuk-chat-bedrock-cloudwatch-role",
+      "arn:aws:iam::*:role/govuk-chat-eventbridge-health-alert"
     ]
   }
   statement {


### PR DESCRIPTION
## What

Add the `iam:PassRole` action on `govuk-chat-eventbridge-health-alert` for `terraform-cloud` role

## Why

This is to give the TFC deployment role permission to assign the `govuk-chat-eventbridge-health-alert` role to an EventBridge Role