### PR TITLE
Mark aws_cloudwatch_event_rule as moved

### DIFF
--- a/terraform/deployments/chat/eventbridge.tf
+++ b/terraform/deployments/chat/eventbridge.tf
@@ -13,6 +13,11 @@ resource "aws_cloudwatch_event_rule" "aws_service_health_alert_dublin" {
   role_arn = aws_iam_role.aws_service_health_alert.arn
 }
 
+moved {
+  from = aws_cloudwatch_event_rule.aws_service_health_alert
+  to   = aws_cloudwatch_event_rule.aws_service_health_alert_dublin
+}
+
 resource "aws_cloudwatch_event_rule" "aws_service_health_alert_london" {
   region      = "eu-west-2"
   name        = "chat-aws-service-health-alert"


### PR DESCRIPTION
When the action to delete the aws_service_health_alert aws_cloudwatch_event_rule runs before the targets are updated it can throw an error that the rule has targets.

This marks the rule as moved.

I've confirmed the rule has been updated as expected in the [eventbridge UI](https://eu-west-1.console.aws.amazon.com/events/home?region=eu-west-1#/eventbus/default/rules/chat-aws-service-health-alert)