### PR TITLE
IA-2490: correct path for gcp-ga4-aggregate-analytics

### DIFF
--- a/terraform/deployments/gcp-ga4-aggregate-analytics/README.md
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/README.md
@@ -1,0 +1,1 @@
+# gcp-ga4-aggregate-analytics

--- a/terraform/deployments/tfc-configuration/gcp-projects.tf
+++ b/terraform/deployments/tfc-configuration/gcp-projects.tf
@@ -38,8 +38,8 @@ module "gcp-ga4-aggregate-analytics" {
   workspace_tags      = ["production", "ga4-aggregate-analytics", "gcp"]
   terraform_version   = var.terraform_version
   execution_mode      = "remote"
-  working_directory   = "/terraform/deployments/ga4-aggregate-analytics/"
-  trigger_patterns    = ["/terraform/deployments/ga4-aggregate-analytics/**/*"]
+  working_directory   = "/terraform/deployments/gcp-ga4-aggregate-analytics/"
+  trigger_patterns    = ["/terraform/deployments/gcp-ga4-aggregate-analytics/**/*"]
   global_remote_state = true
 
   project_name = "govuk-data-engineering"


### PR DESCRIPTION
Corrects `working_directory` and `trigger_patterns` from `ga4-aggregate-analytics` -> `gcp-ga4-aggregate-analytics`