### PR TITLE
Adding postgres17 database to support the AI Accelerator alpha

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -383,7 +383,6 @@ module "variable-set-rds-integration" {
         instance_class               = "db.m6g.large"
         performance_insights_enabled = true
         project                      = "GOV.UK - AI Accelerator"
-        snapshot_identifier          = "govuk-ai-accelerator-postgres-post-encryption"
       }
 
       link_checker_api = {


### PR DESCRIPTION
Adds a postgres17 database for the AI Alpha project.

Uses same engine type and storage as the publishing_api as may end up working on similar large datasets.