### PR TITLE
RDS patch updates for production

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -155,7 +155,7 @@ module "variable-set-rds-production" {
     databases = {
       account_api = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -181,7 +181,7 @@ module "variable-set-rds-production" {
 
       authenticating_proxy = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -208,7 +208,7 @@ module "variable-set-rds-production" {
 
       chat = {
         engine         = "postgres"
-        engine_version = "16"
+        engine_version = "16.10"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -255,7 +255,7 @@ module "variable-set-rds-production" {
 
       collections_publisher = {
         engine         = "mysql"
-        engine_version = "8.0"
+        engine_version = "8.0.43"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -278,7 +278,7 @@ module "variable-set-rds-production" {
 
       content_block_manager = {
         engine                      = "postgres"
-        engine_version              = "17"
+        engine_version              = "17.6"
         allow_major_version_upgrade = true
         engine_params = {
           log_min_duration_statement = { value = 10000 }
@@ -328,7 +328,7 @@ module "variable-set-rds-production" {
 
       content_data_api = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "14.19"
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
@@ -360,7 +360,7 @@ module "variable-set-rds-production" {
 
       content_store = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -386,7 +386,7 @@ module "variable-set-rds-production" {
 
       content_tagger = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -412,7 +412,7 @@ module "variable-set-rds-production" {
 
       draft_content_store = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -438,7 +438,7 @@ module "variable-set-rds-production" {
 
       email_alert_api = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -464,7 +464,7 @@ module "variable-set-rds-production" {
 
       imminence = {
         engine         = "postgres"
-        engine_version = "14"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -492,7 +492,7 @@ module "variable-set-rds-production" {
 
       link_checker_api = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -516,7 +516,7 @@ module "variable-set-rds-production" {
 
       local_links_manager = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -542,7 +542,7 @@ module "variable-set-rds-production" {
 
       locations_api = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -568,7 +568,7 @@ module "variable-set-rds-production" {
 
       publishing_api = {
         engine         = "postgres"
-        engine_version = "13"
+        engine_version = "13.22"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -614,7 +614,7 @@ module "variable-set-rds-production" {
 
       publisher = {
         engine         = "postgres"
-        engine_version = "17"
+        engine_version = "17.6"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -641,7 +641,7 @@ module "variable-set-rds-production" {
 
       release = {
         engine         = "mysql"
-        engine_version = "8.0"
+        engine_version = "8.0.43"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -661,7 +661,7 @@ module "variable-set-rds-production" {
 
       search_admin = {
         engine         = "mysql"
-        engine_version = "8.0"
+        engine_version = "8.0.43"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -681,7 +681,7 @@ module "variable-set-rds-production" {
 
       service_manual_publisher = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -704,7 +704,7 @@ module "variable-set-rds-production" {
 
       signon = {
         engine         = "mysql"
-        engine_version = "8.0"
+        engine_version = "8.0.43"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -727,7 +727,7 @@ module "variable-set-rds-production" {
 
       support_api = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -753,7 +753,7 @@ module "variable-set-rds-production" {
 
       transition = {
         engine         = "postgres"
-        engine_version = "14.18"
+        engine_version = "14.19"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -779,7 +779,7 @@ module "variable-set-rds-production" {
 
       whitehall = {
         engine         = "mysql"
-        engine_version = "8.0"
+        engine_version = "8.0.43"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }


### PR DESCRIPTION
We want all our RDS instances to have the current default patch (for mysql) and minor (for postgres) in production, and for them not to change when we launch new instances from snapshots. So temporarily set all RDS instances in prod to explicitly be the exact engine version. This will mean minor/patch updates for most instances, but these will happen in their maintenance window, not immediately