### PR TITLE
[DO NOT MERGE UNTIL Mon Dec 1] Update publshing API to PG 13.22 on Tuesday morning

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -574,7 +574,7 @@ module "variable-set-rds-production" {
 
       publishing_api = {
         engine                    = "postgres"
-        engine_version            = "13.20"
+        engine_version            = "13.22"
         replica_engine_version    = "13.22"
         replica_apply_immediately = false
         engine_params = {
@@ -611,7 +611,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
         backup_window                = "20:00-20:30"
-        maintenance_window           = "Sat:00:00-Sat:02:00"
+        maintenance_window           = "Tue:00:00-Tue:01:00"
         auto_minor_version_upgrade   = false
         launch_new_db                = false
         launch_new_replica           = false


### PR DESCRIPTION
By Monday the publishing-api read replica will be 13.22, so on Monday lets schedule the primary to update over night.