### PR TITLE
Remove replica_apply_immediately from publishing-api in production, now it's been converted to multi-az

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -608,7 +608,6 @@ module "variable-set-rds-production" {
         isolate                      = false
         cname_point_to_new_instance  = false
         new_db_deletion_protection   = false
-        replica_apply_immediately    = true
       }
 
       publisher = {


### PR DESCRIPTION
The change we needed to apply has been applied, so go back to not applying immediately in production