### PR TITLE
Need to disable deletion protection before we can delete the instances

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -169,10 +169,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       authenticating_proxy = {
@@ -192,10 +193,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       chat = {
@@ -215,10 +217,11 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - AI"
         snapshot_identifier          = "chat-postgres-post-encryption"
         encryption_at_rest           = true
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       ckan = {
@@ -241,6 +244,7 @@ module "variable-set-rds-production" {
         launch_new_db                = false
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       collections_publisher = {
@@ -256,10 +260,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       content_block_manager = {
@@ -279,10 +284,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       content_data_admin = {
@@ -301,10 +307,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       content_data_api = {
@@ -329,10 +336,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       content_store = {
@@ -351,10 +359,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       content_tagger = {
@@ -389,10 +398,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       draft_content_store = {
@@ -411,10 +421,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       email_alert_api = {
@@ -449,10 +460,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       imminence = {
@@ -473,10 +485,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       link_checker_api = {
@@ -496,10 +509,11 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       local_links_manager = {
@@ -518,10 +532,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       locations_api = {
@@ -540,10 +555,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       publishing_api = {
@@ -581,11 +597,12 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         has_read_replica             = true
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         launch_new_replica           = false
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       publisher = {
@@ -605,10 +622,11 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         deletion_protection          = false
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       release = {
@@ -624,10 +642,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Infrastructure"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       search_admin = {
@@ -643,10 +662,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Search"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       service_manual_publisher = {
@@ -665,10 +685,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       signon = {
@@ -684,10 +705,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       support_api = {
@@ -706,10 +728,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       transition = {
@@ -728,10 +751,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
 
       whitehall = {
@@ -747,10 +771,11 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        prepare_to_launch_new_db     = true
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
+        new_db_deletion_protection   = false
       }
     }
   }


### PR DESCRIPTION
I forgot I need to disable deletion protection, and that has to be applied prior to deleting them, so set them to be alive again, but disable deletion protection. None of the instances were actually deleted of course because deletion protection prevented it.