### PR TITLE
Test launch new little 7 dbs in int to test the new process

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -220,7 +220,7 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - DGU"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
         new_db_deletion_protection   = false
@@ -287,7 +287,7 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
         new_db_deletion_protection   = false
@@ -457,7 +457,7 @@ module "variable-set-rds-integration" {
         maintenance_window           = "Mon:00:00-Mon:01:00"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
         new_db_deletion_protection   = false
@@ -593,7 +593,7 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Infrastructure"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
         new_db_deletion_protection   = false
@@ -636,7 +636,7 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        launch_new_db                = false
+        launch_new_db                = true
         isolate                      = false
         cname_point_to_new_instance  = false
         new_db_deletion_protection   = false


### PR DESCRIPTION
I've run the create snapshot script, and now I want to test launching the new instances from it, not from the terraform created snapshots, so this PR launches new little 7 rds instances. I will delete them again later, and the services wont be accessing them since the cnames will remain pointing to the old instances.