### PR TITLE
IA-2768: add govuk-data-infrastructure repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -339,6 +339,18 @@ repos:
     required_status_checks:
       standard_contexts: *standard_security_checks
 
+  govuk-data-infrastructure:
+    can_be_deployed: false
+    up_to_date_branches: true
+    required_pull_request_reviews:
+      require_code_owner_reviews: true
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+    teams:
+      govuk: "maintain"
+      govuk-platform-engineering: "admin"
+      govuk-data-engineering: "admin"
+
   govuk-data-science-workshop:
       archived: true
 


### PR DESCRIPTION
This PR adds a new repo that will eventually contain terraform deployments for data infra GCP projects.