### PR TITLE
Add reboot-db-instances script

### DIFF
--- a/terraform/deployments/rds/reboot-db-instances.sh
+++ b/terraform/deployments/rds/reboot-db-instances.sh
@@ -83,7 +83,7 @@ INSTANCES_FAILED_TO_REBOOT=()
 for DB in "${DBS[@]}"; do
   echo -n "Sending reboot command for ${DB}..."
   TMPFILE=$(mktemp)
-  if ! aws rds reboot-db-instance --db-instance-identifier "$DB" > "$TMPFILE" 2>&1; then
+  if ! aws rds reboot-db-instance --db-instance-identifier "$DB" --no-force-failover > "$TMPFILE" 2>&1; then
     echo "FAILED, output in $TMPFILE and below!"
     cat "$TMPFILE"
     INSTANCES_FAILED_TO_REBOOT+=("$DB")


### PR DESCRIPTION
# What?

Add script to reboot specific db instances.

Note: I have made this script to be compatible with the very old bash which ships with macOS

# How to test?

I've launched some instances in the test account, and you can test this script out in there:

```
$ gds aws govuk-test-fulladmin -- ./reboot-db-instances.sh
[NOTICE]: This role is for emergency use, use `govuk-test-developer` for day-to-day access.
Touch your YubiKey...
The following databases will be rebooted in test:
----------------------------------------------------------------
content-data-api-production-postgres
whitehall-production-mysql
places-manager-production-mysql
----------------------------------------------------------------

AWS ACCOUNT: test
Are you sure you wish to reboot the above instances in test

Type exactly 'yes' (without quotes) to reboot instances: yes
Sending reboot command for content-data-api-production-postgres...success
Sending reboot command for whitehall-production-mysql...success
Sending reboot command for places-manager-production-mysql...success


==============================================================================================
Successfully started reboot for 3/3 instances
```

If you do it twice in quick succession you will see the error handling working (in this case 1 of the 3 instances was still rebooting from the previous command:

```
$ gds aws govuk-test-fulladmin -- ./reboot-db-instances.sh
[NOTICE]: This role is for emergency use, use `govuk-test-developer` for day-to-day access.
Touch your YubiKey...
The following databases will be rebooted in test:
----------------------------------------------------------------
content-data-api-production-postgres
whitehall-production-mysql
places-manager-production-mysql
----------------------------------------------------------------

AWS ACCOUNT: test
Are you sure you wish to reboot the above instances in test

Type exactly 'yes' (without quotes) to reboot instances: yes
Sending reboot command for content-data-api-production-postgres...FAILED, output in /var/folders/g1/0svrq5256nx5vsp7m1l0k0j40000gq/T/tmp.QeaCsbUfzN and below!

An error occurred (InvalidDBInstanceState) when calling the RebootDBInstance operation: Can only reboot db instances with state in: available, storage-optimization, storage-initialization, incompatible-credentials, incompatible-parameters.  Instance content-data-api-production-postgres has state: rebooting.


Sending reboot command for whitehall-production-mysql...success
Sending reboot command for places-manager-production-mysql...success


==============================================================================================
Successfully started reboot for 2/3 instances

The following instances failed to start rebooting:
----------------------------------------------------------------
content-data-api-production-postgres
----------------------------------------------------------------
```

