### PR TITLE
Add a new repo for GOVUK AI work.

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1021,3 +1021,8 @@ repos:
     can_be_deployed: false
     visibility: private
     push_allowances: ["alphagov/gov-uk-ai-accelerator-alpha-team", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+
+  govuk-ai-graph-tools:
+    can_be_deployed: true
+    standard_contexts: *standard_security_checks
+    push_allowances: ["alphagov/gov-uk-ai-accelerator-alpha-team", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]

--- a/terraform/deployments/github/variables.tf
+++ b/terraform/deployments/github/variables.tf
@@ -16,6 +16,6 @@ variable "github_app_pem_file" {
 variable "govuk_ai_accelerator_repo_names" {
   # repos to be used in the GOV.UK Publishing AI alpha
   type    = list(string)
-  default = ["govuk-ai-accelerator", "govuk-ai-accelerator-tooling", "govuk-ai-accelerator-tw-accelerator", "govuk-ai-accelerator-generator-e2e-testing-framework"]
+  default = ["govuk-ai-accelerator", "govuk-ai-accelerator-tooling", "govuk-ai-accelerator-tw-accelerator", "govuk-ai-accelerator-generator-e2e-testing-framework", "govuk-ai-graph-tools"]
 }
 


### PR DESCRIPTION
New AI project within GOVUK will look at content discovery via knowledge graphs and AI tools to help populate those.

This PR simply creates the github repo

uses same naming conventions as the other AI work in GOVUK govuk-ai-[repo-purpose]

added to the same github team, and with same deploy permissions as the 4 other AI repos related to this work.