### PR TITLE
feat: 🎸 tf move resource name change

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -43,7 +43,7 @@ locals {
     coredns        = { addon_version = "v1.12.4-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
     kube-proxy     = { addon_version = "v1.33.7-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE" }
     metrics-server = { addon_version = "v0.8.0-eksbuild.6", resolve_conflicts_on_create = "OVERWRITE" }
-    vpc-cni        = { addon_version = "v1.21.1-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
+    vpc-cni        = { addon_version = "v1.21.1-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE", before_compute = true }
   }
 
   kube_state_metrics_addon = {
@@ -210,6 +210,11 @@ resource "aws_iam_role_policy_attachment" "node" {
   ])
   policy_arn = "arn:aws:iam::aws:policy/${each.key}"
   role       = aws_iam_role.node.name
+}
+
+moved {
+  from = module.eks.aws_eks_addon.this["vpc-cni"]
+  to   = module.eks.aws_eks_addon.before_compute["vpc-cni"]
 }
 
 module "eks" {


### PR DESCRIPTION
This unblocks the creation of new ephemeral clusters.

- deleting and creating the vpc-cni feels dangerous. Update the config with a `moved` tf block and avoid deleting the addon.
- NOOP.

follows from this pr which was reverted because it deleted and created the vpc cni in staging https://github.com/alphagov/govuk-infrastructure/pull/3541