### PR TITLE
BAU - Fix `build-image-from-PR` to not build ARM images on AMD platform

### DIFF
--- a/.github/workflows/build-image-from-pr.yml
+++ b/.github/workflows/build-image-from-pr.yml
@@ -44,7 +44,7 @@ jobs:
             runner: ${{ inputs.amd64_runner_name }}
           - arch: arm64
             runner: ${{ inputs.arm64_runner_name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
     steps:
@@ -55,6 +55,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          platforms: "linux/${{ matrix.arch }}"
 
       - run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         id: local-head


### PR DESCRIPTION
Description:
- Currently the `build-image-from-PR` builds ARM images on AMD runners using emulation which slows the build down. Previously we were running everything on `ubuntu-latest` instead of using correctly using the right runner for each architecture. Now this will use the ARM runner for the ARM build