### PR TITLE
CDN analytics review IAM

### DIFF
--- a/terraform/deployments/cdn-analytics/bigquery.tf
+++ b/terraform/deployments/cdn-analytics/bigquery.tf
@@ -15,11 +15,6 @@ resource "google_bigquery_dataset" "fastly_logs" {
   }
 
   access {
-    role           = "roles/bigquery.admin"
-    group_by_email = "analytics-team@digital.cabinet-office.gov.uk"
-  }
-
-  access {
     role          = "WRITER"
     user_by_email = google_service_account.fastly_writer.email
   }


### PR DESCRIPTION
This PR adds read access for sthe service account data-processing@gds-bq-processing.iam.gserviceaccount.com, used to process Fastly logs for analytics.

Access has been removed for the Analytics Team because it is no longer needed