### PR TITLE
Permit Terraform to perform bedrock:DeleteModelInvocationLoggingConfiguration

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -43,6 +43,7 @@ data "aws_iam_policy_document" "tfc_policy" {
       "apigateway:*",
       "athena:*",
       "autoscaling:*",
+      "bedrock:DeleteModelInvocationLoggingConfiguration",
       "bedrock:GetModelInvocationLoggingConfiguration",
       "bedrock:PutModelInvocationLoggingConfiguration",
       "chatbot:*",


### PR DESCRIPTION
The chat TF root is failing to apply because Terraform is missing permission to perform this action.

This change will be deployed manually.

Slack conversation: https://gds.slack.com/archives/C013F737737/p1773331362186639?thread_ts=1773323023.607809&cid=C013F737737