### PR TITLE
"Forget" the AWS VPC CNI Helm chart

### DIFF
--- a/terraform/deployments/cluster-services/aws_vpc_cni.tf
+++ b/terraform/deployments/cluster-services/aws_vpc_cni.tf
@@ -1,24 +1,6 @@
-resource "helm_release" "aws_vpc_cni" {
-  name = "aws-vpc-cni"
-
-  chart      = "aws-vpc-cni"
-  repository = "https://aws.github.io/eks-charts"
-  version    = "v1.21.1"
-
-  namespace        = "kube-system"
-  create_namespace = false
-
-  timeout = var.helm_timeout_seconds
-
-  values = [yamlencode({
-    enableNetworkPolicy = true
-    serviceAccount = {
-      name   = "aws-vpc-cni-sa"
-      create = true
-      annotations = {
-        "eks.amazonaws.com/role-arn" = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.aws_vpc_cni_role_arn
-      }
-    }
-    originalMatchLabels = true
-  })]
+removed {
+  from = helm_release.aws_vpc_cni
+  lifecycle {
+    destroy = false
+  }
 }


### PR DESCRIPTION
## What
We want to stop using the Helm chart, but just removing it will cause it to uninstall the chart. Uninstalling the VPC CNI chart will break networking on every node.

Instead we "forget" it. The AWS EKS VPC CNI add-on will continue to manage the same things.

A later PR will tidy up the removed block.

## How to review

1. Check the plans and make sure they aren't doing anything but dropping the resource from management.