### PR TITLE
Remove branch protection from docs repo.

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -421,7 +421,7 @@ repos:
 
   govuk-publishing-documentation:
     visibility: private
-    branch_protection: true
+    branch_protection: false
     can_be_deployed: false
 
   govuk-reports-prototype:


### PR DESCRIPTION
Removed branch protection so that I can experiment easier with settin…g up the github pages wokflow for this docs repo.

this repo is being used to experiment with c4lite as a docs tool for GOV.UK. this has the option for building a github pages site to serve the generated docs. This PR removes branch protection from the repo to allow me to quickly merge PRs myself to test this functionality.