### PR TITLE
Add parameter group for Release MySQL 8.4 upgrade

### DIFF
--- a/terraform/deployments/rds/release_mysql_84_upgrade.tf
+++ b/terraform/deployments/rds/release_mysql_84_upgrade.tf
@@ -1,0 +1,11 @@
+resource "aws_db_parameter_group" "release_mysql_84_green_params" {
+  name_prefix = "release-mysql-84-temp-"
+
+  family = "mysql8.4"
+
+  parameter {
+    name         = "max_allowed_packet"
+    value        = 1073741824
+    apply_method = "pending-reboot"
+  }
+}


### PR DESCRIPTION
This is going to be a step in the upgrade runbook. It's necessary to create the blue/green deployment for the DB engine upgrade.

https://github.com/alphagov/govuk-infrastructure/issues/4025