### PR TITLE
Update repos.yml with new fact-check-manager repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -189,6 +189,18 @@ repos:
         - Lint Ruby / Run RuboCop
         - Test Ruby / Run RSpec
 
+  fact-check-manager:
+    can_be_deployed: true
+    required_pull_request_reviews:
+      require_code_owner_reviews: true
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
+      additional_contexts:
+        - Lint JavaScript / Run Standardx
+        - Lint SCSS / Run Stylelint
+        - Test JavaScript / Run Jasmine
+        - Test Ruby / Run Minitest
+
   fastly-exporter:
     archived: true
 


### PR DESCRIPTION
This PR kicks off the process of building the new Fact Check Manager application by getting the initial repo created.

`homepage_url` to follow in a later change once we're a bit farther through the process and have it set up in the docs with something to link to.