### PR TITLE
Launch new RDS instances (without changing cnames)

### DIFF
--- a/terraform/deployments/tfc-configuration/rds.tf
+++ b/terraform/deployments/tfc-configuration/rds.tf
@@ -23,6 +23,11 @@ module "rds-integration" {
     "GOV.UK Production"           = "write"
   }
 
+  envvars = {
+    TF_CLI_ARGS_plan  = "-parallelism=30"
+    TF_CLI_ARGS_apply = "-parallelism=30"
+  }
+
   variable_set_ids = [
     local.aws_credentials["integration"],
     module.variable-set-common.id,

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -163,7 +163,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -185,7 +185,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -229,7 +229,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - DGU"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -247,7 +247,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -269,7 +269,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -290,7 +290,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -317,7 +317,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -338,7 +338,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -375,7 +375,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -396,7 +396,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -433,7 +433,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -456,7 +456,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -478,7 +478,7 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -499,7 +499,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -520,7 +520,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -563,7 +563,7 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
         has_read_replica             = true
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         launch_new_replica           = false
         isolate                      = false
         cname_point_to_new_instance  = false
@@ -586,7 +586,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -604,7 +604,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Infrastructure"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -622,7 +622,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Search"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -643,7 +643,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -661,7 +661,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -682,7 +682,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -703,7 +703,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }
@@ -721,7 +721,7 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
       }


### PR DESCRIPTION
We already tried this, but we were limited to 2hours in terraform cloud, so the run errored. They have kindly increased our limit to 4 hours, so lets try again.

In order to test how long it takes, and whether the parallelism TF_CLI_ARG env vars work correctly (and also that TFC can handle a paralellism of 30), launch new RDS instances. This will also allow me to ensure all the caveats I've put in work correctly together (getting a new name for some instances).

There should also be new security groups for all the instances (which also means I can test access from the cluster, no surprises later please!) created.

I've not set the cnames to change, and the old RDS instances will not be affected.