### PR TITLE
Make content-data-api 256 GB bigger in lower envs

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -272,7 +272,7 @@ module "variable-set-rds-integration" {
         }
         engine_params_family         = "postgres14"
         name                         = "content-data-api"
-        allocated_storage            = 1024
+        allocated_storage            = 1280
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -283,7 +283,7 @@ module "variable-set-rds-staging" {
         }
         engine_params_family         = "postgres14"
         name                         = "content-data-api"
-        allocated_storage            = 1024
+        allocated_storage            = 1280
         instance_class               = "db.m6g.large"
         performance_insights_enabled = false
         project                      = "GOV.UK - Publishing"


### PR DESCRIPTION
In lower envs, where a database sync is done by restoring an anonymised backup from a higher env, then renaming the databases, and finally deleting the older database, content-data-api keeps triggering our alert for free space during the sync. So lets make the lower envs 256 GB bigger to accomodate the sync without worry that it will run out of disk space