### PR TITLE
Fix `build-image-from-pr` workflow cache issue

### DIFF
--- a/.github/workflows/build-image-from-pr.yml
+++ b/.github/workflows/build-image-from-pr.yml
@@ -46,13 +46,15 @@ jobs:
             runner: ${{ inputs.arm64_runner_name }}
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.gitRef }}
           show-progress: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         id: local-head


### PR DESCRIPTION
Description:
- Needs the docker buildx action to work correctly
- No need for `id-token: write`
- https://github.com/alphagov/govuk-infrastructure/issues/3961