### PR TITLE
Lower GOV.UK Chat token threshold in integration

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -98,7 +98,7 @@ module "variable-set-chat-integration" {
     chat_token_limits_per_minute = {
       "claude_sonnet"  = 200000,
       "openai_gpt_oss" = 100000000,
-      "titan_embed"    = 300000
+      "titan_embed"    = 100
     }
   }
 }


### PR DESCRIPTION
This number represents the number of tokens per minute that we have in
our AWS quota for the Titan LLM.

The idea is that it's used to create some Cloudwatch alarms so we get
notified if we're approaching or have exceeded our token quota.

In order to test the alarm, this commit lowers the count for Titan in
the integration environment to 100 tokens/min. This way we can make a
few calls to the LLM to use some tokens and hopefully see the alarm
triggered.

Once this has been verified, the number will be reinstated to the
original value.
