### PR TITLE
Create and destroy ephemeral clusters with a Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,21 @@ lint_docs:
   	  	1>&2 echo -e "\tmake lint_docs LINT_DOCS=./docs/README.md WATCH_DOCS=true"; \
 	fi; \
 	exit $${EXIT_CODE};
+
+.PHONY: ephemeral_cluster
+ephemeral_cluster:
+	@ if [[ -z "$${EPH_CLUSTER_ID}" ]] || [[ ! -v "EPH_CLUSTER_ID" ]]; then \
+		echo "Set the ephemeral cluster id with the EPH_CLUSTER_ID variable"; \
+		printf "\t make create_ephemeral_cluster EPH_CLUSTER_ID=\"eph-new-cluster\"\n"; \
+		exit 1; \
+  	fi; \
+  	cd terraform/deployments/ephemeral; \
+	terraform init; \
+	echo "Ephemeral cluster $${EPH_CLUSTER_ID} will be built by Terraform in Terraform Cloud."; \
+	echo "When the 'cluster_access' workspace is complete you should be able to access to the cluster"; \
+	printf "\t aws eks update-kubeconfig --name $${EPH_CLUSTER_ID}\n"; \
+	echo "Once all workspaces are complete, log into the cluster and run './validate.sh' to test the cluster is functioning"; \
+	open "https://app.terraform.io/app/govuk/projects"; \
+	echo "Press enter to continue"; \
+	read; \
+	terraform apply -var ephemeral_cluster_id="$${EPH_CLUSTER_ID}"; \

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ We set the constraints with minor version precision. However when using this Ter
 We have some [recommended pre-commit hooks](.pre-commit-config.yaml). You need
 to [install `pre-commit`](https://pre-commit.com/#install) for these to run.
 
+## Starting and updating an ephemeral cluster
+
+This repository supports creating ephemeral Kubernetes clusters for the purposes of short-lived tests. To 
+create a new cluster, or update the workspaces for an existing one, use the Make target:
+
+```shell
+make ephemeral_cluster EPH_CLUSTER_ID=eph-new-cluster
+```
+
+## Stopping an ephemeral cluster
+
+To stop an existing ephemeral cluster, see the instructions in the readme in `terraform/deployments/ephemeral/`.
+
 ## Documentation
 
 See the [`docs/` directory](docs/).

--- a/terraform/deployments/ephemeral/variables.tf
+++ b/terraform/deployments/ephemeral/variables.tf
@@ -1,5 +1,15 @@
 variable "ephemeral_cluster_id" {
   type = string
+
+  validation {
+    condition     = length(var.ephemeral_cluster_id) <= 38
+    error_message = "ephemeral_cluster_id must be 38 characters or fewer"
+  }
+
+  validation {
+    condition     = startswith(var.ephemeral_cluster_id, "eph-")
+    error_message = "ephemeral_cluster_id must begin with 'eph-'"
+  }
 }
 
 variable "organization" {

--- a/terraform/deployments/ephemeral/ws/workspace.tf
+++ b/terraform/deployments/ephemeral/ws/workspace.tf
@@ -30,6 +30,8 @@ module "workspace" {
     "common-ephemeral"
   ]
 
+  force_delete = true
+
   tfvars = var.tfvars
 }
 


### PR DESCRIPTION
## What

We're making more and more use of ephemeral clusters, so it feels right to start to put a little more tooling around them.

Also includes some small tweaks to the Terraform to make it safer to automate.

## How to review

1. Compare the code I've written to the written instructions in the readme in `terraform/deployments/ephemeral/``
2. Test it! Spin up a new one and try tear it down