### PR TITLE
Remove `account-api` production logical replication

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -161,22 +161,6 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "account-api"


### PR DESCRIPTION
Description:
- See https://github.com/alphagov/govuk-infrastructure/pull/3134 which imports `account-api` into Terraform
- Remove the logical parameters
- https://github.com/alphagov/govuk-infrastructure/issues/3107