### PR TITLE
Also need to set launch_new_db_from_snapshot = false

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -611,6 +611,7 @@ module "variable-set-rds-staging" {
         prepare_to_launch_new_db     = false
         backup_window                = "07:30-08:00"
         isolate                      = true
+        launch_new_db_from_snapshot  = false
         launch_new_db                = true
         new_db_deletion_protection   = true
         launch_new_replica           = true


### PR DESCRIPTION
Given this has been imported, we need to make terraform think we aren't restoring it from a snapshot (which happened previously)