### PR TITLE
EBS Options for opensearch should be in the blue cluster config

### DIFF
--- a/terraform/deployments/tfc-configuration/variables-integration.tf
+++ b/terraform/deployments/tfc-configuration/variables-integration.tf
@@ -774,12 +774,11 @@ module "variable-set-ai-accelerator-integration" {
       engine_version = "3.1"
       instance_count = 3
       instance_type  = "t3.small.search"
-    }
-
-    ebs_options = {
-      volume_size = 90
-      volume_type = "gp3"
-      throughput  = 250
+      ebs_options = {
+        volume_size = 90
+        volume_type = "gp3"
+        throughput  = 250
+      }
     }
 
     aws_region = "eu-west-1"


### PR DESCRIPTION
EBS options is supposed to be inside the blue cluster config, of course the way we have TFC set up you can't get any helpful error messages about this