### PR TITLE
Move Pod ID Config to Addon Config Block

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -59,7 +59,14 @@ locals {
   }
 
   network_flow_agent_addon = {
-    aws-network-flow-monitoring-agent = { addon_version = "v1.1.3-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE" }
+    aws-network-flow-monitoring-agent = {
+      addon_version               = "v1.1.3-eksbuild.2"
+      resolve_conflicts_on_create = "OVERWRITE"
+      pod_identity_association = [{
+        role_arn        = try(aws_iam_role.network_flow_agent_role[0].arn, "")
+        service_account = "network-flow-monitoring-agent"
+      }]
+    }
   }
 
   # Uncomment to configure optional or per-env addons.

--- a/terraform/deployments/cluster-infrastructure/observability.tf
+++ b/terraform/deployments/cluster-infrastructure/observability.tf
@@ -24,14 +24,7 @@ resource "aws_iam_role_policy_attachment" "network_flow_agent_role_policy" {
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchNetworkFlowMonitorAgentPublishPolicy"
 }
 
-resource "aws_eks_pod_identity_association" "network_flow_agent" {
-  count = var.enable_container_network_observability == true ? 1 : 0
 
-  cluster_name    = var.cluster_name
-  namespace       = "amazon-network-flow-monitoring"
-  service_account = "network-flow-monitoring-agent"
-  role_arn        = aws_iam_role.network_flow_agent_role[0].arn
-}
 
 resource "aws_networkflowmonitor_scope" "govuk" {
   count = var.enable_container_network_observability == true ? 1 : 0


### PR DESCRIPTION
## What?
This moves the Pod Identity Association into the Add-on Configuration, as the Add-on is currently running without an association.