### PR TITLE
Adding a second private repo to store thoughtworks owned code

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1041,3 +1041,9 @@ repos:
     # standard security checks are disabled as not configured for a private repo
     can_be_deployed: false
     visibility: private
+
+  govuk-ai-accelerator-tw-accelerator:
+    # standard security checks are disabled as not configured for a private repo
+    can_be_deployed: false
+    visibility: private
+    

--- a/terraform/deployments/github/variables.tf
+++ b/terraform/deployments/github/variables.tf
@@ -16,6 +16,6 @@ variable "github_app_pem_file" {
 variable "govuk_ai_accelerator_repo_names" {
   # repos to be used in the GOV.UK Publishing AI alpha
   type    = list(string)
-  default = ["govuk-ai-accelerator", "govuk-ai-accelerator-tooling"]
+  default = ["govuk-ai-accelerator", "govuk-ai-accelerator-tooling", "govuk-ai-accelerator-tw-accelerator"]
 }
 


### PR DESCRIPTION
As part of the AI accelerator work we will be working with some thoughtworks code that we don't want to be in a public repo at this stage. This PR creates a repo to have a private fork.