### PR TITLE
add 'govuk-social-data' repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -433,7 +433,7 @@ repos:
 
   govuk-social-data:
     can_be_deployed: false
-    visibility: "internal"
+    visibility: "private"
     standard_contexts: *standard_security_checks 
     push_allowances: []
     required_pull_request_reviews:


### PR DESCRIPTION
This PR updates repos.yml to add the new repository, govuk-social-data. The purpose of this repo is to ingest GOV.UK social media account information from multiple APIs. 

This is not an app repo and will not be deployed. This PR contains pull_allowances for the govuk-data team in the repos definition. 