### PR TITLE
Correct permissiosn of  mirror sync role

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
@@ -440,7 +440,7 @@ data "aws_iam_policy_document" "govuk_mirror_sync" {
   }
 
   statement {
-    sid = "AthenaS3Permissions"
+    sid = "AthenaS3PermissionsInResults"
     actions = [
       "s3:AbortMultipartUpload",
       "s3:GetBucketLocation",
@@ -460,8 +460,26 @@ data "aws_iam_policy_document" "govuk_mirror_sync" {
   }
 
   statement {
+    sid = "AthenaS3PermissionsInDataSource"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject"
+    ]
+    resources = [
+      data.tfe_outputs.fastly_logs.nonsensitive_values.govuk_fastly_logs_s3_bucket_arn,
+      "${data.tfe_outputs.fastly_logs.nonsensitive_values.govuk_fastly_logs_s3_bucket_arn}/*",
+    ]
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      values   = ["athena.amazonaws.com"]
+      variable = "aws:CalledVia"
+    }
+  }
+
+  statement {
     sid = "AthenaGluePermissions"
     actions = [
+      "glue:BatchGetTable",
       "glue:GetDatabase",
       "glue:GetTable",
       "glue:GetTables",
@@ -471,7 +489,7 @@ data "aws_iam_policy_document" "govuk_mirror_sync" {
     resources = [
       "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog",
       "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/fastly_logs",
-      "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/fastly_logs/govuk_www",
+      "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/fastly_logs/govuk_www",
     ]
     condition {
       test     = "ForAnyValue:StringEquals"

--- a/terraform/deployments/govuk-publishing-infrastructure/remote.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/remote.tf
@@ -25,4 +25,10 @@ data "tfe_outputs" "security" {
   workspace    = "security-${var.govuk_environment}"
 }
 
+data "tfe_outputs" "fastly_logs" {
+  organization = "govuk"
+  workspace    = "govuk-fastly-logs-${var.govuk_environment}"
+}
+
+
 data "fastly_ip_ranges" "fastly" {}


### PR DESCRIPTION
The mirror sync role's permissions have been adjusted in two ways

1. Granted "glue:BatchGetTable" on the relevant table ARN
2. Granted "s3:ListBucket" and "s3:GetObject" on the S3 bucket in which the Fastly logs are stored.

These permissions are required when using Athena to query an S3-backed data source. We missed them before because the IAM roles we used to test run the mirror had implicit permission to do these things.

The Fastly lgos bucket ARN is pulled in from its Terraform workspace. It doesn't create a circular dependency.