### PR TITLE
Fix `ecr-production` trigger

### DIFF
--- a/terraform/deployments/tfc-configuration/ecr.tf
+++ b/terraform/deployments/tfc-configuration/ecr.tf
@@ -26,4 +26,6 @@ module "ecr-production" {
     module.variable-set-production.id,
     module.variable-set-ecr-production.id
   ]
+
+  run_trigger_source_workspaces = ["GitHub"]
 }

--- a/terraform/deployments/tfc-configuration/github.tf
+++ b/terraform/deployments/tfc-configuration/github.tf
@@ -25,8 +25,6 @@ module "github" {
   variable_set_ids = [
     local.aws_credentials["tools"],
   ]
-
-  run_trigger_source_workspaces = ["ecr-production"]
 }
 
 resource "tfe_project" "github" {


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/3556 put the trigger on the wrong workspace
- This ensures that `GitHub` will trigger a run in `ecr-production`