### PR TITLE
Demote algorithmic_transparency_record.

### DIFF
--- a/terraform/deployments/search-api-v2/serving_config_global_default.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_default.tf
@@ -113,7 +113,7 @@ module "control_global_boost_demote_medium" {
   engine_id    = google_discovery_engine_search_engine.govuk_global.engine_id
   action = {
     boostAction = {
-      filter     = "link: ANY(${local.demote_pages_medium_expr}) OR document_type: ANY(\"employment_tribunal_decision\", \"foi_release\", \"service_standard_report\") OR organisation_state: ANY(\"devolved\", \"closed\")",
+      filter     = "link: ANY(${local.demote_pages_medium_expr}) OR document_type: ANY(\"algorithmic_transparency_record\", \"employment_tribunal_decision\", \"foi_release\", \"service_standard_report\") OR organisation_state: ANY(\"devolved\", \"closed\")",
       fixedBoost = -0.5
       dataStore  = google_discovery_engine_data_store.govuk_content.name
     }


### PR DESCRIPTION
Currently users searching for GOV.UK chat are likely to click on https://www.gov.uk/algorithmic-transparency-records/dsit-gov-dot-uk-chat from the search results, as it looks relevant. We want them to click on the GOV.UK App page instead.

Demoting the `algorithmic_transparency_record` document type so that users are more likely to click on the GOV.UK app result that we've added a best bet for.