### PR TITLE
GOV.UK Chat: monitor AWS health scheduled changes

### DIFF
--- a/terraform/deployments/chat/eventbridge.tf
+++ b/terraform/deployments/chat/eventbridge.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_event_rule" "aws_service_health_alert_dublin" {
     "detail-type" : ["AWS Health Event"],
     "detail" : {
       "service" : ["BEDROCK", "EKS", "ELASTICACHE", "ES", "RDS"],
-      "eventTypeCategory" : ["issue"]
+      "eventTypeCategory" : ["issue", "scheduledChange"]
     }
   })
   role_arn = aws_iam_role.aws_service_health_alert.arn
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_event_rule" "aws_service_health_alert_london" {
     "detail-type" : ["AWS Health Event"],
     "detail" : {
       "service" : ["BEDROCK", "EKS", "ELASTICACHE", "ES", "RDS"],
-      "eventTypeCategory" : ["issue"]
+      "eventTypeCategory" : ["issue", "scheduledChange"]
     }
   })
   role_arn = aws_iam_role.aws_service_health_alert.arn


### PR DESCRIPTION

In GOV.UK Chat, we have EventBridge alerts configured to tell us when
AWS is experiencing health issues.

We want to expand these to inform us of upcoming scheduled changes too.

To do that, we need to include "scheduledChange" in the
`eventTypeCategory` array.

See https://docs.aws.amazon.com/health/latest/APIReference/API_EventType.html
