### PR TITLE
IA-2581-enable-email-drift-notifications

### DIFF
--- a/terraform/deployments/tfc-configuration/gcp-projects.tf
+++ b/terraform/deployments/tfc-configuration/gcp-projects.tf
@@ -59,6 +59,16 @@ module "gcp-ga4-aggregate-analytics" {
   variable_set_ids = [
     local.gcp_credentials["production"],
   ]
+
+  notifications = [
+    {
+      name             = "configuration-drift-alert"
+      destination_type = "email"
+      email_user_ids   = ["aaron_fowles"]
+      triggers         = ["assessment:check_failure", "assessment:drifted", "assessment:failed"]
+      enabled          = true
+    },
+  ]
 }
 
 module "gcp-gds-bq-processing" {


### PR DESCRIPTION
This is a bit of a test as part of [IA-2581](https://gov-uk.atlassian.net/browse/IA-2581). We are exploring setting up automated drift alerts to a team email but I'd like to find out a bit more about how they work using just my account to start with.

[IA-2581]: https://gov-uk.atlassian.net/browse/IA-2581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ