### PR TITLE
IA-2640: create workspace for gcp-gds-bq-processing-dev

### DIFF
--- a/terraform/deployments/gcp-gds-bq-processing-dev/README.md
+++ b/terraform/deployments/gcp-gds-bq-processing-dev/README.md
@@ -1,0 +1,1 @@
+# gcp-gds-bq-processing-dev

--- a/terraform/deployments/gcp-gds-bq-processing-dev/main.tf
+++ b/terraform/deployments/gcp-gds-bq-processing-dev/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  cloud {
+    organization = "govuk"
+    workspaces {
+      project = "govuk-data-engineering"
+      name    = "gcp-gds-bq-processing-dev"
+    }
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+
+  required_version = "~> 1.14"
+}
+
+provider "google" {
+  project = "gds-bq-processing-dev"
+}

--- a/terraform/deployments/tfc-configuration/gcp-projects.tf
+++ b/terraform/deployments/tfc-configuration/gcp-projects.tf
@@ -91,3 +91,34 @@ module "gcp-gds-bq-processing" {
     local.gcp_credentials["production"],
   ]
 }
+
+module "gcp-gds-bq-processing-dev" {
+  source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
+
+  organization        = var.organization
+  workspace_name      = "gcp-gds-bq-processing-dev"
+  workspace_desc      = "GCP project management for the gds-bq-processing-dev project"
+  workspace_tags      = ["dev", "gds-bq-processing", "gcp"]
+  terraform_version   = var.terraform_version
+  execution_mode      = "remote"
+  working_directory   = "/terraform/deployments/gcp-gds-bq-processing-dev/"
+  trigger_patterns    = ["/terraform/deployments/gcp-gds-bq-processing-dev/**/*"]
+  global_remote_state = true
+  assessments_enabled = true
+
+  project_name = "govuk-data-engineering"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Production"            = "write"
+    "Google Cloud Data Production" = "write"
+  }
+
+  variable_set_ids = [
+    local.gcp_credentials["production"],
+  ]
+}


### PR DESCRIPTION
This creates an empty workspace for an existing GCP project `gds-bq-processing-dev`. It will eventually be useful when we import resources from that project but I will use it as a sandbox for https://gov-uk.atlassian.net/browse/IA-2640.