### PR TITLE
Set all rds instance engine versions to Major for PG and Major.Minor for MySQL

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -132,8 +132,9 @@ module "variable-set-rds-integration" {
 
     databases = {
       account_api = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -188,7 +189,7 @@ module "variable-set-rds-integration" {
 
       ckan = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -240,7 +241,7 @@ module "variable-set-rds-integration" {
 
       content_data_admin = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -257,8 +258,9 @@ module "variable-set-rds-integration" {
       }
 
       content_data_api = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
@@ -299,8 +301,9 @@ module "variable-set-rds-integration" {
       }
 
       content_tagger = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -335,8 +338,9 @@ module "variable-set-rds-integration" {
       }
 
       email_alert_api = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -391,7 +395,7 @@ module "variable-set-rds-integration" {
 
       link_checker_api = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -409,8 +413,9 @@ module "variable-set-rds-integration" {
       }
 
       local_links_manager = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -427,8 +432,9 @@ module "variable-set-rds-integration" {
       }
 
       locations_api = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -446,8 +452,8 @@ module "variable-set-rds-integration" {
 
       publishing_api = {
         engine                 = "postgres"
-        engine_version         = "17.6"
-        replica_engine_version = "17.6"
+        engine_version         = "17"
+        replica_engine_version = "17"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -489,7 +495,7 @@ module "variable-set-rds-integration" {
 
       release = {
         engine         = "mysql"
-        engine_version = "8.0.43"
+        engine_version = "8.0"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -504,7 +510,7 @@ module "variable-set-rds-integration" {
 
       search_admin = {
         engine         = "mysql"
-        engine_version = "8.0.43"
+        engine_version = "8.0"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -519,7 +525,7 @@ module "variable-set-rds-integration" {
 
       service_manual_publisher = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -551,8 +557,9 @@ module "variable-set-rds-integration" {
       }
 
       support_api = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -569,8 +576,9 @@ module "variable-set-rds-integration" {
       }
 
       transition = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -155,7 +155,7 @@ module "variable-set-rds-production" {
     databases = {
       account_api = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -173,7 +173,7 @@ module "variable-set-rds-production" {
 
       authenticating_proxy = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -192,7 +192,7 @@ module "variable-set-rds-production" {
 
       chat = {
         engine         = "postgres"
-        engine_version = "16.10"
+        engine_version = "16"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -210,7 +210,7 @@ module "variable-set-rds-production" {
 
       ckan = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -228,7 +228,7 @@ module "variable-set-rds-production" {
 
       collections_publisher = {
         engine         = "mysql"
-        engine_version = "8.0.43"
+        engine_version = "8.0"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -243,7 +243,7 @@ module "variable-set-rds-production" {
 
       content_block_manager = {
         engine                      = "postgres"
-        engine_version              = "17.6"
+        engine_version              = "17"
         allow_major_version_upgrade = true
         engine_params = {
           log_min_duration_statement = { value = 10000 }
@@ -262,7 +262,7 @@ module "variable-set-rds-production" {
 
       content_data_admin = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -280,7 +280,7 @@ module "variable-set-rds-production" {
 
       content_data_api = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
@@ -304,7 +304,7 @@ module "variable-set-rds-production" {
 
       content_store = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -322,7 +322,7 @@ module "variable-set-rds-production" {
 
       content_tagger = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -340,7 +340,7 @@ module "variable-set-rds-production" {
 
       draft_content_store = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -358,7 +358,7 @@ module "variable-set-rds-production" {
 
       email_alert_api = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -376,7 +376,7 @@ module "variable-set-rds-production" {
 
       imminence = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -396,7 +396,7 @@ module "variable-set-rds-production" {
 
       link_checker_api = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -415,7 +415,7 @@ module "variable-set-rds-production" {
 
       local_links_manager = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -433,7 +433,7 @@ module "variable-set-rds-production" {
 
       locations_api = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -451,8 +451,8 @@ module "variable-set-rds-production" {
 
       publishing_api = {
         engine                    = "postgres"
-        engine_version            = "17.6"
-        replica_engine_version    = "17.6"
+        engine_version            = "17"
+        replica_engine_version    = "17"
         replica_apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
@@ -474,7 +474,7 @@ module "variable-set-rds-production" {
 
       publisher = {
         engine         = "postgres"
-        engine_version = "17.6"
+        engine_version = "17"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -492,7 +492,7 @@ module "variable-set-rds-production" {
 
       release = {
         engine         = "mysql"
-        engine_version = "8.0.43"
+        engine_version = "8.0"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -507,7 +507,7 @@ module "variable-set-rds-production" {
 
       search_admin = {
         engine         = "mysql"
-        engine_version = "8.0.43"
+        engine_version = "8.0"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -522,7 +522,7 @@ module "variable-set-rds-production" {
 
       service_manual_publisher = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -540,7 +540,7 @@ module "variable-set-rds-production" {
 
       signon = {
         engine         = "mysql"
-        engine_version = "8.0.43"
+        engine_version = "8.0"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -555,7 +555,7 @@ module "variable-set-rds-production" {
 
       support_api = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -573,7 +573,7 @@ module "variable-set-rds-production" {
 
       transition = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -591,7 +591,7 @@ module "variable-set-rds-production" {
 
       whitehall = {
         engine         = "mysql"
-        engine_version = "8.0.43"
+        engine_version = "8.0"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -143,8 +143,9 @@ module "variable-set-rds-staging" {
 
     databases = {
       account_api = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -199,7 +200,7 @@ module "variable-set-rds-staging" {
 
       ckan = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -251,7 +252,7 @@ module "variable-set-rds-staging" {
 
       content_data_admin = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -268,8 +269,9 @@ module "variable-set-rds-staging" {
       }
 
       content_data_api = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
@@ -310,8 +312,9 @@ module "variable-set-rds-staging" {
       }
 
       content_tagger = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -346,8 +349,9 @@ module "variable-set-rds-staging" {
       }
 
       email_alert_api = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -385,7 +389,7 @@ module "variable-set-rds-staging" {
 
       link_checker_api = {
         engine         = "postgres"
-        engine_version = "14.19"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -403,8 +407,9 @@ module "variable-set-rds-staging" {
       }
 
       local_links_manager = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -421,8 +426,9 @@ module "variable-set-rds-staging" {
       }
 
       locations_api = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -440,8 +446,8 @@ module "variable-set-rds-staging" {
 
       publishing_api = {
         engine                 = "postgres"
-        engine_version         = "17.6"
-        replica_engine_version = "17.6"
+        engine_version         = "17"
+        replica_engine_version = "17"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -482,7 +488,7 @@ module "variable-set-rds-staging" {
 
       release = {
         engine         = "mysql"
-        engine_version = "8.0.43"
+        engine_version = "8.0"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -497,7 +503,7 @@ module "variable-set-rds-staging" {
 
       search_admin = {
         engine         = "mysql"
-        engine_version = "8.0.43"
+        engine_version = "8.0"
         engine_params = {
           max_allowed_packet = { value = 1073741824 }
         }
@@ -511,8 +517,9 @@ module "variable-set-rds-staging" {
       }
 
       service_manual_publisher = {
-        engine         = "postgres"
-        engine_version = "14.19"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -544,8 +551,9 @@ module "variable-set-rds-staging" {
       }
 
       support_api = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -562,8 +570,9 @@ module "variable-set-rds-staging" {
       }
 
       transition = {
-        engine         = "postgres"
-        engine_version = "14.18"
+        engine            = "postgres"
+        engine_version    = "14"
+        apply_immediately = false
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }


### PR DESCRIPTION
We want auto minor version updates to happen and our terraform not try and change them back, so set the engine_version to major only for postgres or major.minor only for MySQL.

Where the version specfied is not the current default (which is what terraform will try to set it to) I've set apply immediately to false so it doesn't interrupt the working day.