### PR TITLE
Adjust all ephemeral cluster IP CIDR ranges to match live

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-test.tf
+++ b/terraform/deployments/tfc-configuration/variables-test.tf
@@ -10,21 +10,21 @@ module "variable-set-ephemeral" {
     vpc_cidr = "10.10.0.0/16"
 
     eks_control_plane_subnets = {
-      a = { az = "eu-west-1a", cidr = "10.10.4.0/24" }
-      b = { az = "eu-west-1b", cidr = "10.10.5.0/24" }
-      c = { az = "eu-west-1c", cidr = "10.10.6.0/24" }
+      a = { az = "eu-west-1a", cidr = "10.10.19.0/28" }
+      b = { az = "eu-west-1b", cidr = "10.10.19.0/28" }
+      c = { az = "eu-west-1c", cidr = "10.10.19.0/28" }
     }
 
     eks_public_subnets = {
-      a = { az = "eu-west-1a", cidr = "10.10.1.0/24" }
-      b = { az = "eu-west-1b", cidr = "10.10.2.0/24" }
-      c = { az = "eu-west-1c", cidr = "10.10.3.0/24" }
+      a = { az = "eu-west-1a", cidr = "10.10.20.0/24" }
+      b = { az = "eu-west-1b", cidr = "10.10.21.0/24" }
+      c = { az = "eu-west-1c", cidr = "10.10.22.0/24" }
     }
 
     eks_private_subnets = {
-      a = { az = "eu-west-1a", cidr = "10.10.32.0/19" }
-      b = { az = "eu-west-1b", cidr = "10.10.64.0/19" }
-      c = { az = "eu-west-1c", cidr = "10.10.96.0/19" }
+      a = { az = "eu-west-1a", cidr = "10.10.24.0/22" }
+      b = { az = "eu-west-1b", cidr = "10.10.28.0/22" }
+      c = { az = "eu-west-1c", cidr = "10.10.32.0/22" }
     }
 
     legacy_private_subnets = {


### PR DESCRIPTION
The CIDR ranges, both sizes and specific allocations, are different in ephemeral cluster to live clusters, this PR adjusts the cluster ranges so they mimic the live ranges (and more importantly the CIDR range sizes) 