### PR TITLE
Update Argo CD Helm release to v9

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -60,7 +60,7 @@ resource "helm_release" "argo_cd" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://argoproj.github.io/argo-helm"
-  version          = "8.6.4"
+  version          = "9.4.1"
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     global = {
@@ -86,6 +86,7 @@ resource "helm_release" "argo_cd" {
       params = {
         "server.insecure"                 = true
         "controller.sync.timeout.seconds" = 300
+        "applicationsetcontroller.policy" = "sync"
       }
 
       rbac = local.argo_rbac_policy


### PR DESCRIPTION
Description:
- See https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/README.md#900
- Default value for `applicationsetcontroller.policy` in the Helm chart was `sync` but now it is `""`. Explicitly set this so we get the default behaviour back
- https://github.com/alphagov/govuk-infrastructure/pull/3020