### PR TITLE
IA-2582: setup alerting for unauthorised access to gcp-ga4-aggregate-analytics

### DIFF
--- a/terraform/deployments/gcp-ga4-aggregate-analytics/main.tf
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/main.tf
@@ -33,6 +33,7 @@ resource "google_project" "project" {
 }
 
 module "data_access_monitoring" {
-  source     = "./modules/data-access-monitoring"
-  project_id = google_project.project.project_id
+  source                     = "./modules/data-access-monitoring"
+  project_id                 = google_project.project.project_id
+  notification_email_address = data.google_secret_manager_secret_version.slack_alert_channel_email_address.secret_data
 }

--- a/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/README.md
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/README.md
@@ -1,7 +1,9 @@
 # Data Access Monitoring
-This module sets up a dataset called `data_access_log` in the specified project containing a table `cloudaudit_google_cloud_bigquery_v2_AuditData` which captures all data access on GCP BigQuery tables within that project.
+This module implements a security scanner that monitors BigQuery Audit Logs for data access by users not explicitly listed in the authorised_users allow-list.
 
-A configurable allow-list table also exists in that dataset called `authorised_users`. Any users which have queried a table in the project who are not also in `authorised_users` will result in that read being captured in the table `unauthorised_access_alerts`.
+It sets up a dataset called `data_access_log` in the specified project containing a table `cloudaudit_googleapis_com_data_access` which captures all data access on GCP BigQuery tables within that project.
+
+A configurable allow-list table also exists in that dataset called `authorised_users`. Any users which have queried a table in the project who are not also in `authorised_users` will result in that read being captured in the table `unauthorised_access` and an alert email being sent.
 
 It could eventually move to `terraform/shared-modules` once more mature and tested. The required Google Cloud API services would need to be managed directly by module in this case.
 <!-- BEGIN_TF_DOCS -->
@@ -30,6 +32,9 @@ No modules.
 | [google_bigquery_table.authorised_users](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table) | resource |
 | [google_bigquery_table.unauthorised_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table) | resource |
 | [google_logging_project_sink.bq_read_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
+| [google_monitoring_alert_policy.dts_failure_alert](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_monitoring_alert_policy.unauthorised_bq_access_alert](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_monitoring_notification_channel.email_notification_channel](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_notification_channel) | resource |
 | [google_project_iam_audit_config.bq_audit](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_audit_config) | resource |
 | [google_project_iam_member.query_executor_job_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.query_executor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
@@ -40,6 +45,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_notification_email_address"></a> [notification\_email\_address](#input\_notification\_email\_address) | n/a | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/bigquery.tf
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/bigquery.tf
@@ -10,16 +10,14 @@ resource "google_bigquery_table" "authorised_users" {
   dataset_id = google_bigquery_dataset.audit_logs.dataset_id
   table_id   = "authorised_users"
 
-  schema = <<EOF
-[
-  {
-    "name": "user_email",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "The email address of the user authorized to read sensitive data"
-  }
-]
-EOF
+  schema = jsonencode([
+    {
+      name        = "user_email"
+      type        = "STRING"
+      mode        = "REQUIRED"
+      description = "The email address of the user authorised to read sensitive data"
+    }
+  ])
 }
 
 # Table to store the findings
@@ -35,15 +33,38 @@ resource "google_bigquery_table" "unauthorised_access" {
     field = "timestamp"
   }
 
-  schema = <<EOF
-[
-  {"name": "insertId", "type": "STRING", "mode": "REQUIRED", "description": "Unique ID from the audit log to prevent duplicates"},
-  {"name": "timestamp", "type": "TIMESTAMP", "mode": "REQUIRED"},
-  {"name": "user_email", "type": "STRING", "mode": "REQUIRED"},
-  {"name": "resource_name", "type": "STRING", "mode": "REQUIRED"},
-  {"name": "method_name", "type": "STRING", "mode": "REQUIRED"}
-]
-EOF
+  schema = jsonencode([
+    {
+      name        = "insertId"
+      type        = "STRING"
+      mode        = "REQUIRED"
+      description = "Unique ID from the audit log to prevent duplicates"
+    },
+    {
+      name        = "timestamp"
+      type        = "TIMESTAMP"
+      mode        = "REQUIRED"
+      description = "The time the event occurred"
+    },
+    {
+      name        = "user_email"
+      type        = "STRING"
+      mode        = "REQUIRED"
+      description = "The email of the user performing the read"
+    },
+    {
+      name        = "resource_name"
+      type        = "STRING"
+      mode        = "REQUIRED"
+      description = "The full resource name of the table accessed"
+    },
+    {
+      name        = "method_name"
+      type        = "STRING"
+      mode        = "REQUIRED"
+      description = "The API method used (e.g. JobService.InsertJob)"
+    }
+  ])
 }
 
 resource "google_bigquery_data_transfer_config" "detection_query" {
@@ -51,34 +72,21 @@ resource "google_bigquery_data_transfer_config" "detection_query" {
   display_name   = "Detect Unauthorised BQ Reads"
   location       = "europe-west2"
   data_source_id = "scheduled_query"
-  schedule       = "every 5 minutes"
+  schedule       = "every 60 minutes"
 
   service_account_name = google_service_account.query_executor.email
 
+  email_preferences {
+    enable_failure_email = true
+  }
+
   params = {
-    query = <<EOT
-      MERGE `${google_bigquery_table.unauthorised_access.project}.${google_bigquery_table.unauthorised_access.dataset_id}.${google_bigquery_table.unauthorised_access.table_id}` T
-      USING (
-        SELECT 
-          insertId,
-          timestamp,
-          protopayload_auditlog.authenticationInfo.principalEmail as user_email,
-          protopayload_auditlog.resourceName as resource_name,
-          protopayload_auditlog.methodName as method_name,
-        FROM `${google_bigquery_dataset.audit_logs.project}.${google_bigquery_dataset.audit_logs.dataset_id}.cloudaudit_googleapis_com_data_access`
-        WHERE 
-          timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)
-          
-          -- Reference the authorised_users table attribute
-          AND protopayload_auditlog.authenticationInfo.principalEmail NOT IN (
-            SELECT user_email FROM `${google_bigquery_table.authorised_users.project}.${google_bigquery_table.authorised_users.dataset_id}.${google_bigquery_table.authorised_users.table_id}`
-          )
-      ) S
-      ON T.insertId = S.insertId
-      WHEN NOT MATCHED THEN
-        INSERT (insertId, timestamp, user_email, resource_name, method_name)
-        VALUES (S.insertId, S.timestamp, S.user_email, S.resource_name, S.method_name)
-    EOT
+    query = templatefile("${path.module}/detection_query.sql.tftpl", {
+      project_id                = var.project_id
+      audit_log_table           = "${google_bigquery_dataset.audit_logs.project}.${google_bigquery_dataset.audit_logs.dataset_id}.cloudaudit_googleapis_com_data_access"
+      authorised_users_table    = "${google_bigquery_table.authorised_users.project}.${google_bigquery_table.authorised_users.dataset_id}.${google_bigquery_table.authorised_users.table_id}"
+      unauthorised_access_table = "${google_bigquery_table.unauthorised_access.project}.${google_bigquery_table.unauthorised_access.dataset_id}.${google_bigquery_table.unauthorised_access.table_id}"
+    })
   }
 
   # Adding these explicitly as I'm not sure if the dependency will be inferred from the contents of params.query

--- a/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/detection_query.sql.tftpl
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/detection_query.sql.tftpl
@@ -1,0 +1,21 @@
+MERGE `${unauthorised_access_table}` T
+USING (
+  SELECT 
+    insertId,
+    timestamp,
+    protopayload_auditlog.authenticationInfo.principalEmail as user_email,
+    protopayload_auditlog.resourceName as resource_name,
+    protopayload_auditlog.methodName as method_name
+  FROM `${audit_log_table}`
+  WHERE 
+    timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+    
+    -- Filter out authorised users
+    AND protopayload_auditlog.authenticationInfo.principalEmail NOT IN (
+      SELECT user_email FROM `${authorised_users_table}`
+    )
+) S
+ON T.insertId = S.insertId
+WHEN NOT MATCHED THEN
+  INSERT (insertId, timestamp, user_email, resource_name, method_name)
+  VALUES (S.insertId, S.timestamp, S.user_email, S.resource_name, S.method_name)

--- a/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/monitoring.tf
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/monitoring.tf
@@ -1,0 +1,84 @@
+locals {
+  # Automatically extracts the UUID from the resource name string
+  # Pattern: projects/PRJ/locations/LOC/transferConfigs/UUID
+  detection_query_uuid = basename(google_bigquery_data_transfer_config.detection_query.name)
+}
+
+resource "google_monitoring_notification_channel" "notification_email" {
+  project      = var.project_id
+  display_name = "Notification Email Channel"
+  type         = "email"
+  labels = {
+    email_address = var.notification_email_address
+  }
+}
+
+# Alert Policy for Scheduled Query run failures
+resource "google_monitoring_alert_policy" "dts_failure_alert" {
+  project      = var.project_id
+  display_name = "CRITICAL: Unauthorised Access Detection Query unable to run"
+  combiner     = "OR"
+  severity     = "CRITICAL"
+
+  conditions {
+    display_name = "Detection Query Failed"
+    condition_threshold {
+      filter          = "resource.type=\"bigquery_dts_config\" AND resource.labels.config_id=\"${local.detection_query_uuid}\" AND metric.type=\"bigquerydatatransfer.googleapis.com/transfer/run_count\" AND metric.labels.state=\"FAILED\""
+      duration        = "0s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+
+      trigger {
+        count = 1
+      }
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_COUNT"
+      }
+    }
+  }
+
+  documentation {
+    content   = "The query used to detect unauthorised access is not running. Review the Scheduled Query '${google_bigquery_data_transfer_config.detection_query.display_name}' for details."
+    mime_type = "text/markdown"
+    subject   = "GA4 Aggregate Analytics Unauthorised Access Detection Query Failed"
+    links {
+      display_name = "GA4 Aggregate Analytics - Technical Documentation"
+      url          = "https://gov-uk.atlassian.net/wiki/x/AYADMAE"
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.notification_email.name]
+}
+
+resource "google_monitoring_alert_policy" "unauthorised_bq_access_alert" {
+  project      = var.project_id
+  display_name = "CRITICAL: Unauthorised BigQuery Access Detected"
+  combiner     = "OR"
+  severity     = "CRITICAL"
+
+  conditions {
+    display_name = "New rows detected in unauthorised_access table"
+    condition_matched_log {
+      filter = <<-EOT
+        resource.type = "bigquery_resource"
+        AND protoPayload.methodName = "google.cloud.bigquery.v2.JobService.InsertJob"
+        AND protoPayload.serviceData.jobCompletedEvent.job.jobConfiguration.query.destinationTable.tableId = "${google_bigquery_table.unauthorised_access.table_id}"
+        AND protoPayload.serviceData.jobCompletedEvent.job.jobStatistics.query.numDmlAffectedRows > 0
+      EOT
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.notification_email.name]
+
+  documentation {
+    content   = "Unauthorised BigQuery access was detected. Review the 'unauthorised_access' table in dataset '${google_bigquery_dataset.audit_logs.dataset_id}' for details."
+    mime_type = "text/markdown"
+    subject   = "Unauthorised Access to GA4 Aggregate Data"
+    links {
+      display_name = "GA4 Aggregate Analytics - Technical Documentation"
+      url          = "https://gov-uk.atlassian.net/wiki/x/AYADMAE"
+    }
+  }
+}

--- a/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/variables.tf
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/variables.tf
@@ -1,1 +1,6 @@
 variable "project_id" { type = string }
+
+variable "notification_email_address" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/deployments/gcp-ga4-aggregate-analytics/secret.tf
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/secret.tf
@@ -9,7 +9,7 @@ resource "google_secret_manager_secret" "slack_alert_channel_email_address" {
   }
 }
 
-data "google_secret_manager_secret_version" "slack_alert_channel_email_address_secret_value" {
+data "google_secret_manager_secret_version" "slack_alert_channel_email_address" {
   secret = local.slack_alert_channel_email_address_secret_id
 
   depends_on = [google_secret_manager_secret.slack_alert_channel_email_address]


### PR DESCRIPTION
This is the final PR to implement [IA-2582](https://gov-uk.atlassian.net/browse/IA-2582).

- some cleanup of existing config based on feedback (use jsonencode and templatefile rather than strings)
- configure team notification channel
- setup alerting for if the detection query fails
- setup alerting for when unauthorised access is detected

[IA-2582]: https://gov-uk.atlassian.net/browse/IA-2582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ