### PR TITLE
Add `prevent_destroy` lifecycle rule

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -240,6 +240,8 @@ resource "github_repository" "govuk_repos" {
       )
       error_message = "You cannot set a repository as a fork with no source owner or source repository defined."
     }
+
+    prevent_destroy = true
   }
 }
 


### PR DESCRIPTION
Description:
- Prevent Terraform from accidentally destroying GitHub repositories
- https://github.com/alphagov/govuk-infrastructure/issues/3307