### PR TITLE
Remove search specific variables

### DIFF
--- a/terraform/deployments/gcp-gov-graph/variables.tf
+++ b/terraform/deployments/gcp-gov-graph/variables.tf
@@ -51,15 +51,7 @@ variable "services" {
     "secretmanager.googleapis.com",
     "redis.googleapis.com",
     "dlp.googleapis.com",
-    "cloudquotas.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
-    "iamcredentials.googleapis.com",
-    "sts.googleapis.com",
-    "discoveryengine.googleapis.com",
-    "bigquerystorage.googleapis.com",
-    "cloudbuild.googleapis.com",
-    "logging.googleapis.com",
-    "monitoring.googleapis.com"
+    "cloudquotas.googleapis.com"
   ]
 }
 


### PR DESCRIPTION
They were reintroduced in 422ba449e102b94e2f8afe769c4b5d242737bda4 to appease terraform