### PR TITLE
Pin Docker engine version to 28.5.2 in multiarch image build workflow

### DIFF
--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -61,6 +61,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
+        with:
+          version: "version=28.5.2"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.gitRef }}
@@ -131,6 +135,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
+        with:
+          version: "version=28.5.2"
+
       - name: Download Digests
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:


### PR DESCRIPTION
The current Ubuntu runners provided by GitHub contain Docker engine v29, which is incompatible with how we're building container images. This pins the version to 28.5.2.

See also: https://github.com/alphagov/govuk-ruby-images/pull/182