### PR TITLE
pinning Google provider version

### DIFF
--- a/terraform/deployments/gcp-gov-graph/main-gcp.tf
+++ b/terraform/deployments/gcp-gov-graph/main-gcp.tf
@@ -191,7 +191,7 @@ variable "bigquery_zendesk_data_viewer_members" {
 terraform {
   required_providers {
     google = {
-      version = "7.30.0"
+      version = "6.27.0" # Pinning the version required by terraform-google-modules/container-vm/google.
     }
   }
 }


### PR DESCRIPTION
Gov-Graph requires a Google provider version of 6.27.0 to support it's use of VM deployment via https://github.com/terraform-google-modules/terraform-google-container-vm

The longer term plan is to move off VM dependancy for data ingestion, but this reversion is needed to as current TF plans are failing