### PR TITLE
Update autcomplete to manual mode

### DIFF
--- a/terraform/deployments/search-api-v2/completion.tf
+++ b/terraform/deployments/search-api-v2/completion.tf
@@ -12,7 +12,7 @@ resource "restapi_object" "google_discovery_engine_data_store_completion_config"
     queryFrequencyThreshold = 250,
     numUniqueUsersThreshold = 100,
     queryModel              = "automatic",
-    enableMode              = "AUTOMATIC"
+    enableMode              = "MANUAL"
   })
 
   # VAIS adds some properties dynamically, which creates false positive drift


### PR DESCRIPTION
Following an issue with the pipeline of data used by google to populate our autocomplete requests, we are updating the setting to MANUAL. We assume this will result in suggestions even when the datastore is not full. 

https://docs.cloud.google.com/generative-ai-app-builder/docs/reference/rpc/google.cloud.discoveryengine.v1alpha#enablemode