### PR TITLE
Use float for freshness boost

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -58,7 +58,7 @@ module "control_global_boost_freshness_general" {
           },
           {
             attributeValue = "90D",
-            boostAmount    = 0
+            boostAmount    = 0.0
           },
           {
             attributeValue = "365D",


### PR DESCRIPTION
An attempt to avoid drift in the Terraform configuration, caused by explicitly setting the boostAmount to 0 in Terraform which is converted to a null response in the Discovery Engine API. We need the set boostAmount to match what's in the API response to avoid drift.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1949