### PR TITLE
IA-2490: initiate provider with correct project details for ga4-aggregate-analytics

### DIFF
--- a/terraform/deployments/gcp-ga4-aggregate-analytics/dataset.tf
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/dataset.tf
@@ -3,11 +3,13 @@ locals {
   ninety_days_in_ms = 1000 * 60 * 60 * 24 * 90
 }
 
-resource "google_bigquery_dataset" "dataset" {
+resource "google_bigquery_dataset" "raw_events_dataset" {
   dataset_id                      = "analytics_523297687"
   friendly_name                   = "Analytics Property ID 523297687"
-  description                     = "This dataset contains events tables from GA4 property ID 523297687."
+  description                     = "This dataset contains events tables from GA4 property ID 523297687"
   location                        = "europe-west2"
   default_partition_expiration_ms = local.ninety_days_in_ms
   default_table_expiration_ms     = local.ninety_days_in_ms
+
+  depends_on = [google_project_service.project_services]
 }

--- a/terraform/deployments/gcp-ga4-aggregate-analytics/main.tf
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/main.tf
@@ -1,3 +1,7 @@
+locals {
+  gcp_project_id = "ga4-aggregate-analytics"
+}
+
 terraform {
   cloud {
     organization = "govuk"
@@ -17,9 +21,13 @@ terraform {
   required_version = "~> 1.14"
 }
 
+provider "google" {
+  project = local.gcp_project_id
+}
+
 resource "google_project" "project" {
-  name            = "ga4-aggregate-analytics"
-  project_id      = "ga4-aggregate-analytics"
+  name            = local.gcp_project_id
+  project_id      = local.gcp_project_id
   folder_id       = "278098142879"
   billing_account = "015C7A-FAF970-B0D375"
 }

--- a/terraform/deployments/gcp-ga4-aggregate-analytics/service.tf
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/service.tf
@@ -1,0 +1,14 @@
+locals {
+  services = [
+    "bigquery.googleapis.com",
+    "bigquerydatatransfer.googleapis.com",
+    "storage.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "project_services" {
+  for_each = toset(local.services)
+  service  = each.key
+
+  disable_on_destroy = false
+}


### PR DESCRIPTION
On checking the resources created by the [previous change](https://github.com/alphagov/govuk-infrastructure/pull/3732) I noticed that the default value for `project` was falling back to `govuk-production`. The dataset ended up being created in `govuk-production` rather than `ga4-aggregate-analytics`.

As this workspace is dedicated to managing `ga4-aggregate-analytics` I have initiated the provider with those details.

The plan/apply should show a deletion of the dataset in `govuk-production` and a corresponding creation in `ga4-aggregate-analytics` which is what we want.

**This won't result in any data loss - we're still just setting up infra.**