### PR TITLE
Allow launching RDS instances from snapshots created outside of TF or…

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -132,7 +132,9 @@ resource "aws_db_instance" "normalised_instance" {
     if lookup(db, "launch_new_db", false)
   }
 
-  snapshot_identifier         = aws_db_snapshot_copy.encrypted_snapshot[each.key].target_db_snapshot_identifier
+  // This is purposefully not referencing the resource so that we can create snapshots outside of terraform and use them to launch
+  // this instance
+  snapshot_identifier         = "${local.identifier_prefix}${each.value.name}-${each.value.engine}-post-encryption"
   engine                      = each.value.engine
   engine_version              = each.value.engine_version
   username                    = var.database_admin_username

--- a/terraform/deployments/rds/security_groups.tf
+++ b/terraform/deployments/rds/security_groups.tf
@@ -44,7 +44,7 @@ resource "aws_security_group_rule" "postgres" {
 resource "aws_security_group" "normalised_rds" {
   for_each = {
     for db_name, db in var.databases : db_name => db
-    if lookup(db, "prepare_to_launch_new_db", false)
+    if lookup(db, "launch_new_db", false)
   }
 
   name        = "${local.identifier_prefix}${lookup(each.value, "new_name", each.value.name)}-${var.govuk_environment}-${each.value.engine}-rds-access"
@@ -57,7 +57,7 @@ resource "aws_security_group" "normalised_rds" {
 resource "aws_security_group_rule" "normalised_rds_mysql" {
   for_each = {
     for db_name, db in var.databases : db_name => db
-    if lookup(db, "prepare_to_launch_new_db", false) &&
+    if lookup(db, "launch_new_db", false) &&
     db.engine == "mysql" &&
     !lookup(db, "isolate_new_db", false)
   }
@@ -76,7 +76,7 @@ resource "aws_security_group_rule" "normalised_rds_mysql" {
 resource "aws_security_group_rule" "normalised_rds_postgres" {
   for_each = {
     for db_name, db in var.databases : db_name => db
-    if lookup(db, "prepare_to_launch_new_db", false) &&
+    if lookup(db, "launch_new_db", false) &&
     db.engine == "postgres" &&
     !lookup(db, "isolate_new_db", false)
   }


### PR DESCRIPTION
This PR:

* Allows launching new dbs from snapshots created outside of terraform (See https://github.com/alphagov/govuk-infrastructure/pull/3218 for why)
* Moves security group & rule creation into the launch_new_db phase (since we wont be running the prepare phase)