### PR TITLE
BAU - Expand National Data Library ArgoCD permissions

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -35,6 +35,10 @@ locals {
     g, ${var.github_read_write_team}, role:admin
     p, role:nationaldatalibrary, applications, update, datagovuk/*, allow
     p, role:nationaldatalibrary, applications, update, default/dgu-app-of-apps, allow
+    p, role:nationaldatalibrary, applications, sync, datagovuk/*, allow
+    p, role:nationaldatalibrary, applications, sync, default/dgu-app-of-apps, allow
+    p, role:nationaldatalibrary, applications, override, datagovuk/*, allow
+    p, role:nationaldatalibrary, applications, override, default/dgu-app-of-apps, allow
     g, ${var.github_national_data_library_team}, role:nationaldatalibrary
     EOT
   }


### PR DESCRIPTION
Description:
- Give NDL developers ability to manually sync applications in the `datagovuk` namespace
- Give NDL developers ability to sync to an arbitrary branch in the `datagovuk` namespace to allow for testing custom branches
- See https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/#the-override-action