### PR TITLE
Remove `content-tagger` prod logical replication

### DIFF
--- a/terraform/deployments/rds/production_content_tagger_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/production_content_tagger_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["content_tagger"]
-  id = "content-tagger-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["content_tagger"]
-  id = "production-content-tagger-postgres-2025082811531774370000000c"
-}

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -374,22 +374,6 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "content-tagger"


### PR DESCRIPTION
Description:
- Remove `content-tagger` prod logical replication parameters
- https://github.com/alphagov/govuk-infrastructure/issues/3108