### PR TITLE
Associate IAM role with EventBridge Role Target for Chat Service

### DIFF
--- a/terraform/deployments/chat/eventbridge.tf
+++ b/terraform/deployments/chat/eventbridge.tf
@@ -16,6 +16,7 @@ resource "aws_cloudwatch_event_target" "aws_service_health_alert" {
   rule      = aws_cloudwatch_event_rule.aws_service_health_alert.name
   arn       = aws_sns_topic.chat_alerts.arn
   target_id = "chat-aws-service-health-alert-target"
+  role_arn  = aws_iam_role.aws_service_health_alert.arn
 }
 
 resource "aws_iam_role" "aws_service_health_alert" {


### PR DESCRIPTION
## What

Associate IAM role `govuk-chat-eventbridge-health-alert` with SNS target for Eventbridge rule `chat-aws-service-health-alert` 

## Why

So the rule has explicit permission to access the target