### PR TITLE
Set up new Repo for govuk-db-sync App

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -342,6 +342,7 @@ repos:
     archived: true
 
   govuk-db-sync:
+    can_be_deployed: true
     teams: {
       govuk: "maintain",
       govuk-platform-engineering: "admin"


### PR DESCRIPTION
## What?
I am creating a new Repo for `govuk-db-sync` as I have decided it warrants creating its own Repo (as opposed to the existing DB Sync bash script which lives inside the helm chart.

### Related:

* https://github.com/alphagov/govuk-infrastructure/issues/3760