### PR TITLE
Adding delete S3 object permissions to the AI Accelerator IRSA policy

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_iam.tf
@@ -42,7 +42,8 @@ data "aws_iam_policy_document" "govuk_ai_accelerator_s3_access" {
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:PutObject",
-      "s3:PutObjectAcl"
+      "s3:PutObjectAcl",
+      "s3:DeleteObject"
     ]
     resources = ["${aws_s3_bucket.govuk_ai_accelerator_data[0].arn}/*"]
   }


### PR DESCRIPTION
The AI Accelerator has created a lot of objects in the S3 bucket that need to be cleared up. This PR adds deleteobject permissions to the IRSA policy the App uses to enable the team to build the tools needed to better manage the bucket.