### PR TITLE
Rename the chat RDS instance

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -191,7 +191,6 @@ module "variable-set-rds-integration" {
         }
         engine_params_family         = "postgres16"
         name                         = "chat"
-        identifier_override          = "chat-postgres"
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -213,7 +213,6 @@ module "variable-set-rds-production" {
         }
         engine_params_family         = "postgres16"
         name                         = "chat"
-        identifier_override          = "chat-postgres"
         allocated_storage            = 100
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -202,7 +202,6 @@ module "variable-set-rds-staging" {
         }
         engine_params_family         = "postgres16"
         name                         = "chat"
-        identifier_override          = "chat-postgres"
         allocated_storage            = 100
         instance_class               = "db.t4g.small"
         performance_insights_enabled = false


### PR DESCRIPTION
Chat have agreed I can rename their RDS instance, this PR removes the identifier override which will force the instances to rename. Since all access is via our CNAME (with a 30 second ttl) there will likely be a short outage, so I'll apply, then wait 60 seconds, then force a new rollout for the running chat deployments to ensure there's no DNS caching shenanigans or stale connections