### PR TITLE
Update repos.yml with new nokodiff repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -612,6 +612,13 @@ repos:
       additional_contexts:
         - test
 
+  nokodiff:
+    publishes_gem: true
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
+
   optic14n:
     publishes_gem: true
     required_status_checks:


### PR DESCRIPTION
This PR kicks off the process of building the new HTML diffing Gem we are building by getting the initial repo created.

`homepage_url` will follow once we have the Gem built and listed on rubygems