### PR TITLE
BAU - Bump DGU iam-aws-module-6.0

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/ckan_iam.tf
+++ b/terraform/deployments/datagovuk-infrastructure/ckan_iam.tf
@@ -1,13 +1,16 @@
 
 module "ckan_iam_role" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> 5.0"
-  create_role                   = true
-  role_name                     = "${var.ckan_service_account_name}-${local.cluster_id}"
-  role_description              = "Role for CKAN S3 access. Corresponds to ${var.ckan_service_account_namespace}/${var.ckan_service_account_name} k8s ServiceAccount."
-  provider_url                  = local.oidc_provider
-  role_policy_arns              = [aws_iam_policy.ckan.arn]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.ckan_service_account_namespace}:${var.ckan_service_account_name}"]
+  source             = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version            = "~> 6.0"
+  name               = "${var.ckan_service_account_name}-${local.cluster_id}"
+  use_name_prefix    = false
+  description        = "Role for CKAN S3 access. Corresponds to ${var.ckan_service_account_namespace}/${var.ckan_service_account_name} k8s ServiceAccount."
+  enable_oidc        = true
+  oidc_provider_urls = [local.oidc_provider]
+  policies = {
+    "${aws_iam_policy.ckan.name}" = aws_iam_policy.ckan.arn
+  }
+  oidc_subjects = ["system:serviceaccount:${var.ckan_service_account_namespace}:${var.ckan_service_account_name}"]
 }
 
 resource "aws_iam_policy" "ckan" {
@@ -27,4 +30,9 @@ data "aws_iam_policy_document" "ckan" {
       "${aws_s3_bucket.datagovuk-organogram.arn}/*"
     ]
   }
+}
+
+moved {
+  from = module.ckan_iam_role.aws_iam_role_policy_attachment.custom[0]
+  to   = module.ckan_iam_role.aws_iam_role_policy_attachment.this["EKS-CKAN-govuk"]
 }

--- a/terraform/deployments/search-api-v2/modules/serving_config/variables.tf
+++ b/terraform/deployments/search-api-v2/modules/serving_config/variables.tf
@@ -17,19 +17,19 @@ variable "boost_control_ids" {
   description = "The IDs of the boost controls to attach to the serving config"
   type        = list(string)
   # VAIS internally uses null instead of an empty array, so we do the same to avoid drift
-  default     = null
+  default = null
 }
 
 variable "filter_control_ids" {
   description = "The IDs of the filter controls to attach to the serving config"
   type        = list(string)
   # VAIS internally uses null instead of an empty array, so we do the same to avoid drift
-  default     = null
+  default = null
 }
 
 variable "synonyms_control_ids" {
   description = "The IDs of the synonym controls to attach to the serving config"
   type        = list(string)
   # VAIS internally uses null instead of an empty array, so we do the same to avoid drift
-  default     = null
+  default = null
 }


### PR DESCRIPTION
Description:
- See https://github.com/terraform-aws-modules/terraform-aws-iam/blob/master/docs/UPGRADE-6.0.md
- See Terraform plan for review
- The [docs](https://github.com/terraform-aws-modules/terraform-aws-iam/blob/master/docs/UPGRADE-6.0.md#state-changes-1) state to remove all prior policy attachments and that policies will stay attached to the new role with new attachment IDs will be created on next apple. However a `moved` block seems to work just as fine as the [previous](https://github.com/terraform-aws-modules/terraform-aws-iam/blob/c29ec1ed409683086f63f83ff5b10a6f3c296ef2/modules/iam-assumable-role-with-oidc/main.tf#L114) `aws_iam_policy_attachment` name was `custom[0]` and we are now moving to `aws_iam_policy_attachment.this`