### PR TITLE
Feat/dguk 131 : Add WAF rate limiting to Find application ALB

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/outputs.tf
+++ b/terraform/deployments/datagovuk-infrastructure/outputs.tf
@@ -1,0 +1,17 @@
+# WAF Outputs for reference and debugging
+output "find_waf_arn" {
+  description = "ARN of the Find WAF Web ACL"
+  value       = aws_wafv2_web_acl.find.arn
+}
+output "find_waf_id" {
+  description = "ID of the Find WAF Web ACL"
+  value       = aws_wafv2_web_acl.find.id
+}
+output "find_alb_arn" {
+  description = "ARN of the Find ALB"
+  value       = data.aws_lb.find.arn
+}
+output "find_cloudwatch_log_group" {
+  description = "CloudWatch Log Group for WAF logs"
+  value       = aws_cloudwatch_log_group.find_waf.name
+}

--- a/terraform/deployments/datagovuk-infrastructure/variables.tf
+++ b/terraform/deployments/datagovuk-infrastructure/variables.tf
@@ -43,3 +43,22 @@ variable "organogram_bucket_cors_origins" {
     "https://find.eph-aaa113.ephemeral.govuk.digital"
   ]
 }
+
+# Variables for rate limiting configuration
+variable "find_rate_limit_per_5min" {
+  description = "Rate limit for Find app per IP per 5 minutes"
+  type        = number
+  default     = 100
+}
+
+variable "find_rate_limit_warning_per_5min" {
+  description = "Warning threshold before blocking (this is for monitoring only)"
+  type        = number
+  default     = 80
+}
+
+variable "waf_log_retention_days" {
+  description = "CloudWatch log retention for WAF logs in days"
+  type        = number
+  default     = 30
+}


### PR DESCRIPTION
Added AWS WAF rate limiting to Find application ALB to mitigate 503 errors caused by bot traffic. Rate limit: 100 requests per 5 minutes per IP.

Created waf_find.tf with WAF Web ACL, 2 rate-limiting rules, and CloudWatch logging 
Rate limits configurable via Terraform variables 
Custom 429 error page with [GOV.UK](http://gov.uk/) styling 
Two-tiered approach: warning at 80, blocking at 100 req/5min

The following resources will be Created: 
- aws_wafv2_web_acl.find 
- aws_wafv2_web_acl_association.find_alb 
- aws_cloudwatch_log_group.find_waf 
- aws_wafv2_web_acl_logging_configuration.find_waf 