### PR TITLE
IA-2491: import GCP project gds-bq-processing and owners and editors config

### DIFF
--- a/terraform/deployments/gcp-gds-bq-processing/imports.tf
+++ b/terraform/deployments/gcp-gds-bq-processing/imports.tf
@@ -1,0 +1,14 @@
+import {
+  id = "gds-bq-processing"
+  to = google_project.project
+}
+
+import {
+  to = google_project_iam_binding.project_owners
+  id = "gds-bq-processing roles/owner"
+}
+
+import {
+  to = google_project_iam_binding.project_editors
+  id = "gds-bq-processing roles/editor"
+}

--- a/terraform/deployments/gcp-gds-bq-processing/main.tf
+++ b/terraform/deployments/gcp-gds-bq-processing/main.tf
@@ -16,3 +16,14 @@ terraform {
 
   required_version = "~> 1.14"
 }
+
+provider "google" {
+  project = "gds-bq-processing"
+}
+
+resource "google_project" "project" {
+  name            = "gds-bq-processing"
+  project_id      = "gds-bq-processing"
+  folder_id       = "278098142879"
+  billing_account = "015C7A-FAF970-B0D375"
+}

--- a/terraform/deployments/gcp-gds-bq-processing/project_iam_binding.tf
+++ b/terraform/deployments/gcp-gds-bq-processing/project_iam_binding.tf
@@ -1,0 +1,18 @@
+resource "google_project_iam_binding" "project_owners" {
+  project = google_project.project.project_id
+  role    = "roles/owner"
+
+  members = [
+    "group:gcp-gds-bq-processing-owners@digital.cabinet-office.gov.uk",
+    "user:ian.ansell@digital.cabinet-office.gov.uk",
+    "serviceAccount:terraform-cloud-production@govuk-production.iam.gserviceaccount.com",
+  ]
+}
+
+resource "google_project_iam_binding" "project_editors" {
+  project = google_project.project.project_id
+  role    = "roles/editor"
+  members = [
+    "group:gcp-gds-bq-processing-editors@digital.cabinet-office.gov.uk",
+  ]
+}


### PR DESCRIPTION
Import existing `gds-bq-processing` project's config and editor and owner roles management into terraform.

Have also updated [docs](https://gov-uk.atlassian.net/wiki/spaces/GIAT/pages/5131894792/Managing+GCP+projects+with+Terraform#Create-a-GCP-project-via-click-ops-and-import-to-Terraform) with step to add terraform SA when importing a project created previously created via click-ops.