### PR TITLE
BAU - Remove `moved` block

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_ebs_csi_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_ebs_csi_iam.tf
@@ -16,11 +16,6 @@ module "aws_ebs_csi_driver_iam_role" {
   oidc_subjects = ["system:serviceaccount:kube-system:${local.ebs_csi_driver_controller_service_account_name}"]
 }
 
-moved {
-  from = module.aws_ebs_csi_driver_iam_role.aws_iam_role_policy_attachment.custom[0]
-  to   = module.aws_ebs_csi_driver_iam_role.aws_iam_role_policy_attachment.this["AWSEbsCsiController-govuk"]
-}
-
 data "aws_iam_policy_document" "aws_ebs_csi_driver" {
   statement {
     effect = "Allow"

--- a/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_lb_controller_iam.tf
@@ -23,10 +23,6 @@ module "aws_lb_controller_iam_role" {
   oidc_subjects = ["system:serviceaccount:${local.cluster_services_namespace}:${local.aws_lb_controller_service_account_name}"]
 }
 
-moved {
-  from = module.aws_lb_controller_iam_role.aws_iam_role_policy_attachment.custom[0]
-  to   = module.aws_lb_controller_iam_role.aws_iam_role_policy_attachment.this["AWSLoadBalancerController-govuk"]
-}
 
 resource "aws_iam_policy" "aws_lb_controller" {
   name        = "AWSLoadBalancerController-${var.cluster_name}"

--- a/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/cluster_autoscaler_iam.tf
@@ -34,10 +34,6 @@ module "cluster_autoscaler_iam_role" {
   oidc_subjects = ["system:serviceaccount:${local.cluster_autoscaler_service_account_namespace}:${local.cluster_autoscaler_service_account_name}"]
 }
 
-moved {
-  from = module.cluster_autoscaler_iam_role.aws_iam_role_policy_attachment.custom[0]
-  to   = module.cluster_autoscaler_iam_role.aws_iam_role_policy_attachment.this["EKSClusterAutoscaler-govuk"]
-}
 
 resource "aws_iam_policy" "cluster_autoscaler" {
   name        = "EKSClusterAutoscaler-${var.cluster_name}"

--- a/terraform/deployments/cluster-infrastructure/external_dns.tf
+++ b/terraform/deployments/cluster-infrastructure/external_dns.tf
@@ -25,10 +25,6 @@ module "external_dns_iam_role" {
   oidc_subjects = ["system:serviceaccount:${local.cluster_services_namespace}:${local.external_dns_service_account_name}"]
 }
 
-moved {
-  from = module.external_dns_iam_role.aws_iam_role_policy_attachment.custom[0]
-  to   = module.external_dns_iam_role.aws_iam_role_policy_attachment.this["EKSExternalDNS-govuk"]
-}
 
 resource "aws_iam_policy" "external_dns" {
   name        = "EKSExternalDNS-${var.cluster_name}"

--- a/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/external_secrets_iam.tf
@@ -22,10 +22,6 @@ module "external_secrets_iam_role" {
   oidc_subjects = ["system:serviceaccount:${local.cluster_services_namespace}:${local.external_secrets_service_account_name}"]
 }
 
-moved {
-  from = module.external_secrets_iam_role.aws_iam_role_policy_attachment.custom[0]
-  to   = module.external_secrets_iam_role.aws_iam_role_policy_attachment.this["EKSExternalSecrets-govuk"]
-}
 
 resource "aws_iam_policy" "external_secrets" {
   name        = "EKSExternalSecrets-${var.cluster_name}"

--- a/terraform/deployments/cluster-infrastructure/grafana.tf
+++ b/terraform/deployments/cluster-infrastructure/grafana.tf
@@ -17,11 +17,6 @@ module "grafana_iam_role" {
   oidc_subjects = ["system:serviceaccount:${local.monitoring_namespace}:${local.grafana_service_account}"]
 }
 
-moved {
-  from = module.grafana_iam_role.aws_iam_role_policy_attachment.custom[0]
-  to   = module.grafana_iam_role.aws_iam_role_policy_attachment.this["grafana-govuk"]
-}
-
 data "aws_iam_policy_document" "grafana" {
   statement {
     sid    = "AllowReadingMetricsFromCloudWatch"

--- a/terraform/deployments/cluster-services/renovate_irsa.tf
+++ b/terraform/deployments/cluster-services/renovate_irsa.tf
@@ -22,11 +22,6 @@ module "renovate_irsa" {
   }
 }
 
-moved {
-  from = module.renovate_irsa[0].aws_iam_role_policy_attachment.this["policy"]
-  to   = module.renovate_irsa[0].aws_iam_role_policy_attachment.additional["policy"]
-}
-
 data "aws_iam_policy_document" "renovate_eks_describe_addons" {
   statement {
     sid    = "AllowDescribeEKSAddonVersions"

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -121,11 +121,6 @@ data "github_team" "co_platform_engineering" {
   slug = "co-platform-engineering"
 }
 
-moved {
-  from = github_team_repository.govuk_ai_accelerator_repos
-  to   = github_team_repository.govuk_ai_accelerator_repos["govuk-ai-accelerator"]
-}
-
 resource "github_team_repository" "govuk_ai_accelerator_repos" {
   for_each   = toset(var.govuk_ai_accelerator_repo_names)
   repository = each.value

--- a/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
@@ -443,7 +443,7 @@ data "aws_iam_policy_document" "govuk_mirror_sync" {
       "athena:StartQueryExecution"
     ]
     resources = [
-      "arn:aws:athena:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:workgroup/*",
+      "arn:aws:athena:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:workgroup/*",
     ]
   }
 
@@ -495,9 +495,9 @@ data "aws_iam_policy_document" "govuk_mirror_sync" {
       "glue:GetPartitions",
     ]
     resources = [
-      "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog",
-      "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/fastly_logs",
-      "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/fastly_logs/govuk_www",
+      "arn:aws:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog",
+      "arn:aws:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:database/fastly_logs",
+      "arn:aws:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:table/fastly_logs/govuk_www",
     ]
     condition {
       test     = "ForAnyValue:StringEquals"

--- a/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/wafs.tf
@@ -16,11 +16,6 @@ module "infrastructure-sensitive_wafs" {
 }
 
 
-moved {
-  from = aws_wafv2_web_acl.cache_public
-  to   = module.infrastructure-sensitive_wafs.aws_wafv2_web_acl.cache_public
-}
-
 resource "aws_wafv2_web_acl" "default" {
   name  = "x-always-block_web_acl"
   scope = "REGIONAL"


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-infrastructure/pull/2792 introduced some `moved` blocks which can be removed
- Replace `data.aws_region.current.name` with `data.aws_region.current.region` as the former is deprecated