### PR TITLE
Import `content-tagger` production Postgres 14 database into Terraform

### DIFF
--- a/terraform/deployments/rds/production_content_tagger_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/production_content_tagger_postgres_14_upgrade.tf
@@ -1,25 +1,9 @@
-resource "aws_db_parameter_group" "content_tagger_postgresql_14_green_params" {
+import {
+  to = aws_db_instance.instance["content_tagger"]
+  id = "content-tagger-postgres"
+}
 
-  name_prefix = "${var.govuk_environment}-content-tagger-postgres-"
-  family      = "postgres14"
-
-  parameter {
-    name         = "rds.logical_replication"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-
-  lifecycle { create_before_destroy = true }
+import {
+  to = aws_db_parameter_group.engine_params["content_tagger"]
+  id = "production-content-tagger-postgres-2025082811531774370000000c"
 }


### PR DESCRIPTION
Description:
- Import production `content-tagger` Postgres 14 database into Terraform
- https://github.com/alphagov/govuk-infrastructure/issues/3108