### PR TITLE
Revert "Lower GOV.UK Chat token threshold in integration"

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -98,7 +98,7 @@ module "variable-set-chat-integration" {
     chat_token_limits_per_minute = {
       "claude_sonnet"  = 200000,
       "openai_gpt_oss" = 100000000,
-      "titan_embed"    = 100
+      "titan_embed"    = 300000
     }
   }
 }


### PR DESCRIPTION
This reverts commit 187190816b1f6109a7ef5934275b8ae2f9946927.

Testing has finished now, so this reinstates the original value.
