### PR TITLE
Specify principal * for OpenSearch username and password auth

### DIFF
--- a/terraform/shared-modules/opensearch-blue-green-deployment/opensearch-domain/main.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/opensearch-domain/main.tf
@@ -84,8 +84,8 @@ data "aws_iam_policy_document" "opensearch_domain" {
     sid = "AllowOpenSearchAccessFromThisAccount"
 
     principals {
-      type        = "AWS"
-      identifiers = [data.aws_caller_identity.current.account_id]
+      type        = "*"
+      identifiers = ["*"]
     }
 
     actions = ["es:*"]


### PR DESCRIPTION
We're doing username and password auth which means we need to set "Principal" to "*". The terraform docs say to set both type to "*" and identifiers to `["*"]` to achieve this.