### PR TITLE
IA-2581: enable health assessments on GA4 aggregate data GCP projects

### DIFF
--- a/terraform/deployments/tfc-configuration/gcp-projects.tf
+++ b/terraform/deployments/tfc-configuration/gcp-projects.tf
@@ -10,6 +10,7 @@ module "gcp-ga4-analytics" {
   working_directory   = "/terraform/deployments/ga4-analytics/"
   trigger_patterns    = ["/terraform/deployments/ga4-analytics/**/*"]
   global_remote_state = true
+  assessments_enabled = true
 
   project_name = "govuk-infrastructure"
   vcs_repo = {
@@ -41,6 +42,7 @@ module "gcp-ga4-aggregate-analytics" {
   working_directory   = "/terraform/deployments/gcp-ga4-aggregate-analytics/"
   trigger_patterns    = ["/terraform/deployments/gcp-ga4-aggregate-analytics/**/*"]
   global_remote_state = true
+  assessments_enabled = true
 
   project_name = "govuk-data-engineering"
   vcs_repo = {
@@ -71,6 +73,7 @@ module "gcp-gds-bq-processing" {
   working_directory   = "/terraform/deployments/gcp-gds-bq-processing/"
   trigger_patterns    = ["/terraform/deployments/gcp-gds-bq-processing/**/*"]
   global_remote_state = true
+  assessments_enabled = true
 
   project_name = "govuk-data-engineering"
   vcs_repo = {


### PR DESCRIPTION
This is part of https://gov-uk.atlassian.net/browse/IA-2581. I will eventually have lots of questions about configuring alerting based on drift but this PR just enables the health assessments as a start.

The [plan](https://app.terraform.io/app/govuk/workspaces/tfc-configuration/runs/run-vhJYBU8UjFbRJY93) seems to want to change something on a workspace I haven't made changes to - `module.govuk-publishing-infrastructure-production.tfe_workspace.ws`. I'm not sure how that could be happening? 🤔 