### PR TITLE
Remove govuk-chat-gradio-user-research properties

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -330,14 +330,6 @@ repos:
 
   govuk-chat-gradio-user-research:
     visibility: private
-    homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk-chat-gradio-user-research.html"
-    required_status_checks:
-      # standard security checks are disabled as not configured for a private repo
-      additional_contexts:
-        - Tests
-        - Lint
-        - Format
-        - Type checks
 
   govuk-content-api-docs:
     homepage_url: "https://content-api.publishing.service.gov.uk"


### PR DESCRIPTION
This repository is being archived as the project is no longer active. This follows these instructions https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/README.md#archiving-repositories.

It is the first of two PRs to archive the repository. This PR removes the properties. The next will set archived: true.