### PR TITLE
Remove `email-alert-api` production logical replication params

### DIFF
--- a/terraform/deployments/rds/production_email_alert_api_postgres_14_upgrade.tf
+++ b/terraform/deployments/rds/production_email_alert_api_postgres_14_upgrade.tf
@@ -1,9 +1,0 @@
-import {
-  to = aws_db_instance.instance["email_alert_api"]
-  id = "email-alert-api-postgres"
-}
-
-import {
-  to = aws_db_parameter_group.engine_params["email_alert_api"]
-  id = "production-email-alert-api-postgres-2025082811531767830000000b"
-}

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -420,22 +420,6 @@ module "variable-set-rds-production" {
           log_statement              = { value = "all" }
           deadlock_timeout           = { value = 2500 }
           log_lock_waits             = { value = 1 }
-          "rds.logical_replication" = {
-            value        = 1,
-            apply_method = "pending-reboot"
-          }
-          max_wal_senders = {
-            value        = 35,
-            apply_method = "pending-reboot"
-          }
-          max_logical_replication_workers = {
-            value        = 20,
-            apply_method = "pending-reboot"
-          }
-          max_worker_processes = {
-            value        = 40,
-            apply_method = "pending-reboot"
-          }
         }
         engine_params_family         = "postgres14"
         name                         = "email-alert-api"


### PR DESCRIPTION
Description:
- Removes `email-alert-api` production logical replication params
- https://github.com/alphagov/govuk-infrastructure/issues/3155