### PR TITLE
We didn't prepare ckan, so don't launch it

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -238,7 +238,7 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - DGU"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        launch_new_db                = true
+        launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
       }


### PR DESCRIPTION
As part of the test, I prepared chat by accident instead of ckan, given it's just a test this doesn't matter, but I can't launch a db I didn't prepare, so change ckan back to not launch