### PR TITLE
Fix regional validation errors in London CloudWatch alarms

### DIFF
--- a/terraform/deployments/chat/aws_chatbot.tf
+++ b/terraform/deployments/chat/aws_chatbot.tf
@@ -58,13 +58,12 @@ resource "aws_chatbot_slack_channel_configuration" "chat" {
 }
 
 resource "aws_sns_topic" "chat_alerts_dublin" {
-  region       = "eu-west-1"
   name         = "chat-alerts-${var.govuk_environment}-dublin"
   display_name = "Chat Alerts (${var.govuk_environment} Dublin)"
 }
 
 resource "aws_sns_topic" "chat_alerts_london" {
-  region       = "eu-west-2"
+  provider     = aws.london
   name         = "chat-alerts-${var.govuk_environment}-london"
   display_name = "Chat Alerts London (${var.govuk_environment} London)"
 }

--- a/terraform/deployments/chat/cloudwatch_alarms.tf
+++ b/terraform/deployments/chat/cloudwatch_alarms.tf
@@ -395,7 +395,7 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_tita
 }
 
 resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_titan_embed_london" {
-  region              = "eu-west-2"
+  provider            = aws.london
   alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-50-titan-embed-london"
   alarm_description   = <<-EOF
   WARNING - The current ${var.govuk_environment} Bedrock token usage > 50% for Titan Embed in eu-west-2 (Document indexing)
@@ -438,7 +438,7 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_titan
 }
 
 resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_titan_embed_london" {
-  region              = "eu-west-2"
+  provider            = aws.london
   alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-100-titan-embed-london"
   alarm_description   = <<-EOF
   CRITICAL - The current ${var.govuk_environment} Bedrock token usage > 100% for Titan Embed in eu-west-2 (Document indexing)

--- a/terraform/deployments/chat/main.tf
+++ b/terraform/deployments/chat/main.tf
@@ -30,6 +30,22 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+  default_tags {
+    tags = {
+      product              = "govuk"
+      system               = "govuk-chat"
+      environment          = var.govuk_environment
+      owner                = "govuk-platform-engineering@digital.cabinet-office.gov.uk"
+      repository           = "govuk-infrastructure"
+      terraform-deployment = basename(abspath(path.root))
+      Service              = "govuk-chat"
+    }
+  }
+}
+
+provider "aws" {
   alias  = "global"
   region = "us-east-1"
 }


### PR DESCRIPTION
## Description 

Use aliased AWSprovider with "eu-west-2" region

I've tried to add a new aws_sns_topic with the "eu-west-2", but i'm still
getting failures when i try to apply the changes.

I suspect it's using the default provider at some point, which is
configured with the "eu-west-1" region.

My hope is that by adding an aliased provider with the "eu-west-2" region,
we can ensure that the correct provider is used for the new resources.
