### PR TITLE
BAU - `search-api-v2` terraform version set by `tfc-configuration`

### DIFF
--- a/terraform/deployments/tfc-configuration/modules/search-api-v2/main.tf
+++ b/terraform/deployments/tfc-configuration/modules/search-api-v2/main.tf
@@ -17,7 +17,7 @@ resource "tfe_workspace" "environment_workspace" {
   source_url  = "https://github.com/alphagov/search-v2-infrastructure/tree/main/terraform/meta"
 
   working_directory = "terraform/deployments/search-api-v2"
-  terraform_version = "~> 1.14.0"
+  terraform_version = var.terraform_version
 
   # Don't auto-apply in production (to allow catching issues in lower environments)
   auto_apply = var.name != "production"

--- a/terraform/deployments/tfc-configuration/modules/search-api-v2/variables.tf
+++ b/terraform/deployments/tfc-configuration/modules/search-api-v2/variables.tf
@@ -42,3 +42,9 @@ variable "google_service_account_email" {
   description = "The GCP service account email runs will use to authenticate"
   type        = string
 }
+
+variable "terraform_version" {
+  type        = string
+  description = "Version constraint for Terraform for this workspace."
+  default     = "~> 1.14.9"
+}

--- a/terraform/deployments/tfc-configuration/search-api-v2.tf
+++ b/terraform/deployments/tfc-configuration/search-api-v2.tf
@@ -12,6 +12,7 @@ module "environment_integration" {
   google_workload_provider_name = "projects/780375417592/locations/global/workloadIdentityPools/terraform-cloud-id-pool/providers/terraform-cloud-provider-oidc"
   google_service_account_email  = "tfc-service-account@search-api-v2-integration.iam.gserviceaccount.com"
   tfc_project                   = tfe_project.project
+  terraform_version             = var.terraform_version
   vcs_repo_branch               = "main"
 }
 
@@ -25,6 +26,7 @@ module "environment_staging" {
   google_workload_provider_name = "projects/773027887517/locations/global/workloadIdentityPools/terraform-cloud-id-pool/providers/terraform-cloud-provider-oidc"
   google_service_account_email  = "tfc-service-account@search-api-v2-staging.iam.gserviceaccount.com"
   tfc_project                   = tfe_project.project
+  terraform_version             = var.terraform_version
   vcs_repo_branch               = "main"
 }
 
@@ -38,5 +40,6 @@ module "environment_production" {
   google_workload_provider_name = "projects/931453572747/locations/global/workloadIdentityPools/terraform-cloud-id-pool/providers/terraform-cloud-provider-oidc"
   google_service_account_email  = "tfc-service-account@search-api-v2-production.iam.gserviceaccount.com"
   tfc_project                   = tfe_project.project
+  terraform_version             = var.terraform_version
   vcs_repo_branch               = "main"
 }


### PR DESCRIPTION
Description:
- Set `search-api-v2`'s terraform version through `tfc-configuration`