### PR TITLE
Add `codecommit` permissions to `tfc-aws-config`

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -48,6 +48,7 @@ data "aws_iam_policy_document" "tfc_policy" {
       "chatbot:*",
       "cloudfront:*",
       "cloudwatch:*",
+      "codecommit:*",
       "ec2:*",
       "ecr:*",
       "eks:*",


### PR DESCRIPTION
Description:
- For the GitHub Terraform workspace to manage codecommit repositories it needs to be able to perform actions on `codecommit`
- https://github.com/alphagov/govuk-infrastructure/issues/2187