### PR TITLE
Bump prod account-api postgres 14 param group

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -155,7 +155,7 @@ module "variable-set-rds-production" {
     databases = {
       account_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -178,7 +178,7 @@ module "variable-set-rds-production" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "account-api"
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"


### PR DESCRIPTION
Description:
- Set `account-api` parameter group to be `14.18`
- https://github.com/alphagov/govuk-infrastructure/issues/3107