### PR TITLE
Bump `content-tagger` Postgres 14 param group staging

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -348,7 +348,7 @@ module "variable-set-rds-staging" {
 
       content_tagger = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "14.18"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -371,7 +371,7 @@ module "variable-set-rds-staging" {
             apply_method = "pending-reboot"
           }
         }
-        engine_params_family         = "postgres13"
+        engine_params_family         = "postgres14"
         name                         = "content-tagger"
         allocated_storage            = 100
         instance_class               = "db.t4g.small"


### PR DESCRIPTION
Description:
- Bump `content-tagger` Postgres 14 param group to 14.18 in staging
- https://github.com/alphagov/govuk-infrastructure/issues/3108