### PR TITLE
Demote HMRC specialist manual sections.

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_default.tf
@@ -8,6 +8,7 @@ module "serving_config_global_default" {
   boost_control_ids = [
     module.control_global_boost_demote_low.id,
     module.control_global_boost_demote_medium.id,
+    module.control_global_boost_demote_low_pages.id,
     module.control_global_boost_demote_pages.id,
     module.control_global_boost_demote_strong.id,
     module.control_global_boost_promote_low.id,
@@ -67,8 +68,34 @@ module "control_global_boost_demote_low" {
 }
 
 locals {
+  # Pages to demote by 0.25
+  # We do not have any pages that are demoted by -0.25 yet. This is a placeholder
+  # for when we do. Remove the dummy page when a real page is added.
+  demote_pages_low = [
+    "/this/page/does/not/exist"
+  ]
+  demote_pages_low_expr = join(",", [for page in local.demote_pages_low : "\"${page}\""])
+}
+
+module "control_global_boost_demote_low_pages" {
+  source = "./modules/control"
+
+  id           = "boost_demote_pages_low"
+  display_name = "Boost: Demote specific pages low"
+  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
+  action = {
+    boostAction = {
+      filter     = "link: ANY(${local.demote_pages_low_expr})",
+      fixedBoost = -0.25
+      dataStore  = google_discovery_engine_data_store.govuk_content.name
+    }
+  }
+}
+
+locals {
   # Pages to demote by 0.5
   demote_pages_medium = [
+    "/hmrc-internal-manuals/self-assessment-manual/sam100130",
     "/hmrc-internal-manuals/tax-credits-manual/tcm1000248",
     "/hmrc-internal-manuals/tax-credits-manual/tcm1000267",
     "/hmrc-internal-manuals/tax-credits-manual/tcm1000541",

--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -13,6 +13,7 @@ module "serving_config_global_variant" {
     module.control_global_boost_promote_medium.id,
     module.control_global_boost_promote_low.id,
     module.control_global_boost_demote_low.id,
+    module.control_global_boost_demote_low_pages.id,
     module.control_global_boost_demote_medium.id,
     module.control_global_boost_demote_pages.id,
     module.control_global_boost_demote_strong.id,


### PR DESCRIPTION
Change demote value of 5 HMRC pages. These pages are still being surfaced and so require a stronger demote value (-0.5 instead of -0.25)

Demote another HMRC specialist manual section. This manual section is getting bad feedback because it is being surfaced but is generally not what users are looking for. This means we need to demote it.

This change means we currently don't demote pages by -0.25. This PR does not delete that code because we would like to keep the option to quickly demote pages by that value.

https://gov-uk.atlassian.net/browse/SCH-1524