### PR TITLE
Per-model token limit alarms for GOV.UK Chat

### DIFF
--- a/terraform/deployments/chat/cloudwatch_alarms.tf
+++ b/terraform/deployments/chat/cloudwatch_alarms.tf
@@ -1,15 +1,19 @@
 locals {
-  period      = 300
-  stat        = "Sum"
-  unit        = "Count"
-  token_limit = 3000000
+  period                     = 300
+  stat                       = "Sum"
+  unit                       = "Count"
+  claude_sonnet_model_id     = "eu.anthropic.claude-sonnet-4-202505"
+  claude_sonnet_token_limit  = var.chat_token_limits_per_minute["claude_sonnet"]
+  openai_gpt_oss_model_id    = "openai.gpt-oss-120b-1:0"
+  openai_gpt_oss_token_limit = var.chat_token_limits_per_minute["openai_gpt_oss"]
+  titan_embed_model_id       = "amazon.titan-embed-text-v2:0"
+  titan_embed_token_limit    = var.chat_token_limits_per_minute["titan_embed"]
 }
 
-# Bedrock token usage over 50% alarm
-resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50" {
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-50"
+resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_claude_sonnet" {
+  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-50-claude-sonnet"
   alarm_description   = <<-EOF
-  WARNING - The current ${var.govuk_environment} Bedrock token usage > 50%
+  WARNING - The current ${var.govuk_environment} Bedrock token usage > 50% for Claude Sonnet
 
   Runbook:
   https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
@@ -28,6 +32,9 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50" {
       period      = local.period
       stat        = local.stat
       unit        = local.unit
+      dimensions = {
+        ModelId = local.claude_sonnet_model_id
+      }
     }
     return_data = false
   }
@@ -41,6 +48,9 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50" {
       period      = local.period
       stat        = local.stat
       unit        = local.unit
+      dimensions = {
+        ModelId = local.claude_sonnet_model_id
+      }
     }
     return_data = false
   }
@@ -54,6 +64,9 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50" {
       period      = local.period
       stat        = local.stat
       unit        = local.unit
+      dimensions = {
+        ModelId = local.claude_sonnet_model_id
+      }
     }
     return_data = false
   }
@@ -61,7 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50" {
   # e1: Percentage Calculation
   metric_query {
     id          = "e1"
-    expression  = "((m1 + m2 + (m3 * 5)) / ${local.token_limit}) * 100"
+    expression  = "((m1 + m2 + (m3 * 5)) / ${local.claude_sonnet_token_limit}) * 100"
     label       = "Expression1"
     return_data = true
   }
@@ -71,11 +84,10 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50" {
   insufficient_data_actions = []
 }
 
-# Bedrock token usage over 100% alarm
-resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100" {
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-100"
+resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_claude_sonnet" {
+  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-100-claude-sonnet"
   alarm_description   = <<-EOF
-  CRITICAL - The current ${var.govuk_environment} Bedrock token usage > 100%
+  CRITICAL - The current ${var.govuk_environment} Bedrock token usage > 100% for Claude Sonnet
 
   Runbook:
   https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
@@ -94,6 +106,9 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100" {
       period      = local.period
       stat        = local.stat
       unit        = local.unit
+      dimensions = {
+        ModelId = local.claude_sonnet_model_id
+      }
     }
     return_data = false
   }
@@ -107,6 +122,9 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100" {
       period      = local.period
       stat        = local.stat
       unit        = local.unit
+      dimensions = {
+        ModelId = local.claude_sonnet_model_id
+      }
     }
     return_data = false
   }
@@ -120,6 +138,9 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100" {
       period      = local.period
       stat        = local.stat
       unit        = local.unit
+      dimensions = {
+        ModelId = local.claude_sonnet_model_id
+      }
     }
     return_data = false
   }
@@ -127,7 +148,239 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100" {
   # e1: Percentage Calculation
   metric_query {
     id          = "e1"
-    expression  = "((m1 + m2 + (m3 * 5)) / ${local.token_limit}) * 100"
+    expression  = "((m1 + m2 + (m3 * 5)) / ${local.claude_sonnet_token_limit}) * 100"
+    label       = "Expression1"
+    return_data = true
+  }
+
+  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_gpt_oss" {
+  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-50-gpt-oss"
+  alarm_description   = <<-EOF
+  WARNING - The current ${var.govuk_environment} Bedrock token usage > 50% for OpenAI GPT-OSS
+
+  Runbook:
+  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
+  EOF
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 50
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+
+  # m1: CacheWriteInputTokenCount
+  metric_query {
+    id = "m1"
+    metric {
+      namespace   = "AWS/Bedrock"
+      metric_name = "CacheWriteInputTokenCount"
+      period      = local.period
+      stat        = local.stat
+      unit        = local.unit
+      dimensions = {
+        ModelId = local.openai_gpt_oss_model_id
+      }
+    }
+    return_data = false
+  }
+
+  # m2: InputTokenCount
+  metric_query {
+    id = "m2"
+    metric {
+      namespace   = "AWS/Bedrock"
+      metric_name = "InputTokenCount"
+      period      = local.period
+      stat        = local.stat
+      unit        = local.unit
+      dimensions = {
+        ModelId = local.openai_gpt_oss_model_id
+      }
+    }
+    return_data = false
+  }
+
+  # m3: OutputTokenCount
+  metric_query {
+    id = "m3"
+    metric {
+      namespace   = "AWS/Bedrock"
+      metric_name = "OutputTokenCount"
+      period      = local.period
+      stat        = local.stat
+      unit        = local.unit
+      dimensions = {
+        ModelId = local.openai_gpt_oss_model_id
+      }
+    }
+    return_data = false
+  }
+
+  # e1: Percentage Calculation
+  metric_query {
+    id          = "e1"
+    expression  = "((m1 + m2 + (m3 * 5)) / ${local.openai_gpt_oss_token_limit}) * 100"
+    label       = "Expression1"
+    return_data = true
+  }
+
+  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_gpt_oss" {
+  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-100-gpt-oss"
+  alarm_description   = <<-EOF
+  CRITICAL - The current ${var.govuk_environment} Bedrock token usage > 100% for OpenAI GPT-OSS
+
+  Runbook:
+  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
+  EOF
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 100
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+
+  # m1: CacheWriteInputTokenCount
+  metric_query {
+    id = "m1"
+    metric {
+      namespace   = "AWS/Bedrock"
+      metric_name = "CacheWriteInputTokenCount"
+      period      = local.period
+      stat        = local.stat
+      unit        = local.unit
+      dimensions = {
+        ModelId = local.openai_gpt_oss_model_id
+      }
+    }
+    return_data = false
+  }
+
+  # m2: InputTokenCount
+  metric_query {
+    id = "m2"
+    metric {
+      namespace   = "AWS/Bedrock"
+      metric_name = "InputTokenCount"
+      period      = local.period
+      stat        = local.stat
+      unit        = local.unit
+      dimensions = {
+        ModelId = local.openai_gpt_oss_model_id
+      }
+    }
+    return_data = false
+  }
+
+  # m3: OutputTokenCount
+  metric_query {
+    id = "m3"
+    metric {
+      namespace   = "AWS/Bedrock"
+      metric_name = "OutputTokenCount"
+      period      = local.period
+      stat        = local.stat
+      unit        = local.unit
+      dimensions = {
+        ModelId = local.openai_gpt_oss_model_id
+      }
+    }
+    return_data = false
+  }
+
+  # e1: Percentage Calculation
+  metric_query {
+    id          = "e1"
+    expression  = "((m1 + m2 + (m3 * 5)) / ${local.openai_gpt_oss_token_limit}) * 100"
+    label       = "Expression1"
+    return_data = true
+  }
+
+  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_titan_embed" {
+  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-50-titan-embed"
+  alarm_description   = <<-EOF
+  WARNING - The current ${var.govuk_environment} Bedrock token usage > 50% for Titan Embed
+
+  Runbook:
+  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
+  EOF
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 50
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+
+  # m1: InputTokenCount
+  metric_query {
+    id = "m1"
+    metric {
+      namespace   = "AWS/Bedrock"
+      metric_name = "InputTokenCount"
+      period      = local.period
+      stat        = local.stat
+      unit        = local.unit
+      dimensions = {
+        ModelId = local.titan_embed_model_id
+      }
+    }
+    return_data = false
+  }
+
+  # e1: Percentage Calculation
+  metric_query {
+    id          = "e1"
+    expression  = "m1 / ${local.titan_embed_token_limit} * 100"
+    label       = "Expression1"
+    return_data = true
+  }
+
+  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_titan_embed" {
+  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-100-titan-embed"
+  alarm_description   = <<-EOF
+  CRITICAL - The current ${var.govuk_environment} Bedrock token usage > 100% for Titan Embed
+
+  Runbook:
+  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
+  EOF
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 100
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+
+  # m1: InputTokenCount
+  metric_query {
+    id = "m1"
+    metric {
+      namespace   = "AWS/Bedrock"
+      metric_name = "InputTokenCount"
+      period      = local.period
+      stat        = local.stat
+      unit        = local.unit
+      dimensions = {
+        ModelId = local.titan_embed_model_id
+      }
+    }
+    return_data = false
+  }
+
+  # e1: Percentage Calculation
+  metric_query {
+    id          = "e1"
+    expression  = "m1 / ${local.titan_embed_token_limit} * 100"
     label       = "Expression1"
     return_data = true
   }

--- a/terraform/deployments/chat/variables.tf
+++ b/terraform/deployments/chat/variables.tf
@@ -42,3 +42,5 @@ variable "chat_slack_channel_id" {
   description = "ID of Slack channel for CloudWatch Alarms"
   default     = "C06AWTPNJMV"
 }
+
+

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -94,6 +94,11 @@ module "variable-set-chat-integration" {
     chat_redis_cluster_multi_az_enabled           = false
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"
+    chat_token_limits_per_minute                  = {
+      "claude_sonnet" = 200000,
+      "openai_gpt_oss" = 100000000,
+      "titan_embed" = 300000
+    }
   }
 }
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -117,6 +117,11 @@ module "variable-set-chat-production" {
     chat_redis_cluster_multi_az_enabled           = true
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "2"
+    chat_token_limits_per_minute                  = {
+      "claude_sonnet" = 9000000,
+      "openai_gpt_oss" = 100000000,
+      "titan_embed" = 600000
+    }
   }
 }
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -106,6 +106,11 @@ module "variable-set-chat-staging" {
     chat_redis_cluster_multi_az_enabled           = false
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"
+    chat_token_limits_per_minute                  = {
+      "claude_sonnet" = 9000000,
+      "openai_gpt_oss" = 100000000,
+      "titan_embed" = 600000
+    }
   }
 }
 

--- a/terraform/deployments/tfc-configuration/variables.tf
+++ b/terraform/deployments/tfc-configuration/variables.tf
@@ -126,3 +126,8 @@ variable "variable_set_names" {
   description = "List of names of existing Variable Sets to add to the workspace."
   default     = []
 }
+
+variable "chat_token_limits_per_minute" {
+  type        = map(number)
+  description = "A map of model names to AWS Bedrock token limits per minute for GOV.UK Chat."
+}


### PR DESCRIPTION

https://gdsgovukagents.atlassian.net/browse/CHAT-283

Currently we have two alarms configured for GOV.UK Chat for token usage:

1. When we reach 50% of our allowed token quota
2. When we reach 100% of our allowed token quota

We assume for both alarms, in all environments, that the token limit is
3,000,000.

However we're actually using multiple models in Chat, and each of these
models has a different token limit. So this commit configures 2 alarms
per model. The key difference is that we now specify a `dimensions`
property within the alarm metrics so that the alarm can specify the
model ID as well.

Additionally, each environment has different quotas, so we need to also
configure different threshold values per environment.

Initially I'd tried to set the model IDs and token limits in a local
variable map, and used Terraform's `for_each` directive to loop over
them and configure two alarms for each model. But that became a little
complicated.

For Claude Sonnet and GPT OSS models, we want to alert based on a
combination of three metrics: `CacheWriteInputTokenCount`,
`InputTokenCount` and `OutputTokenCount`. But for Titan, all we're
interested in is the `InputTokenCount`. This made for some
difficult-to-read custom logic within the `resource` directive using the
`for_each` approach.

So this file has become a little verbose now, and there's quite a bit of
duplication. But I think it makes it overall easier to understand having
6 alarms defined rather than trying to shorten the code at the cost of
readability.
