### PR TITLE
Add OK actions to cloudwatch alarms for platform engineering

### DIFF
--- a/terraform/deployments/cluster-infrastructure/alarms.tf
+++ b/terraform/deployments/cluster-infrastructure/alarms.tf
@@ -30,6 +30,7 @@ resource "aws_cloudwatch_metric_alarm" "node_group_limit" {
   evaluation_periods  = 2
 
   alarm_actions = [aws_sns_topic.slack_channel.arn]
+  ok_actions    = [aws_sns_topic.slack_channel.arn]
 
   metric_query {
     id          = "count"

--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -218,6 +218,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_freestoragespace" {
     * 1024 * 1024 * 1024 # allocated_storage is in GB, metric value is in bytes
   )
   alarm_actions     = [aws_sns_topic.rds_alerts.arn]
+  ok_actions        = [aws_sns_topic.rds_alerts.arn]
   alarm_description = "Available storage space on ${aws_db_instance.instance[each.key].identifier} RDS is below ${each.value.storage_alarm_threshold_percentage}%."
 }
 
@@ -242,6 +243,7 @@ resource "aws_cloudwatch_metric_alarm" "normalised_rds_freestoragespace" {
     * 1024 * 1024 * 1024 # allocated_storage is in GB, metric value is in bytes
   )
   alarm_actions     = [aws_sns_topic.rds_alerts.arn]
+  ok_actions        = [aws_sns_topic.rds_alerts.arn]
   alarm_description = "Available storage space on ${aws_db_instance.normalised_instance[each.key].identifier} RDS is below ${each.value.storage_alarm_threshold_percentage}%."
 }
 


### PR DESCRIPTION
We keep investigating alarms that are resolved, it would be nicer if in slack we saw that it had gone ok again