### PR TITLE
Bump infrastructure-sensitive module to 0.0.25

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -5,7 +5,7 @@
 
 module "infrastructure-sensitive_wafs" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/wafs"
-  version = "0.0.24"
+  version = "0.0.25"
 
   cache_public_base_rate_limit = var.cache_public_base_rate_limit
   cache_public_post_rate_limit = var.cache_public_post_rate_limit

--- a/terraform/deployments/tfc-configuration/variables-sensitive.tf
+++ b/terraform/deployments/tfc-configuration/variables-sensitive.tf
@@ -1,4 +1,4 @@
 module "sensitive-variables" {
   source  = "app.terraform.io/govuk/infrastructure-sensitive/govuk//modules/variables"
-  version = "0.0.24"
+  version = "0.0.25"
 }


### PR DESCRIPTION
We released a new version of it with updates IP allow lists.