### PR TITLE
Fix Flapping Plans by making audit_logs explicit

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb.tf
@@ -12,6 +12,12 @@ resource "aws_docdb_cluster_parameter_group" "licensify_parameter_group" {
   name        = "licensify-parameter-group"
   description = "Licensify DocumentDB cluster parameter group"
 
+  parameter {
+    name         = "audit_logs"
+    value        = "disabled"
+    apply_method = "pending-reboot"
+  }
+
   # Licensify doesn't support connecting to MongoDB via TLS
   parameter {
     name  = "tls"

--- a/terraform/deployments/govuk-publishing-infrastructure/shared_documentdb.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/shared_documentdb.tf
@@ -23,6 +23,12 @@ resource "aws_docdb_cluster_parameter_group" "shared_parameter_group" {
   description = "Shared DocumentDB cluster parameter group"
 
   parameter {
+    name         = "audit_logs"
+    value        = "disabled"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
     name  = "tls"
     value = "disabled"
   }


### PR DESCRIPTION
## What?

Because the `audit_logs` parameter keeps on flapping with every other plan/apply of this Terraform Deployment, this just sets it explicitly to try and stop Terraform from thinking the value has drifted.