### PR TITLE
chore: 🤖 remove old unused imports

### DIFF
--- a/terraform/deployments/cluster-access/imports.tf
+++ b/terraform/deployments/cluster-access/imports.tf
@@ -1,0 +1,147 @@
+removed {
+  from = kubernetes_cluster_role_binding.cluster_admins
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_cluster_role_binding_v1.cluster_admins
+  id = "cluster-admins"
+}
+
+
+removed {
+  from = kubernetes_cluster_role.developer
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_cluster_role_v1.developer
+  id = "developer"
+}
+
+removed {
+  from = kubernetes_cluster_role_binding.developer
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_cluster_role_binding_v1.developer
+  id = "developer-cluster-binding"
+}
+
+removed {
+  from = kubernetes_role.licensing
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_role_v1.licensing
+  id = "licensify/licensing"
+}
+
+removed {
+  from = kubernetes_role_binding.licensing
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_role_binding_v1.licensing
+  id = "licensify/licensing-binding"
+}
+
+removed {
+  from = kubernetes_cluster_role.readonly
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_cluster_role_v1.readonly
+  id = "readonly"
+}
+
+removed {
+  from = kubernetes_cluster_role_binding.readonly
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_cluster_role_binding_v1.readonly
+  id = "readonly-cluster-binding"
+}
+
+
+removed {
+  from = kubernetes_cluster_role.ithctester
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_cluster_role_v1.ithctester
+  id = "ithctester"
+}
+
+removed {
+  from = kubernetes_cluster_role_binding.ithctester
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_cluster_role_binding_v1.ithctester
+  id = "ithctester-cluster-binding"
+}
+
+
+import {
+  to = kubernetes_role_v1.developer[each.key]
+  id = "${each.key}/developer"
+
+  for_each = toset(local.developer_namespaces)
+}
+
+import {
+  to = kubernetes_role_binding_v1.developer[each.key]
+  id = "${each.key}/developer-binding"
+
+  for_each = toset(local.developer_namespaces)
+}
+
+import {
+  to = kubernetes_role_v1.readonly[each.key]
+  id = "${each.key}/readonly"
+
+  for_each = toset(local.developer_namespaces)
+}
+
+import {
+  to = kubernetes_role_binding_v1.readonly[each.key]
+  id = "${each.key}/readonly-binding"
+
+  for_each = toset(local.developer_namespaces)
+}


### PR DESCRIPTION
NOOP

We have upgraded the kubernetes provider to v3 and that deprecated some k8s resources. After importing these to the new resources we can remove the old import statements