### PR TITLE
Have eph clusters create the same legacy subnets as live clusters

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-test.tf
+++ b/terraform/deployments/tfc-configuration/variables-test.tf
@@ -27,7 +27,23 @@ module "variable-set-ephemeral" {
       c = { az = "eu-west-1c", cidr = "10.10.96.0/19" }
     }
 
-    legacy_private_subnets = {}
+    legacy_private_subnets = {
+      a = { az = "eu-west-1a", cidr = "10.10.4.0/24", nat = true }
+      b = { az = "eu-west-1b", cidr = "10.10.5.0/24", nat = true }
+      c = { az = "eu-west-1c", cidr = "10.10.6.0/24", nat = true }
+
+      rds_a = { az = "eu-west-1a", cidr = "10.10.10.0/24", nat = false }
+      rds_b = { az = "eu-west-1b", cidr = "10.10.11.0/24", nat = false }
+      rds_c = { az = "eu-west-1c", cidr = "10.10.12.0/24", nat = false }
+
+      elasticache_a = { az = "eu-west-1a", cidr = "10.10.7.0/24", nat = false }
+      elasticache_b = { az = "eu-west-1b", cidr = "10.10.8.0/24", nat = false }
+      elasticache_c = { az = "eu-west-1c", cidr = "10.10.9.0/24", nat = false }
+
+      elasticsearch_a = { az = "eu-west-1a", cidr = "10.10.16.0/24", nat = false }
+      elasticsearch_b = { az = "eu-west-1b", cidr = "10.10.17.0/24", nat = false }
+      elasticsearch_c = { az = "eu-west-1c", cidr = "10.10.18.0/24", nat = false }
+    }
 
     govuk_environment = "ephemeral"
   }


### PR DESCRIPTION
Bring the ephemeral cluster config closer to live by defining the same legacy subnets as the live deployments