### PR TITLE
[CHAT-341] Add aliased AWS provider for eu-west-2 and fix regional chat alarms

### DIFF
--- a/terraform/deployments/chat/aws_chatbot.tf
+++ b/terraform/deployments/chat/aws_chatbot.tf
@@ -54,10 +54,17 @@ resource "aws_chatbot_slack_channel_configuration" "chat" {
   slack_team_id      = data.aws_chatbot_slack_workspace.gds.slack_team_id
   slack_channel_id   = var.chat_slack_channel_id
   iam_role_arn       = aws_iam_role.chatbot.arn
-  sns_topic_arns     = [aws_sns_topic.chat_alerts.arn]
+  sns_topic_arns     = [aws_sns_topic.chat_alerts_dublin.arn, aws_sns_topic.chat_alerts_london.arn]
 }
 
-resource "aws_sns_topic" "chat_alerts" {
-  name         = "chat-alerts-${var.govuk_environment}"
-  display_name = "Chat Alerts (${var.govuk_environment})"
+resource "aws_sns_topic" "chat_alerts_dublin" {
+  region       = "eu-west-1"
+  name         = "chat-alerts-${var.govuk_environment}-dublin"
+  display_name = "Chat Alerts (${var.govuk_environment} Dublin)"
+}
+
+resource "aws_sns_topic" "chat_alerts_london" {
+  region       = "eu-west-2"
+  name         = "chat-alerts-${var.govuk_environment}-london"
+  display_name = "Chat Alerts London (${var.govuk_environment} London)"
 }

--- a/terraform/deployments/chat/cloudwatch.tf
+++ b/terraform/deployments/chat/cloudwatch.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_log_group" "bedrock_log_group_dublin" {
 
 moved {
   from = aws_cloudwatch_log_group.bedrock_log_group
-  to = aws_cloudwatch_log_group.bedrock_log_group_dublin
+  to   = aws_cloudwatch_log_group.bedrock_log_group_dublin
 }
 
 resource "aws_cloudwatch_log_group" "bedrock_log_group_london" {

--- a/terraform/deployments/chat/cloudwatch_alarms.tf
+++ b/terraform/deployments/chat/cloudwatch_alarms.tf
@@ -80,8 +80,8 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_claud
     return_data = true
   }
 
-  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
   insufficient_data_actions = []
 }
 
@@ -154,8 +154,8 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_clau
     return_data = true
   }
 
-  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
   insufficient_data_actions = []
 }
 
@@ -228,8 +228,8 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_gpt_o
     return_data = true
   }
 
-  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
   insufficient_data_actions = []
 }
 
@@ -302,8 +302,8 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_gpt_
     return_data = true
   }
 
-  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
   insufficient_data_actions = []
 }
 
@@ -346,8 +346,8 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_titan
     return_data = true
   }
 
-  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
   insufficient_data_actions = []
 }
 
@@ -389,8 +389,8 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_tita
     return_data = true
   }
 
-  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
   insufficient_data_actions = []
 }
 
@@ -432,8 +432,8 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_titan
     return_data = true
   }
 
-  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  alarm_actions             = [aws_sns_topic.chat_alerts_london.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts_london.arn]
   insufficient_data_actions = []
 }
 
@@ -475,7 +475,7 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_tita
     return_data = true
   }
 
-  alarm_actions             = [aws_sns_topic.chat_alerts.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts.arn]
+  alarm_actions             = [aws_sns_topic.chat_alerts_london.arn]
+  ok_actions                = [aws_sns_topic.chat_alerts_london.arn]
   insufficient_data_actions = []
 }

--- a/terraform/deployments/chat/eventbridge.tf
+++ b/terraform/deployments/chat/eventbridge.tf
@@ -12,10 +12,19 @@ resource "aws_cloudwatch_event_rule" "aws_service_health_alert" {
   role_arn = aws_iam_role.aws_service_health_alert.arn
 }
 
-resource "aws_cloudwatch_event_target" "aws_service_health_alert" {
+resource "aws_cloudwatch_event_target" "aws_service_health_alert_dublin" {
+  region    = "eu-west-1"
   rule      = aws_cloudwatch_event_rule.aws_service_health_alert.name
-  arn       = aws_sns_topic.chat_alerts.arn
-  target_id = "chat-aws-service-health-alert-target"
+  arn       = aws_sns_topic.chat_alerts_dublin.arn
+  target_id = "chat-aws-service-health-alert-target-dublin"
+  role_arn  = aws_iam_role.aws_service_health_alert.arn
+}
+
+resource "aws_cloudwatch_event_target" "aws_service_health_alert_london" {
+  region    = "eu-west-2"
+  rule      = aws_cloudwatch_event_rule.aws_service_health_alert.name
+  arn       = aws_sns_topic.chat_alerts_london.arn
+  target_id = "chat-aws-service-health-alert-target-london"
   role_arn  = aws_iam_role.aws_service_health_alert.arn
 }
 
@@ -36,9 +45,12 @@ data "aws_iam_policy_document" "aws_service_health_alert_assume_role" {
 
 data "aws_iam_policy_document" "aws_service_health_alert" {
   statement {
-    actions   = ["sns:Publish"]
-    effect    = "Allow"
-    resources = [aws_sns_topic.chat_alerts.arn]
+    actions = ["sns:Publish"]
+    effect  = "Allow"
+    resources = [
+      aws_sns_topic.chat_alerts_dublin.arn,
+      aws_sns_topic.chat_alerts_london.arn
+    ]
   }
 }
 


### PR DESCRIPTION
## Description 

Fixes a failure during `terraform apply` where CloudWatch alarms in London (`eu-west-2`) were failing to create. This was caused by a regional mismatch. The alarms were being passed an SNS topic ARN from the default Dublin (`eu-west-1`) provider, which is not supported by the CloudWatch API.

This commit:
- Adds an aliased AWS provider for `eu-west-2` (London).
- Updates Titan embedding alarms to use the `aws.london` provider.
- Creates a regional SNS topic in `eu-west-2` to satisfy CloudWatch action requirements.
- Updates the AWS Chatbot configuration to aggregate alerts from both the Dublin and London SNS topics into the Slack channel.

## Jira ticket 

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-341