### PR TITLE
Update required checks for Content Block Manager

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -112,8 +112,9 @@ repos:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Test Ruby / Run Minitest
+        - Test Ruby / Run Rspec
         - Test features / Run Cucumber
+        - Check coverage / Combine coverage
 
   content-data-admin:
     can_be_deployed: true


### PR DESCRIPTION
We don’t use Minitest anymore. Additionally, I’ve added the coverage check as a required check.