### PR TITLE
Add s3 buckets for ai accelarator

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_s3.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "https_only" {
 
 resource "aws_s3_bucket_policy" "govuk_ai_accelerator_data_bucket_policy" {
   bucket = aws_s3_bucket.govuk_ai_accelerator_data[0].id
-  policy = data.aws_iam_policy_document.https_only.json
+  policy = data.aws_iam_policy_document.https_only[0].json
 
   count = var.govuk_environment == "integration" ? 1 : 0
 }


### PR DESCRIPTION
PR to add a new bucket for the AI Accelerator work in GOV.UK Publishing.

Should be encrypted, versioned and not public.

This configuration is based on the work by GOV.UK Forms: https://github.com/alphagov/forms-deploy/blob/main/infra/modules/secure-bucket/main.tf