### PR TITLE
refactor: 💡 remove the new_name var, it's no longer needed

### DIFF
--- a/terraform/deployments/rds/security_groups.tf
+++ b/terraform/deployments/rds/security_groups.tf
@@ -1,9 +1,9 @@
 resource "aws_security_group" "instance" {
   for_each = var.databases
 
-  name        = "${local.identifier_prefix}${each.value.new_name != null ? each.value.new_name : each.value.name}-${var.govuk_environment}-${each.value.engine}-rds"
+  name        = "${local.identifier_prefix}${each.value.name}-${var.govuk_environment}-${each.value.engine}-rds"
   vpc_id      = data.tfe_outputs.vpc.nonsensitive_values.id
-  description = "Access to ${each.value.new_name != null ? each.value.new_name : each.value.name} RDS"
+  description = "Access to ${each.value.name} RDS"
 
   lifecycle { create_before_destroy = true }
 }

--- a/terraform/deployments/rds/variables.tf
+++ b/terraform/deployments/rds/variables.tf
@@ -36,7 +36,6 @@ variable "databases" {
     maintenance_window           = optional(string)
     backup_window                = optional(string)
     backup_retention_period      = optional(number)
-    new_name                     = optional(string)
     snapshot_identifier          = optional(string)
     apply_immediately            = optional(bool)
     allow_major_version_upgrade  = optional(bool, false)

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -271,8 +271,7 @@ module "variable-set-rds-integration" {
           log_lock_waits                       = { value = 1 }
         }
         engine_params_family         = "postgres14"
-        name                         = "blue-content-data-api-postgresql-primary"
-        new_name                     = "content-data-api"
+        name                         = "content-data-api"
         allocated_storage            = 1024
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
@@ -380,8 +379,7 @@ module "variable-set-rds-integration" {
           password_encryption        = { value = "md5" }
         }
         engine_params_family         = "postgres14"
-        name                         = "imminence"
-        new_name                     = "places-manager"
+        name                         = "places-manager"
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = false

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -293,8 +293,7 @@ module "variable-set-rds-production" {
           log_lock_waits                       = { value = 1 }
         }
         engine_params_family         = "postgres14"
-        name                         = "blue-content-data-api-postgresql-primary"
-        new_name                     = "content-data-api"
+        name                         = "content-data-api"
         allocated_storage            = 1024
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
@@ -385,8 +384,7 @@ module "variable-set-rds-production" {
           password_encryption        = { value = "md5" }
         }
         engine_params_family         = "postgres14"
-        name                         = "imminence"
-        new_name                     = "places-manager"
+        name                         = "places-manager"
         allocated_storage            = 100
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -282,8 +282,7 @@ module "variable-set-rds-staging" {
           log_lock_waits                       = { value = 1 }
         }
         engine_params_family         = "postgres14"
-        name                         = "blue-content-data-api-postgresql-primary"
-        new_name                     = "content-data-api"
+        name                         = "content-data-api"
         allocated_storage            = 1024
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
@@ -374,8 +373,7 @@ module "variable-set-rds-staging" {
           password_encryption        = { value = "md5" }
         }
         engine_params_family         = "postgres14"
-        name                         = "imminence"
-        new_name                     = "places-manager"
+        name                         = "places-manager"
         allocated_storage            = 100
         instance_class               = "db.t4g.medium"
         performance_insights_enabled = false


### PR DESCRIPTION
- remove `new_name` var. It was useful for helping to rename things without breaking everything, now everything is renamed, remove it