### PR TITLE
IA-2491: fix GCP gds-bq-processing custom_role error

### DIFF
--- a/terraform/deployments/gcp-gds-bq-processing/project_iam_custom_roles.tf
+++ b/terraform/deployments/gcp-gds-bq-processing/project_iam_custom_roles.tf
@@ -43,8 +43,6 @@ resource "google_project_iam_custom_role" "code_viewer" {
     "dataform.workspaces.queryDirectoryContents",
     "dataform.workspaces.readFile",
     "dataform.workspaces.searchFiles",
-    "resourcemanager.projects.get",
-    "resourcemanager.projects.list",
     //
   ]
   role_id = "code_viewer"


### PR DESCRIPTION
This 6cb22c54c98e045234083d002b855cefc66d801e apply seemed to fail as it was giving `resourcemanager.*` permissions to a custom role. Those permissions were copied from [here](https://docs.cloud.google.com/iam/docs/roles-permissions/dataform#dataform.viewer) and not actually needed so I have removed them.