### PR TITLE
Add attribution token to search event schema

### DIFF
--- a/terraform/deployments/search-api-v2/files/search-event-schema.json
+++ b/terraform/deployments/search-api-v2/files/search-event-schema.json
@@ -25,6 +25,11 @@
     "mode": "REPEATED"
   },
   {
+    "name": "attributionToken",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
     "name": "documents",
     "type": "RECORD",
     "mode": "REPEATED",


### PR DESCRIPTION
The Vertex product manager has asked the search team to include attribution tokens in the search user events that are sent to Vertex, to enable them to analyse relevance quality and diagnose ranking issues more effectively. This change to add the attribution token to the search event table schemas in BigQuery is a prerequisite to taking the data from GA4 and sending it to Vertex.

The search event table schema is used for the [search_event table](https://github.com/alphagov/govuk-infrastructure/blob/a84f3cf9528361c46a34fe78ef59115129c85654/terraform/deployments/search-api-v2/events_ingestion.tf#L39) and the [search_intraday_event table](https://github.com/alphagov/govuk-infrastructure/blob/a84f3cf9528361c46a34fe78ef59115129c85654/terraform/deployments/search-api-v2/events_ingestion.tf#L73).

JIRA ticket: https://gov-uk.atlassian.net/browse/SCH-1519