### PR TITLE
Adds a startup script for asset manager that includes the log driver

### DIFF
--- a/terraform/deployments/gcp-gov-graph/gce.tf
+++ b/terraform/deployments/gcp-gov-graph/gce.tf
@@ -582,6 +582,11 @@ resource "google_compute_instance_template" "whitehall" {
 resource "google_compute_instance_template" "asset_manager" {
   name         = "asset-manager"
   machine_type = "c2d-highmem-2"
+  metadata_startup_script = templatefile("scripts/asset_manager_startup.sh.tftpl", {
+    project_id = var.project_id
+    image      = module.asset-manager-container.source_image
+    }
+  )
 
   disk {
     boot         = true

--- a/terraform/deployments/gcp-gov-graph/scripts/asset_manager_startup.sh.tftpl
+++ b/terraform/deployments/gcp-gov-graph/scripts/asset_manager_startup.sh.tftpl
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export PROJECT_ID="${project_id}"
+export IMAGE="${image}"
+
+docker run -d \
+  --name asset-manager \
+  --log-driver=gcplogs \
+  --log-opt gcp-project=$PROJECT_ID \
+  $IMAGE


### PR DESCRIPTION
This is based on the documentation here https://docs.docker.com/engine/logging/drivers/gcplogs/ for logging with GCP and docker. I'm hoping that changing the log driver like this will allow the logs to be piped through to google cloud logging