### PR TITLE
Set blocked_encryption_types in S3 SSE config

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_s3.tf
@@ -28,6 +28,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "govuk_ai_accelera
   bucket = aws_s3_bucket.govuk_ai_accelerator_data[0].id
 
   rule {
+    blocked_encryption_types = ["NONE"]
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }

--- a/terraform/shared-modules/s3/main.tf
+++ b/terraform/shared-modules/s3/main.tf
@@ -135,6 +135,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 
   rule {
+    blocked_encryption_types = ["NONE"]
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }


### PR DESCRIPTION
The TF provider wants to make perpetual changes if this isn't set