### PR TITLE
[PNP-9876] Mark Government Frontend as archived

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -260,7 +260,8 @@ repos:
       additional_contexts:
         - test
 
-  government-frontend: {}
+  government-frontend:
+    archived: true
 
   govspeak:
     homepage_url: "https://govspeak-preview.publishing.service.gov.uk/"


### PR DESCRIPTION
Related PRs:

- https://github.com/alphagov/govuk-e2e-tests/pull/452
- https://github.com/alphagov/govuk-docker/pull/973
- https://github.com/alphagov/govuk-dependabot-merger/pull/129
- https://github.com/alphagov/publishing-api/pull/3956
- https://github.com/alphagov/govuk-helm-charts/pull/4153

This follows Step 2 of [Remove from govuk-infrastructure](https://docs.publishing.service.gov.uk/manual/retiring-an-application.html#remove-from-govuk-infrastructure)

Follows from https://github.com/alphagov/govuk-infrastructure/pull/3964

[Jira card](https://gov-uk.atlassian.net/browse/PNP-9876)