### PR TITLE
Test removing token param from tfc-configuration

### DIFF
--- a/terraform/deployments/tfc-configuration/provider.tf
+++ b/terraform/deployments/tfc-configuration/provider.tf
@@ -19,5 +19,5 @@ terraform {
 provider "tfe" {
   hostname     = var.tfc_hostname
   organization = var.organization
-  token        = var.token
+  # token        = var.token
 }

--- a/terraform/deployments/tfc-configuration/variables.tf
+++ b/terraform/deployments/tfc-configuration/variables.tf
@@ -14,11 +14,11 @@ variable "organization" {
   default     = "govuk"
 }
 
-variable "token" {
-  type        = string
-  description = "Account token"
-  sensitive   = true
-}
+# variable "token" {
+#   type        = string
+#   description = "Account token"
+#   sensitive   = true
+# }
 
 #
 # Projects


### PR DESCRIPTION
I want to test if we really need to provide TFE provider auth credentials when running in terraform cloud. This should prove it by removing the token configuration 