### PR TITLE
Return all RDS instances to default apply immediately setting

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -132,9 +132,8 @@ module "variable-set-rds-integration" {
 
     databases = {
       account_api = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -258,9 +257,8 @@ module "variable-set-rds-integration" {
       }
 
       content_data_api = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
@@ -301,9 +299,8 @@ module "variable-set-rds-integration" {
       }
 
       content_tagger = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -338,9 +335,8 @@ module "variable-set-rds-integration" {
       }
 
       email_alert_api = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -413,9 +409,8 @@ module "variable-set-rds-integration" {
       }
 
       local_links_manager = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -432,9 +427,8 @@ module "variable-set-rds-integration" {
       }
 
       locations_api = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -557,9 +551,8 @@ module "variable-set-rds-integration" {
       }
 
       support_api = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -576,9 +569,8 @@ module "variable-set-rds-integration" {
       }
 
       transition = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -450,10 +450,9 @@ module "variable-set-rds-production" {
       }
 
       publishing_api = {
-        engine                    = "postgres"
-        engine_version            = "17"
-        replica_engine_version    = "17"
-        replica_apply_immediately = false
+        engine                 = "postgres"
+        engine_version         = "17"
+        replica_engine_version = "17"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -143,9 +143,8 @@ module "variable-set-rds-staging" {
 
     databases = {
       account_api = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -269,9 +268,8 @@ module "variable-set-rds-staging" {
       }
 
       content_data_api = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           work_mem                             = { value = "GREATEST({DBInstanceClassMemory/${1024 * 16}},65536)" }
           autovacuum_max_workers               = { value = 1, apply_method = "pending-reboot" }
@@ -312,9 +310,8 @@ module "variable-set-rds-staging" {
       }
 
       content_tagger = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -349,9 +346,8 @@ module "variable-set-rds-staging" {
       }
 
       email_alert_api = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -407,9 +403,8 @@ module "variable-set-rds-staging" {
       }
 
       local_links_manager = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -426,9 +421,8 @@ module "variable-set-rds-staging" {
       }
 
       locations_api = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -517,9 +511,8 @@ module "variable-set-rds-staging" {
       }
 
       service_manual_publisher = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -551,9 +544,8 @@ module "variable-set-rds-staging" {
       }
 
       support_api = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }
@@ -570,9 +562,8 @@ module "variable-set-rds-staging" {
       }
 
       transition = {
-        engine            = "postgres"
-        engine_version    = "14"
-        apply_immediately = false
+        engine         = "postgres"
+        engine_version = "14"
         engine_params = {
           log_min_duration_statement = { value = 10000 }
           log_statement              = { value = "all" }


### PR DESCRIPTION
The final step of cleaning up the RDS terraform:

* Remove the apply_immediately attribute from all RDS instances so they return to our defaults for each environment

I have double checked and all RDS instances correctly patched to the default minor version over the weekend, and now all show no pending maintenance, so this is safe to apply