### PR TITLE
Don't require prod access to merge chat-v1-iterations-2026

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -314,6 +314,7 @@ repos:
 
   govuk-chat-v1-iterations-2026:
     visibility: private
+    need_production_access_to_merge: false
     required_status_checks:
       # standard security checks are disabled as not configured for a private repo
       additional_contexts:


### PR DESCRIPTION
This repo does not result in a production deploy and is frequently contributed to from Data Scientists who haven't been granted the "production deploy" access.