### PR TITLE
Disable the blue Elasticsearch cluster in Staging

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -871,6 +871,7 @@ module "variable-set-elasticsearch-staging" {
     govuk_environment      = "staging"
     engine_version         = "6.7"
     zone_awareness_enabled = true
+    elasticsearch_enabled  = false
 
     instance_count = 3
     instance_type  = "r5.2xlarge.elasticsearch"


### PR DESCRIPTION
A new green cluster has been instantiated in staging and now serves all traffic. The blue cluster is no longer required and can be safely disabled until it is needed again for future upgrades.

Jira https://gov-uk.atlassian.net/browse/SCH-1606