### PR TITLE
You cannot modify the storage size without also specifying the IOPS and throughput

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -767,6 +767,8 @@ module "variable-set-rds-production" {
         engine_params_family         = "mysql8.0"
         name                         = "whitehall"
         allocated_storage            = 400
+        iops                         = 12000
+        storage_throughput           = 500
         instance_class               = "db.m7g.xlarge"
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"


### PR DESCRIPTION
Turns out, due to [a quirk in the terraform provider](https://github.com/hashicorp/terraform-provider-aws/issues/28271) you can launch an RDS instance only specifying the storage size, but you can't modify it later unless you specify IOPS and throughput as well.

So this PR specifies it as the same values as the lower envs.