### PR TITLE
feat: 🎸 add renovate irsa

### DIFF
--- a/terraform/deployments/cluster-services/renovate_irsa.tf
+++ b/terraform/deployments/cluster-services/renovate_irsa.tf
@@ -1,0 +1,43 @@
+locals {
+  renovate_service_account_name = "renovate-irsa"
+}
+
+module "renovate_irsa" {
+  count = (var.govuk_environment == "production" ? 1 : 0)
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.20"
+
+  role_name            = "${local.renovate_service_account_name}-${data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id}"
+  role_description     = "AWS Role and EKS service account that allows renovate to query the AWS API through the AWS SDK for EKS the latest EKS addon versions"
+  max_session_duration = 7200
+
+  role_policy_arns = { policy = aws_iam_policy.renovate_eks_describe_addons[0].arn }
+  oidc_providers = {
+    main = {
+      provider_arn               = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_oidc_provider_arn
+      namespace_service_accounts = ["cluster-services:${local.renovate_service_account_name}"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "renovate_eks_describe_addons" {
+  statement {
+    sid    = "AllowDescribeEKSAddonVersions"
+    effect = "Allow"
+    actions = [
+      "eks:DescribeAddonVersions"
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "renovate_eks_describe_addons" {
+  count       = (var.govuk_environment == "production" ? 1 : 0)
+  name        = "renovate_eks_describe_addons"
+  description = "Permissions to allow renovate to describe eks addons"
+  policy      = data.aws_iam_policy_document.renovate_eks_describe_addons.json
+}
+


### PR DESCRIPTION
This is the 1/3 prs to enable renovate to watch eks addons for updates:

1. create the new renovate irsa
1. [pass the new service account with correct aws permissions to the renovate cron job](https://github.com/alphagov/govuk-helm-charts/pull/3983)
1. [configure the `renovate.json` to check for any updated eks addons and add gha to ensure that the hardcoded k8s version in `renovate.json` is up to date](https://github.com/alphagov/govuk-infrastructure/pull/3473)

related:  https://github.com/alphagov/govuk-infrastructure/issues/3423