### PR TITLE
Group `required_version` updates separate in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,14 +17,6 @@
   "terraform": {
     "managerFilePatterns": [
       "/^/terraform/.*\\.tf$/"
-    ],
-    "packageRules": [
-      {
-        "matchDepTypes": [
-          "required_version"
-        ],
-        "rangeStrategy": "bump"
-      }
     ]
   },
   "prHourlyLimit": 20,
@@ -38,6 +30,21 @@
       "matchDatasources": [
         "aws-eks-addon"
       ]
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": [
+        "Terraform Version"
+      ],
+      "groupName": "Terraform Version"
+    },
+    {
+      "matchManagers": ["terraform"],
+      "matchDepTypes": [
+        "required_version"
+      ],
+      "rangeStrategy": "bump",
+      "groupName": "Terraform required_version"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Description:
- Keep Terraform version and `required_version` updates separately
- https://github.com/alphagov/govuk-infrastructure/issues/2187