### PR TITLE
GOV.UK Chat: add Cloudwatch alarms for new models

### DIFF
--- a/terraform/deployments/chat/cloudwatch_alarms.tf
+++ b/terraform/deployments/chat/cloudwatch_alarms.tf
@@ -7,38 +7,38 @@ locals {
     claude_sonnet = {
       model_id    = "eu.anthropic.claude-sonnet-4-20250514-v1:0"
       token_limit = var.chat_token_limits_per_minute["claude_sonnet"]
-      expression  = "((m1 + m2 + (m3 * 5)) / TOKEN_LIMIT) * 100"
+      expression  = "((CacheWriteInputTokenCount + InputTokenCount + (OutputTokenCount * 5)) / TOKEN_LIMIT) * 100"
       sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
     }
     claude_sonnet_4_5 = {
       model_id    = "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
       token_limit = var.chat_token_limits_per_minute["claude_sonnet_4_5"]
-      expression  = "((m1 + m2 + (m3 * 5)) / TOKEN_LIMIT) * 100"
+      expression  = "((CacheWriteInputTokenCount + InputTokenCount + (OutputTokenCount)) / TOKEN_LIMIT) * 100"
       sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
     }
     haiku_4_5 = {
       model_id    = "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
       token_limit = var.chat_token_limits_per_minute["haiku_4_5"]
-      expression  = "((m1 + m2 + (m3 * 5)) / TOKEN_LIMIT) * 100"
+      expression  = "((CacheWriteInputTokenCount + InputTokenCount + (OutputTokenCount * 5)) / TOKEN_LIMIT) * 100"
       sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
     }
     openai_gpt_oss = {
       model_id    = "openai.gpt-oss-120b-1:0"
       token_limit = var.chat_token_limits_per_minute["openai_gpt_oss"]
-      expression  = "((m1 + m2 + (m3 * 5)) / TOKEN_LIMIT) * 100"
+      expression  = "((CacheWriteInputTokenCount + InputTokenCount + (OutputTokenCount * 5)) / TOKEN_LIMIT) * 100"
       sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
     }
     titan_embed_dublin = {
       model_id    = "amazon.titan-embed-text-v2:0"
       token_limit = var.chat_token_limits_per_minute["titan_embed"]
-      expression  = "m2 / TOKEN_LIMIT * 100"
+      expression  = "InputTokenCount / TOKEN_LIMIT * 100"
       region      = "eu-west-1"
       sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
     }
     titan_embed_london = {
       model_id    = "amazon.titan-embed-text-v2:0"
       token_limit = var.chat_token_limits_per_minute["titan_embed"]
-      expression  = "m2 / TOKEN_LIMIT * 100"
+      expression  = "InputTokenCount / TOKEN_LIMIT * 100"
       region      = "eu-west-2"
       sns_topic   = aws_sns_topic.chat_alerts_london.arn
     }
@@ -124,11 +124,10 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold" {
   evaluation_periods  = 1
   treat_missing_data  = "notBreaching"
 
-  # m1: CacheWriteInputTokenCount
   dynamic "metric_query" {
-    for_each = strcontains(local.models[each.value.model_key].expression, "m1") ? [1] : []
+    for_each = strcontains(local.models[each.value.model_key].expression, "CacheWriteInputTokenCount") ? [1] : []
     content {
-      id = "m1"
+      id = "CacheWriteInputTokenCount"
       metric {
         namespace   = "AWS/Bedrock"
         metric_name = "CacheWriteInputTokenCount"
@@ -141,11 +140,10 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold" {
     }
   }
 
-  # m2: InputTokenCount
   dynamic "metric_query" {
-    for_each = strcontains(local.models[each.value.model_key].expression, "m2") ? [1] : []
+    for_each = strcontains(local.models[each.value.model_key].expression, "InputTokenCount") ? [1] : []
     content {
-      id = "m2"
+      id = "InputTokenCount"
       metric {
         namespace   = "AWS/Bedrock"
         metric_name = "InputTokenCount"
@@ -158,11 +156,10 @@ resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold" {
     }
   }
 
-  # m3: OutputTokenCount
   dynamic "metric_query" {
-    for_each = strcontains(local.models[each.value.model_key].expression, "m3") ? [1] : []
+    for_each = strcontains(local.models[each.value.model_key].expression, "OutputTokenCount") ? [1] : []
     content {
-      id = "m3"
+      id = "OutputTokenCount"
       metric {
         namespace   = "AWS/Bedrock"
         metric_name = "OutputTokenCount"

--- a/terraform/deployments/chat/cloudwatch_alarms.tf
+++ b/terraform/deployments/chat/cloudwatch_alarms.tf
@@ -1,480 +1,161 @@
 locals {
-  period                     = 300
-  stat                       = "Sum"
-  unit                       = "Count"
-  claude_sonnet_model_id     = "eu.anthropic.claude-sonnet-4-202505"
-  claude_sonnet_token_limit  = var.chat_token_limits_per_minute["claude_sonnet"]
-  openai_gpt_oss_model_id    = "openai.gpt-oss-120b-1:0"
-  openai_gpt_oss_token_limit = var.chat_token_limits_per_minute["openai_gpt_oss"]
-  titan_embed_model_id       = "amazon.titan-embed-text-v2:0"
-  titan_embed_token_limit    = var.chat_token_limits_per_minute["titan_embed"]
+  period = 300
+  stat   = "Sum"
+  unit   = "Count"
+
+  models = {
+    claude_sonnet = {
+      model_id    = "eu.anthropic.claude-sonnet-4-202505"
+      token_limit = var.chat_token_limits_per_minute["claude_sonnet"]
+      expression  = "((m1 + m2 + (m3 * 5)) / TOKEN_LIMIT) * 100"
+      sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
+    }
+    openai_gpt_oss = {
+      model_id    = "openai.gpt-oss-120b-1:0"
+      token_limit = var.chat_token_limits_per_minute["openai_gpt_oss"]
+      expression  = "((m1 + m2 + (m3 * 5)) / TOKEN_LIMIT) * 100"
+      sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
+    }
+    titan_embed_dublin = {
+      model_id    = "amazon.titan-embed-text-v2:0"
+      token_limit = var.chat_token_limits_per_minute["titan_embed"]
+      expression  = "m2 / TOKEN_LIMIT * 100"
+      region      = "eu-west-1"
+      sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
+    }
+    titan_embed_london = {
+      model_id    = "amazon.titan-embed-text-v2:0"
+      token_limit = var.chat_token_limits_per_minute["titan_embed"]
+      expression  = "m2 / TOKEN_LIMIT * 100"
+      region      = "eu-west-2"
+      sns_topic   = aws_sns_topic.chat_alerts_london.arn
+    }
+  }
+
+  alarms = {
+    "bedrock_token_threshold_50_percent_claude_sonnet" = {
+      model_key          = "claude_sonnet",
+      threshold          = 50,
+      "description_name" = "Claude Sonnet 4"
+    }
+    "bedrock_token_threshold_100_percent_claude_sonnet" = {
+      model_key          = "claude_sonnet",
+      threshold          = 100,
+      "description_name" = "Claude Sonnet 4"
+    }
+    "bedrock_token_threshold_50_percent_gpt_oss" = {
+      model_key          = "openai_gpt_oss",
+      threshold          = 50,
+      "description_name" = "OpenAI GPT-OSS"
+    }
+    "bedrock_token_threshold_100_percent_gpt_oss" = {
+      model_key          = "openai_gpt_oss",
+      threshold          = 100,
+      "description_name" = "OpenAI GPT-OSS"
+    }
+    "bedrock_token_threshold_50_percent_titan_embed_dublin" = {
+      model_key          = "titan_embed_dublin",
+      threshold          = 50,
+      "description_name" = "Titan Embed in eu-west-1 (User questions)"
+    }
+    "bedrock_token_threshold_100_percent_titan_embed_dublin" = {
+      model_key          = "titan_embed_dublin",
+      threshold          = 100,
+      "description_name" = "Titan Embed in eu-west-1 (User questions)"
+    }
+    "bedrock_token_threshold_50_percent_titan_embed_london" = {
+      model_key          = "titan_embed_london",
+      threshold          = 50,
+      "description_name" = "Titan Embed in eu-west-2 (Document indexing)"
+    }
+    "bedrock_token_threshold_100_percent_titan_embed_london" = {
+      model_key          = "titan_embed_london",
+      threshold          = 100,
+      "description_name" = "Titan Embed in eu-west-2 (Document indexing)"
+    }
+  }
 }
 
-resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_claude_sonnet" {
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-50-claude-sonnet"
+resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold" {
+  for_each = local.alarms
+
+  region              = lookup(local.models[each.value.model_key], "region", null)
+  alarm_name          = "govuk-chat-${var.govuk_environment}-${replace(each.key, "_", "-")}"
   alarm_description   = <<-EOF
-  WARNING - The current ${var.govuk_environment} Bedrock token usage > 50% for Claude Sonnet
+  ${each.value.threshold == 50 ? "WARNING" : "CRITICAL"} - The current ${var.govuk_environment} Bedrock token usage > ${each.value.threshold}% for ${each.value.description_name}
 
   Runbook:
   https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
   EOF
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 50
+  threshold           = each.value.threshold
   evaluation_periods  = 1
   treat_missing_data  = "notBreaching"
 
   # m1: CacheWriteInputTokenCount
-  metric_query {
-    id = "m1"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "CacheWriteInputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.claude_sonnet_model_id
+  dynamic "metric_query" {
+    for_each = strcontains(local.models[each.value.model_key].expression, "m1") ? [1] : []
+    content {
+      id = "m1"
+      metric {
+        namespace   = "AWS/Bedrock"
+        metric_name = "CacheWriteInputTokenCount"
+        period      = local.period
+        stat        = local.stat
+        unit        = local.unit
+        dimensions  = { ModelId = local.models[each.value.model_key].model_id }
       }
+      return_data = false
     }
-    return_data = false
   }
 
   # m2: InputTokenCount
-  metric_query {
-    id = "m2"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "InputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.claude_sonnet_model_id
+  dynamic "metric_query" {
+    for_each = strcontains(local.models[each.value.model_key].expression, "m2") ? [1] : []
+    content {
+      id = "m2"
+      metric {
+        namespace   = "AWS/Bedrock"
+        metric_name = "InputTokenCount"
+        period      = local.period
+        stat        = local.stat
+        unit        = local.unit
+        dimensions  = { ModelId = local.models[each.value.model_key].model_id }
       }
+      return_data = false
     }
-    return_data = false
   }
 
   # m3: OutputTokenCount
-  metric_query {
-    id = "m3"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "OutputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.claude_sonnet_model_id
+  dynamic "metric_query" {
+    for_each = strcontains(local.models[each.value.model_key].expression, "m3") ? [1] : []
+    content {
+      id = "m3"
+      metric {
+        namespace   = "AWS/Bedrock"
+        metric_name = "OutputTokenCount"
+        period      = local.period
+        stat        = local.stat
+        unit        = local.unit
+        dimensions  = { ModelId = local.models[each.value.model_key].model_id }
       }
+      return_data = false
     }
-    return_data = false
   }
 
   # e1: Percentage Calculation
   metric_query {
-    id          = "e1"
-    expression  = "((m1 + m2 + (m3 * 5)) / ${local.claude_sonnet_token_limit}) * 100"
+    id = "e1"
+    expression = replace(
+      local.models[each.value.model_key].expression,
+      "TOKEN_LIMIT",
+      local.models[each.value.model_key].token_limit
+    )
     label       = "Expression1"
     return_data = true
   }
 
-  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
-  insufficient_data_actions = []
-}
-
-resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_claude_sonnet" {
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-100-claude-sonnet"
-  alarm_description   = <<-EOF
-  CRITICAL - The current ${var.govuk_environment} Bedrock token usage > 100% for Claude Sonnet
-
-  Runbook:
-  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
-  EOF
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 100
-  evaluation_periods  = 1
-  treat_missing_data  = "notBreaching"
-
-  # m1: CacheWriteInputTokenCount
-  metric_query {
-    id = "m1"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "CacheWriteInputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.claude_sonnet_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # m2: InputTokenCount
-  metric_query {
-    id = "m2"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "InputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.claude_sonnet_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # m3: OutputTokenCount
-  metric_query {
-    id = "m3"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "OutputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.claude_sonnet_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # e1: Percentage Calculation
-  metric_query {
-    id          = "e1"
-    expression  = "((m1 + m2 + (m3 * 5)) / ${local.claude_sonnet_token_limit}) * 100"
-    label       = "Expression1"
-    return_data = true
-  }
-
-  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
-  insufficient_data_actions = []
-}
-
-resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_gpt_oss" {
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-50-gpt-oss"
-  alarm_description   = <<-EOF
-  WARNING - The current ${var.govuk_environment} Bedrock token usage > 50% for OpenAI GPT-OSS
-
-  Runbook:
-  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
-  EOF
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 50
-  evaluation_periods  = 1
-  treat_missing_data  = "notBreaching"
-
-  # m1: CacheWriteInputTokenCount
-  metric_query {
-    id = "m1"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "CacheWriteInputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.openai_gpt_oss_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # m2: InputTokenCount
-  metric_query {
-    id = "m2"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "InputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.openai_gpt_oss_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # m3: OutputTokenCount
-  metric_query {
-    id = "m3"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "OutputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.openai_gpt_oss_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # e1: Percentage Calculation
-  metric_query {
-    id          = "e1"
-    expression  = "((m1 + m2 + (m3 * 5)) / ${local.openai_gpt_oss_token_limit}) * 100"
-    label       = "Expression1"
-    return_data = true
-  }
-
-  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
-  insufficient_data_actions = []
-}
-
-resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_gpt_oss" {
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-100-gpt-oss"
-  alarm_description   = <<-EOF
-  CRITICAL - The current ${var.govuk_environment} Bedrock token usage > 100% for OpenAI GPT-OSS
-
-  Runbook:
-  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
-  EOF
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 100
-  evaluation_periods  = 1
-  treat_missing_data  = "notBreaching"
-
-  # m1: CacheWriteInputTokenCount
-  metric_query {
-    id = "m1"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "CacheWriteInputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.openai_gpt_oss_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # m2: InputTokenCount
-  metric_query {
-    id = "m2"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "InputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.openai_gpt_oss_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # m3: OutputTokenCount
-  metric_query {
-    id = "m3"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "OutputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.openai_gpt_oss_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # e1: Percentage Calculation
-  metric_query {
-    id          = "e1"
-    expression  = "((m1 + m2 + (m3 * 5)) / ${local.openai_gpt_oss_token_limit}) * 100"
-    label       = "Expression1"
-    return_data = true
-  }
-
-  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
-  insufficient_data_actions = []
-}
-
-
-resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_titan_embed_dublin" {
-  region              = "eu-west-1"
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-50-titan-embed-dublin"
-  alarm_description   = <<-EOF
-  WARNING - The current ${var.govuk_environment} Bedrock token usage > 50% for Titan Embed in eu-west-1 (User questions)
-
-  Runbook:
-  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
-  EOF
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 50
-  evaluation_periods  = 1
-  treat_missing_data  = "notBreaching"
-
-  # m1: InputTokenCount
-  metric_query {
-    id = "m1"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "InputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.titan_embed_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # e1: Percentage Calculation
-  metric_query {
-    id          = "e1"
-    expression  = "m1 / ${local.titan_embed_token_limit} * 100"
-    label       = "Expression1"
-    return_data = true
-  }
-
-  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
-  insufficient_data_actions = []
-}
-
-resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_titan_embed_dublin" {
-  region              = "eu-west-1"
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-100-titan-embed-dublin"
-  alarm_description   = <<-EOF
-  CRITICAL - The current ${var.govuk_environment} Bedrock token usage > 100% for Titan Embed in eu-west-1 (User questions)
-
-  Runbook:
-  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
-  EOF
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 100
-  evaluation_periods  = 1
-  treat_missing_data  = "notBreaching"
-
-  # m1: InputTokenCount
-  metric_query {
-    id = "m1"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "InputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.titan_embed_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # e1: Percentage Calculation
-  metric_query {
-    id          = "e1"
-    expression  = "m1 / ${local.titan_embed_token_limit} * 100"
-    label       = "Expression1"
-    return_data = true
-  }
-
-  alarm_actions             = [aws_sns_topic.chat_alerts_dublin.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts_dublin.arn]
-  insufficient_data_actions = []
-}
-
-resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_50_percent_titan_embed_london" {
-  region              = "eu-west-2"
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-50-titan-embed-london"
-  alarm_description   = <<-EOF
-  WARNING - The current ${var.govuk_environment} Bedrock token usage > 50% for Titan Embed in eu-west-2 (Document indexing)
-
-  Runbook:
-  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
-  EOF
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 50
-  evaluation_periods  = 1
-  treat_missing_data  = "notBreaching"
-
-  # m1: InputTokenCount
-  metric_query {
-    id = "m1"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "InputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.titan_embed_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # e1: Percentage Calculation
-  metric_query {
-    id          = "e1"
-    expression  = "m1 / ${local.titan_embed_token_limit} * 100"
-    label       = "Expression1"
-    return_data = true
-  }
-
-  alarm_actions             = [aws_sns_topic.chat_alerts_london.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts_london.arn]
-  insufficient_data_actions = []
-}
-
-resource "aws_cloudwatch_metric_alarm" "bedrock_token_threshold_100_percent_titan_embed_london" {
-  region              = "eu-west-2"
-  alarm_name          = "govuk-chat-${var.govuk_environment}-bedrock-token-threshold-100-titan-embed-london"
-  alarm_description   = <<-EOF
-  CRITICAL - The current ${var.govuk_environment} Bedrock token usage > 100% for Titan Embed in eu-west-2 (Document indexing)
-
-  Runbook:
-  https://docs.publishing.service.gov.uk/manual/alerts/chat-ai-alerts.html#bedrock-token-threshold-alerts
-  EOF
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 100
-  evaluation_periods  = 1
-  treat_missing_data  = "notBreaching"
-
-  # m1: InputTokenCount
-  metric_query {
-    id = "m1"
-    metric {
-      namespace   = "AWS/Bedrock"
-      metric_name = "InputTokenCount"
-      period      = local.period
-      stat        = local.stat
-      unit        = local.unit
-      dimensions = {
-        ModelId = local.titan_embed_model_id
-      }
-    }
-    return_data = false
-  }
-
-  # e1: Percentage Calculation
-  metric_query {
-    id          = "e1"
-    expression  = "m1 / ${local.titan_embed_token_limit} * 100"
-    label       = "Expression1"
-    return_data = true
-  }
-
-  alarm_actions             = [aws_sns_topic.chat_alerts_london.arn]
-  ok_actions                = [aws_sns_topic.chat_alerts_london.arn]
+  alarm_actions             = [local.models[each.value.model_key].sns_topic]
+  ok_actions                = [local.models[each.value.model_key].sns_topic]
   insufficient_data_actions = []
 }

--- a/terraform/deployments/chat/cloudwatch_alarms.tf
+++ b/terraform/deployments/chat/cloudwatch_alarms.tf
@@ -10,6 +10,18 @@ locals {
       expression  = "((m1 + m2 + (m3 * 5)) / TOKEN_LIMIT) * 100"
       sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
     }
+    claude_sonnet_4_5 = {
+      model_id    = "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+      token_limit = var.chat_token_limits_per_minute["claude_sonnet_4_5"]
+      expression  = "((m1 + m2 + (m3 * 5)) / TOKEN_LIMIT) * 100"
+      sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
+    }
+    haiku_4_5 = {
+      model_id    = "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+      token_limit = var.chat_token_limits_per_minute["haiku_4_5"]
+      expression  = "((m1 + m2 + (m3 * 5)) / TOKEN_LIMIT) * 100"
+      sns_topic   = aws_sns_topic.chat_alerts_dublin.arn
+    }
     openai_gpt_oss = {
       model_id    = "openai.gpt-oss-120b-1:0"
       token_limit = var.chat_token_limits_per_minute["openai_gpt_oss"]
@@ -42,6 +54,26 @@ locals {
       model_key          = "claude_sonnet",
       threshold          = 100,
       "description_name" = "Claude Sonnet 4"
+    }
+    "bedrock_token_threshold_50_percent_claude_sonnet_4_5" = {
+      model_key          = "claude_sonnet_4_5",
+      threshold          = 50,
+      "description_name" = "Claude Sonnet 4.5"
+    }
+    "bedrock_token_threshold_100_percent_claude_sonnet_4_5" = {
+      model_key          = "claude_sonnet_4_5",
+      threshold          = 100,
+      "description_name" = "Claude Sonnet 4.5"
+    }
+    "bedrock_token_threshold_50_percent_haiku_4_5" = {
+      model_key          = "haiku_4_5",
+      threshold          = 50,
+      "description_name" = "Haiku 4.5"
+    }
+    "bedrock_token_threshold_100_percent_haiku_4_5" = {
+      model_key          = "haiku_4_5",
+      threshold          = 100,
+      "description_name" = "Haiku 4.5"
     }
     "bedrock_token_threshold_50_percent_gpt_oss" = {
       model_key          = "openai_gpt_oss",

--- a/terraform/deployments/chat/cloudwatch_alarms.tf
+++ b/terraform/deployments/chat/cloudwatch_alarms.tf
@@ -5,7 +5,7 @@ locals {
 
   models = {
     claude_sonnet = {
-      model_id    = "eu.anthropic.claude-sonnet-4-202505"
+      model_id    = "eu.anthropic.claude-sonnet-4-20250514-v1:0"
       token_limit = var.chat_token_limits_per_minute["claude_sonnet"]
       expression  = "((m1 + m2 + (m3 * 5)) / TOKEN_LIMIT) * 100"
       sns_topic   = aws_sns_topic.chat_alerts_dublin.arn

--- a/terraform/deployments/chat/variables.tf
+++ b/terraform/deployments/chat/variables.tf
@@ -36,7 +36,12 @@ variable "chat_slack_channel_id" {
 }
 
 variable "chat_token_limits_per_minute" {
-  type        = map(number)
+  type = object({
+    claude_sonnet     = number
+    claude_sonnet_4_5 = number
+    haiku_4_5         = number
+    openai_gpt_oss    = number
+    titan_embed       = number
+  })
   description = "A map of model names to AWS Bedrock token limits per minute."
-  default     = {}
 }

--- a/terraform/variables/integration/chat.tfvars
+++ b/terraform/variables/integration/chat.tfvars
@@ -4,7 +4,9 @@ chat_redis_cluster_multi_az_enabled           = false
 chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
 chat_redis_cluster_num_cache_clusters         = "1"
 chat_token_limits_per_minute = {
-  "claude_sonnet"  = 9000000,
-  "openai_gpt_oss" = 100000000,
-  "titan_embed"    = 1200000
+  "claude_sonnet"     = 9000000, # Sonnet 4
+  "claude_sonnet_4_5" = 6000000,
+  "haiku_4_5"         = 6000000,
+  "openai_gpt_oss"    = 100000000,
+  "titan_embed"       = 1200000
 }

--- a/terraform/variables/production/chat.tfvars
+++ b/terraform/variables/production/chat.tfvars
@@ -4,7 +4,9 @@ chat_redis_cluster_multi_az_enabled           = true
 chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
 chat_redis_cluster_num_cache_clusters         = "2"
 chat_token_limits_per_minute = {
-  "claude_sonnet"  = 9000000,
-  "openai_gpt_oss" = 100000000,
-  "titan_embed"    = 1200000
+  "claude_sonnet"     = 9000000, # Sonnet 4
+  "claude_sonnet_4_5" = 6000000,
+  "haiku_4_5"         = 6000000,
+  "openai_gpt_oss"    = 100000000,
+  "titan_embed"       = 1200000
 }

--- a/terraform/variables/staging/chat.tfvars
+++ b/terraform/variables/staging/chat.tfvars
@@ -4,7 +4,9 @@ chat_redis_cluster_multi_az_enabled           = false
 chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
 chat_redis_cluster_num_cache_clusters         = "1"
 chat_token_limits_per_minute = {
-  "claude_sonnet"  = 9000000,
-  "openai_gpt_oss" = 100000000,
-  "titan_embed"    = 1200000
+  "claude_sonnet"     = 9000000, # Sonnet 4
+  "claude_sonnet_4_5" = 6000000,
+  "haiku_4_5"         = 6000000,
+  "openai_gpt_oss"    = 100000000,
+  "titan_embed"       = 1200000
 }


### PR DESCRIPTION

We're using 2 new models (Haiku 4.5 and Sonnet 4.5) in GOV.UK Chat, so
we want to configure Cloudwatch alarms for their usage.

We currently use 3 models on Chat, and each model has 2 alarms
configured (one for 50% rate limit usage and one for 100% usage).

We're now supporting 2 more models - which means 4 more alarms.

This code previously defined quite a long resource for each individual
alarm and would have got pretty unwieldy soon if we added 4 more.

So the first commit here refactors the code to use variables and a single
`resource` block. The second commit adds the new alarms for the new models.