### PR TITLE
Allow overriding the Git branch monitored by an ephemeral cluster's Terraform

### DIFF
--- a/terraform/deployments/ephemeral/README.md
+++ b/terraform/deployments/ephemeral/README.md
@@ -6,8 +6,16 @@ This module is used to provision ephemeral EKS clusters via Terraform Cloud.
 1. ensure you are in the correct dir `terraform/deployments/ephemeral`
 1. Ensure you have logged in to Terraform Cloud via the Terraform CLI (`terraform login`)
 1. Do a `terraform init`
-1. Run an apply with your chosen ephemeral cluster ID (this isn't generated for you)
-   `terraform apply -var ephemeral_cluster_id=${EPH_CLUSTER_ID}`
+1. Run an apply with your chosen ephemeral cluster ID (this isn't generated for you):
+   ```
+   terraform apply -var ephemeral_cluster_id=${EPH_CLUSTER_ID}`
+   ``` 
+   If your new ephemeral cluster should be based on a branch other than `main`, provide the `git_branch` variable:
+
+   ```
+   terraform apply -var ephemeral_cluster_id=${EPH_CLUSTER_ID} -var git_branch="$(git branch --show-current)"
+   ```
+   
 1. When `cluster_access` has applied successfully you can gain access to the cluster with `aws eks update-kubeconfig --name ${EPH_CLUSTER_ID} --kubeconfig <optional_new_kube_config>`
 1. Once all the Terraform workspaces have successfully applied, log into the cluster and
    run `./validate.sh` to test that the cluster is functioning and able to accept ingress.

--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -57,6 +57,7 @@ module "vpc" {
   name                 = "vpc"
   ephemeral_cluster_id = var.ephemeral_cluster_id
   variable_set_id      = module.var_set.id
+  git_branch           = var.git_branch
 
   depends_on = [tfe_project.project]
 }
@@ -67,6 +68,7 @@ module "cluster_infrastructure" {
   name                 = "cluster-infrastructure"
   ephemeral_cluster_id = var.ephemeral_cluster_id
   variable_set_id      = module.var_set.id
+  git_branch           = var.git_branch
 
   depends_on = [module.vpc, tfe_project.project]
 }
@@ -77,6 +79,7 @@ module "cluster_access" {
   name                 = "cluster-access"
   ephemeral_cluster_id = var.ephemeral_cluster_id
   variable_set_id      = module.var_set.id
+  git_branch           = var.git_branch
 
   tfvars = {
     ship_kubernetes_events_to_logit = false
@@ -91,6 +94,7 @@ module "cluster_services" {
   name                 = "cluster-services"
   ephemeral_cluster_id = var.ephemeral_cluster_id
   variable_set_id      = module.var_set.id
+  git_branch           = var.git_branch
 
   tfvars = {
     ship_kubernetes_events_to_logit = false
@@ -118,6 +122,7 @@ module "datagovuk_infrastructure" {
   name                 = "datagovuk-infrastructure"
   ephemeral_cluster_id = var.ephemeral_cluster_id
   variable_set_id      = module.var_set.id
+  git_branch           = var.git_branch
 
   depends_on = [module.cluster_services, tfe_project.project]
 }

--- a/terraform/deployments/ephemeral/variables.tf
+++ b/terraform/deployments/ephemeral/variables.tf
@@ -6,3 +6,9 @@ variable "organization" {
   type    = string
   default = "govuk"
 }
+
+variable "git_branch" {
+  type        = string
+  description = "The name of the Git branch on which the ephemeral cluster should be based. Defaults to main."
+  default     = "main"
+}


### PR DESCRIPTION
## What

By default it uses the main branch. By setting the branch in Terraform, we make it easier and quicker for ourselves to iterate.

## How to review

Try applying the Terraform from this branch, as documented, and note the VCS branch value in TFC.