### PR TITLE
Use default account for Dataform repo connection

### DIFF
--- a/terraform/deployments/search-api-v2/dataform.tf
+++ b/terraform/deployments/search-api-v2/dataform.tf
@@ -21,7 +21,7 @@ resource "google_secret_manager_secret_iam_member" "member" {
   project   = var.gcp_project_id
   secret_id = "github_search_v2_api_dataform_ssh_key"
   role      = "roles/secretmanager.secretAccessor"
-  member    = google_service_account.dataform_service_account.member
+  member    = "serviceAccount:service-${var.gcp_project_number}@gcp-sa-dataform.iam.gserviceaccount.com"
 }
 
 # Create Dataform repository with GitHub integration


### PR DESCRIPTION
We're getting a "Permission Denied" error trying to use the custom dataform service account to connect to our Github repo.

From the Google docs [1] "You must use a custom service account to run workflows in your repository, but the default Dataform service agent is still used for all other repository operations."

[1] https://docs.cloud.google.com/dataform/docs/create-repository#repository-settings

This reverts one of the changes brought in here: https://github.com/alphagov/govuk-infrastructure/pull/3800