### PR TITLE
Trigger `ecr-production` workspace run from `GitHub` Terraform workspace run

### DIFF
--- a/terraform/deployments/tfc-configuration/github.tf
+++ b/terraform/deployments/tfc-configuration/github.tf
@@ -25,28 +25,10 @@ module "github" {
   variable_set_ids = [
     local.aws_credentials["tools"],
   ]
+
+  run_trigger_source_workspaces = ["ecr-production"]
 }
 
 resource "tfe_project" "github" {
   name = "govuk-github"
-}
-
-import {
-  to = module.github.tfe_workspace.ws
-  id = "ws-DBicPsBVXrHAqGmC"
-}
-
-import {
-  to = tfe_project.github
-  id = "prj-2VUNgc12nAZA3zkP"
-}
-
-import {
-  to = module.github.tfe_workspace_settings.ws
-  id = "ws-DBicPsBVXrHAqGmC"
-}
-
-import {
-  to = module.github.tfe_team_access.managed["GOV.UK Production"]
-  id = "govuk/Github/tws-mfwVh5vf98AE21Po"
 }


### PR DESCRIPTION
Description:
- If applications are deleted we also want the ECR repositories to be deleted as well. To ensure this happens we want `ecr-production` to be triggered when `GitHub` Terraform workspace is run
- Remove completed imports
- https://github.com/alphagov/govuk-infrastructure/issues/2187