### PR TITLE
Disable the blue Elasticsearch cluster in Production

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -670,6 +670,7 @@ module "variable-set-elasticsearch-production" {
 
     engine_version         = "6.7"
     zone_awareness_enabled = true
+    elasticsearch_enabled  = false
 
     instance_count = 3
     instance_type  = "r5.4xlarge.elasticsearch"


### PR DESCRIPTION
Blue cluster running elasticsearch 6.7 can be disabled, all traffic is now being served by the green cluster running es 6.8

| Blue cluster (6.7) | Green cluster (6.8) |
|-|-|
|<img width="1374" height="457" alt="Screenshot 2026-01-15 at 10 04 37" src="https://github.com/user-attachments/assets/b85580f5-708d-41a4-bd4c-bb1ffcc87969" />|<img width="1376" height="471" alt="Screenshot 2026-01-15 at 10 06 07" src="https://github.com/user-attachments/assets/136eb737-946b-4b78-91b4-7e479617f07e" />|

