### PR TITLE
Remove `has_downloads` from GitHub repositories

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -186,7 +186,6 @@ resource "github_repository" "govuk_repos" {
   allow_squash_merge = true
   allow_merge_commit = true
 
-  has_downloads        = true
   vulnerability_alerts = !try(each.value.archived, false) # Archived repos cannot have vulnerability alerts
 
   delete_branch_on_merge = true


### PR DESCRIPTION
Description:
- The download feature was deprecated in [2013](https://github.blog/news-insights/the-library/goodbye-uploads/)
> In addition to providing downloadable source code archives, GitHub previously allowed you to upload files (separate from the versioned files) in the repository, and make it available for download in the Downloads Tab. Supporting these types of uploads was a source of great confusion and pain – they were too similar to the files in a Git repository. As part of our ongoing effort to keep GitHub focused on building software, we are deprecating the Downloads Tab.
- Hence we can safely remove `has_downloads` attribute from the `github_repository` resource
- See https://github.com/orgs/community/discussions/102145#discussioncomment-8351756 for deprecation of the `has_downloads` option and future removal