### PR TITLE
Bump Terraform version to `1.12.0`

### DIFF
--- a/terraform/deployments/tfc-configuration/variables.tf
+++ b/terraform/deployments/tfc-configuration/variables.tf
@@ -70,7 +70,7 @@ variable "workspace_tags" {
 variable "terraform_version" {
   type        = string
   description = "Version constraint for Terraform for this workspace."
-  default     = "~> 1.10.5"
+  default     = "~> 1.12.0"
 }
 
 variable "trigger_patterns" {


### PR DESCRIPTION
Description:
- Set Terraform version to `1.12.0`
- https://github.com/alphagov/govuk-infrastructure/issues/2187