### PR TITLE
Destroy old CNAMES in staging only

### DIFF
--- a/terraform/deployments/rds/rds.tf
+++ b/terraform/deployments/rds/rds.tf
@@ -338,7 +338,7 @@ resource "aws_db_instance" "replica" {
 resource "aws_route53_record" "replica_cname" {
   for_each = {
     for key, value in var.databases : key => value
-    if value.has_read_replica
+    if value.has_read_replica && var.govuk_environment != "staging"
   }
 
   # Zone is <environment>.govuk-internal.digital.


### PR DESCRIPTION
Ensure the old cnames are deleted in staging, and staging only.

The entire resource in question will be deleted on monday/tuesday so it's not worth doing a real config through tfc-configuration etc