### PR TITLE
Enable aws-ebs-csi-driver controller metrics

### DIFF
--- a/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
+++ b/terraform/deployments/cluster-services/aws_ebs_csi_driver.tf
@@ -8,6 +8,7 @@ resource "helm_release" "aws_ebs_csi_driver" {
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     controller = {
+      enableMetrics = true
       serviceAccount = {
         create = true
         name   = "ebs-csi-controller-sa"


### PR DESCRIPTION
Description:
- This turns on metrics for the AWS EBS CSI Driver controller which will deploy a `Service` object and a `ServiceMonitor`
- See https://github.com/alphagov/govuk-infrastructure/issues/3457