### PR TITLE
Archive govuk-chat-gradio-user-research repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -330,6 +330,7 @@ repos:
 
   govuk-chat-gradio-user-research:
     visibility: private
+    archived: true
 
   govuk-content-api-docs:
     homepage_url: "https://content-api.publishing.service.gov.uk"


### PR DESCRIPTION
Ahead of archving this repo the properties were removed in this PR https://github.com/alphagov/govuk-infrastructure/pull/3303.

This archives the repo.