### PR TITLE
Prepare small 6 in all envs

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -219,6 +219,8 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - DGU"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -287,6 +289,8 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -458,6 +462,8 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -595,6 +601,8 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Infrastructure"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -616,6 +624,8 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Search"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = true
         isolate                      = true
         launch_new_db                = true
@@ -640,6 +650,8 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -246,6 +246,8 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - DGU"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -319,6 +321,8 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -507,6 +511,8 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -652,6 +658,8 @@ module "variable-set-rds-production" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Infrastructure"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -672,6 +680,8 @@ module "variable-set-rds-production" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Search"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -695,6 +705,8 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -231,6 +231,8 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = true
         project                      = "GOV.UK - DGU"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -301,6 +303,8 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -478,6 +482,8 @@ module "variable-set-rds-staging" {
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -619,6 +625,8 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Infrastructure"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -640,6 +648,8 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Search"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false
@@ -664,6 +674,8 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
+        backup_window                = "08:00-08:30"
+        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = false
         launch_new_db                = false


### PR DESCRIPTION
* Bring all prod "little 7" to consistent minor (postgres)/patch (mysql) level
* Disable auto minor version upgrades for them
* Move their backup window
* Slightly reorder variables (move launch_new_db down 1 so the order of the operations is a bit more sane)

We want all our RDS instances to have the current default patch (for mysql) and minor (for postgres) in production, and for them not to change when we launch new instances from snapshots. So temporarily set all of the "little 7" RDS instances in all envs to explicitly be the exact engine version. This will mean minor/patch updates for most instances, but these will happen in their maintenance window, not immediately

Usually in non-prod envs we apply immediately, but in this case I don't want to disrupt devs more than we need to, so let it happen in their usual maintenance window and disable apply immediately.

We also don't want them to do any minor updates for now, so disable that.

Finally the backup window has been shifted