### PR TITLE
Allow the mirror sync IAM role to perform "s3:HeadObject"

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
@@ -412,6 +412,7 @@ data "aws_iam_policy_document" "govuk_mirror_sync" {
       "s3:GetObject",
       "s3:GetObjectVersion",
       "s3:GetObjectVersionTagging",
+      "s3:HeadObject",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",


### PR DESCRIPTION
It did not previously need to do it, but it does it now as part of its in-process uploads.