### PR TITLE
Enable `external-dns` metrics

### DIFF
--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -24,8 +24,11 @@ resource "helm_release" "external_dns" {
       }
     }
     automountServiceAccountToken = true
-    revisionHistoryLimit         = 10
-    txtOwnerId                   = "govuk"
+    serviceMonitor = {
+      enabled = true
+    }
+    revisionHistoryLimit = 10
+    txtOwnerId           = "govuk"
     domainFilters = [
       data.tfe_outputs.cluster_infrastructure.nonsensitive_values.external_dns_zone_name
     ]


### PR DESCRIPTION
Description:
- Turns on the `ServiceMonitor` which enables Prometheus to scrape the Service endpoints for `external-dns` pods
- https://github.com/alphagov/govuk-infrastructure/issues/3457