### PR TITLE
Remove references to govuk_aws_state_bucket and cluster_infrastructure_state_bucket variables

### DIFF
--- a/terraform/deployments/chat/variables.tf
+++ b/terraform/deployments/chat/variables.tf
@@ -7,10 +7,6 @@ variable "aws_region_global" {
   type    = string
   default = "us-east-1"
 }
-variable "govuk_aws_state_bucket" {
-  type        = string
-  description = "Bucket where govuk-aws state is stored"
-}
 variable "govuk_environment" {
   type        = string
   description = "Acceptable values are test, integration, staging, production"

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -1,8 +1,3 @@
-variable "govuk_aws_state_bucket" {
-  type        = string
-  description = "The name of the S3 bucket used for govuk-aws's Terraform state files."
-}
-
 variable "cluster_log_retention_in_days" {
   type        = number
   description = "Number of days to retain cluster log events in CloudWatch."

--- a/terraform/deployments/cluster-services/variables.tf
+++ b/terraform/deployments/cluster-services/variables.tf
@@ -46,11 +46,6 @@ variable "helm_timeout_seconds" {
   default     = "1200"
 }
 
-variable "govuk_aws_state_bucket" {
-  type        = string
-  description = "Name of the S3 bucket used for govuk-aws's Terraform state."
-}
-
 variable "govuk_environment" {
   type        = string
   description = "Acceptable values are test, integration, staging, production"

--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -16,7 +16,6 @@ module "var_set" {
 
     force_destroy = true
 
-    govuk_aws_state_bucket    = ""
     publishing_service_domain = "${var.ephemeral_cluster_id}.publishing.service.gov.uk"
 
     enable_arm_workers_blue    = true

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -1,8 +1,3 @@
-variable "govuk_aws_state_bucket" {
-  type        = string
-  description = "The name of the S3 bucket used for govuk-aws's Terraform state files."
-}
-
 variable "govuk_environment" {
   type        = string
   description = "GOV.UK environment where resources are being deployed"

--- a/terraform/deployments/opensearch/variables.tf
+++ b/terraform/deployments/opensearch/variables.tf
@@ -39,10 +39,6 @@ variable "aws_region" {
   description = "AWS region"
   default     = "eu-west-1"
 }
-variable "govuk_aws_state_bucket" {
-  type        = string
-  description = "Bucket where govuk-aws state is stored"
-}
 variable "govuk_environment" {
   type        = string
   description = "Acceptable values are test, integration, staging, production"

--- a/terraform/deployments/rds/variables.tf
+++ b/terraform/deployments/rds/variables.tf
@@ -9,11 +9,6 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "govuk_aws_state_bucket" {
-  type        = string
-  description = "Bucket where govuk-aws state is stored"
-}
-
 variable "databases" {
   description = "Databases to create and their configuration."
 

--- a/terraform/deployments/security/variables.tf
+++ b/terraform/deployments/security/variables.tf
@@ -4,11 +4,6 @@ variable "aws_region" {
   default     = "eu-west-1"
 }
 
-variable "govuk_aws_state_bucket" {
-  type        = string
-  description = "Bucket where govuk-aws state is stored"
-}
-
 variable "govuk_environment" {
   type        = string
   description = "GOV.UK environment where resources are being deployed"

--- a/terraform/variables/integration/common.tfvars
+++ b/terraform/variables/integration/common.tfvars
@@ -2,9 +2,6 @@
 # Only add variables here if they are shared across multiple workspaces in the integration environment.
 # Variables that are only used by a single workspace should be added to that workspace's specific tfvars file.
 
-govuk_aws_state_bucket              = "govuk-terraform-steppingstone-integration"
-cluster_infrastructure_state_bucket = "govuk-terraform-integration"
-
 cluster_version               = "1.34"
 cluster_log_retention_in_days = 731
 

--- a/terraform/variables/production/common.tfvars
+++ b/terraform/variables/production/common.tfvars
@@ -2,9 +2,6 @@
 # Only add variables here if they are shared across multiple workspaces in the integration environment.
 # Variables that are only used by a single workspace should be added to that workspace's specific tfvars file.
 
-govuk_aws_state_bucket              = "govuk-terraform-steppingstone-production"
-cluster_infrastructure_state_bucket = "govuk-terraform-production"
-
 cluster_version               = "1.34" # Don't forget to change this in variables-test.tf too
 cluster_log_retention_in_days = 731
 

--- a/terraform/variables/staging/common.tfvars
+++ b/terraform/variables/staging/common.tfvars
@@ -2,9 +2,6 @@
 # Only add variables here if they are shared across multiple workspaces in the staging environment.
 # Variables that are only used by a single workspace should be added to that workspace's specific tfvars file.
 
-govuk_aws_state_bucket              = "govuk-terraform-steppingstone-staging"
-cluster_infrastructure_state_bucket = "govuk-terraform-staging"
-
 cluster_version               = "1.34"
 cluster_log_retention_in_days = 731
 


### PR DESCRIPTION
These are no longer in use anywhere

https://github.com/alphagov/govuk-infrastructure/issues/3935