### PR TITLE
[DO NOT MERGE UNTIL Tue Dec 2] Change publishing_api production RDS to Sat morn maintenance window

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -611,7 +611,7 @@ module "variable-set-rds-production" {
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
         backup_window                = "20:00-20:30"
-        maintenance_window           = "Tue:00:00-Tue:01:00"
+        maintenance_window           = "Sat:00:00-Sat:02:00"
         auto_minor_version_upgrade   = false
         launch_new_db                = false
         launch_new_replica           = false


### PR DESCRIPTION
On Tuesday publishing api will have upgraded 13.22, this sets the maintenance window back to Saturday morning