### PR TITLE
Add variable for per-model token limit alarms for GOV.UK Chat

### DIFF
--- a/terraform/deployments/chat/variables.tf
+++ b/terraform/deployments/chat/variables.tf
@@ -42,3 +42,9 @@ variable "chat_slack_channel_id" {
   description = "ID of Slack channel for CloudWatch Alarms"
   default     = "C06AWTPNJMV"
 }
+
+variable "chat_token_limits_per_minute" {
+  type        = map(number)
+  description = "A map of model names to AWS Bedrock token limits per minute."
+  default     = {}
+}

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -95,6 +95,11 @@ module "variable-set-chat-integration" {
     chat_redis_cluster_multi_az_enabled           = false
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"
+    chat_token_limits_per_minute = {
+      "claude_sonnet"  = 200000,
+      "openai_gpt_oss" = 100000000,
+      "titan_embed"    = 300000
+    }
   }
 }
 

--- a/terraform/deployments/tfc-configuration/variables-production.tf
+++ b/terraform/deployments/tfc-configuration/variables-production.tf
@@ -117,6 +117,11 @@ module "variable-set-chat-production" {
     chat_redis_cluster_multi_az_enabled           = true
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "2"
+    chat_token_limits_per_minute = {
+      "claude_sonnet"  = 9000000,
+      "openai_gpt_oss" = 100000000,
+      "titan_embed"    = 600000
+    }
   }
 }
 

--- a/terraform/deployments/tfc-configuration/variables-staging.tf
+++ b/terraform/deployments/tfc-configuration/variables-staging.tf
@@ -106,6 +106,11 @@ module "variable-set-chat-staging" {
     chat_redis_cluster_multi_az_enabled           = false
     chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
     chat_redis_cluster_num_cache_clusters         = "1"
+    chat_token_limits_per_minute = {
+      "claude_sonnet"  = 9000000,
+      "openai_gpt_oss" = 100000000,
+      "titan_embed"    = 600000
+    }
   }
 }
 


### PR DESCRIPTION
https://gdsgovukagents.atlassian.net/browse/CHAT-283

This adds a new variable - `chat_token_limits_per_minute` - which is a
map of model IDs to token counts rate limit quotas for using in GOV.UK Chat.

We currently have a single value which we use in Cloudwatch alarms to
let us know if we're getting close to hitting our rate limit.

However each model we use has a different quota, so we need to be more
granular in the approach.

This commit defines the variable and creates an instance of it in each
environment. Integration has a slightly lower quota than staging and
production so we need to define it on a per-environment basis.

In a later commit we'll update the Cloudwatch alarms to actually use
this variable.
