### PR TITLE
Enable AWS VPC CNI network policy enforcement

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_vpc_cni_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_vpc_cni_iam.tf
@@ -1,0 +1,13 @@
+module "aws_vpc_cni_iam_role" {
+  source             = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version            = "~> 6.0"
+  name               = "aws-vpc-cni-${var.cluster_name}"
+  use_name_prefix    = false
+  description        = "Role used by the AWS VPC CNI for address management"
+  enable_oidc        = true
+  oidc_provider_urls = [module.eks.oidc_provider]
+  policies = {
+    "managed_cni_policy" = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  }
+  oidc_subjects = ["system:serviceaccount:kube-system:aws-vpc-cni-sa"]
+}

--- a/terraform/deployments/cluster-infrastructure/outputs.tf
+++ b/terraform/deployments/cluster-infrastructure/outputs.tf
@@ -98,6 +98,11 @@ output "aws_lb_controller_role_arn" {
   value       = module.aws_lb_controller_iam_role.arn
 }
 
+output "aws_vpc_cni_role_arn" {
+  description = "IAM role ARN corresponding to the Kubernetes service account for the AWS VPC CNI plugin"
+  value       = module.aws_vpc_cni_iam_role.arn
+}
+
 output "aws_lb_controller_service_account_name" {
   description = "Name of the k8s service account for the AWS Load Balancer Controller."
   value       = local.aws_lb_controller_service_account_name

--- a/terraform/deployments/cluster-services/aws_vpc_cni.tf
+++ b/terraform/deployments/cluster-services/aws_vpc_cni.tf
@@ -1,0 +1,24 @@
+resource "helm_release" "aws_vpc_cni" {
+  name = "aws-vpc-cni"
+
+  chart      = "aws-vpc-cni"
+  repository = "https://aws.github.io/eks-charts"
+  version    = "v1.21.1"
+
+  namespace        = "kube-system"
+  create_namespace = false
+
+  timeout = var.helm_timeout_seconds
+
+  values = [yamlencode({
+    enableNetworkPolicy = true
+    serviceAccount = {
+      name   = "aws-vpc-cni-sa"
+      create = true
+      annotations = {
+        "eks.amazonaws.com/role-arn" = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.aws_vpc_cni_role_arn
+      }
+    }
+    originalMatchLabels = true
+  })]
+}


### PR DESCRIPTION
## What

We've been using the AWS VPC CNI since we established the cluster, but it hasn't had network policy enforcement enabled.

To enable it, we deploy the official Helm chart to configure it correctly, and provide it with a dedicated IAM role to use.

This has been tested in an ephemeral cluster and we've validated that

1. the default behaviour is permissive.
2. when the first rule is added, nothing outside of that rule is affected

> [!CAUTION]
> Do not merge this PR once you've approved it. @AP-Hunt needs to [re-annotate some resources](https://github.com/aws/eks-charts/blob/master/stable/aws-vpc-cni/README.md#adopting-the-existing-aws-node-resources-in-an-eks-cluster) in each environment to ensure the Helm chart will get successfully applied

## How to review
Use the ephemeral cluster `eph-andy-260226`. This branch is running in it.

Per https://github.com/alphagov/govuk-platform-internal/issues/101 there are 3 pods running: A, B, and C. A and C are making HTTP requests to B to demonstrate network connectivity.

1. Check the logs for A and C to see that they're making successful requsests.
2. Apply the following network policy to prevent A's egress
    ```yaml
    apiVersion: networking.k8s.io/v1
    kind: NetworkPolicy
    metadata:
      name: deny-deploy-a-egress
    spec:
      podSelector:
        matchLabels:
          app: deploy-a
      policyTypes:
        - Egress
      egress: []
    
    ```
3. Check the logs of A and C again. A should be reporting timeouts, and C should be showing successful requests.
4. Remove the network policy and check that both are working again.