### PR TITLE
Bump kube-proxy to v1.34.0-eksbuild.2

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -41,7 +41,7 @@ locals {
 
   default_cluster_addons = {
     coredns        = { addon_version = "v1.13.2-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
-    kube-proxy     = { addon_version = "v1.33.8-eksbuild.4", resolve_conflicts_on_create = "OVERWRITE" }
+    kube-proxy     = { addon_version = "v1.34.0-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE" }
     metrics-server = { addon_version = "v0.8.1-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
     vpc-cni = {
       addon_version               = "v1.21.1-eksbuild.3",


### PR DESCRIPTION
We bumped the version in the console (as we normally do), but didn't reflect it in code yet.