### PR TITLE
Remove `package: write` permission from GitHub Token

### DIFF
--- a/.github/workflows/build-image-from-pr.yml
+++ b/.github/workflows/build-image-from-pr.yml
@@ -48,7 +48,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Description:
- Workflow isn't publishing to GitHub Container Registry but just building the image
- https://github.com/alphagov/govuk-infrastructure/issues/3961