### PR TITLE
Rename alert destination following team name change

### DIFF
--- a/terraform/deployments/cluster-services/templates/alertmanager-config.tpl
+++ b/terraform/deployments/cluster-services/templates/alertmanager-config.tpl
@@ -42,7 +42,7 @@ alertmanager:
         client_url: "https://${alertmanager_host}/#/alerts?receiver={{ .Receiver | urlquery }}"
     - name: 'slack-signon-token-expiry'
       slack_configs:
-      - channel: '#govuk-publishing-platform-system-alerts'
+      - channel: '#govuk-content-apis-system-alerts'
         send_resolved: true
         icon_url: https://avatars3.githubusercontent.com/u/3380462
         title: |-


### PR DESCRIPTION
The team is focusing on APIs so the name was changed to reflect that.