### PR TITLE
Enable the CloudBilling API in Google Cloud Platform

### DIFF
--- a/terraform/deployments/tfc-aws-config/gcp_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/gcp_oidc.tf
@@ -7,7 +7,8 @@ data "google_project" "project" {}
 resource "google_project_service" "enable" {
   for_each = toset([
     "cloudresourcemanager.googleapis.com",
-    "iamcredentials.googleapis.com"
+    "iamcredentials.googleapis.com",
+    "cloudbilling.googleapis.com"
   ])
   service = each.key
 }


### PR DESCRIPTION
The new "gcp-ga4-aggregate-analytics" Terraform deployment makes use of the service, but the service wasn't enabled.