### PR TITLE
Add an opinionated reusable workflow for go testing

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,63 @@
+name: Go Test
+
+on:
+  workflow_call:
+        
+jobs:
+  test-go:
+    name: Test Go
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          show-progress: false
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: Unit tests
+        run: make unit_tests
+      - name: Integration Tests
+        run: make integration_tests
+        timeout-minutes: 15
+      - name: Download coverage report from main
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Download coverage report (they expire after 90 days, so don't fail if there isn't one)
+          if ! gh run download --name coverage-report-main --dir coverage/report-main/; then
+            echo "Failed to download coverage report artifact 'coverage-report-main', continuing anyway"
+          fi
+      - name: Generate coverage report
+        run: make coverage_report
+      - name: Post PR Comment with Coverage
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          set -euo pipefail
+
+          # Clear any previous comment
+          gh pr comment "${PR_NUMBER}" --delete-last --yes || true
+
+          # Post updated coverage report
+          gh pr comment "${PR_NUMBER}" --body-file coverage/report/overall-coverage.md
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          name: coverage-report-main
+          path: coverage/report/
+          if-no-files-found: error
+          retention-days: 90
+          overwrite: true
+          include-hidden-files: false
+          archive: true

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -734,7 +734,7 @@ repos:
     homepage_url: "https://docs.publishing.service.gov.uk/repos/router.html"
     required_status_checks:
       additional_contexts:
-        - Test Go
+        - Test Go / Test Go
 
   router-api:
     archived: true


### PR DESCRIPTION
This takes the go test workflow from router and brings it into this repo as a reusable workflow.