### PR TITLE
Configure Renovate to bump the `terraform_version` variable

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,19 @@
       "depNameTemplate": "{{depName}}",
       "datasourceTemplate": "aws-eks-addon",
       "versioningTemplate": "aws-eks-addon"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/.*tfc-configuration\\/variables\\.tf/"
+      ],
+      "matchStrings": [
+        "default\\s+=\\s+\"~>\\s+(?<currentValue>[0-9.]+)\""
+      ],
+      "packageNameTemplate": "hashicorp/terraform",
+      "depNameTemplate": "Terraform Version",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
Description:
- Use a custom regex to match on [govuk-infrastructure/terraform/deployments/tfc-configuration/variables.tf](https://github.com/alphagov/govuk-infrastructure/blob/7b3b326dbe237dab3f76befa7c749dea07e8ef31/terraform/deployments/tfc-configuration/variables.tf#L70) `terraform_version` variable
- See https://regex101.com/r/Tp2nnd/1 for sample string that matches the regex (e.g. `default ~> "1.14.1"`)
- https://github.com/alphagov/govuk-infrastructure/issues/2187