### PR TITLE
New DB Sync App Repo (resolved conflict)

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -341,6 +341,13 @@ repos:
   govuk-data-science-workshop:
       archived: true
 
+  govuk-db-sync:
+    can_be_deployed: true
+    teams: {
+      govuk: "maintain",
+      govuk-platform-engineering: "admin"
+    }
+
   govuk-dependabot-merger:
     required_status_checks:
       standard_contexts: *standard_security_checks


### PR DESCRIPTION
## What?
This replaces the previous PR that ended up in a mess of merge conflicts.

It creates a repo for the new DB Sync App that we intend to use to succeed the DB Backup scripts.

### Related

* Task https://github.com/alphagov/govuk-infrastructure/issues/3760
* Replaces https://github.com/alphagov/govuk-infrastructure/pull/4005