### PR TITLE
Allow green ES6 clusters access to blue snapsnot buckets

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -857,7 +857,9 @@ module "variable-set-elasticsearch-green-integration" {
 
     elasticsearch6_manual_snapshot_bucket_arns = [
       "arn:aws:s3:::govuk-staging-green-elasticsearch6-manual-snapshots",
-      "arn:aws:s3:::govuk-integration-green-elasticsearch6-manual-snapshots"
+      "arn:aws:s3:::govuk-integration-green-elasticsearch6-manual-snapshots",
+      "arn:aws:s3:::govuk-staging-elasticsearch6-manual-snapshots",
+      "arn:aws:s3:::govuk-integration-elasticsearch6-manual-snapshots"
     ]
 
     encryption_at_rest = true

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -867,6 +867,7 @@ module "variable-set-elasticsearch-green-production" {
 
     elasticsearch6_manual_snapshot_bucket_arns = [
       "arn:aws:s3:::govuk-production-green-elasticsearch6-manual-snapshots",
+      "arn:aws:s3:::govuk-production-elasticsearch6-manual-snapshots"
     ]
 
     encryption_at_rest = true

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -860,7 +860,9 @@ module "variable-set-elasticsearch-green-staging" {
 
     elasticsearch6_manual_snapshot_bucket_arns = [
       "arn:aws:s3:::govuk-production-green-elasticsearch6-manual-snapshots",
-      "arn:aws:s3:::govuk-staging-green-elasticsearch6-manual-snapshots"
+      "arn:aws:s3:::govuk-staging-green-elasticsearch6-manual-snapshots",
+      "arn:aws:s3:::govuk-production-elasticsearch6-manual-snapshots",
+      "arn:aws:s3:::govuk-staging-elasticsearch6-manual-snapshots"
     ]
 
     encryption_at_rest = true


### PR DESCRIPTION
This is required to restore a snapshot of the original ES 6.7 cluster into the new ES 6.8 cluster