### PR TITLE
Change to (hopefully) supported instance types.

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -844,11 +844,11 @@ module "variable-set-elasticsearch-green-integration" {
     zone_awareness_enabled = true
 
     instance_count = 3
-    instance_type  = "r7g.xlarge.elasticsearch"
+    instance_type  = "r7i.xlarge.elasticsearch"
 
     dedicated_master = {
       instance_count = 3
-      instance_type  = "c7g.xlarge.elasticsearch"
+      instance_type  = "c7i.xlarge.elasticsearch"
     }
 
     tls_security_policy = "Policy-Min-TLS-1-0-2019-07"

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -854,11 +854,11 @@ module "variable-set-elasticsearch-green-production" {
     zone_awareness_enabled = true
 
     instance_count = 3
-    instance_type  = "r7g.4xlarge.elasticsearch"
+    instance_type  = "r7i.4xlarge.elasticsearch"
 
     dedicated_master = {
       instance_count = 3
-      instance_type  = "c7g.xlarge.elasticsearch"
+      instance_type  = "c7i.xlarge.elasticsearch"
     }
 
     tls_security_policy = "Policy-Min-TLS-1-0-2019-07"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -847,11 +847,11 @@ module "variable-set-elasticsearch-green-staging" {
     zone_awareness_enabled = true
 
     instance_count = 3
-    instance_type  = "r7g.2xlarge.elasticsearch"
+    instance_type  = "r7i.2xlarge.elasticsearch"
 
     dedicated_master = {
       instance_count = 3
-      instance_type  = "c7g.large.elasticsearch"
+      instance_type  = "c7i.large.elasticsearch"
     }
 
     tls_security_policy = "Policy-Min-TLS-1-0-2019-07"


### PR DESCRIPTION
## What?
It looks like ES6.8 does not support Graviton (at all), so switch back to the Intel instance type. :-(