### PR TITLE
Archive `govuk-exporter

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -376,10 +376,7 @@ repos:
     can_be_deployed: true
 
   govuk-exporter:
-    can_be_deployed: true
-    required_status_checks:
-      additional_contexts:
-        - Test Go
+    archived: true
 
   govuk-fastly:
     can_be_deployed: true


### PR DESCRIPTION
Description:
- Retires `govuk-exporter` as the functionality has been moved into `govuk-mirror`
- https://github.com/alphagov/govuk-infrastructure/issues/3205