### PR TITLE
Import `govuk-user-management` run trigger for `cluster-services-*`

### DIFF
--- a/terraform/deployments/tfc-configuration/cluster-services.tf
+++ b/terraform/deployments/tfc-configuration/cluster-services.tf
@@ -27,6 +27,8 @@ module "cluster-services-integration" {
     module.variable-set-common.id,
     module.variable-set-integration.id
   ]
+
+  run_trigger_source_workspaces = ["govuk-user-management"]
 }
 
 module "cluster-services-staging" {
@@ -57,6 +59,8 @@ module "cluster-services-staging" {
     module.variable-set-common.id,
     module.variable-set-staging.id
   ]
+
+  run_trigger_source_workspaces = ["govuk-user-management"]
 }
 
 module "cluster-services-production" {
@@ -87,4 +91,21 @@ module "cluster-services-production" {
     module.variable-set-common.id,
     module.variable-set-production.id
   ]
+
+  run_trigger_source_workspaces = ["cluster-services-staging"]
+}
+
+import {
+  to = module.cluster-services-integration.tfe_run_trigger.rt["govuk-user-management"]
+  id = "rt-QG5dJ7mgszV33D18"
+}
+
+import {
+  to = module.cluster-services-staging.tfe_run_trigger.rt["govuk-user-management"]
+  id = "rt-TxjmoeQWmmxcLCCd"
+}
+
+import {
+  to = module.cluster-services-production.tfe_run_trigger.rt["cluster-services-staging"]
+  id = "rt-hiFdm9BTshymKcTX"
 }


### PR DESCRIPTION
Description:
- Trigger a run in `cluster-services-staging` and `cluster-services-integration`  whenever a run in `govuk-user-management` is triggered
- Trigger a run in `cluster-services-production` when `cluster-services-staging` is triggered
- Import this into Terraform as it is clickopsed
- See run in `tfc-configuration` to review
- https://github.com/alphagov/govuk-infrastructure/issues/2187