### PR TITLE
Create a new IAM role for govuk-ai-graph-tools

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/ai_graph_tools_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/ai_graph_tools_iam.tf
@@ -1,0 +1,112 @@
+# IAM role for govuk-ai-graph-tools application with access to Bedrock and S3
+
+locals {
+  govuk_ai_graph_tools_service_account_name = "govuk-ai-graph-tools-app"
+}
+
+data "aws_iam_policy_document" "govuk_ai_graph_tools_bedrock_access" {
+  count = var.enable_govuk_ai_graph_tools ? 1 : 0
+
+  statement {
+    sid = "BedrockAssumeInvokeModelsRolePolicy"
+    actions = [
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "BedrockAssumeListModelsRolePolicy"
+    actions = [
+      "bedrock:ListFoundationModels"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "govuk_ai_graph_tools_s3_access" {
+  count = var.enable_govuk_ai_graph_tools && var.enable_govuk_ai_accelerator ? 1 : 0
+
+  statement {
+    sid       = "GovukAiAcceleratorS3RootAccessPolicy"
+    actions   = ["s3:GetBucketLocation", "s3:ListBucket"]
+    resources = [aws_s3_bucket.govuk_ai_accelerator_data[0].arn]
+  }
+
+  statement {
+    sid = "GovukAiAcceleratorS3ObjectAccessPolicy"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:DeleteObject"
+    ]
+    resources = ["${aws_s3_bucket.govuk_ai_accelerator_data[0].arn}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "govuk_ai_graph_tools_opensearch" {
+  count = var.enable_govuk_ai_graph_tools ? 1 : 0
+
+  statement {
+    sid     = "GovukAiAcceleratorOpenSearchAccessPolicy"
+    actions = ["es:*"]
+
+    resources = ["arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/ai-accelerator-blue"]
+  }
+}
+
+resource "aws_iam_policy" "govuk_ai_graph_tools_opensearch_policy" {
+  count = var.enable_govuk_ai_graph_tools ? 1 : 0
+
+  name        = "govuk-${var.govuk_environment}-govuk-ai-graph-tools-opensearch-policy"
+  description = "Policy for govuk-ai-graph-tools application with access to OpenSearch"
+  policy      = data.aws_iam_policy_document.govuk_ai_graph_tools_opensearch[0].json
+}
+
+resource "aws_iam_policy" "govuk_ai_graph_tools_s3_access_policy" {
+  count = var.enable_govuk_ai_graph_tools && var.enable_govuk_ai_accelerator ? 1 : 0
+
+  name        = "govuk-${var.govuk_environment}-govuk-ai-graph-tools-s3-policy"
+  description = "Policy for govuk-ai-graph-tools application with access to S3"
+  policy      = data.aws_iam_policy_document.govuk_ai_graph_tools_s3_access[0].json
+}
+
+resource "aws_iam_policy" "govuk_ai_graph_tools_bedrock_access_policy" {
+  count = var.enable_govuk_ai_graph_tools ? 1 : 0
+
+  name        = "govuk-${var.govuk_environment}-govuk-ai-graph-tools-bedrock-policy"
+  description = "Policy for govuk-ai-graph-tools application with access to bedrock"
+  policy      = data.aws_iam_policy_document.govuk_ai_graph_tools_bedrock_access[0].json
+}
+
+# IRSA role for GOVUK AI graph tools service account
+module "govuk_ai_graph_tools_irsa_role" {
+  count = var.enable_govuk_ai_graph_tools ? 1 : 0
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.0"
+
+  name                 = "${local.govuk_ai_graph_tools_service_account_name}-${data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id}"
+  use_name_prefix      = false
+  description          = "Role for govuk-ai-graph-tools application. Corresponds to ${local.govuk_ai_graph_tools_service_account_name} k8s ServiceAccount."
+  max_session_duration = 28800
+
+  policies = {
+    opensearch                                                             = aws_iam_policy.govuk_ai_graph_tools_opensearch_policy[0].arn
+    neptune                                                                = data.tfe_outputs.neptune[0].nonsensitive_values.neptune_policy_arn["ai_accelerator"],
+    "${aws_iam_policy.govuk_ai_graph_tools_s3_access_policy[0].name}"      = aws_iam_policy.govuk_ai_graph_tools_s3_access_policy[0].arn,
+    "${aws_iam_policy.govuk_ai_graph_tools_bedrock_access_policy[0].name}" = aws_iam_policy.govuk_ai_graph_tools_bedrock_access_policy[0].arn
+  }
+
+  oidc_providers = {
+    main = {
+      provider_arn               = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_oidc_provider_arn
+      namespace_service_accounts = ["apps:${local.govuk_ai_graph_tools_service_account_name}"]
+    }
+  }
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -216,3 +216,8 @@ variable "enable_govuk_ai_accelerator" {
   description = "Should the GOVUK AI accelerator infrastucture be deployed. Should only enable on integration for the Alpha."
 }
 
+variable "enable_govuk_ai_graph_tools" {
+  type        = bool
+  default     = false
+  description = "Should the GOVUK AI graph tools infrastructure be deployed. Should only enable on integration for the Alpha."
+}

--- a/terraform/variables/integration/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/integration/govuk-publishing-infrastructure.tfvars
@@ -1,4 +1,5 @@
 enable_govuk_ai_accelerator       = true
+enable_govuk_ai_graph_tools       = true
 subdomain_delegation_name_servers = {}
 subdomain_dns_records = [
   { type = "A", name = "@", ttl = 10800, value = ["151.101.0.144", "151.101.64.144", "151.101.128.144", "151.101.192.144"] },


### PR DESCRIPTION
## What
The role is identical in permissions to `govuk-ai-accelerator`, but is separate so that the two things don't share a role. 

## How to review

I cloned `ai_accelerator_iam.tf` as a starting point. Make sure I didn't miss changing any references.