### PR TITLE
Add govuk-synthetic-test-runner repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -909,6 +909,13 @@ repos:
         - Test
     standard_contexts: *standard_security_checks
 
+  govuk-synthetic-test-runner:
+    can_be_deployed: true
+    required_status_checks:
+      additional_contexts:
+        - Test
+    standard_contexts: *standard_security_checks
+
   govuk-user-reviewer:
     visibility: private
     homepage_url: "https://github.com/alphagov/govuk-rfcs/pull/75"


### PR DESCRIPTION
This will replace the govuk-synthetic-test-app as there were issues will the ECR image pull through cache not working.

I wasn't able to find any error logs in cloudtrail to diagnose the issue with the govuk-synthetic-test-app repo and comparisons of the repo metadata against the govuk-synthetic-test-app-canary repo didn't reveal any major differences between them. 

Rather than spend much more time looking into it as this issue only affects the govuk-synthetic-test-app repo, I'll add a new govuk-synthetic-test-runnner repo and then copying the files over from the govuk-synthetic-test-app repo, hopefully this will get the ECR pull through cache working.

https://github.com/alphagov/govuk-infrastructure/issues/3052