### PR TITLE
Extend EKS log group retention to 2 years

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -8,7 +8,7 @@ module "variable-set-integration" {
     cluster_infrastructure_state_bucket = "govuk-terraform-integration"
 
     cluster_version               = "1.33"
-    cluster_log_retention_in_days = 7
+    cluster_log_retention_in_days = 728
 
     vpc_cidr = "10.1.0.0/16"
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -7,7 +7,7 @@ module "variable-set-production" {
     cluster_infrastructure_state_bucket = "govuk-terraform-production"
 
     cluster_version               = "1.33" # Don't forget to change this in variables-test.tf too
-    cluster_log_retention_in_days = 7
+    cluster_log_retention_in_days = 728
 
     vpc_cidr = "10.13.0.0/16"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -7,7 +7,7 @@ module "variable-set-staging" {
     cluster_infrastructure_state_bucket = "govuk-terraform-staging"
 
     cluster_version               = "1.33"
-    cluster_log_retention_in_days = 7
+    cluster_log_retention_in_days = 728
 
     vpc_cidr = "10.12.0.0/16"
 


### PR DESCRIPTION
Extend EKS cluster log duration to 2 years for integration, staging, and production

Resolves https://github.com/alphagov/govuk-infrastructure/issues/3707