### PR TITLE
Add ability to grant namespaced and cluster-wide permissions to roles

### DIFF
--- a/terraform/deployments/cluster-access/eks_access.tf
+++ b/terraform/deployments/cluster-access/eks_access.tf
@@ -432,7 +432,7 @@ module "dguengineer" {
   access_policy_scope      = "namespace"
   access_policy_namespaces = ["datagovuk"]
 
-  role_rules = [
+  namespace_role_rules = [
     {
       api_groups = ["", "apps"],
       resources  = ["pods", "pods/logs", "deployments", "replicasets", "statefulsets"]

--- a/terraform/deployments/cluster-access/modules/access-entry/variables.tf
+++ b/terraform/deployments/cluster-access/modules/access-entry/variables.tf
@@ -37,7 +37,7 @@ variable "access_policy_namespaces" {
   }
 }
 
-variable "role_rules" {
+variable "namespace_role_rules" {
   type = list(
     object({
       api_groups = list(string)
@@ -45,5 +45,18 @@ variable "role_rules" {
       verbs      = list(string)
     })
   )
-  description = "List of rules to apply to kubernetes role resources"
+  description = "List of rules to apply to kubernetes namespace role resources"
+  default     = []
+}
+
+variable "cluster_role_rules" {
+  type = list(
+    object({
+      api_groups = list(string)
+      resources  = list(string)
+      verbs      = list(string)
+    })
+  )
+  description = "List of rules to apply to kubernetes cluster role resources"
+  default     = []
 }


### PR DESCRIPTION
Also add default cluster-wide permission to list and get namespaces

This is required for a lot of k8s tooling to work (e.g. kubens), and the risk in adding this is very low

https://github.com/alphagov/govuk-infrastructure/issues/3441