### PR TITLE
BAU - Update `external-dns` to 1.17.0

### DIFF
--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -2,7 +2,7 @@ resource "helm_release" "external_dns" {
   name             = "external-dns"
   repository       = "https://kubernetes-sigs.github.io/external-dns"
   chart            = "external-dns"
-  version          = "1.16.1"
+  version          = "1.17.0"
   namespace        = local.services_ns
   create_namespace = true
 


### PR DESCRIPTION
Description:
- Update `external-dns` to 1.17.0 as CRDs have now been applied