### PR TITLE
Add new RDS instance for fact check manager in integration as a normalised instance only

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -419,6 +419,27 @@ module "variable-set-rds-integration" {
         new_db_deletion_protection   = true
       }
 
+      fact_check_manager = {
+        engine         = "postgres"
+        engine_version = "17"
+        engine_params = {
+          log_min_duration_statement = { value = 10000 }
+          log_statement              = { value = "all" }
+          deadlock_timeout           = { value = 2500 }
+          log_lock_waits             = { value = 1 }
+        }
+        engine_params_family         = "postgres17"
+        name                         = "fact-check-manager"
+        allocated_storage            = 100
+        instance_class               = "db.t4g.small"
+        performance_insights_enabled = true
+        project                      = "GOV.UK - Publishing"
+        launch_new_db                = true
+        new_db_deletion_protection   = true
+        cname_point_to_new_instance  = true
+        destroy_old_instance         = true
+      }
+
       imminence = {
         engine         = "postgres"
         engine_version = "14"


### PR DESCRIPTION
Fact Check Manager is a new application in development designed to handle fact checking requests for Publisher and other applications in GOV.UK.

This database will remain empty for the time being but is required for upcoming early work on the application.

https://gov-uk.atlassian.net/browse/MAIN-7151

This PR supersedes #3288 