### PR TITLE
Migrate AI Accelerator Data S3 Bucket to Shared S3 Module

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_iam.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "govuk_ai_accelerator_s3_access" {
   statement {
     sid       = "GovukAiAcceleratorS3RootAccessPolicy"
     actions   = ["s3:GetBucketLocation", "s3:ListBucket"]
-    resources = [aws_s3_bucket.govuk_ai_accelerator_data[0].arn]
+    resources = [module.secure_s3_bucket_ai_accelerator_data[0].arn]
   }
 
   statement {
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "govuk_ai_accelerator_s3_access" {
       "s3:PutObjectAcl",
       "s3:DeleteObject"
     ]
-    resources = ["${aws_s3_bucket.govuk_ai_accelerator_data[0].arn}/*"]
+    resources = ["${module.secure_s3_bucket_ai_accelerator_data[0].arn}/*"]
   }
 }
 

--- a/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_s3.tf
@@ -1,85 +1,43 @@
-resource "aws_s3_bucket" "govuk_ai_accelerator_data" {
-  bucket = "govuk-ai-accelerator-data-integration"
-  count  = var.enable_govuk_ai_accelerator ? 1 : 0
+module "secure_s3_bucket_ai_accelerator_data" {
+  source            = "../../shared-modules/s3"
+  count             = var.enable_govuk_ai_accelerator ? 1 : 0
+  govuk_environment = var.govuk_environment
+
+  name = "govuk-ai-accelerator-data-${var.govuk_environment}"
+
 }
 
-resource "aws_s3_bucket_public_access_block" "govuk_ai_accelerator_data_access_block" {
-  bucket = aws_s3_bucket.govuk_ai_accelerator_data[0].id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-
-  count = var.enable_govuk_ai_accelerator ? 1 : 0
+moved {
+  from = aws_s3_bucket.govuk_ai_accelerator_data[0].id
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket.this.id
 }
 
-resource "aws_s3_bucket_versioning" "govuk_ai_accelerator_data_versioning" {
-  bucket = aws_s3_bucket.govuk_ai_accelerator_data[0].id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
-
-  count = var.enable_govuk_ai_accelerator ? 1 : 0
+moved {
+  from = aws_s3_bucket_public_access_block.govuk_ai_accelerator_data_access_block[0].id
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_public_access_block.this.id
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "govuk_ai_accelerator_data_encryption" {
-  bucket = aws_s3_bucket.govuk_ai_accelerator_data[0].id
-
-  rule {
-    blocked_encryption_types = ["NONE"]
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
-    }
-  }
-
-  count = var.enable_govuk_ai_accelerator ? 1 : 0
+moved {
+  from = aws_s3_bucket_versioning.govuk_ai_accelerator_data_versioning[0].id
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_versioning.this.id
 }
 
-data "aws_iam_policy_document" "https_only" {
-  count = var.enable_govuk_ai_accelerator ? 1 : 0
-
-  statement {
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-    sid     = "https_only"
-    effect  = "Deny"
-    actions = ["s3:*"]
-    resources = [
-      aws_s3_bucket.govuk_ai_accelerator_data[0].arn,
-      "${aws_s3_bucket.govuk_ai_accelerator_data[0].arn}/*"
-    ]
-    condition {
-      test     = "Bool"
-      values   = ["false"]
-      variable = "aws:SecureTransport"
-    }
-  }
+moved {
+  from = aws_s3_bucket_server_side_encryption_configuration.govuk_ai_accelerator_data_encryption[0].id
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_server_side_encryption_configuration.this.id
 }
 
-resource "aws_s3_bucket_policy" "govuk_ai_accelerator_data_bucket_policy" {
-  bucket = aws_s3_bucket.govuk_ai_accelerator_data[0].id
-  policy = data.aws_iam_policy_document.https_only[0].json
-
-  count = var.enable_govuk_ai_accelerator ? 1 : 0
+moved {
+  from = aws_s3_bucket_policy.govuk_ai_accelerator_data_bucket_policy[0].id
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_policy.this.id
 }
 
-resource "aws_s3_bucket_ownership_controls" "govuk_ai_accelerator_data_owner_controls" {
-  bucket = aws_s3_bucket.govuk_ai_accelerator_data[0].id
-  rule {
-    object_ownership = "BucketOwnerEnforced"
-  }
-
-  count = var.enable_govuk_ai_accelerator ? 1 : 0
+moved {
+  from = aws_s3_bucket_ownership_controls.govuk_ai_accelerator_data_owner_controls[0].id
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_ownership_controls.this.id
 }
 
-resource "aws_s3_bucket_logging" "govuk_ai_accelerator_data_logging" {
-  bucket        = aws_s3_bucket.govuk_ai_accelerator_data[0].id
-  target_bucket = "govuk-integration-aws-logging"
-  target_prefix = "s3/govuk-ai-accelerator-data-integration/"
-
-  count = var.enable_govuk_ai_accelerator ? 1 : 0
+moved {
+  from = aws_s3_bucket_logging.govuk_ai_accelerator_data_logging[0].id
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_logging.this.id
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/ai_accelerator_s3.tf
@@ -8,36 +8,36 @@ module "secure_s3_bucket_ai_accelerator_data" {
 }
 
 moved {
-  from = aws_s3_bucket.govuk_ai_accelerator_data[0].id
-  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket.this.id
+  from = aws_s3_bucket.govuk_ai_accelerator_data[0]
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket.this
 }
 
 moved {
-  from = aws_s3_bucket_public_access_block.govuk_ai_accelerator_data_access_block[0].id
-  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_public_access_block.this.id
+  from = aws_s3_bucket_public_access_block.govuk_ai_accelerator_data_access_block[0]
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_public_access_block.this[0]
 }
 
 moved {
-  from = aws_s3_bucket_versioning.govuk_ai_accelerator_data_versioning[0].id
-  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_versioning.this.id
+  from = aws_s3_bucket_versioning.govuk_ai_accelerator_data_versioning[0]
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_versioning.this
 }
 
 moved {
-  from = aws_s3_bucket_server_side_encryption_configuration.govuk_ai_accelerator_data_encryption[0].id
-  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_server_side_encryption_configuration.this.id
+  from = aws_s3_bucket_server_side_encryption_configuration.govuk_ai_accelerator_data_encryption[0]
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_server_side_encryption_configuration.this
 }
 
 moved {
-  from = aws_s3_bucket_policy.govuk_ai_accelerator_data_bucket_policy[0].id
-  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_policy.this.id
+  from = aws_s3_bucket_policy.govuk_ai_accelerator_data_bucket_policy[0]
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_policy.bucket_policy
 }
 
 moved {
-  from = aws_s3_bucket_ownership_controls.govuk_ai_accelerator_data_owner_controls[0].id
-  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_ownership_controls.this.id
+  from = aws_s3_bucket_ownership_controls.govuk_ai_accelerator_data_owner_controls[0]
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_ownership_controls.owner
 }
 
 moved {
-  from = aws_s3_bucket_logging.govuk_ai_accelerator_data_logging[0].id
-  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_logging.this.id
+  from = aws_s3_bucket_logging.govuk_ai_accelerator_data_logging[0]
+  to   = module.secure_s3_bucket_ai_accelerator_data[0].aws_s3_bucket_logging.this
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/ai_graph_tools_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/ai_graph_tools_iam.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "govuk_ai_graph_tools_s3_access" {
   statement {
     sid       = "GovukAiAcceleratorS3RootAccessPolicy"
     actions   = ["s3:GetBucketLocation", "s3:ListBucket"]
-    resources = [aws_s3_bucket.govuk_ai_accelerator_data[0].arn]
+    resources = [module.secure_s3_bucket_ai_accelerator_data[0].arn]
   }
 
   statement {
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "govuk_ai_graph_tools_s3_access" {
       "s3:PutObjectAcl",
       "s3:DeleteObject"
     ]
-    resources = ["${aws_s3_bucket.govuk_ai_accelerator_data[0].arn}/*"]
+    resources = ["${module.secure_s3_bucket_ai_accelerator_data[0].arn}/*"]
   }
 }
 


### PR DESCRIPTION
## What?
This migrates another bucket to use the Shared S3 Module.

### Related

* Closes https://github.com/alphagov/govuk-infrastructure/issues/3894