### PR TITLE
Pin AWS provider to 6.37 in govuk-publishing-infrastructure

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/main.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/main.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.28"
+      version = "6.37"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
v6.38 contains a breaking change for RabbitMQ-based Amazon MQ brokers. Applying TF on that version causes the following error:

```
 Error: updating MQ Broker (b-...) users: operation error mq: CreateUser, https response error StatusCode: 409, RequestID: ..., ConflictException: The users API does not apply to RabbitMQ brokers. To manage broker users, please use the RabbitMQ web console, or the management API. 
```