### PR TITLE
BAU - Remove `tfe_oauth_client` GitHub from the wrong location

### DIFF
--- a/terraform/deployments/gcp-gov-graph/modules/gov-graph/main.tf
+++ b/terraform/deployments/gcp-gov-graph/modules/gov-graph/main.tf
@@ -51,11 +51,6 @@ resource "google_project_service" "api_service" {
   disable_dependent_services = true
 }
 
-data "tfe_oauth_client" "github" {
-  organization     = var.tfc_organization_name
-  service_provider = "github"
-}
-
 # Set up Workload Identity Federation between Terraform Cloud and GCP
 # see https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples
 resource "google_iam_workload_identity_pool" "tfc_pool" {

--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
@@ -79,11 +79,6 @@ resource "google_service_usage_consumer_quota_override" "discoveryengine_documen
   override_value = var.discovery_engine_quota_documents
 }
 
-data "tfe_oauth_client" "github" {
-  organization     = var.tfc_organization_name
-  service_provider = "github"
-}
-
 # Set up Workload Identity Federation between Terraform Cloud and GCP
 # see https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples
 resource "google_iam_workload_identity_pool" "tfc_pool" {

--- a/terraform/deployments/tfc-configuration/gov-graph.tf
+++ b/terraform/deployments/tfc-configuration/gov-graph.tf
@@ -14,7 +14,7 @@ module "gov-graph-dev" {
   working_directory = "/terraform/deployments/gcp-gov-graph/"
   trigger_patterns  = ["/terraform/deployments/gcp-gov-graph/**/*"]
 
-  project_name = "govuk-data-engineering"
+  project_name = tfe_project.data-engineering-project.name
   vcs_repo = {
     identifier     = "alphagov/govuk-infrastructure"
     branch         = "main"
@@ -30,8 +30,6 @@ module "gov-graph-dev" {
     local.gcp_credentials["integration"],
     module.variable-set-gov-graph-dev.id
   ]
-
-  depends_on = [tfe_project.data-engineering-project]
 }
 
 module "gov-graph-staging" {
@@ -46,7 +44,7 @@ module "gov-graph-staging" {
   working_directory = "/terraform/deployments/gcp-gov-graph/"
   trigger_patterns  = ["/terraform/deployments/gcp-gov-graph/**/*"]
 
-  project_name = "govuk-data-engineering"
+  project_name = tfe_project.data-engineering-project.name
   vcs_repo = {
     identifier     = "alphagov/govuk-infrastructure"
     branch         = "main"
@@ -78,7 +76,7 @@ module "gov-graph-production" {
   working_directory = "/terraform/deployments/gcp-gov-graph/"
   trigger_patterns  = ["/terraform/deployments/gcp-gov-graph/**/*"]
 
-  project_name = "govuk-data-engineering"
+  project_name = tfe_project.data-engineering-project.name
   vcs_repo = {
     identifier     = "alphagov/govuk-infrastructure"
     branch         = "main"
@@ -94,6 +92,4 @@ module "gov-graph-production" {
     local.gcp_credentials["production"],
     module.variable-set-gov-graph-production.id
   ]
-
-  depends_on = [tfe_project.data-engineering-project]
 }


### PR DESCRIPTION
Description:
- `tfe_oauth_client` data resource is only needed in `tfc-configuration` to establish the VCS connection. The modules (e.g. `search-api-v2` and `gov-graph`) don't need it
- Remove the `depends_on` annotation as setting the project name via `tfe_project.data-engineering-project.name` will let Terraform detect the dependency automatically