### PR TITLE
Update reboot-db-instances

### DIFF
--- a/terraform/deployments/rds/reboot-db-instances.sh
+++ b/terraform/deployments/rds/reboot-db-instances.sh
@@ -2,12 +2,72 @@
 
 set -euo pipefail
 
-# Set 1 DB instance per line for the instances you wish to reboot
-DBS=(
-  "content-data-api-production-postgres"
-  "whitehall-production-mysql"
-  "places-manager-production-mysql"
+# Change GOVUK_ENVIRONMENT and the DBS assignment on line 66 to choose which databases to reboot
+GOVUK_ENVIRONMENT=integration
+
+# shellcheck disable=SC2034
+BIG_20_DBS=(
+  "account-api-postgres"
+  "authenticating-proxy-postgres"
+  "blue-content-data-api-postgresql-primary-postgres"
+  "collections-publisher-mysql"
+  "content-block-manager-postgres"
+  "content-store-postgres"
+  "content-tagger-postgres"
+  "draft-content-store-postgres"
+  "email-alert-api-postgres"
+  "imminence-postgres"
+  "local-links-manager-postgres"
+  "locations-api-postgres"
+  "publisher-postgres"
+  "publishing-api-postgres"
+  "search-admin-mysql"
+  "signon-mysql"
+  "transition-postgres"
+  "whitehall-mysql"
 )
+
+# shellcheck disable=SC2034
+BIG_20_DBS_NEW_NAMES=(
+  "account-api-${GOVUK_ENVIRONMENT}-postgres"
+  "authenticating-proxy-${GOVUK_ENVIRONMENT}-postgres"
+  "content-data-api-${GOVUK_ENVIRONMENT}-postgres"
+  "collections-publisher-${GOVUK_ENVIRONMENT}-mysql"
+  "content-block-manager-${GOVUK_ENVIRONMENT}-postgres"
+  "content-store-${GOVUK_ENVIRONMENT}-postgres"
+  "content-tagger-${GOVUK_ENVIRONMENT}-postgres"
+  "draft-content-store-${GOVUK_ENVIRONMENT}-postgres"
+  "email-alert-api-${GOVUK_ENVIRONMENT}-postgres"
+  "places-manager-${GOVUK_ENVIRONMENT}-postgres"
+  "local-links-manager-${GOVUK_ENVIRONMENT}-postgres"
+  "locations-api-${GOVUK_ENVIRONMENT}-postgres"
+  "publisher-${GOVUK_ENVIRONMENT}-postgres"
+  "publishing-api-${GOVUK_ENVIRONMENT}-postgres"
+  "search-admin-${GOVUK_ENVIRONMENT}-mysql"
+  "signon-${GOVUK_ENVIRONMENT}-mysql"
+  "transition-${GOVUK_ENVIRONMENT}-postgres"
+  "whitehall-${GOVUK_ENVIRONMENT}-mysql"  
+)
+
+# shellcheck disable=SC2034
+LITTLE_7_DBS=(
+  "ckan-postgres"
+  "release-mysql"
+  "search-admin-mysql"
+  "link-checker-api-postgres"
+  "service-manual-publisher-postgres"
+)
+
+# shellcheck disable=SC2034
+LITTLE_7_DBS_NEW_NAMES=(
+  "ckan-${GOVUK_ENVIRONMENT}-postgres"
+  "release-${GOVUK_ENVIRONMENT}-mysql"
+  "search-admin-${GOVUK_ENVIRONMENT}-mysql"
+  "link-checker-api-${GOVUK_ENVIRONMENT}-postgres"
+  "service-manual-publisher-${GOVUK_ENVIRONMENT}-postgres"  
+)
+
+DBS=("${LITTLE_7_DBS[@]}")
 
 function usage {
   echo
@@ -49,6 +109,11 @@ fi
 
 if ! ACCOUNT_NAME=$(account_name "$ACCOUNT_ID"); then
   echo "Error: The ACCOUNT ID $ACCOUNT_ID is not a GOV.UK Account ID. Perhaps you used gds cli with the wrong account?"
+  usage
+fi
+
+if [ "$ACCOUNT_NAME" != "$GOVUK_ENVIRONMENT" ]; then
+  echo "Error: Account NAME is not the same as the GOVUK_ENVIRONMENT env var!"
   usage
 fi
 


### PR DESCRIPTION
Update reboot instances script to prepare for phased reboots, and with pre-populated arrays for the different phases and their new names.