### PR TITLE
Return rds backup and maintenance windows to previous values & enable auto minor updates

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -223,7 +223,6 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = true
         project                      = "GOV.UK - DGU"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -298,7 +297,6 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -506,7 +504,6 @@ module "variable-set-rds-integration" {
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -641,7 +638,6 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Infrastructure"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -665,7 +661,6 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Search"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -692,7 +687,6 @@ module "variable-set-rds-integration" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -170,7 +170,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -197,7 +196,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -246,7 +244,6 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - DGU"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -270,7 +267,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -297,7 +293,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -322,7 +317,6 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -355,7 +349,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -381,7 +374,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -407,7 +399,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -433,7 +424,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -459,7 +449,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -487,7 +476,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -513,7 +501,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -540,7 +527,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -566,7 +552,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Web"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -597,7 +582,6 @@ module "variable-set-rds-production" {
         has_read_replica             = true
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -624,7 +608,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -646,7 +629,6 @@ module "variable-set-rds-production" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Infrastructure"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -669,7 +651,6 @@ module "variable-set-rds-production" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Search"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -695,7 +676,6 @@ module "variable-set-rds-production" {
         performance_insights_enabled = true
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -719,7 +699,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -745,7 +724,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -771,7 +749,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true
@@ -796,7 +773,6 @@ module "variable-set-rds-production" {
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
         prepare_to_launch_new_db     = false
-        auto_minor_version_upgrade   = false
         isolate                      = true
         launch_new_db                = true
         new_db_deletion_protection   = true

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -233,7 +233,6 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = true
         project                      = "GOV.UK - DGU"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -308,7 +307,6 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -494,7 +492,6 @@ module "variable-set-rds-staging" {
         project                      = "GOV.UK - Publishing"
         maintenance_window           = "Mon:00:00-Mon:01:00"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -628,7 +625,6 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Infrastructure"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -652,7 +648,6 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Search"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true
@@ -679,7 +674,6 @@ module "variable-set-rds-staging" {
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"
         encryption_at_rest           = false
-        auto_minor_version_upgrade   = false
         prepare_to_launch_new_db     = false
         isolate                      = true
         launch_new_db                = true


### PR DESCRIPTION
This PR removes the maintenance and backup window overrides that we previously needed. I restored to what was in terraform before we did the work, I did this by looking at what was set at commit 1464688fd1f7a9bc87e299e62c8170a4852119c4 from October 20

It also enables auto minor version updates (by removing the setting and relying on the default of true)