### PR TITLE
AWS is sensitive about the Service Account name

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -64,7 +64,7 @@ locals {
       resolve_conflicts_on_create = "OVERWRITE"
       pod_identity_association = [{
         role_arn        = try(aws_iam_role.network_flow_agent_role[0].arn, "")
-        service_account = "network-flow-monitoring-agent"
+        service_account = "aws-network-flow-monitor-agent-service-account"
       }]
     }
   }


### PR DESCRIPTION
## What?
This changes the name of the Service Account as AWS is particular about the name of the service account to be used.

In true AWS Tech Docs fashion, they provide an example when using the CLI:
```
aws eks create-addon --cluster-name CLUSTER NAME --addon-name aws-network-flow-monitoring-agent --region AWS REGION --pod-identity-associations serviceAccount=aws-network-flow-monitor-agent-service-account,roleArn=IAM ROLE ARN
```
...but at no point do they ever explicitly indicate that the SDK expects/requires the Service Account name shown in the example above.