### PR TITLE
Fix ephemeral cluster control plane CIDR ranges

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-test.tf
+++ b/terraform/deployments/tfc-configuration/variables-test.tf
@@ -11,8 +11,8 @@ module "variable-set-ephemeral" {
 
     eks_control_plane_subnets = {
       a = { az = "eu-west-1a", cidr = "10.10.19.0/28" }
-      b = { az = "eu-west-1b", cidr = "10.10.19.0/28" }
-      c = { az = "eu-west-1c", cidr = "10.10.19.0/28" }
+      b = { az = "eu-west-1b", cidr = "10.10.19.16/28" }
+      c = { az = "eu-west-1c", cidr = "10.10.19.32/28" }
     }
 
     eks_public_subnets = {


### PR DESCRIPTION
Doh, I didn't notice I was missing the final portion of the CIDRs for the control plane