### PR TITLE
Cloudwatch alarms: update Bedrock token limits

### DIFF
--- a/terraform/variables/integration/chat.tfvars
+++ b/terraform/variables/integration/chat.tfvars
@@ -5,8 +5,8 @@ chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
 chat_redis_cluster_num_cache_clusters         = "1"
 chat_token_limits_per_minute = {
   "claude_sonnet"     = 9000000, # Sonnet 4
-  "claude_sonnet_4_5" = 6000000,
-  "haiku_4_5"         = 6000000,
+  "claude_sonnet_4_5" = 15000000,
+  "haiku_4_5"         = 5000000,
   "openai_gpt_oss"    = 100000000,
   "titan_embed"       = 1200000
 }

--- a/terraform/variables/production/chat.tfvars
+++ b/terraform/variables/production/chat.tfvars
@@ -5,8 +5,8 @@ chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
 chat_redis_cluster_num_cache_clusters         = "2"
 chat_token_limits_per_minute = {
   "claude_sonnet"     = 9000000, # Sonnet 4
-  "claude_sonnet_4_5" = 6000000,
-  "haiku_4_5"         = 6000000,
+  "claude_sonnet_4_5" = 15000000,
+  "haiku_4_5"         = 5000000,
   "openai_gpt_oss"    = 100000000,
   "titan_embed"       = 1200000
 }

--- a/terraform/variables/staging/chat.tfvars
+++ b/terraform/variables/staging/chat.tfvars
@@ -5,8 +5,8 @@ chat_redis_cluster_node_type                  = "cache.r6g.xlarge"
 chat_redis_cluster_num_cache_clusters         = "1"
 chat_token_limits_per_minute = {
   "claude_sonnet"     = 9000000, # Sonnet 4
-  "claude_sonnet_4_5" = 6000000,
-  "haiku_4_5"         = 6000000,
+  "claude_sonnet_4_5" = 15000000,
+  "haiku_4_5"         = 5000000,
   "openai_gpt_oss"    = 100000000,
   "titan_embed"       = 1200000
 }


### PR DESCRIPTION

On GOV.UK Chat we have some Cloudwatch alarms configured to trigger when
we get close to our Bedrock token quota.

The trigger is calculated based on the maximum tokens/minute we have
available in AWS.

AWS have just bumped out Sonnet 4.5 quota up to 15m tokens/min, so this
updates the variable for that model.

Additionally, it fixes a wrong value for Haiku 4.5. Our limit is
actually 5m tokens/min, not the 6m value we had here.
