### PR TITLE
[PP-7451] Allow language specification for CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,12 @@ name: CodeQL Analysis
 
 on:
   workflow_call:
+    inputs:
+      languages:
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed
+        description: Languages to analyse. Defaults to languages of found file extensions
+        required: false
+        type: string
 
 jobs:
   analyze:
@@ -34,6 +40,7 @@ jobs:
                 # ensure that developers are not distracted by low severity, none issues.
                 # Explanation of security severity scores: https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/about-code-scanning-alerts#about-security-severity-levels
                 security-severity: /([7-9]|10)\.(\d)+/
+        languages: ${{ inputs.languages }}
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3


### PR DESCRIPTION
The CodeQL action decides which languages to analyse based on the file extensions present in a repo. However, if it finds no analysable code for one of those languages, it will error

https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/no-source-code-seen-during-build

This change will allow us to specify which languages should be analysed so that we can exclude a language for which there's no analysable code

https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed

This does mean that if analysable code is later added to a repo where its language has been ignored, we wouldn't be analysing it. That doesn't feel great, but this seems to be a limitation of CodeQL

The following PR exhibited this error: https://github.com/alphagov/govuk-content-api-docs/pull/204. We have .js files in that repo but they only contain (magic) comments. This wasn't an issue with older versions of CodeQL. We're currently using 2.23.5 - the last merged PR used 2.23.2 and passed the CodeQL checks: https://github.com/alphagov/govuk-content-api-docs/pull/203