### PR TITLE
Add ai-accelerator workspace in integration

### DIFF
--- a/terraform/deployments/tfc-configuration/ai-accelerator.tf
+++ b/terraform/deployments/tfc-configuration/ai-accelerator.tf
@@ -1,0 +1,34 @@
+module "ai-accelerator-integration" {
+  source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
+
+  organization      = var.organization
+  workspace_name    = "ai-accelerator"
+  workspace_desc    = "This module manages the resources needed for the ai-accelerator"
+  workspace_tags    = ["integration", "ai-accelerator", "aws"]
+  terraform_version = var.terraform_version
+  execution_mode    = "remote"
+  working_directory = "/terraform/deployments/ai-accelerator/"
+  trigger_patterns = [
+    "/terraform/deployments/ai-accelerator/**/*",
+    "/terraform/shared-modules/opensearch-blue-green-deployment/**/*",
+  ]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "add-opensearch-deployment" ## FIXME: Change to main
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production (r/o)" = "write"
+    "GOV.UK Production"           = "write"
+  }
+
+  variable_set_ids = [
+    local.aws_credentials["integration"],
+    module.variable-set-integration.id,
+    module.variable-set-ai-accelerator-integration.id
+  ]
+}

--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -758,3 +758,22 @@ module "variable-set-gov-graph-dev" {
     project_id                   = "govuk-knowledge-graph-dev"
   }
 }
+
+module "variable-set-ai-accelerator-integration" {
+  source = "./variable-set"
+
+  name = "ai-accelerator"
+
+  tfvars = {
+    current_live_domain = "blue"
+    launch_blue_domain  = true
+    launch_green_domain = false
+    blue_cluster_options = {
+      engine         = "OpenSearch"
+      engine_version = "3.1"
+      instance_count = 1
+      instance_type  = "t3.small.search"
+    }
+    aws_region = "eu-west-1"
+  }
+}


### PR DESCRIPTION
I can't test my deployment in an eph cluster because they don't have a root dns workspace or a cluster specific ACM cert specific to the project and workspace. So for now add the workspace into integration pointing at my branch with the variables i need set.

Once I have the opensearch PR merged I will change it to point at main