### PR TITLE
feat/dguk-115: updated WAF rate limits for staging and production

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/locals.tf
+++ b/terraform/deployments/datagovuk-infrastructure/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  # Environment-specific rate Limits
+  # Production and Staging: 400 warning / 500 block over 5 minutes
+  # Integration and Test: 80 warning / 100 block over 5 minutes
+  waf_rate_limits = var.govuk_environment == "production" || var.govuk_environment == "staging" ? {
+    warning = 400
+    block   = 500
+    } : {
+    warning = 80
+    block   = 100
+  }
+}

--- a/terraform/deployments/datagovuk-infrastructure/outputs.tf
+++ b/terraform/deployments/datagovuk-infrastructure/outputs.tf
@@ -15,3 +15,11 @@ output "find_cloudwatch_log_group" {
   description = "CloudWatch Log Group for WAF logs"
   value       = aws_cloudwatch_log_group.find_waf.name
 }
+output "find_waf_rate_limits" {
+  description = "Current rate limit configuration for Find WAF"
+  value = {
+    environment = var.govuk_environment
+    warning     = local.waf_rate_limits.warning
+    block       = local.waf_rate_limits.block
+  }
+}

--- a/terraform/deployments/datagovuk-infrastructure/waf_find.tf
+++ b/terraform/deployments/datagovuk-infrastructure/waf_find.tf
@@ -34,7 +34,7 @@ resource "aws_wafv2_web_acl" "find" {
     }
     statement {
       rate_based_statement {
-        limit              = var.find_rate_limit_warning_per_5min
+        limit              = local.waf_rate_limits.warning
         aggregate_key_type = "FORWARDED_IP"
         # Fastly CDN passes real client IP in True-Client-IP header
         # This ensures we rate limit per actual client IP, not Fastly's IPs
@@ -91,7 +91,7 @@ resource "aws_wafv2_web_acl" "find" {
     }
     statement {
       rate_based_statement {
-        limit              = var.find_rate_limit_per_5min
+        limit              = local.waf_rate_limits.block
         aggregate_key_type = "FORWARDED_IP"
         forwarded_ip_config {
           fallback_behavior = "MATCH"


### PR DESCRIPTION
Updated waf_find.tf to use the locals instead of variables.

WAF rate limits for Staging and Production for 5 minutes

warning = 400
block = 500

WAF rate limits for test and integration for 5 minutes

warning = 80
block = 100