### PR TITLE
Add govuk-chat-opensearch repo

### DIFF
--- a/terraform/deployments/github/import.tf
+++ b/terraform/deployments/github/import.tf
@@ -1,0 +1,4 @@
+import {
+  to = github_repository.govuk_repos["govuk-chat-opensearch"]
+  id = "govuk-chat-opensearch"
+}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -332,6 +332,8 @@ repos:
     visibility: private
     archived: true
 
+  govuk-chat-opensearch: {}
+
   govuk-content-api-docs:
     homepage_url: "https://content-api.publishing.service.gov.uk"
     need_production_access_to_merge: false


### PR DESCRIPTION
This repo doesn't have any config attached to it. It just needs to be
public but doesn't have any tests or specific requirements on merging,
etc.

The repo already exists, so the import file has been created and
populated, as per the docs[1].

[1]: https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/README.md#adding-existing-repositories