### PR TITLE
Add content block embed code highlighter repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -93,6 +93,13 @@ repos:
       additional_contexts:
         - Playwright / Run Tests
         - Vitest / Run Tests
+  
+  content-block-embed-code-highlighter:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - Playwright / Run Tests
+        - Vitest / Run Tests
 
   content-block-manager:
     can_be_deployed: true


### PR DESCRIPTION
This is a library that will allow content block embed codes to be highlighted within publishing apps.