### PR TITLE
Remove `email-alert-api` integration logical replication

### DIFF
--- a/terraform/deployments/rds/integration_email_alert_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/integration_email_alert_api_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["email_alert_api"]
-  id = "email-alert-api-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["email_alert_api"]
-  id = "integration-email-alert-api-postgres-20250828113749103100000003"
-}

--- a/terraform/deployments/rds/staging_email_alert_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/staging_email_alert_api_postgres_14_upgrade.tf
@@ -1,0 +1,25 @@
+resource "aws_db_parameter_group" "email_alert_api_postgresql_14_green_params" {
+
+  name_prefix = "${var.govuk_environment}-email-alert-api-postgres-"
+  family      = "postgres14"
+
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_logical_replication_workers"
+    value        = "20"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_worker_processes"
+    value        = "25"
+    apply_method = "pending-reboot"
+  }
+
+  lifecycle { create_before_destroy = true }
+}

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -399,22 +399,6 @@ module "variable-set-rds-integration" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "email-alert-api"


### PR DESCRIPTION
Description:
- Removes `email-alert-api` integration logical replication
- Adds staging Postgres 14 parameter group
- https://github.com/alphagov/govuk-infrastructure/issues/3155