### PR TITLE
Grant network flow monitor access to TFC Role

### DIFF
--- a/terraform/deployments/tfc-aws-config/aws_oidc.tf
+++ b/terraform/deployments/tfc-aws-config/aws_oidc.tf
@@ -83,6 +83,7 @@ data "aws_iam_policy_document" "tfc_policy" {
       "lambda:*",
       "logs:*",
       "mq:*",
+      "networkflowmonitor:*",
       "pi:*", # Performance Insights
       "rds:*",
       "route53:*",
@@ -125,7 +126,8 @@ data "aws_iam_policy_document" "tfc_policy" {
       "arn:aws:iam::*:role/govuk-*-csp-reports-firehose-role",
       "arn:aws:iam::*:role/govuk-chat-bedrock-access-role",
       "arn:aws:iam::*:role/govuk-chat-bedrock-cloudwatch-role",
-      "arn:aws:iam::*:role/govuk-chat-eventbridge-health-alert"
+      "arn:aws:iam::*:role/govuk-chat-eventbridge-health-alert",
+      "arn:aws:iam::*:role/network-flow-agent-role"
     ]
   }
   statement {


### PR DESCRIPTION
## What?
This adds the necessary permissions for Terraform Cloud to apply the new Network Flow Monitor resources as part of https://github.com/alphagov/govuk-infrastructure/issues/3913.