### PR TITLE
Tidy-up Kube State Metrics Config (Make it Default)

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -40,8 +40,9 @@ locals {
   }
 
   default_cluster_addons = {
-    coredns        = { addon_version = "v1.13.2-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
-    kube-proxy     = { addon_version = "v1.34.5-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE" }
+    coredns = { addon_version = "v1.13.2-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
+    kube-proxy = { addon_version = "v1.34.5-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE"
+    kube-state-metrics = { addon_version = "v2.18.0-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" } }
     metrics-server = { addon_version = "v0.8.1-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
     vpc-cni = {
       addon_version               = "v1.21.1-eksbuild.5",
@@ -53,11 +54,10 @@ locals {
     }
   }
 
-  kube_state_metrics_addon = {
-    kube-state-metrics = { addon_version = "v2.18.0-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
-  }
+  # Uncomment to configure optional or per-env addons.
+  # enabled_cluster_addons = merge(local.default_cluster_addons, var.enable_network_flow_addon ? local.network_flow_agent_addon : {})
 
-  enabled_cluster_addons = merge(local.default_cluster_addons, var.enable_kube_state_metrics ? local.kube_state_metrics_addon : {})
+  enabled_cluster_addons = local.default_cluster_addons
 
   managed_node_group_defaults = {
     capacity_type                  = var.x86_workers_default_capacity_type

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -51,12 +51,6 @@ variable "force_destroy" {
   default     = false
 }
 
-variable "enable_kube_state_metrics" {
-  type        = bool
-  description = "Enable the Kube State Metrics EKS Add-on. For Pod State Metrics."
-  default     = false
-}
-
 variable "enable_arm_workers_blue" {
   type        = bool
   description = "Whether to enable the 'blue' ARM/Graviton-based Managed Node Group"

--- a/terraform/variables/integration/common.tfvars
+++ b/terraform/variables/integration/common.tfvars
@@ -53,8 +53,6 @@ legacy_private_subnets = {
 govuk_environment = "integration"
 force_destroy     = true
 
-enable_kube_state_metrics = true
-
 enable_arm_workers_blue  = false
 enable_arm_workers_green = true
 enable_tetragon          = true

--- a/terraform/variables/production/common.tfvars
+++ b/terraform/variables/production/common.tfvars
@@ -48,8 +48,6 @@ legacy_private_subnets = {
 
 govuk_environment = "production"
 
-enable_kube_state_metrics = false
-
 enable_arm_workers_blue  = false
 enable_arm_workers_green = true
 enable_x86_workers       = false

--- a/terraform/variables/staging/common.tfvars
+++ b/terraform/variables/staging/common.tfvars
@@ -48,8 +48,6 @@ legacy_private_subnets = {
 
 govuk_environment = "staging"
 
-enable_kube_state_metrics = false
-
 enable_arm_workers_blue  = false
 enable_arm_workers_green = true
 enable_x86_workers       = false


### PR DESCRIPTION
## What?
~~This tweaks our Terraform to allow us to enable the Network Flow Monitoring Agent per environment. To make the config a little cleaner, I am also making the Kube State Metrics Addon a default for the clusters (and supplying a Prometheus Dashboard in a separate PR to help expose these metrics) as it gives us usable health metrics with no noticeable drawbacks.~~ Breaking this up into two PRs.

This tidies-up our Kube State Metrics configuration (before we start configuring the Cluster Addons to enable the Network Flow Monitor in integration).

### Related

* https://github.com/alphagov/govuk-infrastructure/issues/3913