### PR TITLE
Increase concurrent PRs to 20

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,12 +20,13 @@
     ],
     "packageRules": [
       {
-        "matchDepTypes": ["helm_release", "provider", "modules", "required_provider", "required_version"],
+        "matchDepTypes": ["required_version"],
         "rangeStrategy": "bump"
       }
     ]
   },
   "prHourlyLimit": 20,
+  "prConcurrentLimit": 20,
   "labels": [
     "dependencies",
     "renovate"


### PR DESCRIPTION
Description:
- Increase the amount of concurrent PRs that Renovate can open to 20
- For `required_version` bump the range
- https://github.com/alphagov/govuk-infrastructure/issues/2187