### PR TITLE
Disable triggered runs for ephemeral workspaces

### DIFF
--- a/terraform/deployments/ephemeral/ws/workspace.tf
+++ b/terraform/deployments/ephemeral/ws/workspace.tf
@@ -8,7 +8,7 @@ module "workspace" {
   terraform_version   = var.terraform_version
   execution_mode      = "remote"
   working_directory   = "/terraform/deployments/${var.name}/"
-  trigger_patterns    = ["/terraform/deployments/${var.name}/**/*"]
+  trigger_patterns    = []
   global_remote_state = true
   queue_all_runs      = false
 


### PR DESCRIPTION
## Summary

Sets `trigger_patterns = []` on ephemeral TFC workspaces so that commits to `main` no longer auto-trigger plans against them.

## Problem

Ephemeral workspaces share the same deployment directories as production (e.g. `terraform/deployments/cluster-infrastructure/`). The previous `trigger_patterns` glob meant every merged PR touching those directories triggered a plan against every live ephemeral cluster — wasting TFC capacity and risking unintended applies.

## Change

`trigger_patterns` is set to an empty list rather than removed entirely. Removing it would fall back to the module default of `null`, which causes TFC to use the `working_directory` as the trigger scope, the same behaviour we're trying to avoid.

Runs are still triggered:
- On initial workspace creation (via `tfe_workspace_run`)
- By the shutdown script (via TFC API)
- Manually via `terraform apply` or the TFC UI
