### PR TITLE
Add govuk-cli repository

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -406,6 +406,8 @@ repos:
     required_pull_request_reviews:
       require_code_owner_reviews: true
 
+  govuk-cli: {}
+
   terraform-govuk-infrastructure-sensitive:
     visibility: private
     up_to_date_branches: true


### PR DESCRIPTION
This repo doesn't need any special config at the moment, so has no config values.

I just stuck it somewhere in the file. The file is hopelessly unorganised, so this isn't really making it worse.

https://github.com/alphagov/govuk-infrastructure/issues/4169