### PR TITLE
IA-2491: bind code-viewers group to gds-bq-processing dataform.viewer role permissions

### DIFF
--- a/terraform/deployments/gcp-gds-bq-processing/project_iam_binding.tf
+++ b/terraform/deployments/gcp-gds-bq-processing/project_iam_binding.tf
@@ -4,7 +4,6 @@ resource "google_project_iam_binding" "project_owners" {
 
   members = [
     "group:gcp-gds-bq-processing-owners@digital.cabinet-office.gov.uk",
-    "user:ian.ansell@digital.cabinet-office.gov.uk",
     "serviceAccount:terraform-cloud-production@govuk-production.iam.gserviceaccount.com",
   ]
 }
@@ -14,5 +13,20 @@ resource "google_project_iam_binding" "project_editors" {
   role    = "roles/editor"
   members = [
     "group:gcp-gds-bq-processing-editors@digital.cabinet-office.gov.uk",
+  ]
+}
+
+# Creating this role with no members allows terraform to enforce that nobody should have project-wide roles/viewer access.
+resource "google_project_iam_binding" "project_viewers" {
+  project = google_project.project.project_id
+  role    = "roles/viewer"
+  members = []
+}
+
+resource "google_project_iam_binding" "code_viewers" {
+  project = google_project.project.project_id
+  role    = google_project_iam_custom_role.code_viewer.name
+  members = [
+    "group:gcp-gds-bq-processing-code-viewers@digital.cabinet-office.gov.uk",
   ]
 }

--- a/terraform/deployments/gcp-gds-bq-processing/project_iam_custom_roles.tf
+++ b/terraform/deployments/gcp-gds-bq-processing/project_iam_custom_roles.tf
@@ -1,0 +1,52 @@
+resource "google_project_iam_custom_role" "code_viewer" {
+  description = "Permissions to read code but restricted from viewing BigQuery data"
+  permissions = [
+    // These permissions are equivalent to https://docs.cloud.google.com/iam/docs/roles-permissions/dataform#dataform.viewer
+    "dataform.commentThreads.get",
+    "dataform.commentThreads.list",
+    "dataform.comments.get",
+    "dataform.comments.list",
+    "dataform.compilationResults.get",
+    "dataform.compilationResults.list",
+    "dataform.compilationResults.query",
+    "dataform.config.get",
+    "dataform.folders.get",
+    "dataform.folders.getIamPolicy",
+    "dataform.folders.queryContents",
+    "dataform.locations.get",
+    "dataform.locations.list",
+    "dataform.operations.get",
+    "dataform.operations.list",
+    "dataform.releaseConfigs.get",
+    "dataform.releaseConfigs.list",
+    "dataform.repositories.computeAccessTokenStatus",
+    "dataform.repositories.fetchHistory",
+    "dataform.repositories.fetchRemoteBranches",
+    "dataform.repositories.get",
+    "dataform.repositories.getIamPolicy",
+    "dataform.repositories.list",
+    "dataform.repositories.queryDirectoryContents",
+    "dataform.repositories.readFile",
+    "dataform.teamFolders.get",
+    "dataform.teamFolders.getIamPolicy",
+    "dataform.workflowConfigs.get",
+    "dataform.workflowConfigs.list",
+    "dataform.workflowInvocations.get",
+    "dataform.workflowInvocations.list",
+    "dataform.workflowInvocations.query",
+    "dataform.workspaces.fetchFileDiff",
+    "dataform.workspaces.fetchFileGitStatuses",
+    "dataform.workspaces.fetchGitAheadBehind",
+    "dataform.workspaces.get",
+    "dataform.workspaces.getIamPolicy",
+    "dataform.workspaces.list",
+    "dataform.workspaces.queryDirectoryContents",
+    "dataform.workspaces.readFile",
+    "dataform.workspaces.searchFiles",
+    "resourcemanager.projects.get",
+    "resourcemanager.projects.list",
+    //
+  ]
+  role_id = "code_viewer"
+  title   = "Code Viewer"
+}


### PR DESCRIPTION
- remove Ian (as he is already part of the necessary group)
- propose managing project viewer access in terraform to blat any permissions granted by click-ops
- propose a `code-viewers` group to only have dataform viewer permissions. We have opted for a custom role as we can see a use-case where access to other code that is not in dataform would also be granted in the future.

Once reviewed and tweaked if need be, we can change membership of the groups and see if analysts can only see what they should.