### PR TITLE
Add `content-tagger` production postgres14 parameter group

### DIFF
--- a/terraform/deployments/rds/production_content_tagger_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/production_content_tagger_postgres_14_upgrade.tf
@@ -1,0 +1,25 @@
+resource "aws_db_parameter_group" "content_tagger_postgresql_14_green_params" {
+
+  name_prefix = "${var.govuk_environment}-content-tagger-postgres-"
+  family      = "postgres14"
+
+  parameter {
+    name         = "rds.logical_replication"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_logical_replication_workers"
+    value        = "20"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "max_worker_processes"
+    value        = "25"
+    apply_method = "pending-reboot"
+  }
+
+  lifecycle { create_before_destroy = true }
+}

--- a/terraform/deployments/rds/staging_content_tagger_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/staging_content_tagger_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["content_tagger"]
-  id = "content-tagger-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["content_tagger"]
-  id = "staging-content-tagger-postgres-20250828115303735900000007"
-}


### PR DESCRIPTION
Description:
- Add `content-tagger` production postgres14 parameter group
- https://github.com/alphagov/govuk-infrastructure/issues/3108