### PR TITLE
Temporarily remove aws_service_health_alert_dublin

### DIFF
--- a/terraform/deployments/chat/eventbridge.tf
+++ b/terraform/deployments/chat/eventbridge.tf
@@ -33,6 +33,7 @@ resource "aws_cloudwatch_event_rule" "aws_service_health_alert_london" {
   role_arn = aws_iam_role.aws_service_health_alert.arn
 }
 
+/* temporarily remove so ghost resource can be removed
 resource "aws_cloudwatch_event_target" "aws_service_health_alert_dublin" {
   region    = "eu-west-1"
   rule      = aws_cloudwatch_event_rule.aws_service_health_alert_dublin.name
@@ -40,6 +41,7 @@ resource "aws_cloudwatch_event_target" "aws_service_health_alert_dublin" {
   target_id = "chat-aws-service-health-alert-target-dublin"
   role_arn  = aws_iam_role.aws_service_health_alert.arn
 }
+*/
 
 resource "aws_cloudwatch_event_target" "aws_service_health_alert_london" {
   region    = "eu-west-2"


### PR DESCRIPTION
I thought that moving the resource in this PR:
https://github.com/alphagov/govuk-infrastructure/pulls?q=is%3Apr+is%3Aclosed

would resolve the delete failing in the apply, but it hasn't.

Essentially what has happened is in an apply a resource with the same name has been created while an old one was being deleted.

I think the simplest and safest way to resolve this is to remove the target so the delete can run and then we can add it straight back in a follow up PR.