### PR TITLE
Add `build-image-on-PR` reusable workflow

### DIFF
--- a/.github/workflows/build-image-from-pr.yml
+++ b/.github/workflows/build-image-from-pr.yml
@@ -1,0 +1,84 @@
+name: Build image from PR
+
+on:
+  workflow_call:
+    inputs:
+      imageName:
+        required: false
+        type: string
+        default: ${{ github.event.repository.name }}
+      dockerfilePath:
+        required: false
+        type: string
+        default: Dockerfile
+      context:
+        required: false
+        type: string
+        default: .
+      buildArgs:
+        required: false
+        type: string
+      gitRef:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      arm64_runner_name:
+        required: false
+        type: string
+        default: ubuntu-24.04-arm
+      amd64_runner_name:
+        required: false
+        type: string
+        default: ubuntu-latest
+
+jobs:
+  build-image-from-PR:
+    name: Build image for ${{ inputs.imageName }} from $${{ inputs.gitRef }}
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+        include:
+          - arch: amd64
+            runner: ${{ inputs.amd64_runner_name }}
+          - arch: arm64
+            runner: ${{ inputs.arm64_runner_name }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.gitRef }}
+          show-progress: false
+
+      - run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        id: local-head
+
+      - name: Generate Image Metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}
+          labels: |
+            org.opencontainers.image.vendor=GDS
+          tags: |
+            type=raw,priority=500,value=${{ inputs.gitRef }},enable=${{ startsWith(inputs.gitRef, 'v') }}
+            type=raw,priority=400,value=${{ steps.local-head.outputs.sha }},enable=${{ !startsWith(inputs.gitRef, 'v') }}
+
+      - name: Build image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          file: ${{ inputs.dockerfilepath }}
+          context: ${{ inputs.context }}
+          platforms: "linux/${{ matrix.arch }}"
+          build-args: ${{ inputs.buildArgs }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false


### PR DESCRIPTION
Description:
- This reusable workflow allows repositories to check whether their image builds on PR runs
- Builds both x86 and ARM images
- https://github.com/alphagov/govuk-infrastructure/issues/3961