### PR TITLE
Only check github team membership in deploy workflow for deploys to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,12 +39,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TEAM: gov-uk-production-deploy
           GITHUB_USER: ${{ github.triggering_actor }}
-          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
           TEAM_MEMBERSHIP=$(gh api "orgs/alphagov/teams/$GITHUB_TEAM/memberships/$GITHUB_USER" -q .state || echo false)
 
-          if ! [[ "$TEAM_MEMBERSHIP" = active || "$ENVIRONMENT" = integration ]]; then
-            echo "::error title=Insufficient permissions to deploy::User $TRIGGERING_ACTOR needs to be a member of the GOV.UK Production Deploy team"
+          if [[ "$TEAM_MEMBERSHIP" != "active" && "$ENVIRONMENT" = "production" ]]; then
+            echo "::error title=Insufficient permissions to deploy::User $GITHUB_USER needs to be a member of the GOV.UK Production Deploy team"
             exit 1
           fi
 


### PR DESCRIPTION
This check is currently broken. This change will unblock deploys for apps that deploy straight to staging, such as mirror. It should not increase risk in any meaningful way.