### PR TITLE
Use a valid log group retention period

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -8,7 +8,7 @@ module "variable-set-integration" {
     cluster_infrastructure_state_bucket = "govuk-terraform-integration"
 
     cluster_version               = "1.33"
-    cluster_log_retention_in_days = 728
+    cluster_log_retention_in_days = 731
 
     vpc_cidr = "10.1.0.0/16"
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -7,7 +7,7 @@ module "variable-set-production" {
     cluster_infrastructure_state_bucket = "govuk-terraform-production"
 
     cluster_version               = "1.33" # Don't forget to change this in variables-test.tf too
-    cluster_log_retention_in_days = 728
+    cluster_log_retention_in_days = 731
 
     vpc_cidr = "10.13.0.0/16"
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -7,7 +7,7 @@ module "variable-set-staging" {
     cluster_infrastructure_state_bucket = "govuk-terraform-staging"
 
     cluster_version               = "1.33"
-    cluster_log_retention_in_days = 728
+    cluster_log_retention_in_days = 731
 
     vpc_cidr = "10.12.0.0/16"
 


### PR DESCRIPTION
728 isn't a valid retention period, set it to 731 instead:

```
Error: expected retention_in_days to be one of [0 1 3 5 7 14 30 60 90 120 150 180 365 [400 545 731 1096](tel:4005457311096) 1827 2192 2557 2922 3288 3653], got 728```