### PR TITLE
Sch 2050 update documentation for new vertex name

### DIFF
--- a/terraform/deployments/search-api-v2/datastore_schema.tf
+++ b/terraform/deployments/search-api-v2/datastore_schema.tf
@@ -38,8 +38,8 @@ resource "restapi_object" "google_discovery_engine_datastore_schema" {
         # of the main body of content
         #
         # Note: We've decided not to use this as structured fields don't contribute enough to
-        # relevance. Vertex does not support removing a field from the schema (as of Jan 2024) so it
-        # stays here.
+        # relevance. Discovery Engine does not support removing a field from the schema (as of Jan 2024)
+        # so it stays here.
         additional_searchable_text = {
           type       = "string"
           searchable = true
@@ -52,7 +52,7 @@ resource "restapi_object" "google_discovery_engine_datastore_schema" {
           indexable   = true
         }
         # Absolute URL including protocol and host even for content on GOV.UK proper (used for
-        # Vertex to incorporate popularity/event signals and for internal purposes)
+        # Discovery Engine to incorporate popularity/event signals and for internal purposes)
         url = {
           type               = "string"
           retrievable        = true
@@ -175,8 +175,8 @@ resource "restapi_object" "google_discovery_engine_datastore_schema" {
         #
         # Note: We've decided not to use this in the end as there isn't enough of a risk and we
         # cannot guarantee atomic writes anyway. It is now included in the `debug` object field.
-        # Vertex does not support removing a field from the schema (as of Jan 2024) so it stays
-        # here.
+        # Discovery Engine does not support removing a field from the schema (as of Jan 2024)
+        # so it stays here.
         payload_version = {
           type = "integer"
         }
@@ -189,7 +189,7 @@ resource "restapi_object" "google_discovery_engine_datastore_schema" {
             payload_version = {
               type = "integer"
             }
-            # Timestamp of when this document was last synced to Vertex
+            # Timestamp of when this document was last synced to Discovery Engine
             last_synced_at = {
               type = "string"
             }
@@ -199,9 +199,9 @@ resource "restapi_object" "google_discovery_engine_datastore_schema" {
     }
   })
 
-  # VAIS adds some "output-only" properties dynamically, which creates false positive drift.
-  # Terraform also alphabetises the properties, which again causes false positive drift (as VAIS
-  # returns them in undefined order)
+  # Discovery Engine adds some "output-only" properties dynamically, which creates false positive drift.
+  # Terraform also alphabetises the properties, which again causes false positive drift (as Discovery
+  # Engine returns them in undefined order)
   ignore_changes_to = [
     "fieldConfigs",
     "structSchema",

--- a/terraform/deployments/search-api-v2/events_ingestion.tf
+++ b/terraform/deployments/search-api-v2/events_ingestion.tf
@@ -47,7 +47,7 @@ resource "google_bigquery_table" "search_event" {
 
 }
 
-# ga4 'select_item' events get transformed and inserted into this time-partitioned search-event table defined with a Discovery Engine schema
+# ga4 'page_view' events get transformed and inserted into this time-partitioned search-event table defined with a Discovery Engine schema
 resource "google_bigquery_table" "view_item_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "view-item-event"
@@ -81,7 +81,7 @@ resource "google_bigquery_table" "search_intraday_event" {
 
 }
 
-# ga4 'select_item' intraday events get transformed and inserted into this time-partitioned view-item-intraday-event table defined with a Discovery Engine schema
+# ga4 'page_view' intraday events get transformed and inserted into this time-partitioned view-item-intraday-event table defined with a Discovery Engine schema
 resource "google_bigquery_table" "view_item_intraday_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "view-item-intraday-event"

--- a/terraform/deployments/search-api-v2/events_ingestion.tf
+++ b/terraform/deployments/search-api-v2/events_ingestion.tf
@@ -28,14 +28,14 @@ resource "google_project_iam_binding" "analytics_write" {
   ]
 }
 
-# top level dataset to store events for ingestion into vertex
+# top level dataset to store events for ingestion into into Discovery Engine (previously marketed as "Vertex AI Search")
 resource "google_bigquery_dataset" "dataset" {
   dataset_id                 = "analytics_events_vertex"
   location                   = var.gcp_region
   delete_contents_on_destroy = true
 }
 
-# ga4 'view_item_list' events get transformed and inserted into this time-partitioned search-event table defined with a vertex schema
+# ga4 'view_item_list' events get transformed and inserted into this time-partitioned search-event table defined with a Discovery Engine schema
 resource "google_bigquery_table" "search_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "search-event"
@@ -47,7 +47,7 @@ resource "google_bigquery_table" "search_event" {
 
 }
 
-# ga4 'select_item' events get transformed and inserted into this time-partitioned search-event table defined with a vertex schema
+# ga4 'select_item' events get transformed and inserted into this time-partitioned search-event table defined with a Discovery Engine schema
 resource "google_bigquery_table" "view_item_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "view-item-event"
@@ -58,7 +58,7 @@ resource "google_bigquery_table" "view_item_event" {
   }
 }
 
-# ga4 'select_item' events get transformed and inserted into this time-partitioned view-item-external-link-event table defined with a vertex schema
+# ga4 'select_item' events get transformed and inserted into this time-partitioned view-item-external-link-event table defined with a Discovery Engine schema
 resource "google_bigquery_table" "view_item_external_link_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "view-item-external-link-event"
@@ -69,7 +69,7 @@ resource "google_bigquery_table" "view_item_external_link_event" {
   }
 }
 
-# ga4 'view_item_list' intraday events get transformed and inserted into this time-partitioned search-intraday-event table defined with a vertex schema
+# ga4 'view_item_list' intraday events get transformed and inserted into this time-partitioned search-intraday-event table defined with a Discovery Engine schema
 resource "google_bigquery_table" "search_intraday_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "search-intraday-event"
@@ -81,7 +81,7 @@ resource "google_bigquery_table" "search_intraday_event" {
 
 }
 
-# ga4 'select_item' intraday events get transformed and inserted into this time-partitioned view-item-intraday-event table defined with a vertex schema
+# ga4 'select_item' intraday events get transformed and inserted into this time-partitioned view-item-intraday-event table defined with a Discovery Engine schema
 resource "google_bigquery_table" "view_item_intraday_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "view-item-intraday-event"
@@ -92,7 +92,7 @@ resource "google_bigquery_table" "view_item_intraday_event" {
   }
 }
 
-# ga4 'select_item' intraday events get transformed and inserted into this time-partitioned view-item-external-link-intraday-event table defined with a vertex schema
+# ga4 'select_item' intraday events get transformed and inserted into this time-partitioned view-item-external-link-intraday-event table defined with a Discovery Engine schema
 resource "google_bigquery_table" "view_item_external_link_intraday_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "view-item-external-link-intraday-event"

--- a/terraform/deployments/search-api-v2/events_ingestion.tf
+++ b/terraform/deployments/search-api-v2/events_ingestion.tf
@@ -28,14 +28,15 @@ resource "google_project_iam_binding" "analytics_write" {
   ]
 }
 
-# top level dataset to store events for ingestion into into Discovery Engine (previously marketed as "Vertex AI Search")
+# top level dataset to store events for ingestion into Discovery Engine (previously marketed as "Vertex AI Search")
 resource "google_bigquery_dataset" "dataset" {
   dataset_id                 = "analytics_events_vertex"
   location                   = var.gcp_region
   delete_contents_on_destroy = true
 }
 
-# ga4 'view_item_list' events get transformed and inserted into this time-partitioned search-event table defined with a Discovery Engine schema
+# ga4 'view_item_list' events get transformed and inserted into this time-partitioned search-event table defined with a
+# Discovery Engine 'search' schema: https://docs.cloud.google.com/generative-ai-app-builder/docs/user-events#bigquery_4
 resource "google_bigquery_table" "search_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "search-event"
@@ -47,7 +48,8 @@ resource "google_bigquery_table" "search_event" {
 
 }
 
-# ga4 'page_view' events get transformed and inserted into this time-partitioned search-event table defined with a Discovery Engine schema
+# ga4 'page_view' events get transformed and inserted into this time-partitioned view-item-event table defined with a
+# Discovery Engine 'view item' schema: https://docs.cloud.google.com/generative-ai-app-builder/docs/user-events#bigquery
 resource "google_bigquery_table" "view_item_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "view-item-event"
@@ -58,7 +60,9 @@ resource "google_bigquery_table" "view_item_event" {
   }
 }
 
-# ga4 'select_item' events get transformed and inserted into this time-partitioned view-item-external-link-event table defined with a Discovery Engine schema
+# ga4 'select_item' events get transformed and inserted into this time-partitioned view-item-external-link-event table
+# defined with a Discovery Engine 'view item' schema:
+# https://docs.cloud.google.com/generative-ai-app-builder/docs/user-events#bigquery
 resource "google_bigquery_table" "view_item_external_link_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "view-item-external-link-event"
@@ -69,7 +73,9 @@ resource "google_bigquery_table" "view_item_external_link_event" {
   }
 }
 
-# ga4 'view_item_list' intraday events get transformed and inserted into this time-partitioned search-intraday-event table defined with a Discovery Engine schema
+# ga4 'view_item_list' intraday events get transformed and inserted into this time-partitioned search-intraday-event
+# table defined with a Discovery Engine 'search' schema:
+# https://docs.cloud.google.com/generative-ai-app-builder/docs/user-events#bigquery_4
 resource "google_bigquery_table" "search_intraday_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "search-intraday-event"
@@ -81,7 +87,9 @@ resource "google_bigquery_table" "search_intraday_event" {
 
 }
 
-# ga4 'page_view' intraday events get transformed and inserted into this time-partitioned view-item-intraday-event table defined with a Discovery Engine schema
+# ga4 'page_view' intraday events get transformed and inserted into this time-partitioned view-item-intraday-event table
+# defined with a Discovery Engine 'view item' schema:
+# https://docs.cloud.google.com/generative-ai-app-builder/docs/user-events#bigquery
 resource "google_bigquery_table" "view_item_intraday_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "view-item-intraday-event"
@@ -92,7 +100,9 @@ resource "google_bigquery_table" "view_item_intraday_event" {
   }
 }
 
-# ga4 'select_item' intraday events get transformed and inserted into this time-partitioned view-item-external-link-intraday-event table defined with a Discovery Engine schema
+# ga4 'select_item' intraday events get transformed and inserted into this time-partitioned
+# view-item-external-link-intraday-event table defined with a Discovery Engine 'view item' schema:
+# https://docs.cloud.google.com/generative-ai-app-builder/docs/user-events#bigquery
 resource "google_bigquery_table" "view_item_external_link_intraday_event" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "view-item-external-link-intraday-event"


### PR DESCRIPTION
Changes references from "Vertex" to "Discovery Engine", since Google have rebranded "Vertex AI Search" to "Agent Search". Here we're using the API name "Discovery Engine" instead, because it's more stable and a more familiar name for developers.

At the same time, I've added some links to help with documentation and corrected some comments related to GA4 events.

I haven't touched anything to do with automated evaluations, since this is due to be retired. See https://gov-uk.atlassian.net/browse/SCH-490

Jira ticket (for this PR): https://gov-uk.atlassian.net/browse/SCH-2050