### PR TITLE
Remove configuration from govuk-chat-gradio-prototype

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -315,14 +315,6 @@ repos:
 
   govuk-chat-gradio-prototype:
     visibility: private
-    homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk-chat-gradio-prototype.html"
-    required_status_checks:
-      # standard security checks are disabled as not configured for a private repo
-      additional_contexts:
-        - Tests
-        - Lint
-        - Format
-        - Type checks
 
   govuk-chat-v1-iterations-2026:
     visibility: private


### PR DESCRIPTION
This has been done, as per the guide in: https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/README.md#archiving-repositories, to enable archiving this repository.

This is to be followed up with a change of status to `archived: true` in a subsequent PR.

Seemingly this also fixes the lack of trailing new line on this file (I edited this via the GitHub UI)