### PR TITLE
Bump `email-alert-api` Postgres 14 integration parameter group

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -393,7 +393,7 @@ module "variable-set-rds-integration" {
 
       email_alert_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -416,7 +416,7 @@ module "variable-set-rds-integration" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "email-alert-api"
         allocated_storage            = 1000
         instance_class               = "db.m6g.large"


### PR DESCRIPTION
Description:
- Bump the `email-alert-api` Postgres 14 integration parameter group
- https://github.com/alphagov/govuk-infrastructure/issues/3155