### PR TITLE
opensearch: Use tfe_outputs for all remote values instead of terraform_remote_state

### DIFF
--- a/terraform/deployments/opensearch/data.tf
+++ b/terraform/deployments/opensearch/data.tf
@@ -6,38 +6,15 @@ data "tfe_outputs" "cluster_infrastructure" {
   organization = "govuk"
   workspace    = "cluster-infrastructure-${var.govuk_environment}"
 }
-data "terraform_remote_state" "infra_vpc" {
-  backend = "s3"
-  config = {
-    bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-vpc.tfstate"
-    region = data.aws_region.current.region
-  }
-}
-data "terraform_remote_state" "infra_security_groups" {
-  backend = "s3"
-  config = {
-    bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-security-groups.tfstate"
-    region = data.aws_region.current.region
-  }
+
+data "tfe_outputs" "vpc" {
+  organization = "govuk"
+  workspace    = "vpc-${var.govuk_environment}"
 }
 
-data "terraform_remote_state" "infra_root_dns_zones" {
-  backend = "s3"
-  config = {
-    bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-root-dns-zones.tfstate"
-    region = var.aws_region
-  }
-}
-data "terraform_remote_state" "infra_networking" {
-  backend = "s3"
-  config = {
-    bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-networking.tfstate"
-    region = var.aws_region
-  }
+data "tfe_outputs" "root_dns" {
+  organization = "govuk"
+  workspace    = "root-dns-${var.govuk_environment}"
 }
 
 data "aws_acm_certificate" "govuk_internal" {

--- a/terraform/deployments/opensearch/main.tf
+++ b/terraform/deployments/opensearch/main.tf
@@ -2,7 +2,7 @@ terraform {
   cloud {
     organization = "govuk"
     workspaces {
-      tags = ["opensearch", "eks", "aws"]
+      tags = ["opensearch", "aws"]
     }
   }
   required_version = "~> 1.14"
@@ -32,7 +32,7 @@ provider "aws" {
 
 locals {
   domain      = "${var.service}-engine"
-  subnet_ids  = data.terraform_remote_state.infra_networking.outputs.private_subnet_rds_ids
+  subnet_ids  = [for k, v in data.tfe_outputs.vpc.nonsensitive_values.private_subnet_ids : v if startswith(k, "rds_")]
   master_user = "${var.service}-masteruser"
 }
 
@@ -192,7 +192,7 @@ resource "aws_secretsmanager_secret_version" "opensearch_passwords" {
 }
 
 resource "aws_route53_record" "service_record" {
-  zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
+  zone_id = data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_id
   name    = "chat-opensearch.${var.govuk_environment}.govuk-internal.digital"
   type    = "CNAME"
   ttl     = 300
@@ -202,7 +202,7 @@ resource "aws_route53_record" "service_record" {
 # This CNAME record is for the Test Opensearch snapshot import K8s cronjob:
 resource "aws_route53_record" "test_service_record" {
   count   = var.govuk_environment == "integration" ? 1 : 0
-  zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
+  zone_id = data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_id
   name    = "chat-opensearch-test.${var.govuk_environment}.govuk-internal.digital"
   type    = "CNAME"
   ttl     = 300

--- a/terraform/deployments/opensearch/security_groups.tf
+++ b/terraform/deployments/opensearch/security_groups.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "opensearch" {
   name        = "opensearch"
-  vpc_id      = data.terraform_remote_state.infra_vpc.outputs.vpc_id
+  vpc_id      = data.tfe_outputs.vpc.nonsensitive_values.id
   description = "Allow access to Opensearch from EKS nodes"
 }
 


### PR DESCRIPTION
The state in the buckets referenced here hasn't been used in years and is extremely outdated

https://github.com/alphagov/govuk-infrastructure/issues/3935