### PR TITLE
[SCH-1623] Delete objects from search analytics buckets

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/search_analytics_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_analytics_s3.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "search_analytics" {
   bucket        = "govuk-search-analytics-${var.govuk_environment}"
-  force_destroy = var.force_destroy
+  force_destroy = true
   tags = {
     System = "Search"
     Name   = "Search analytics reports for ${var.govuk_environment}"


### PR DESCRIPTION
We ceased using these buckets when universal analytics was retired in 2024, and have confirmed with our performance analyst that the objects stored within them are no longer needed. We need to delete the objects in the buckets before we can destroy the buckets themselves (in a later PR).

See [Jira ticket SCH-1623](https://gov-uk.atlassian.net/browse/SCH-1623)