### PR TITLE
[PP-7517] Add new govuk_content_item_loader repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -472,6 +472,15 @@ repos:
         - Run RSpec
         - Test GOV.UK Chat / Run RSpec
 
+  govuk_content_item_loader:
+    can_be_deployed: true
+    homepage_url: "https://rubygems.org/gems/govuk_content_item_loader"
+    publishes_gem: true
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - test
+
   govuk_document_types:
     homepage_url: "https://docs.publishing.service.gov.uk/document-types.html"
     publishes_gem: true


### PR DESCRIPTION
New repo for a gem to provide medium-term sharing mechanism for logic that needs to be used consistently across seven frontend applications.

It was considered unsuitable for existing gems (See: https://github.com/alphagov/govuk_app_config/pull/575)