### PR TITLE
Add `ALPHAGOV_RUBYGEMS_API_KEY` to gem repos

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -333,3 +333,8 @@ resource "github_actions_organization_secret_repositories" "slack_webhook_url" {
   secret_name             = "GOVUK_SLACK_WEBHOOK_URL" # pragma: allowlist secret
   selected_repository_ids = [for repo in data.github_repository.govuk : repo.repo_id]
 }
+
+resource "github_actions_organization_secret_repositories" "rubygems_api_key" {
+  secret_name             = "ALPHAGOV_RUBYGEMS_API_KEY" # pragma: allowlist secret
+  selected_repository_ids = [for repo in local.gems : repo.repo_id]
+}


### PR DESCRIPTION
It's currently a manual task performed by GitHub Admins.  Adding the secret to selected repos in the Terraform deployment will automate the process. 

All but one repo already have this secret so I'm not sure what will happen on apply.

### Follow up tasks:

- [ ] Update the [Dev docs](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#:~:text=The%20ALPHAGOV_RUBYGEMS_API_KEY%20secret%20is%20an%20organisation%20secret%20that%20is%20added%20to%20individual%20repositories%20by%20a%20GitHub%20Admin.%20Please%20talk%20to%20GOV.UK%20Senior%20Tech%20for%20this%20to%20be%20added%20to%20a%20repo.)