### PR TITLE
Add GitHub Actions OIDC role for govuk-chat-evaluation Bedrock CI

### DIFF
--- a/terraform/deployments/chat-evaluation-ci/github_oidc_provider.tf
+++ b/terraform/deployments/chat-evaluation-ci/github_oidc_provider.tf
@@ -1,0 +1,9 @@
+data "tls_certificate" "github_actions" {
+  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+}
+
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.github_actions.certificates[0].sha1_fingerprint]
+}

--- a/terraform/deployments/chat-evaluation-ci/iam_github_actions_bedrock.tf
+++ b/terraform/deployments/chat-evaluation-ci/iam_github_actions_bedrock.tf
@@ -1,0 +1,68 @@
+locals {
+  github_subjects = [
+    "repo:${var.github_repository}:ref:refs/heads/*",
+    "repo:${var.github_repository}:pull_request",
+  ]
+
+  bedrock_model_arns = [for id in var.bedrock_model_ids : "arn:aws:bedrock:${var.aws_region}::foundation-model/${id}"]
+}
+
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    sid     = "GitHubActionsAssumeRoleWithWebIdentity"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = local.github_subjects
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions_bedrock_ci" {
+  name                 = var.role_name
+  assume_role_policy   = data.aws_iam_policy_document.github_actions_assume_role.json
+  max_session_duration = 3600
+}
+
+data "aws_iam_policy_document" "bedrock_invoke_policy" {
+  statement {
+    sid    = "InvokeBedrock"
+    effect = "Allow"
+    actions = [
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream",
+    ]
+    resources = local.bedrock_model_arns
+  }
+
+  statement {
+    sid       = "ListFoundationModels"
+    effect    = "Allow"
+    actions   = ["bedrock:ListFoundationModels"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "bedrock_invoke_policy" {
+  name        = "${var.role_name}-policy"
+  description = "Allow GitHub Actions CI to invoke specified Bedrock models in ${var.aws_region}"
+  policy      = data.aws_iam_policy_document.bedrock_invoke_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach_bedrock_invoke" {
+  role       = aws_iam_role.github_actions_bedrock_ci.name
+  policy_arn = aws_iam_policy.bedrock_invoke_policy.arn
+}

--- a/terraform/deployments/chat-evaluation-ci/main.tf
+++ b/terraform/deployments/chat-evaluation-ci/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  cloud {
+    organization = "govuk"
+    workspaces {
+      tags = ["chat-evaluation-ci", "test", "aws"]
+    }
+  }
+
+  required_version = "~> 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      product              = "govuk"
+      system               = "govuk-chat-evaluation"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      repository           = "govuk-infrastructure"
+      terraform-deployment = basename(abspath(path.root))
+      Service              = "govuk-chat-evaluation-ci"
+    }
+  }
+}

--- a/terraform/deployments/chat-evaluation-ci/outputs.tf
+++ b/terraform/deployments/chat-evaluation-ci/outputs.tf
@@ -1,0 +1,14 @@
+output "github_actions_role_arn" {
+  value       = aws_iam_role.github_actions_bedrock_ci.arn
+  description = "Role ARN for GitHub Actions to assume (use in govuk-chat-evaluation CI)."
+}
+
+output "github_actions_oidc_provider_arn" {
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+  description = "OIDC provider ARN created in the govuk-test account."
+}
+
+output "bedrock_model_arns" {
+  value       = local.bedrock_model_arns
+  description = "Foundation model ARNs that CI role is allowed to invoke."
+}

--- a/terraform/deployments/chat-evaluation-ci/variables.tf
+++ b/terraform/deployments/chat-evaluation-ci/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region to target for Bedrock model ARN and provider configuration."
+  default     = "eu-west-1"
+}
+
+variable "govuk_environment" {
+  type        = string
+  description = "GOV.UK environment/account target. This root is intended for the test account."
+  default     = "test"
+}
+
+variable "github_repository" {
+  type        = string
+  description = "GitHub repository allowed to assume the Bedrock CI role, in OWNER/REPO form."
+  default     = "alphagov/govuk-chat-evaluation"
+}
+
+variable "role_name" {
+  type        = string
+  description = "Name of IAM role assumed by GitHub Actions to run Bedrock tests."
+  default     = "github_action_govuk_chat_evaluation_bedrock_ci"
+}
+
+variable "bedrock_model_ids" {
+  type        = list(string)
+  description = "Bedrock foundation model IDs allowed for invocation."
+  default     = ["openai.gpt-oss-120b-1:0"]
+}

--- a/terraform/deployments/tfc-configuration/chat-evaluation-ci.tf
+++ b/terraform/deployments/tfc-configuration/chat-evaluation-ci.tf
@@ -1,0 +1,30 @@
+module "chat-evaluation-ci-test" {
+  source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
+
+  organization        = var.organization
+  workspace_name      = "chat-evaluation-ci-test"
+  workspace_desc      = "This module manages resources needed to operate the CI of GOV.UK Chat"
+  workspace_tags      = ["test", "chat-evaluation-ci", "aws"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/chat-evaluation-ci/"
+  trigger_patterns    = ["/terraform/deployments/chat-evaluation-ci/**/*"]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production (r/o)" = "write"
+    "GOV.UK Production"           = "write"
+  }
+
+  variable_set_ids = [
+    local.aws_credentials["test"],
+  ]
+}


### PR DESCRIPTION
Add new `chat-ci` Terraform deployment that creates:

- GitHub Actions OIDC provider in the govuk-test AWS account
- IAM role assumable by `alphagov/govuk-chat-evaluation` workflows
- Bedrock invoke policy scoped to `openai.gpt-oss-120b-1:0` model

This allows govuk-chat-evaluation CI to run `real_bedrock` pytest-marked tests by authenticating via OIDC and invoking the Bedrock model in eu-west-1.

Also adds the `chat-ci` workspace configuration in tfc-configuration.

Trello: https://trello.com/c/hBGL3B9V/2994-can-our-real-openai-auto-eval-tests-be-real-bedrock