### PR TITLE
Allow national data library team to log in through dex

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-common.tf
+++ b/terraform/deployments/tfc-configuration/variables-common.tf
@@ -5,8 +5,13 @@ module "variable-set-common" {
   priority = false
   tfvars = {
     dex_github_orgs_teams = [{
-      name  = "alphagov"
-      teams = ["gov-uk", "gov-uk-production-deploy", "gov-uk-ithc-and-penetration-testing"]
+      name = "alphagov"
+      teams = [
+        "gov-uk",
+        "gov-uk-production-deploy",
+        "gov-uk-ithc-and-penetration-testing",
+        "national-data-library",
+      ]
     }]
   }
 }


### PR DESCRIPTION
Precursor to configuring the permissions for the ndl team in each of our different apps