### PR TITLE
cluster-access: modularise fulladmin role

### DIFF
--- a/terraform/deployments/cluster-access/eks_access.tf
+++ b/terraform/deployments/cluster-access/eks_access.tf
@@ -1,5 +1,5 @@
 
-data "aws_iam_roles" "cluster-admin" { name_regex = "(\\..*-fulladmin$|\\..*-platformengineer$)" }
+data "aws_iam_roles" "cluster-admin" { name_regex = "\\..*-platformengineer$" }
 
 locals {
   developer_namespaces = ["apps", "datagovuk", "licensify"]
@@ -46,6 +46,25 @@ resource "kubernetes_cluster_role_binding_v1" "cluster_admins" {
     name      = "cluster-admins"
     api_group = "rbac.authorization.k8s.io"
   }
+}
+
+module "fulladmin" {
+  source = "./modules/access-entry"
+
+  name = "fulladmin"
+
+  cluster_name = local.cluster_name
+
+  access_policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+  access_policy_scope = "cluster"
+
+  cluster_role_rules = [
+    {
+      api_groups = ["*"]
+      resources  = ["*"]
+      verbs      = ["*"]
+    }
+  ]
 }
 
 module "developer" {


### PR DESCRIPTION
Two things to consider with this one:

* This leaves the existing TF intact, since I want to move the platformengineer role over last
* The existing TF doesn't actually include a role definition. It just binds the `cluster-admin` role that EKS manages to the users. I have copied the rules from the pre-canned `cluster-admin` role into the TF so we can manage it properly and make changes to it in the future if necessary

https://github.com/alphagov/govuk-infrastructure/issues/3442