### PR TITLE
Rename resources to eliminate the normalised_ prefix

### DIFF
--- a/terraform/deployments/rds/outputs.tf
+++ b/terraform/deployments/rds/outputs.tf
@@ -1,24 +1,24 @@
 output "rds_instance_id" {
   description = "RDS instance IDs"
-  value       = { for k, v in aws_db_instance.normalised_instance : k => v.id }
+  value       = { for k, v in aws_db_instance.instance : k => v.id }
 }
 
 output "rds_resource_id" {
   description = "RDS instance resource IDs"
-  value       = { for k, v in aws_db_instance.normalised_instance : k => v.resource_id }
+  value       = { for k, v in aws_db_instance.instance : k => v.resource_id }
 }
 
 output "rds_endpoint" {
   description = "RDS instance endpoints"
-  value       = { for k, v in aws_db_instance.normalised_instance : k => v.endpoint }
+  value       = { for k, v in aws_db_instance.instance : k => v.endpoint }
 }
 
 output "rds_address" {
   description = "RDS instance addresses"
-  value       = { for k, v in aws_db_instance.normalised_instance : k => v.address }
+  value       = { for k, v in aws_db_instance.instance : k => v.address }
 }
 
 output "sg_rds" {
   description = "RDS instance security groups"
-  value       = { for k, v in aws_security_group.normalised_rds : k => v.id }
+  value       = { for k, v in aws_security_group.rds : k => v.id }
 }

--- a/terraform/deployments/rds/security_groups.tf
+++ b/terraform/deployments/rds/security_groups.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "normalised_rds" {
+resource "aws_security_group" "rds" {
   for_each = var.databases
 
   name        = "${local.identifier_prefix}${each.value.new_name != null ? each.value.new_name : each.value.name}-${var.govuk_environment}-${each.value.engine}-rds-access"
@@ -8,13 +8,13 @@ resource "aws_security_group" "normalised_rds" {
   lifecycle { create_before_destroy = true }
 }
 
-resource "aws_security_group_rule" "normalised_rds_mysql" {
+resource "aws_security_group_rule" "rds_mysql" {
   for_each = {
     for db_name, db in var.databases : db_name => db
     if db.engine == "mysql"
   }
 
-  security_group_id = aws_security_group.normalised_rds[each.key].id
+  security_group_id = aws_security_group.rds[each.key].id
   description       = "Access to MySQL database from EKS worker nodes"
 
   type      = "ingress"
@@ -25,13 +25,13 @@ resource "aws_security_group_rule" "normalised_rds_mysql" {
   source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
 
-resource "aws_security_group_rule" "normalised_rds_postgres" {
+resource "aws_security_group_rule" "rds_postgres" {
   for_each = {
     for db_name, db in var.databases : db_name => db
     if db.engine == "postgres"
   }
 
-  security_group_id = aws_security_group.normalised_rds[each.key].id
+  security_group_id = aws_security_group.rds[each.key].id
   description       = "Access to PostgreSQL database from EKS worker nodes"
 
   type      = "ingress"

--- a/terraform/deployments/rds/state_moves.tf
+++ b/terraform/deployments/rds/state_moves.tf
@@ -1,0 +1,29 @@
+moved {
+  from = aws_db_instance.normalised_instance
+  to   = aws_db_instance.instance
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.normalised_rds_freestoragespace
+  to   = aws_cloudwatch_metric_alarm.rds_freestoragespace
+}
+
+moved {
+  from = aws_db_instance.normalised_replica
+  to   = aws_db_instance.replica
+}
+
+moved {
+  from = aws_security_group.normalised_rds
+  to   = aws_security_group.rds
+}
+
+moved {
+  from = aws_security_group_rule.normalised_rds_mysql
+  to   = aws_security_group_rule.rds_mysql
+}
+
+moved {
+  from = aws_security_group_rule.normalised_rds_postgres
+  to   = aws_security_group_rule.rds_postgres
+}


### PR DESCRIPTION
During the migration work we ended up with a lot of duplicate resources, all the new ones were prefixed normalised_, now the work is complete, and the old resources have been deleted we should tidy up the naming

* Rename all `normalised_*` resources to remove the prefix
* Move the resources in the state into the correct new names 

Note the terraform plans for this show no changes (it does highlight the state moves though), as you would expect