### PR TITLE
fix: 🐛 ext dns deploy error in ephemeral clusters

### DIFF
--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -25,7 +25,7 @@ resource "helm_release" "external_dns" {
     }
     automountServiceAccountToken = true
     serviceMonitor = {
-      enabled = true
+      enabled = var.ext_dns_enable_service_monitor
     }
     revisionHistoryLimit = 10
     txtOwnerId           = "govuk"

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -97,3 +97,9 @@ variable "ship_kubernetes_events_to_logit" {
   description = "Whether to deploy the kubernetes-events-shipper helm chart which ships kubernetes events to logit"
   default     = true
 }
+
+variable "ext_dns_enable_service_monitor" {
+  type        = bool
+  description = "Whether to enable service monitors for external dns"
+  default     = true
+}

--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -24,9 +24,10 @@ module "var_set" {
     enable_x86_workers         = false
     arm_workers_instance_types = ["m7g.2xlarge"]
 
-    backup_retention_period = 0
-    skip_final_snapshot     = true
-    multi_az                = true
+    backup_retention_period        = 0
+    skip_final_snapshot            = true
+    multi_az                       = true
+    ext_dns_enable_service_monitor = false
 
     databases = {
       ckan = {


### PR DESCRIPTION
NOOP
- ephemeral clusters fail to build first time as external dns in `cluster-services` fails with the following error:

```
Error: installation failed
with helm_release.external_dns
on external_dns.tf line 1, in resource "helm_release" "external_dns":

resource "helm_release" "external_dns" {

unable to build kubernetes objects from release manifest: resource mapping not found for name: "external-dns" namespace: "cluster-services" from "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first
```

Because prom is created by argo, external_dns fails. Turn off service monitor in ephemeral.