### PR TITLE
Enforce TLS connections to S3 buckets across the board

### DIFF
--- a/terraform/deployments/cluster-services/tempo.tf
+++ b/terraform/deployments/cluster-services/tempo.tf
@@ -9,6 +9,29 @@ resource "aws_s3_bucket" "tempo" {
   force_destroy = var.force_destroy
 }
 
+resource "aws_s3_bucket_policy" "tempo_bucket_policy" {
+  bucket = aws_s3_bucket.tempo.id
+  policy = data.aws_iam_policy_document.tempo_bucket_policy.json
+}
+
+data "aws_iam_policy_document" "tempo_bucket_policy" {
+  statement {
+    sid    = "DenyNonTLS"
+    effect = "Deny"
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+    actions   = ["s3:*"]
+    resources = ["${aws_s3_bucket.tempo.arn}/*"]
+    condition {
+      test     = "Bool"
+      values   = [false]
+      variable = "aws:SecureTransport"
+    }
+  }
+}
+
 module "tempo_iam_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
   version = "~> 5.27"

--- a/terraform/deployments/csp-reporter/buckets.tf
+++ b/terraform/deployments/csp-reporter/buckets.tf
@@ -19,3 +19,26 @@ resource "aws_s3_bucket_lifecycle_configuration" "csp_reports_lifecycle" {
     }
   }
 }
+
+resource "aws_s3_bucket_policy" "csp_reports" {
+  bucket = aws_s3_bucket.csp_reports.id
+  policy = data.aws_iam_policy_document.csp_reports_bucket_policy.json
+}
+
+data "aws_iam_policy_document" "csp_reports_bucket_policy" {
+  statement {
+    sid    = "DenyNonTLS"
+    effect = "Deny"
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+    actions   = ["s3:*"]
+    resources = ["${aws_s3_bucket.csp_reports.arn}/*"]
+    condition {
+      test     = "Bool"
+      values   = [false]
+      variable = "aws:SecureTransport"
+    }
+  }
+}

--- a/terraform/deployments/elasticsearch/s3.tf
+++ b/terraform/deployments/elasticsearch/s3.tf
@@ -46,4 +46,20 @@ data "aws_iam_policy_document" "manual_snapshots_cross_account_access" {
       "${aws_s3_bucket.manual_snapshots.arn}/*",
     ]
   }
+
+  statement {
+    sid    = "DenyNonTLS"
+    effect = "Deny"
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+    actions   = ["s3:*"]
+    resources = ["${aws_s3_bucket.manual_snapshots.arn}/*"]
+    condition {
+      test     = "Bool"
+      values   = [false]
+      variable = "aws:SecureTransport"
+    }
+  }
 }

--- a/terraform/deployments/logging/aws_logging.tf
+++ b/terraform/deployments/logging/aws_logging.tf
@@ -12,6 +12,22 @@ data "aws_iam_policy_document" "s3_aws_logging" {
       identifiers = [data.aws_elb_service_account.main.arn]
     }
   }
+
+  statement {
+    sid    = "DenyNonTLS"
+    effect = "Deny"
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+    actions   = ["s3:*"]
+    resources = ["arn:aws:s3:::govuk-${var.govuk_environment}-aws-logging/*"]
+    condition {
+      test     = "Bool"
+      values   = [false]
+      variable = "aws:SecureTransport"
+    }
+  }
 }
 
 data "aws_iam_policy_document" "s3_govuk_aws_logging_replication_policy" {


### PR DESCRIPTION
We had a small number of buckets whose policies didn't enforce it, and a smaller number which already did. THey all now deny access if not over TLS.