### PR TITLE
Align whitehall RDS storage size in production with lower envs

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -766,7 +766,7 @@ module "variable-set-rds-production" {
         }
         engine_params_family         = "mysql8.0"
         name                         = "whitehall"
-        allocated_storage            = 300
+        allocated_storage            = 400
         instance_class               = "db.m7g.xlarge"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"


### PR DESCRIPTION
Whitehall has larger storage size in lower envs, being on gp3 storage type this also means in lower envs it has significantly higher performance than in production.

This PR alters the storage size to be 400GB which makes it match the lower envs.

Our [module means all production changes (including this one)](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/rds/rds.tf#L71) occur in the next maintenance window.

As per https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ModifyInstance.Settings.html changing the Allocated Storage can be applied during the maintenance window:

> If you choose to apply the change immediately, it occurs immediately.
> 
> If you don't choose to apply the change immediately, it occurs during the next maintenance window.

and also that it wont incur downtime

> Downtime doesn't occur during this change. Performance might be degraded during the change. |  

The maintenance window is at a very quiet time for us and so the possibly degraded performance shouldn't affect us.

We do not modify the maintenance window for Whitehall in production, meaning [the variable default applies](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/rds/rds.tf#L63), following on from this, this means [the maintenance will occur on Monday between 04:00am to 06:00am UTC](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/rds/variables.tf#L33-L37)