### PR TITLE
Revert temporarily removing aws_service_health_alert_dublin

### DIFF
--- a/terraform/deployments/chat/eventbridge.tf
+++ b/terraform/deployments/chat/eventbridge.tf
@@ -33,7 +33,6 @@ resource "aws_cloudwatch_event_rule" "aws_service_health_alert_london" {
   role_arn = aws_iam_role.aws_service_health_alert.arn
 }
 
-/* temporarily remove so ghost resource can be removed
 resource "aws_cloudwatch_event_target" "aws_service_health_alert_dublin" {
   region    = "eu-west-1"
   rule      = aws_cloudwatch_event_rule.aws_service_health_alert_dublin.name
@@ -41,7 +40,6 @@ resource "aws_cloudwatch_event_target" "aws_service_health_alert_dublin" {
   target_id = "chat-aws-service-health-alert-target-dublin"
   role_arn  = aws_iam_role.aws_service_health_alert.arn
 }
-*/
 
 resource "aws_cloudwatch_event_target" "aws_service_health_alert_london" {
   region    = "eu-west-2"


### PR DESCRIPTION
Now that the target was removed and the [aws_service_health_alert](https://github.com/alphagov/govuk-infrastructure/pulls?q=is%3Apr+is%3Aclosed) with it. We can re-add them without causing any issues.