### PR TITLE
IA-2582: correct metric label in filter

### DIFF
--- a/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/monitoring.tf
+++ b/terraform/deployments/gcp-ga4-aggregate-analytics/modules/data-access-monitoring/monitoring.tf
@@ -23,7 +23,7 @@ resource "google_monitoring_alert_policy" "dts_failure_alert" {
   conditions {
     display_name = "Detection Query Failed"
     condition_threshold {
-      filter          = "resource.type=\"bigquery_dts_config\" AND resource.labels.config_id=\"${local.detection_query_uuid}\" AND metric.type=\"bigquerydatatransfer.googleapis.com/transfer_config/completed_runs\" AND metric.labels.completion_status=\"FAILED\""
+      filter          = "resource.type=\"bigquery_dts_config\" AND resource.labels.config_id=\"${local.detection_query_uuid}\" AND metric.type=\"bigquerydatatransfer.googleapis.com/transfer_config/completed_runs\" AND metric.labels.completion_state=\"FAILED\""
       duration        = "0s"
       comparison      = "COMPARISON_GT"
       threshold_value = 0


### PR DESCRIPTION
label should be completion_state, not completion_status. Tested in [UI](https://console.cloud.google.com/monitoring/metrics-explorer;duration=P14D?project=ga4-aggregate-analytics&pageState=%7B%22xyChart%22:%7B%22constantLines%22:%5B%5D,%22dataSets%22:%5B%7B%22plotType%22:%22LINE%22,%22pointConnectionMethod%22:%22GAP_DETECTION%22,%22targetAxis%22:%22Y1%22,%22timeSeriesFilter%22:%7B%22aggregations%22:%5B%7B%22alignmentPeriod%22:%2260s%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%5D,%22perSeriesAligner%22:%22ALIGN_RATE%22%7D%5D,%22apiSource%22:%22DEFAULT_CLOUD%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22filter%22:%22metric.type%3D%5C%22bigquerydatatransfer.googleapis.com%2Ftransfer_config%2Fcompleted_runs%5C%22%20resource.type%3D%5C%22bigquery_dts_config%5C%22%20metric.label.%5C%22completion_state%5C%22%3D%5C%22FAILED%5C%22%22,%22groupByFields%22:%5B%5D,%22minAlignmentPeriod%22:%2260s%22,%22perSeriesAligner%22:%22ALIGN_RATE%22%7D%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22y1Axis%22:%7B%22label%22:%22%22,%22scale%22:%22LINEAR%22%7D%7D%7D).