### PR TITLE
Add new role to gcp integration access group

### DIFF
--- a/terraform/deployments/search-api-v2/service_accounts.tf
+++ b/terraform/deployments/search-api-v2/service_accounts.tf
@@ -6,6 +6,17 @@ resource "google_service_account" "api" {
   description  = "Service account to provide access to the search-api-v2 Rails app and document sync worker"
 }
 
+resource "google_service_account_iam_binding" "sa_token_creator_iam" {
+  # Only create this resource if the environment is integration.
+  count = terraform.workspace == "search-api-v2-integration" ? 1 : 0
+
+  service_account_id = google_service_account.api.id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  members = [
+    "group:govuk-gcp-access-integration@digital.cabinet-office.gov.uk"
+  ]
+}
+
 resource "google_service_account_key" "api" {
   service_account_id = google_service_account.api.id
 }


### PR DESCRIPTION
JIRA: https://gov-uk.atlassian.net/browse/SCH-1777

Add token creator role to the govuk-gcp-access-integration access_group, to allow service account impersonation of the search_api_v2 service account for local development

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account_iam#google_service_account_iam_member https://docs.cloud.google.com/iam/docs/service-account-permissions#token-creator-role

Related PR: https://github.com/alphagov/search-api-v2/pull/626