### PR TITLE
BAU - Update `external-dns` to 1.19.0

### DIFF
--- a/terraform/deployments/cluster-services/external_dns.tf
+++ b/terraform/deployments/cluster-services/external_dns.tf
@@ -2,7 +2,7 @@ resource "helm_release" "external_dns" {
   name             = "external-dns"
   repository       = "https://kubernetes-sigs.github.io/external-dns"
   chart            = "external-dns"
-  version          = "1.17.0"
+  version          = "1.19.0"
   namespace        = local.services_ns
   create_namespace = true
 


### PR DESCRIPTION
Description:
- See https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.19.0 and https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.18.0
- No CRD changes in this