### PR TITLE
Remove redundant code

### DIFF
--- a/terraform/deployments/gcp-gov-graph/imports.tf
+++ b/terraform/deployments/gcp-gov-graph/imports.tf
@@ -1,0 +1,4 @@
+import {
+  id = var.project_id
+  to = google_project.environment_project
+}

--- a/terraform/deployments/gcp-gov-graph/main.tf
+++ b/terraform/deployments/gcp-gov-graph/main.tf
@@ -39,77 +39,10 @@ resource "google_project" "environment_project" {
   }
 }
 
-resource "google_project_iam_member" "environment_project_owner" {
-  project = google_project.environment_project.project_id
-  role    = "roles/owner"
-
-  member = "group:${var.access_group_name}@digital.cabinet-office.gov.uk"
-}
-
 resource "google_project_service" "api_service" {
   for_each = var.google_cloud_apis
 
   project                    = google_project.environment_project.project_id
   service                    = each.value
   disable_dependent_services = true
-}
-
-# Set up Workload Identity Federation between Terraform Cloud and GCP
-# see https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples
-resource "google_iam_workload_identity_pool" "tfc_pool" {
-  project                   = google_project.environment_project.project_id
-  workload_identity_pool_id = "terraform-cloud-id-pool"
-
-  display_name = "Terraform Cloud ID Pool"
-  description  = "Pool to enable access to project resources for Terraform Cloud"
-}
-
-resource "google_iam_workload_identity_pool_provider" "tfc_provider" {
-  project                            = google_project.environment_project.project_id
-  workload_identity_pool_id          = google_iam_workload_identity_pool.tfc_pool.workload_identity_pool_id
-  workload_identity_pool_provider_id = "terraform-cloud-provider-oidc"
-
-  display_name = "Terraform Cloud OIDC Provider"
-  description  = "Configures Terraform Cloud as an external identity provider for this project"
-
-  attribute_mapping = {
-    "google.subject"                        = "assertion.sub",
-    "attribute.aud"                         = "assertion.aud",
-    "attribute.terraform_run_phase"         = "assertion.terraform_run_phase",
-    "attribute.terraform_project_id"        = "assertion.terraform_project_id",
-    "attribute.terraform_project_name"      = "assertion.terraform_project_name",
-    "attribute.terraform_workspace_id"      = "assertion.terraform_workspace_id",
-    "attribute.terraform_workspace_name"    = "assertion.terraform_workspace_name",
-    "attribute.terraform_organization_id"   = "assertion.terraform_organization_id",
-    "attribute.terraform_organization_name" = "assertion.terraform_organization_name",
-    "attribute.terraform_run_id"            = "assertion.terraform_run_id",
-    "attribute.terraform_full_workspace"    = "assertion.terraform_full_workspace",
-  }
-
-  oidc {
-    issuer_uri = "https://${var.tfc_hostname}"
-  }
-
-  attribute_condition = "assertion.sub.startsWith(\"organization:${var.tfc_organization_name}:project:${var.tfc_project_name}:workspace:${var.environment_workspace_name}\")"
-}
-
-resource "google_service_account" "tfc_service_account" {
-  project = google_project.environment_project.project_id
-
-  account_id   = "tfc-service-account"
-  display_name = "Terraform Cloud Service Account"
-  description  = "Used by Terraform Cloud to manage resources in this project through Workload Identity Federation"
-}
-
-resource "google_service_account_iam_member" "tfc_service_account_member" {
-  service_account_id = google_service_account.tfc_service_account.name
-  role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.tfc_pool.name}/*"
-}
-
-resource "google_project_iam_member" "tfc_project_member" {
-  project = google_project.environment_project.project_id
-
-  role   = "roles/owner"
-  member = "serviceAccount:${google_service_account.tfc_service_account.email}"
 }

--- a/terraform/deployments/gcp-gov-graph/variables.tf
+++ b/terraform/deployments/gcp-gov-graph/variables.tf
@@ -82,3 +82,7 @@ variable "location" {
   description = "Google Cloud Storage location"
   default     = "EUROPE-WEST2"
 }
+
+variable "project_id" {
+  type = string
+}


### PR DESCRIPTION
Originally the gov-graph project was copied from search api. There is a good amount on terraform that's specific to search that can and should be removed