### PR TITLE
Increase content-data-api DB storage in integration to match other environments

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -310,7 +310,7 @@ module "variable-set-rds-integration" {
         engine_params_family         = "postgres14"
         name                         = "blue-content-data-api-postgresql-primary"
         new_name                     = "content-data-api"
-        allocated_storage            = 500
+        allocated_storage            = 1024
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"


### PR DESCRIPTION
This is running out of disk space and it's got half as much storage as the other environments