### PR TITLE
Allow national data library team to log in readonly to argocd

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -30,6 +30,7 @@ locals {
     "policy.csv" = <<-EOT
     g, ${var.github_read_only_team}, role:readonly
     g, ${var.github_ithc_team}, role:readonly
+    g, ${var.github_national_data_library_team}, role:readonly
     g, ${var.github_read_write_team}, role:admin
     EOT
   }

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -40,6 +40,12 @@ variable "github_ithc_team" {
   default     = "alphagov:gov-uk-ithc-and-penetration-testing"
 }
 
+variable "github_national_data_library_team" {
+  type        = string
+  description = "Name of the GitHub team for the National Data Library team to have read-only access to Dex SSO-enabled applications"
+  default     = "alphagov:national-data-library"
+}
+
 variable "helm_timeout_seconds" {
   type        = number
   description = "Timeout for helm install/upgrade operations."


### PR DESCRIPTION
Readonly is the default, but lets be explicit about as we are about the ITHC team