### PR TITLE
Remove the billing.user role from the GCP principal

### DIFF
--- a/terraform/deployments/tfc-aws-config/gcp_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/gcp_oidc.tf
@@ -52,11 +52,6 @@ data "google_iam_policy" "tfc" {
     role    = "roles/resourcemanager.projectCreator"
     members = [local.tfc_identity_principal]
   }
-
-  binding {
-    role    = "roles/billing.user"
-    members = [local.tfc_identity_principal]
-  }
 }
 
 resource "google_service_account_iam_policy" "tfc" {


### PR DESCRIPTION
The `billing.user` role cannot be given to the resource type we specified. We should roll it back while we work out what it should be, so that the Terraform can still be applied if it needs to be.

> Error setting IAM policy for service account
> 'projects/govuk-production/serviceAccounts/terraform-cloud-production@govuk-production.iam.gserviceaccount.com':
> googleapi: Error 400: Role roles/billing.user is not supported for this
> resource., badRequestâ