### PR TITLE
chat: use tfe_outputs for all remote values instead of terraform_remote_state

### DIFF
--- a/terraform/deployments/chat/data.tf
+++ b/terraform/deployments/chat/data.tf
@@ -14,20 +14,7 @@ data "tfe_outputs" "vpc" {
   workspace    = "vpc-${var.govuk_environment}"
 }
 
-data "terraform_remote_state" "infra_networking" {
-  backend = "s3"
-  config = {
-    bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-networking.tfstate"
-    region = var.aws_region
-  }
-}
-
-data "terraform_remote_state" "infra_root_dns_zones" {
-  backend = "s3"
-  config = {
-    bucket = var.govuk_aws_state_bucket
-    key    = "govuk/infra-root-dns-zones.tfstate"
-    region = var.aws_region
-  }
+data "tfe_outputs" "root_dns" {
+  organization = "govuk"
+  workspace    = "root-dns-${var.govuk_environment}"
 }

--- a/terraform/deployments/chat/main.tf
+++ b/terraform/deployments/chat/main.tf
@@ -35,5 +35,5 @@ provider "aws" {
 }
 
 locals {
-  internal_dns_zone_id = data.terraform_remote_state.infra_root_dns_zones.outputs.internal_root_zone_id
+  internal_dns_zone_id = data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_id
 }

--- a/terraform/deployments/chat/redis.tf
+++ b/terraform/deployments/chat/redis.tf
@@ -1,6 +1,6 @@
 locals {
   chat_redis_name     = "chat-redis"
-  elasticache_subnets = data.terraform_remote_state.infra_networking.outputs.private_subnet_elasticache_ids
+  elasticache_subnets = [for k, v in data.tfe_outputs.vpc.nonsensitive_values.private_subnet_ids : v if startswith(k, "elasticache_")]
 }
 
 resource "aws_elasticache_subnet_group" "chat_redis_cluster" {


### PR DESCRIPTION
The state in the buckets referenced here hasn't been used in years and is extremely outdated

https://github.com/alphagov/govuk-infrastructure/issues/3935