### PR TITLE
Set up Network Flow Agent for EKS (Integration)

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -54,12 +54,20 @@ locals {
     }
   }
 
+  eks_pod_identity_addon = {
+    eks-pod-identity-agent = { addon_version = "v1.3.10-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE" }
+  }
+
   network_flow_agent_addon = {
     aws-network-flow-monitoring-agent = { addon_version = "v1.1.3-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE" }
   }
 
   # Uncomment to configure optional or per-env addons.
-  enabled_cluster_addons = merge(local.default_cluster_addons, var.enable_network_flow_addon ? local.network_flow_agent_addon : {})
+  enabled_cluster_addons = merge(
+    local.default_cluster_addons,
+    var.enable_eks_pod_identity_addon ? local.eks_pod_identity_addon : {},
+    var.enable_network_flow_addon ? local.network_flow_agent_addon : {},
+  )
 
   managed_node_group_defaults = {
     capacity_type                  = var.x86_workers_default_capacity_type

--- a/terraform/deployments/cluster-infrastructure/observability.tf
+++ b/terraform/deployments/cluster-infrastructure/observability.tf
@@ -1,0 +1,65 @@
+data "aws_iam_policy_document" "network_flow_agent_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "network_flow_agent_role" {
+  count = var.enable_container_network_observability == true ? 1 : 0
+
+  name                  = "network-flow-agent-role"
+  description           = "Network Flow Monitoring Agent IAM role"
+  assume_role_policy    = data.aws_iam_policy_document.network_flow_agent_assume_role.json
+  force_detach_policies = true
+}
+
+resource "aws_iam_role_policy_attachment" "network_flow_agent_role_policy" {
+  count = var.enable_container_network_observability == true ? 1 : 0
+
+  role       = aws_iam_role.network_flow_agent_role[0].name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchNetworkFlowMonitorAgentPublishPolicy"
+}
+
+resource "aws_eks_pod_identity_association" "network_flow_agent" {
+  count = var.enable_container_network_observability == true ? 1 : 0
+
+  cluster_name    = var.cluster_name
+  namespace       = "amazon-network-flow-monitoring"
+  service_account = "network-flow-monitoring-agent"
+  role_arn        = aws_iam_role.network_flow_agent_role[0].arn
+}
+
+resource "aws_networkflowmonitor_scope" "govuk" {
+  count = var.enable_container_network_observability == true ? 1 : 0
+
+  target {
+    region = "eu-west-1"
+    target_identifier {
+      target_type = "ACCOUNT"
+      target_id {
+        account_id = data.aws_caller_identity.current.account_id
+      }
+    }
+  }
+}
+
+resource "aws_networkflowmonitor_monitor" "govuk" {
+  count = var.enable_container_network_observability == true ? 1 : 0
+
+  monitor_name = "eks-govuk-monitor"
+  scope_arn    = aws_networkflowmonitor_scope.govuk[0].scope_arn
+
+  local_resource {
+    type       = "AWS::EKS::Cluster"
+    identifier = module.eks.cluster_arn
+  }
+
+  remote_resource {
+    type       = "AWS::Region"
+    identifier = "eu-west-1"
+  }
+}

--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -46,6 +46,18 @@ variable "force_destroy" {
   default     = false
 }
 
+variable "enable_container_network_observability" {
+  type        = bool
+  description = "Whether to enable Container Network Observability configuration"
+  default     = false
+}
+
+variable "enable_eks_pod_identity_addon" {
+  type        = bool
+  description = "Whether to enable the EKS Pod Identity Agent addon"
+  default     = false
+}
+
 variable "enable_network_flow_addon" {
   type        = bool
   description = "Whether to enable the Network Flow Agent addon"

--- a/terraform/variables/integration/cluster-infrastructure.tfvars
+++ b/terraform/variables/integration/cluster-infrastructure.tfvars
@@ -1,2 +1,4 @@
 # Variables for the cluster-infrastructure-integration workspace
-enable_network_flow_addon = true
+enable_container_network_observability = true
+enable_eks_pod_identity_addon          = true
+enable_network_flow_addon              = true


### PR DESCRIPTION
## What?

This sets up the necessary resources for the EKS Network Flow Agent Add-on, and also enables the EKS Pod Identity Agent as this is the recommended way to configure the Network Flow Agent's permissions. I have tried to stick to using variables (flags) to enable the necessary features including for EKS Pod Identities.