### PR TITLE
Allow apply immediately to be set per instance

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -68,7 +68,7 @@ resource "aws_db_instance" "instance" {
   monitoring_role_arn         = data.tfe_outputs.logging.nonsensitive_values.rds_enhanced_monitoring_role_arn
   vpc_security_group_ids      = [aws_security_group.rds[each.key].id]
   ca_cert_identifier          = "rds-ca-rsa2048-g1"
-  apply_immediately           = var.govuk_environment != "production"
+  apply_immediately           = lookup(each.value, "apply_immediately", var.govuk_environment != "production")
   allow_major_version_upgrade = lookup(each.value, "allow_major_version_upgrade", false)
   auto_minor_version_upgrade  = lookup(each.value, "auto_minor_version_upgrade", true)
 
@@ -153,7 +153,7 @@ resource "aws_db_instance" "normalised_instance" {
   monitoring_role_arn         = data.tfe_outputs.logging.nonsensitive_values.rds_enhanced_monitoring_role_arn
   vpc_security_group_ids      = [aws_security_group.normalised_rds[each.key].id]
   ca_cert_identifier          = "rds-ca-rsa2048-g1"
-  apply_immediately           = var.govuk_environment != "production"
+  apply_immediately           = lookup(each.value, "apply_immediately", var.govuk_environment != "production")
   allow_major_version_upgrade = lookup(each.value, "allow_major_version_upgrade", false)
   auto_minor_version_upgrade  = lookup(each.value, "auto_minor_version_upgrade", true)
 


### PR DESCRIPTION
Allow apply immediately to be set per instance and continue to default to false in prod

I have put this in it's own PR so we can see nice clean no change diffs before I actually override it for some RDS instances in the lower envs.