### PR TITLE
BAU - Update Terraform to `1.15.1`

### DIFF
--- a/terraform/deployments/ephemeral/ws/variables.tf
+++ b/terraform/deployments/ephemeral/ws/variables.tf
@@ -13,7 +13,7 @@ variable "name" {
 
 variable "terraform_version" {
   type    = string
-  default = "~> 1.15.2"
+  default = "~> 1.15.1"
 }
 
 variable "variable_set_id" {

--- a/terraform/deployments/tfc-configuration/modules/search-api-v2/variables.tf
+++ b/terraform/deployments/tfc-configuration/modules/search-api-v2/variables.tf
@@ -46,5 +46,5 @@ variable "google_service_account_email" {
 variable "terraform_version" {
   type        = string
   description = "Version constraint for Terraform for this workspace."
-  default     = "~> 1.14.9"
+  default     = "~> 1.15.1"
 }

--- a/terraform/deployments/tfc-configuration/variables.tf
+++ b/terraform/deployments/tfc-configuration/variables.tf
@@ -70,7 +70,7 @@ variable "workspace_tags" {
 variable "terraform_version" {
   type        = string
   description = "Version constraint for Terraform for this workspace."
-  default     = "~> 1.15.2"
+  default     = "~> 1.15.1"
 }
 
 variable "trigger_patterns" {


### PR DESCRIPTION
Description:
- Terraform Cloud hasn't made `1.15.2` available so use `1.15.1`