### PR TITLE
Update defaults for ai-accelerator opensearch

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -768,12 +768,20 @@ module "variable-set-ai-accelerator-integration" {
     current_live_domain = "blue"
     launch_blue_domain  = true
     launch_green_domain = false
+
     blue_cluster_options = {
       engine         = "OpenSearch"
       engine_version = "3.1"
-      instance_count = 1
+      instance_count = 3
       instance_type  = "t3.small.search"
     }
+
+    ebs_options = {
+      volume_size = 90
+      volume_type = "gp3"
+      throughput  = 250
+    }
+
     aws_region = "eu-west-1"
   }
 }


### PR DESCRIPTION
With zone awareness enabled there has to be at least 3 nodes.

Also provide ebs volumes for each node (the same as all our other open/elastic search clusters