### PR TITLE
Configure Renovate to bump ephemeral Terraform version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,7 +55,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/.*tfc-configuration\\/variables\\.tf/"
+        "/.*tfc-configuration\\/variables\\.tf/",
+        "/.*ws\\/variables\\.tf/"
       ],
       "matchStrings": [
         "default\\s+=\\s+\"~>\\s+(?<currentValue>[0-9.]+)\""


### PR DESCRIPTION
Description:
- Configure Renovate to bump the Terraform version in the ephemeral environment
- https://github.com/alphagov/govuk-infrastructure/pull/3589