### PR TITLE
Archive govuk-chat-gradio-prototype

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -315,6 +315,7 @@ repos:
 
   govuk-chat-gradio-prototype:
     visibility: private
+    archived: true
 
   govuk-chat-v1-iterations-2026:
     visibility: private


### PR DESCRIPTION
This follows up: https://github.com/alphagov/govuk-infrastructure/pull/3825 with the second part of the [archiving process](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/README.md#archiving-repositories) for a repository.