### PR TITLE
Remove DNS record for ai-experiments.publishing.service.gov.uk

### DIFF
--- a/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
+++ b/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf
@@ -258,7 +258,6 @@ module "govuk-publishing-infrastructure-variable-set-production" {
       { type = "CNAME", name = "app", ttl = 3600, value = ["www-gov-uk.map.fastly.net."] },
       { type = "CNAME", name = "assets", ttl = 300, value = ["www-gov-uk.map.fastly.net."] },
       { type = "CNAME", name = "assets-origin", ttl = 300, value = ["assets-origin.eks.production.govuk.digital."] },
-      { type = "CNAME", name = "ai-experiments", ttl = 3600, value = ["aquatic-mesa-7tplnrte33vmdttn9m1jjs44.herokudns.com."] },
       { type = "CNAME", name = "bouncer", ttl = 3600, value = ["bouncer.eks.production.govuk.digital."] },
       { type = "CNAME", name = "chat", ttl = 300, value = ["chat.eks.production.govuk.digital."] },
       { type = "CNAME", name = "ckan", ttl = 300, value = ["ckan.eks.production.govuk.digital."] },


### PR DESCRIPTION
It's no longer used. It was for a blog microsite that either hasn’t materialised or was taken down.
Consulted with the AI team.