### PR TITLE
Set permissions for the AI Alpha github team to maintain. 

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -125,7 +125,7 @@ resource "github_team_repository" "govuk_ai_accelerator_repos" {
   for_each   = toset(var.govuk_ai_accelerator_repo_names)
   repository = each.value
   team_id    = github_team.govuk_ai_accelerator.id
-  permission = "push"
+  permission = "maintain"
 }
 
 resource "github_team_repository" "govuk_production_admin_repos" {


### PR DESCRIPTION
This team only has access to the 3 repos that constitute the Publishing alpha. this is to allow the MSP team to manage their code within the team.

Currently they are in the setup phase of the alpha and are making frequent code changes as they setup the code.