### PR TITLE
Make the tw-accelerator repo deployable

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1014,7 +1014,7 @@ repos:
 
   govuk-ai-accelerator-tw-accelerator:
     # standard security checks are disabled as not configured for a private repo
-    can_be_deployed: false
+    can_be_deployed: true
     visibility: private
     push_allowances: ["alphagov/gov-uk-ai-accelerator-alpha-team", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
     


### PR DESCRIPTION
This repo was marked as deployable false, this is now being changed to true.