### PR TITLE
ci: 🎡 add explicit permissions to gha workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,6 +4,8 @@ on:
     paths: ['.github/workflows/**', '.github/actions/**', '.github/actionlint.yml']
 jobs:
   actionlint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -5,6 +5,10 @@ on:
 env:
   TF_IN_AUTOMATION: true
   TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
+
+permissions:
+  contents: read
+
 jobs:
   tflint:
     runs-on: ubuntu-latest

--- a/.github/workflows/guardrail_adr_numbering.yml
+++ b/.github/workflows/guardrail_adr_numbering.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   check-adr-numbering:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
Fixes:

- https://github.com/alphagov/govuk-infrastructure/security/code-scanning/27
- https://github.com/alphagov/govuk-infrastructure/security/code-scanning/28
- https://github.com/alphagov/govuk-infrastructure/security/code-scanning/29

reference: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions