### PR TITLE
Import `email-alert-api` integration Postgres 14 into Terraform

### DIFF
--- a/terraform/deployments/rds/integration_email_alert_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/integration_email_alert_api_postgres_14_upgrade.tf
@@ -1,25 +1,9 @@
-resource "aws_db_parameter_group" "email_alert_api_postgresql_14_green_params" {
+import {
+  to = aws_db_instance.instance["email_alert_api"]
+  id = "email-alert-api-postgres"
+}
 
-  name_prefix = "${var.govuk_environment}-email-alert-api-postgres-"
-  family      = "postgres14"
-
-  parameter {
-    name         = "rds.logical_replication"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-
-  lifecycle { create_before_destroy = true }
+import {
+  to = aws_db_parameter_group.engine_params["email_alert_api"]
+  id = "integration-email-alert-api-postgres-20250828113749103100000003"
 }


### PR DESCRIPTION
Description:
- Import `email-alert-api` integration Postgres 14 into Terraform
- https://github.com/alphagov/govuk-infrastructure/issues/3155