### PR TITLE
Revert "Switch back release in integration"

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -606,8 +606,7 @@ module "variable-set-rds-integration" {
         backup_window                = "08:00-08:30"
         auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
-        isolate_new_db               = true
-        isolate                      = false
+        isolate                      = true
         launch_new_db                = true
         cname_point_to_new_instance  = false
         new_db_deletion_protection   = true


### PR DESCRIPTION
Switch back went fine. Revert the switch back and continue with migration to the new instance

Reverts alphagov/govuk-infrastructure#3280