### PR TITLE
Update licensing clone DocDB to 5.0.0

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb_clone.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb_clone.tf
@@ -6,11 +6,40 @@ data "aws_db_cluster_snapshot" "licensify_cluster_snapshot" {
   most_recent           = true
 }
 
+resource "aws_docdb_cluster_parameter_group" "licensify_clone_parameter_group" {
+  count       = var.create_licensify_documentdb_clone ? 1 : 0
+  family      = "docdb5.0"
+  name        = "licensify-clone-parameter-group"
+  description = "Licensify Clone DocumentDB cluster parameter group"
+
+  parameter {
+    name         = "audit_logs"
+    value        = "disabled"
+    apply_method = "pending-reboot"
+  }
+
+  # Licensify doesn't support connecting to MongoDB via TLS
+  parameter {
+    name  = "tls"
+    value = "disabled"
+  }
+
+  parameter {
+    name  = "profiler"
+    value = "enabled"
+  }
+
+  parameter {
+    name  = "profiler_threshold_ms"
+    value = 300
+  }
+}
+
 resource "aws_docdb_cluster" "licensify_cluster_clone" {
   count                           = var.create_licensify_documentdb_clone ? 1 : 0
   cluster_identifier              = "licensify-documentdb-clone-${var.govuk_environment}"
   db_subnet_group_name            = aws_docdb_subnet_group.licensify_cluster_subnet.name
-  db_cluster_parameter_group_name = aws_docdb_cluster_parameter_group.licensify_parameter_group.name
+  db_cluster_parameter_group_name = aws_docdb_cluster_parameter_group.licensify_clone_parameter_group[0].name
   master_username                 = "master"
   master_password                 = random_password.licensify_documentdb_master.result
   storage_encrypted               = true
@@ -19,7 +48,13 @@ resource "aws_docdb_cluster" "licensify_cluster_clone" {
   enabled_cloudwatch_logs_exports = ["profiler"]
   backup_retention_period         = 1
   snapshot_identifier             = data.aws_db_cluster_snapshot.licensify_cluster_snapshot.id
-  engine_version                  = "3.6.0"
+  engine_version                  = "5.0.0"
+
+  lifecycle {
+    ignore_changes = [
+      snapshot_identifier
+    ]
+  }
 }
 
 resource "aws_docdb_cluster_instance" "licensify_cluster_clone_instances" {


### PR DESCRIPTION
The lifecycle block is to prevent TF from trying to recreate the instance when the latest DB snapshot changes.

https://github.com/alphagov/govuk-infrastructure/issues/3928