### PR TITLE
[SCH-1762] Increase unique users threshold for Search API V2 autocomplete

### DIFF
--- a/terraform/deployments/search-api-v2/completion.tf
+++ b/terraform/deployments/search-api-v2/completion.tf
@@ -10,7 +10,7 @@ resource "restapi_object" "google_discovery_engine_data_store_completion_config"
     maxSuggestions          = 5,
     minPrefixLength         = 3,
     queryFrequencyThreshold = 250,
-    numUniqueUsersThreshold = 10,
+    numUniqueUsersThreshold = 100,
     queryModel              = "automatic",
     enableMode              = "AUTOMATIC"
   })


### PR DESCRIPTION
Recently we had some search terms that were not appropriate become autocomplete suggestions. It looks like, from our investigations, that this is due to a user events issue, but it re-alerted us to the risk of unwanted terms becoming autocomplete suggestions. We've reviewed the unique users thresholds in light of this.

I've not deployed this to `integration` to test it, as autocomplete doesn't currently work on `integration`.

See [Jira ticket SCH-1762](https://gov-uk.atlassian.net/browse/SCH-1762)