### PR TITLE
Bump `email-alert-api` Postgres 14 parameter group in staging

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -408,7 +408,7 @@ module "variable-set-rds-staging" {
 
       email_alert_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -431,7 +431,7 @@ module "variable-set-rds-staging" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "email-alert-api"
         allocated_storage            = 1000
         instance_class               = "db.m6g.xlarge"


### PR DESCRIPTION
Description:
- Bump the `email-alert-api` Postgres 14 parameter group in staging to 14.18
- https://github.com/alphagov/govuk-infrastructure/issues/3155