### PR TITLE
Add govuk-ia-utility configuration to repos.yml

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -400,6 +400,14 @@ repos:
   govuk-graphql:
     branch_protection: false
     can_be_deployed: true
+    
+  govuk-ia-utility:
+    can_be_deployed: false
+    standard_contexts: *standard_security_checks 
+    push_allowances: ["alphagov/gov-uk-data"]
+    required_pull_request_reviews:
+      pull_request_bypassers:
+        - "alphagov/gov-uk-data"
 
   govuk-infrastructure:
     up_to_date_branches: true


### PR DESCRIPTION
This PR updates repos.yml to add the new repository, govuk-ia-utility The purpose of this repo is act as a utility account which provides tools to other GOVUK Insights and Analytics repos. 

This is not an app repo and will not be deployed. This PR contains pull_allowances for the govuk-data team in the repos definition.