### PR TITLE
Import `publishing-api` postgres 17 into Terraform

### DIFF
--- a/terraform/deployments/rds/staging_publishing_api_postgres_17_upgrade.tf
+++ b/terraform/deployments/rds/staging_publishing_api_postgres_17_upgrade.tf
@@ -1,25 +1,14 @@
-resource "aws_db_parameter_group" "publishing_api_postgresql_17_green_params" {
+import {
+  to = aws_db_instance.normalised_instance["publishing_api"]
+  id = "publishing-api-staging-postgres"
+}
 
-  name_prefix = "${var.govuk_environment}-publishing-api-postgres-"
-  family      = "postgres17"
+import {
+  to = aws_db_parameter_group.engine_params["publishing_api"]
+  id = "staging-publishing-api-postgres-20251215134108173900000001"
+}
 
-  parameter {
-    name         = "rds.logical_replication"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-
-  lifecycle { create_before_destroy = true }
+import {
+  to = aws_db_instance.normalised_replica["publishing_api"]
+  id = "publishing-api-staging-postgres-replica"
 }


### PR DESCRIPTION
Description:
- Import `publishing-api` Postgres 17 database and replica into terraform
- https://github.com/alphagov/govuk-infrastructure/issues/3358