### PR TITLE
Create a readonly service account for search-api-v2

### DIFF
--- a/terraform/deployments/search-api-v2/service_accounts.tf
+++ b/terraform/deployments/search-api-v2/service_accounts.tf
@@ -95,3 +95,20 @@ resource "google_service_account" "analytics_events_pipeline" {
   display_name = "analytics-events-pipeline"
   description  = "Service account for reading GA4 search events data and importing events into our project"
 }
+
+## Read only service account for local development
+
+resource "google_service_account" "postman" {
+  account_id   = "postman-read-only"
+  display_name = "postman-read-only"
+  description  = "Service account to provide read only access to Postman"
+}
+
+resource "google_project_iam_binding" "postman" {
+  project = var.gcp_project_id
+  role    = "roles/discoveryengine.viewer"
+
+  members = [
+    google_service_account.postman.member
+  ]
+}


### PR DESCRIPTION
With DiscoveryEngine viewer role
https://docs.cloud.google.com/iam/docs/roles-permissions/discoveryengine#discoveryengine.viewer

jira: https://gov-uk.atlassian.net/browse/SCH-1776