### PR TITLE
Change demote value of 5 HMRC pages.

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_default.tf
@@ -69,12 +69,10 @@ module "control_global_boost_demote_low" {
 
 locals {
   # Pages to demote by 0.25
+  # We do not have any pages that are demoted by -0.25 yet. This is a placeholder
+  # for when we do. Remove the dummy page when a real page is added.
   demote_pages_low = [
-    "/hmrc-internal-manuals/tax-credits-manual/tcm1000248",
-    "/hmrc-internal-manuals/tax-credits-manual/tcm1000267",
-    "/hmrc-internal-manuals/tax-credits-manual/tcm1000541",
-    "/hmrc-internal-manuals/tax-credits-manual/tcm1000659",
-    "/hmrc-internal-manuals/tax-credits-manual/tcm1000398"
+    "/this/page/does/not/exist"
   ]
   demote_pages_low_expr = join(",", [for page in local.demote_pages_low : "\"${page}\""])
 }
@@ -94,6 +92,19 @@ module "control_global_boost_demote_low_pages" {
   }
 }
 
+locals {
+  # Pages to demote by 0.5
+  demote_pages_medium = [
+    "/hmrc-internal-manuals/self-assessment-manual/sam100130",
+    "/hmrc-internal-manuals/tax-credits-manual/tcm1000248",
+    "/hmrc-internal-manuals/tax-credits-manual/tcm1000267",
+    "/hmrc-internal-manuals/tax-credits-manual/tcm1000541",
+    "/hmrc-internal-manuals/tax-credits-manual/tcm1000659",
+    "/hmrc-internal-manuals/tax-credits-manual/tcm1000398"
+  ]
+  demote_pages_medium_expr = join(",", [for page in local.demote_pages_medium : "\"${page}\""])
+}
+
 module "control_global_boost_demote_medium" {
   source = "./modules/control"
 
@@ -102,7 +113,7 @@ module "control_global_boost_demote_medium" {
   engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
   action = {
     boostAction = {
-      filter     = "document_type: ANY(\"employment_tribunal_decision\", \"foi_release\", \"service_standard_report\") OR organisation_state: ANY(\"devolved\", \"closed\")",
+      filter     = "link: ANY(${local.demote_pages_medium_expr}) OR document_type: ANY(\"employment_tribunal_decision\", \"foi_release\", \"service_standard_report\") OR organisation_state: ANY(\"devolved\", \"closed\")",
       fixedBoost = -0.5
       dataStore  = google_discovery_engine_data_store.govuk_content.name
     }


### PR DESCRIPTION
These pages are still being surfaced and so require a stronger demote value (-0.5 instead of -0.25)

Demote another HMRC specialist manual section. This manual section is getting bad feedback because it is being surfaced but is generally not what users are looking for. This means we need to demote it.

This change means we currently don't demote pages by -0.25 anymore. This PR does not delete that code because we would like to keep the option to quickly demote pages by that value in future

https://gov-uk.atlassian.net/browse/SCH-1524