### PR TITLE
IA-2640: add gcp-project-init module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,4 @@
 /terraform/deployments/gcp-gds-bq-processing/ @alphagov/gov-uk-platform-engineering @alphagov/govuk-data-engineering
 /terraform/deployments/gcp-gov-graph/ @alphagov/gov-uk-platform-engineering @alphagov/govuk-data-engineering
 /terraform/variables/**/gcp-gov-graph.tfvars @alphagov/gov-uk-platform-engineering @alphagov/govuk-data-engineering
+/terraform/shared-modules/gcp-project-init/ @alphagov/gov-uk-platform-engineering @alphagov/govuk-data-engineering

--- a/terraform/deployments/gcp-gds-bq-processing-dev/imports.tf
+++ b/terraform/deployments/gcp-gds-bq-processing-dev/imports.tf
@@ -1,0 +1,4 @@
+import {
+  id = "gds-bq-processing-dev"
+  to = module.managed_project.google_project.project
+}

--- a/terraform/deployments/gcp-gds-bq-processing-dev/main.tf
+++ b/terraform/deployments/gcp-gds-bq-processing-dev/main.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 7.0"
+      version = "~> 7.30.0"
     }
   }
 

--- a/terraform/deployments/gcp-gds-bq-processing-dev/main.tf
+++ b/terraform/deployments/gcp-gds-bq-processing-dev/main.tf
@@ -20,3 +20,17 @@ terraform {
 provider "google" {
   project = "gds-bq-processing-dev"
 }
+
+module "managed_project" {
+  source = "../../shared-modules/gcp-project-init"
+
+  project_id   = "gds-bq-processing-dev"
+  project_name = "gds-bq-processing-dev"
+  project_owners = [
+    "group:gcp-gds-bq-processing-dev-owners@digital.cabinet-office.gov.uk",
+  ]
+  project_editors = [
+    "group:gcp-gds-bq-processing-dev-editors@digital.cabinet-office.gov.uk",
+    "serviceAccount:912027178151-compute@developer.gserviceaccount.com",
+  ]
+}

--- a/terraform/deployments/gcp-gds-bq-processing-dev/outputs.tf
+++ b/terraform/deployments/gcp-gds-bq-processing-dev/outputs.tf
@@ -1,0 +1,15 @@
+output "project_id" {
+  value = module.managed_project.project.project_id
+}
+
+output "project_owner_members" {
+  value = module.managed_project.iam_binding_project_owners.members
+}
+
+output "project_editor_members" {
+  value = module.managed_project.iam_binding_project_editors.members
+}
+
+output "project_viewer_members" {
+  value = module.managed_project.iam_binding_project_viewers.members
+}

--- a/terraform/deployments/tfc-configuration/gcp-projects.tf
+++ b/terraform/deployments/tfc-configuration/gcp-projects.tf
@@ -95,14 +95,17 @@ module "gcp-gds-bq-processing" {
 module "gcp-gds-bq-processing-dev" {
   source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
 
-  organization        = var.organization
-  workspace_name      = "gcp-gds-bq-processing-dev"
-  workspace_desc      = "GCP project management for the gds-bq-processing-dev project"
-  workspace_tags      = ["dev", "gds-bq-processing", "gcp"]
-  terraform_version   = var.terraform_version
-  execution_mode      = "remote"
-  working_directory   = "/terraform/deployments/gcp-gds-bq-processing-dev/"
-  trigger_patterns    = ["/terraform/deployments/gcp-gds-bq-processing-dev/**/*"]
+  organization      = var.organization
+  workspace_name    = "gcp-gds-bq-processing-dev"
+  workspace_desc    = "GCP project management for the gds-bq-processing-dev project"
+  workspace_tags    = ["dev", "gds-bq-processing", "gcp"]
+  terraform_version = var.terraform_version
+  execution_mode    = "remote"
+  working_directory = "/terraform/deployments/gcp-gds-bq-processing-dev/"
+  trigger_patterns = [
+    "/terraform/deployments/gcp-gds-bq-processing-dev/**/*",
+    "/terraform/shared-modules/gcp-project-init/**/*",
+  ]
   global_remote_state = true
   assessments_enabled = true
 

--- a/terraform/shared-modules/gcp-project-init/README.md
+++ b/terraform/shared-modules/gcp-project-init/README.md
@@ -1,0 +1,74 @@
+# gcp-project-init
+
+This module is intended to provide a baseline configuration for some essentials when creating a new GCP project.
+
+- Ensure a GCP project is under the appropriate folder with the correct billing details.
+- Ensure that the terraform cloud (TFC) service account is added with correct permissions to manage resources within the project.
+- Optionally enforce any additional project-level permissions for users, groups and service accounts.
+
+## Usage
+
+See the examples below, and see [USAGE.md](./USAGE.md) for a complete list of all options with descriptions.
+
+If you use this module in your workspace you should add its path to your `trigger_patterns` to ensure changes to the module are included in your workspace plans. E.g.:
+
+```hcl
+trigger_patterns = [
+  ..., # your existing paths
+  "/terraform/shared-modules/gcp-project-init/**/*",
+]
+```
+
+## Examples
+
+### Create a new project
+`main.tf`
+```hcl
+module "managed_project" {
+  source = "../../shared-modules/gcp-project-init"
+
+  project_id   = "my-project-id"
+  project_name = "my-project-name"
+}
+```
+
+### Manage an existing project
+Importing the project configuration is quite straight-forward (see `imports.tf` below). Importing the existing `project_owners`, `project_editors` and `project_viewers` is more complicated. Crucially, the plan in TFC will not accurately show the changes if you do not first import them. You will have to choose whether you do add each of the bindings to `imports.tf` (which is very fiddly) or configure them so that they exactly match current state. For example, to configure them explicitly in the module definition you would ensure `project_owners` matches the list of project owners shown in the GCP Cloud Console.
+
+`main.tf`
+```hcl
+module "managed_project" {
+  source = "../../shared-modules/gcp-project-init"
+
+  project_id   = "my-project-id"
+  project_name = "my-project-name"
+  project_owners = [
+    "user:existing.user@email.com",
+    "serviceAccount:existing.service.account@email.com",
+    "group:existing.group@email.com",
+  ]
+}
+```
+
+`imports.tf`
+```hcl
+import {
+  id = "my-project-id"
+  to = module.managed_project.google_project.project
+}
+```
+
+### Overriding defaults
+The terraform SA will _always_ be added as project owner whenever you use this module, even if `project_owners` is empty. The default value is set to `terraform-cloud-production@govuk-production.iam.gserviceaccount` but you can change the terraform SA used by specifying a value for `terraform_service_account`. Similarly, the `billing_account` and `folder_id` have default values that work for the Insights & Analytics Team but you can override these values if you need to [see USAGE.md](/terraform/shared-modules/gcp-project-init/USAGE.md). For example - 
+
+```hcl
+module "managed_project" {
+  source = "../../shared-modules/gcp-project-init"
+
+  project_id   = "my-project-id"
+  project_name = "my-project-name"
+  terraform_service_account = "different-service-account@email.com"
+  billing_account = "my-different-billing-account"
+  folder_id = "my-different-folder-id"
+}
+```

--- a/terraform/shared-modules/gcp-project-init/USAGE.md
+++ b/terraform/shared-modules/gcp-project-init/USAGE.md
@@ -22,5 +22,8 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_iam_binding_project_editors"></a> [iam\_binding\_project\_editors](#output\_iam\_binding\_project\_editors) | The project's IAM binding for roles/editor |
+| <a name="output_iam_binding_project_owners"></a> [iam\_binding\_project\_owners](#output\_iam\_binding\_project\_owners) | The project's IAM binding for roles/owner |
+| <a name="output_iam_binding_project_viewers"></a> [iam\_binding\_project\_viewers](#output\_iam\_binding\_project\_viewers) | The project's IAM binding for roles/viewer |
 | <a name="output_project"></a> [project](#output\_project) | The entire google\_project resource object. |
 <!-- END_TF_DOCS -->

--- a/terraform/shared-modules/gcp-project-init/USAGE.md
+++ b/terraform/shared-modules/gcp-project-init/USAGE.md
@@ -1,0 +1,26 @@
+<!-- BEGIN_TF_DOCS -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID to manage. | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The name of the GCP project. | `string` | n/a | yes |
+| <a name="input_billing_account"></a> [billing\_account](#input\_billing\_account) | The default billing account ID to associate with the project. | `string` | `"015C7A-FAF970-B0D375"` | no |
+| <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | The Folder ID to create the project under. | `string` | `"278098142879"` | no |
+| <a name="input_project_editors"></a> [project\_editors](#input\_project\_editors) | A list of IAM members (users, groups, or SAs) to be granted roles/editor. | `list(string)` | `[]` | no |
+| <a name="input_project_owners"></a> [project\_owners](#input\_project\_owners) | A list of IAM members (users, groups, or SAs) to be granted roles/owner. | `list(string)` | `[]` | no |
+| <a name="input_project_viewers"></a> [project\_viewers](#input\_project\_viewers) | A list of IAM members (users, groups, or SAs) to be granted roles/viewer. | `list(string)` | `[]` | no |
+| <a name="input_terraform_service_account"></a> [terraform\_service\_account](#input\_terraform\_service\_account) | The Terraform service account email to be hard-coded as an owner. | `string` | `"serviceAccount:terraform-cloud-production@govuk-production.iam.gserviceaccount.com"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_project"></a> [project](#output\_project) | The entire google\_project resource object. |
+<!-- END_TF_DOCS -->

--- a/terraform/shared-modules/gcp-project-init/main.tf
+++ b/terraform/shared-modules/gcp-project-init/main.tf
@@ -1,0 +1,10 @@
+resource "google_project" "project" {
+  name            = var.project_name
+  project_id      = var.project_id
+  folder_id       = var.folder_id
+  billing_account = var.billing_account
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/shared-modules/gcp-project-init/outputs.tf
+++ b/terraform/shared-modules/gcp-project-init/outputs.tf
@@ -1,0 +1,19 @@
+output "project" {
+  description = "The entire google_project resource object."
+  value       = google_project.project
+}
+
+output "iam_binding_project_owners" {
+  description = "The project's IAM binding for roles/owner"
+  value       = google_project_iam_binding.project_owners
+}
+
+output "iam_binding_project_editors" {
+  description = "The project's IAM binding for roles/editor"
+  value       = google_project_iam_binding.project_editors
+}
+
+output "iam_binding_project_viewers" {
+  description = "The project's IAM binding for roles/viewer"
+  value       = google_project_iam_binding.project_viewers
+}

--- a/terraform/shared-modules/gcp-project-init/project_iam_binding.tf
+++ b/terraform/shared-modules/gcp-project-init/project_iam_binding.tf
@@ -1,0 +1,21 @@
+resource "google_project_iam_binding" "project_owners" {
+  project = google_project.project.project_id
+  role    = "roles/owner"
+
+  members = concat(
+    [var.terraform_service_account],
+    var.project_owners
+  )
+}
+
+resource "google_project_iam_binding" "project_editors" {
+  project = google_project.project.project_id
+  role    = "roles/editor"
+  members = var.project_editors
+}
+
+resource "google_project_iam_binding" "project_viewers" {
+  project = google_project.project.project_id
+  role    = "roles/viewer"
+  members = var.project_viewers
+}

--- a/terraform/shared-modules/gcp-project-init/variables.tf
+++ b/terraform/shared-modules/gcp-project-init/variables.tf
@@ -1,0 +1,45 @@
+variable "project_id" {
+  description = "The GCP project ID to manage."
+  type        = string
+}
+
+variable "project_name" {
+  description = "The name of the GCP project."
+  type        = string
+}
+
+variable "billing_account" {
+  description = "The default billing account ID to associate with the project."
+  type        = string
+  default     = "015C7A-FAF970-B0D375"
+}
+
+variable "folder_id" {
+  description = "The Folder ID to create the project under."
+  type        = string
+  default     = "278098142879"
+}
+
+variable "terraform_service_account" {
+  description = "The Terraform service account email to be hard-coded as an owner."
+  type        = string
+  default     = "serviceAccount:terraform-cloud-production@govuk-production.iam.gserviceaccount.com"
+}
+
+variable "project_owners" {
+  description = "A list of IAM members (users, groups, or SAs) to be granted roles/owner."
+  type        = list(string)
+  default     = []
+}
+
+variable "project_editors" {
+  description = "A list of IAM members (users, groups, or SAs) to be granted roles/editor."
+  type        = list(string)
+  default     = []
+}
+
+variable "project_viewers" {
+  description = "A list of IAM members (users, groups, or SAs) to be granted roles/viewer."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
First-pass at a modular approach to allow existing GCP projects to be configured with sensible defaults and remove some boilerplate. It will also update the `roles/owner` role to have at least the terraform SA configured and keep all project-level roles explicitly managed by terraform.

A few things to consider:

- is it clear that the terraform account will be added as owner by default?
- I've opted for bindings for project-level permissions as that's what the team currently uses. Adding the terraform SA as a member would be more straight-forward but could get dropped if a binding then replaces it. It feels cleaner to enforce all project level roles must be defined in this module IMO.
- turns out imports are not allowed in modules.
- I've added the users who are currently configured at the project-level. Should we create Google Groups for them now or come to that later?