### PR TITLE
fix: 🐛 add opensearch permissions to ai-accelerator irsa

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_iam.tf
@@ -48,6 +48,25 @@ data "aws_iam_policy_document" "govuk_ai_accelerator_s3_access" {
   }
 }
 
+data "aws_iam_policy_document" "govuk_ai_accelerator_opensearch" {
+  count = var.enable_govuk_ai_accelerator ? 1 : 0
+
+  statement {
+    sid     = "GovukAiAcceleratorOpenSearchAccessPolicy"
+    actions = ["es:*"]
+
+    resources = ["arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/ai-accelerator-blue"]
+  }
+}
+
+resource "aws_iam_policy" "govuk_ai_accelerator_opensearch_policy" {
+  count = var.enable_govuk_ai_accelerator ? 1 : 0
+
+  name        = "govuk-${var.govuk_environment}-govuk-ai-accelerator-opensearch-policy"
+  description = "Policy for govuk-ai-accelerator application with access to OpenSearch"
+  policy      = data.aws_iam_policy_document.govuk_ai_accelerator_opensearch[0].json
+}
+
 resource "aws_iam_policy" "govuk_ai_accelerator_s3_access_policy" {
   count = var.enable_govuk_ai_accelerator ? 1 : 0
 
@@ -77,6 +96,7 @@ module "govuk_reports_iam_role" {
   max_session_duration = 28800
 
   policies = {
+    opensearch                                                             = aws_iam_policy.govuk_ai_accelerator_opensearch_policy[0].arn
     neptune                                                                = data.tfe_outputs.neptune[0].nonsensitive_values.neptune_policy_arn["ai_accelerator"],
     "${aws_iam_policy.govuk_ai_accelerator_s3_access_policy[0].name}"      = aws_iam_policy.govuk_ai_accelerator_s3_access_policy[0].arn,
     "${aws_iam_policy.govuk_ai_accelerator_bedrock_access_policy[0].name}" = aws_iam_policy.govuk_ai_accelerator_bedrock_access_policy[0].arn


### PR DESCRIPTION
ai-accelerator are getting 403s when reaching out to their cluster, add permissions to their irsa

```
botocore.errorfactory.AccessDeniedException: An error occurred (AccessDeniedException) when calling the DescribeDomain operation: [User: arn:aws:sts::xxx:assumed-role/govuk-ai-accelerator-app-govuk/botocore-session-1772789327 is not authorized to perform: es:DescribeDomain on resource: arn:aws:es:zzz:xxxx:domain/ai-accelerator-blue because no identity-based policy allows the es:DescribeDomain action, User: arn:aws:sts::xxxxxx:assumed-role/govuk-ai-accelerator-app-govuk/botocore-session-1772789327 is not authorized to perform: es:DescribeElasticsearchDomain on resource: arn:aws:zzzzz:xxxxx:domain/ai-accelerator-blue because no identity-based policy allows the es:DescribeElasticsearchDomain action]
```

https://github.com/alphagov/govuk-infrastructure/issues/3709