### PR TITLE
Set `publishing-api` param group to 17

### DIFF
--- a/terraform/deployments/rds/staging_publishing_api_postgres_17_upgrade.tf
+++ b/terraform/deployments/rds/staging_publishing_api_postgres_17_upgrade.tf
@@ -1,7 +1,7 @@
-resource "aws_db_parameter_group" "publishing_api_postgresql_14_green_params" {
+resource "aws_db_parameter_group" "publishing_api_postgresql_17_green_params" {
 
   name_prefix = "${var.govuk_environment}-publishing-api-postgres-"
-  family      = "postgres14"
+  family      = "postgres17"
 
   parameter {
     name         = "rds.logical_replication"


### PR DESCRIPTION
Description:
- Parameter group set to 17 for postgres upgrade
- https://github.com/alphagov/govuk-infrastructure/issues/3358