### PR TITLE
Grant GCP principal used by Terraform more power

### DIFF
--- a/terraform/deployments/tfc-aws-config/gcp_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/gcp_oidc.tf
@@ -1,5 +1,6 @@
 locals {
-  google_project = var.govuk_environment == "staging" ? "govuk-staging-160211" : "govuk-${var.govuk_environment}"
+  google_project         = var.govuk_environment == "staging" ? "govuk-staging-160211" : "govuk-${var.govuk_environment}"
+  tfc_identity_principal = "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/terraform-cloud-${var.govuk_environment}/subject/govuk"
 }
 
 data "google_project" "project" {}
@@ -43,10 +44,18 @@ resource "google_project_iam_member" "tfc" {
 
 data "google_iam_policy" "tfc" {
   binding {
-    role = "roles/iam.workloadIdentityUser"
-    members = [
-      "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/terraform-cloud-${var.govuk_environment}/subject/govuk"
-    ]
+    role    = "roles/iam.workloadIdentityUser"
+    members = [local.tfc_identity_principal]
+  }
+
+  binding {
+    role    = "roles/resourcemanager.projectCreator"
+    members = [local.tfc_identity_principal]
+  }
+
+  binding {
+    role    = "roles/billing.user"
+    members = [local.tfc_identity_principal]
   }
 }
 


### PR DESCRIPTION
The principal is now
* a billing user
* a project creator

It needs to be a project creator according to the GCP Terraform provider docs [1], and it needs to be a billing user because the "gcp-ga4-aggregate-analytics" Terraform root needs it.

[1] https://registry.terraform.io/providers/hashicorp/google/7.18.0/docs/resources/google_project