### PR TITLE
Add standard GHA workflows for app image builds and deployments

### DIFF
--- a/actions-templates/README.md
+++ b/actions-templates/README.md
@@ -1,0 +1,2 @@
+This directory contains the standard `deploy.yml` and `release.yml` GitHub Actions workflows
+necessary to build container images for a GOV.UK app and deploy those images to Kubernetes.

--- a/actions-templates/deploy.yml
+++ b/actions-templates/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy
+
+run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to ${{ inputs.environment || 'integration' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      gitRef:
+        description: 'Commit, tag or branch name to deploy'
+        required: true
+        type: string
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        type: choice
+        options:
+        - integration
+        - staging
+        - production
+        default: 'integration'
+  release:
+    types: [released]
+
+jobs:
+  build-and-publish-image:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
+    name: Build and publish image
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
+    with:
+      gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+  trigger-deploy:
+    name: Trigger deploy to ${{ inputs.environment || 'integration' }}
+    needs: build-and-publish-image
+    uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yml@main
+    with:
+      imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
+      environment: ${{ inputs.environment || 'integration' }}
+    secrets:
+      WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
+      WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}

--- a/actions-templates/release.yml
+++ b/actions-templates/release.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    name: Release
+    uses: alphagov/govuk-infrastructure/.github/workflows/release.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
These workflows are used by every GOV.UK app, but we don't have a reference copy of these outside of the app repos that use them.

Keeping them in govuk-infrastructure allows us to maintain an authoritative copy of these workflows, and gives us an easy way to reference them in documentation.