### PR TITLE
feat/dguk-131: updated header_name from true-client-ip to x-forwarded-for

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/waf_find.tf
+++ b/terraform/deployments/datagovuk-infrastructure/waf_find.tf
@@ -36,7 +36,7 @@ resource "aws_wafv2_web_acl" "find" {
       rate_based_statement {
         limit              = var.find_rate_limit_warning_per_5min
         aggregate_key_type = "FORWARDED_IP"
-        # Fastly CDN passes real client IP in x-forwarded-for header
+        # Fastly CDN passes real client IP in True-Client-IP header
         # This ensures we rate limit per actual client IP, not Fastly's IPs
         forwarded_ip_config {
           fallback_behavior = "MATCH"


### PR DESCRIPTION
Changed from header_name = "true-client-ip" to header_name= "True-Client-IP" case sensitive

This change is for both rules warning and blocking will now be aggregate rate limits based on client IP from the True-Client-IP header instead of the non existent true-client-ip header