### PR TITLE
Use GCP resource for freshness control

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -7,7 +7,7 @@ module "serving_config_global_variant" {
 
   boost_control_ids = [
     # specific to serving_config_global_variant
-    module.control_global_boost_freshness_general.id,
+    google_discovery_engine_control.boost_freshness_general.control_id,
 
     # identical to serving_config_global_default
     module.control_global_boost_promote_medium.id,
@@ -28,47 +28,44 @@ module "serving_config_global_variant" {
   ]
 }
 
-module "control_global_boost_freshness_general" {
-  source = "./modules/control"
-
-  id           = "boost_freshness_general"
-  display_name = "Boost: Freshness (general)"
-  engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
-  action = {
-    boostAction = {
-      dataStore = google_discovery_engine_data_store.govuk_content.name,
-      filter    = "content_purpose_supergroup: ANY(\"news_and_communications\")",
-      interpolationBoostSpec = {
-        fieldName         = "public_timestamp_datetime",
-        attributeType     = "FRESHNESS",
-        interpolationType = "LINEAR",
-        # Control points explained
-        # 0.2 (decaying to 0.05), for the first 7 days
-        # 0.05 (decaying to 0), for 8 days to 90 days
-        # 0 (decaying to -0.5) for 91 days to 365 days
-        # -0.5 (decaying to -0.75) for 366 days to 1460 days
-        controlPoints = [
-          {
-            attributeValue = "0D",
-            boostAmount    = 0.2
-          },
-          {
-            attributeValue = "7D",
-            boostAmount    = 0.05
-          },
-          {
-            attributeValue = "90D",
-            boostAmount    = 0
-          },
-          {
-            attributeValue = "365D",
-            boostAmount    = -0.5
-          },
-          {
-            attributeValue = "1460D",
-            boostAmount    = -0.75
-          }
-        ]
+resource "google_discovery_engine_control" "boost_freshness_general" {
+  location      = google_discovery_engine_search_engine.govuk_global.location
+  engine_id     = google_discovery_engine_search_engine.govuk_global.engine_id
+  control_id    = "boost_freshness_general"
+  display_name  = "Boost: Freshness (general)"
+  solution_type = "SOLUTION_TYPE_SEARCH"
+  use_cases     = ["SEARCH_USE_CASE_SEARCH"]
+  boost_action {
+    data_store = google_discovery_engine_data_store.govuk_content.name
+    filter     = "content_purpose_supergroup: ANY(\"news_and_communications\")"
+    interpolation_boost_spec {
+      field_name         = "public_timestamp_datetime"
+      attribute_type     = "FRESHNESS"
+      interpolation_type = "LINEAR"
+      # Control points explained
+      # 0.2 (decaying to 0.05), for the first 7 days
+      # 0.05 (decaying to 0), for 8 days to 90 days
+      # 0 (decaying to -0.5) for 91 days to 365 days
+      # -0.5 (decaying to -0.75) for 366 days to 1460 days
+      control_point {
+        attribute_value = "0D"
+        boost_amount    = 0.2
+      }
+      control_point {
+        attribute_value = "7D"
+        boost_amount    = 0.05
+      }
+      control_point {
+        attribute_value = "90D"
+        boost_amount    = 0
+      }
+      control_point {
+        attribute_value = "365D"
+        boost_amount    = -0.5
+      }
+      control_point {
+        attribute_value = "1460D"
+        boost_amount    = -0.75
       }
     }
   }


### PR DESCRIPTION
When the site search serving configurations were first defined in Terraform, Google resources to define controls didn't exist so these were written using restapi objects.

Now that a Google resource does exist for controls, we can switch to using that to simplify the code and so that we can benefit from better validation and type management.