### PR TITLE
New private repo for experimenting with architecture diagramming tools for Publishing

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -419,6 +419,11 @@ repos:
       source_owner: "alexbasista"
       source_repo: "terraform-tfe-workspacer"
 
+  govuk-publishing-documentation:
+    visibility: private
+    branch_protection: true
+    can_be_deployed: false
+
   govuk-reports-prototype:
     need_production_access_to_merge: false
     branch_protection: false


### PR DESCRIPTION
We want to document the publishing infrastructure in a maintainable fashion. Currently it is in a mural board.

To enable this this repo is being made to allow us to manage documentation as code as we experiment with a couple of tools.

Note I have made this repo private for this process. It may well be we make a new, public, repo once we have established what this repo will contain.