### PR TITLE
update renovate to ignore GovGraph

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,5 +82,8 @@
             "datasourceTemplate": "github-releases",
             "versioningTemplate": "github-releases"
         }
+    ],
+    "ignorePaths": [
+        "terraform/deployments/gcp-gov-graph/**"
     ]
 }


### PR DESCRIPTION
GovGraph need to use a pinned version of the Google Provider.
While work is underway to remove this dependancy it would be useful it ignore GovGraph and allow other deployments to update their dependancies with Renovate