### PR TITLE
Add `fork` option to GitHub repository

### DIFF
--- a/terraform/deployments/github/README.md
+++ b/terraform/deployments/github/README.md
@@ -93,6 +93,17 @@ To configure a `private` or `internal` repository, set the `visibility` explicit
 
 Note: Private repositories can't use GitHub Actions workflows that upload SARIF files, and therefore can't use the predefined standard security checks.
 
+### Forked repositories
+
+To indicate that a repository is forked set the following properties in the `fork` object:
+
+```
+  fork:
+    enabled: true
+    source_owner: "github_fork_owner"
+    source_repo: "github_fork_repo"
+```
+
 ### Adding existing repositories 
 
 > Skip this step if you are creating a new repository.

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -179,6 +179,10 @@ resource "github_repository" "govuk_repos" {
   visibility = try(each.value.visibility, "public")
   topics     = try(each.value.archived, false) ? null : try(each.value.topics, ["govuk"])
 
+  fork         = try(each.value.fork.enabled, false)
+  source_owner = try(each.value.fork.source_owner, null)
+  source_repo  = try(each.value.fork.source_repo, null)
+
   allow_squash_merge = true
   allow_merge_commit = true
 
@@ -227,6 +231,14 @@ resource "github_repository" "govuk_repos" {
         try(length(data.github_repository.govuk[format("alphagov/%s", each.key)].pages), 0) == 0
       )
       error_message = "You cannot archive a Repo with an active GitHub Pages Configuration. Remove this first."
+    }
+
+    precondition {
+      condition = (
+        !try(each.value.fork.enabled, false) ||
+        (try(each.value.fork.source_owner, "") != "" && try(each.value.fork.source_repo, "") != "")
+      )
+      error_message = "You cannot set a repository as a fork with no source owner or source repository defined."
     }
   }
 }

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -203,6 +203,10 @@ repos:
 
   fastly-exporter:
     archived: true
+    fork:
+      enabled: true
+      source_owner: "alexbasista"
+      source_repo: "terraform-tfe-workspacer"
 
   feedback:
     can_be_deployed: true
@@ -413,6 +417,10 @@ repos:
 
   terraform-govuk-tfe-workspacer:
     up_to_date_branches: true
+    fork:
+      enabled: true
+      source_owner: "alexbasista"
+      source_repo: "terraform-tfe-workspacer"
 
   govuk-reports-prototype:
     need_production_access_to_merge: false
@@ -584,6 +592,10 @@ repos:
   markdown-toolbar-element:
     archived: true
     homepage_url: "https://alphagov.github.io/markdown-toolbar-element"
+    fork:
+      enabled: true
+      source_owner: "alexbasista"
+      source_repo: "terraform-tfe-workspacer"
 
   miller-columns-element:
     archived: true
@@ -970,6 +982,10 @@ repos:
 
   github-trello-poster:
     archived: true
+    fork:
+      enabled: true
+      source_owner: "alexbasista"
+      source_repo: "terraform-tfe-workspacer"
 
   ckan-mock-harvest-sources: {}
   govuk-pact-broker: {}

--- a/terraform/deployments/github/schemas/repos.schema.json
+++ b/terraform/deployments/github/schemas/repos.schema.json
@@ -38,6 +38,24 @@
               "description": "If omitted, defaults to true",
               "type": "boolean" 
             },
+            "fork": {
+              "description": "Describes whether the repository is a fork.",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Describes whether the repository is a fork. If omitted, defaults to false",
+                  "type": "boolean"
+                },
+                "source_owner": {
+                  "description": "Describes the source owner of the fork.",
+                  "type": "string"
+                },
+                "source_repo": {
+                  "description": "Describes the source repository of the fork.",
+                  "type": "string"
+                }
+              }
+            },
             "need_production_access_to_merge": { 
               "description": "If omitted, defaults to true",
               "type": "boolean" 


### PR DESCRIPTION
Description:
- Add fork configuration to GitHub repository
- Add a precondition check that fails to create the forked resource if `source_owner` and `source_repo` aren't present as these are required
- Set `terraform-govuk-tfe-workspacer`, `markdown-toolbar-element`, `fastly-exporter` and `github-trello-poster` as a fork to stop GitHub terraform provider deleting and re-creating the repository