### PR TITLE
Grants cluster access to the team maintaining Licensify

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -28,9 +28,10 @@ locals {
     "policy.default" = "role:admin"
     } : {
     "policy.csv" = <<-EOT
-    g, ${var.github_read_only_team}, role:readonly
     g, ${var.github_ithc_team}, role:readonly
+    g, ${var.github_licensing_team}, role:readonly
     g, ${var.github_national_data_library_team}, role:readonly
+    g, ${var.github_read_only_team}, role:readonly
     g, ${var.github_read_write_team}, role:admin
     EOT
   }

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -46,6 +46,12 @@ variable "github_national_data_library_team" {
   default     = "alphagov:national-data-library"
 }
 
+variable "github_licensing_team" {
+  type        = string
+  description = "Name of the GitHub team for the team maintaining Licensify to have read-only access to Dex SSO-enabled applications"
+  default     = "alphagov:gov-uk-licensing-support"
+}
+
 variable "helm_timeout_seconds" {
   type        = number
   description = "Timeout for helm install/upgrade operations."

--- a/terraform/deployments/tfc-configuration/variables-common.tf
+++ b/terraform/deployments/tfc-configuration/variables-common.tf
@@ -8,8 +8,9 @@ module "variable-set-common" {
       name = "alphagov"
       teams = [
         "gov-uk",
-        "gov-uk-production-deploy",
         "gov-uk-ithc-and-penetration-testing",
+        "gov-uk-licensing-support",
+        "gov-uk-production-deploy",
         "national-data-library",
       ]
     }]


### PR DESCRIPTION
Access granted to everything behind Dex, plus ArgoCD