### PR TITLE
Make pact tests a required status check

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -753,6 +753,7 @@ repos:
       additional_contexts:
         - Lint Ruby / Run RuboCop
         - Test Ruby / Run RSpec
+        - Run Pact tests / Verify pact tests
 
   search-api-v2:
     can_be_deployed: true


### PR DESCRIPTION
Currently a PR could in theory be merged to `search-api` even if the pact tests failed. The code with the failing pact tests wouldn't be deployed, as `release.yml` workflow wouldn't be triggered as `ci.yml` would be deemed to have failed. 

Making pact tests a required status check so that code with failing pact tests can't be merged by mistake, to avoid the annoyance of having to revert a PR with failing pact tests.