### PR TITLE
Mark govuk-cli repository as deployable

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -426,7 +426,8 @@ repos:
     required_pull_request_reviews:
       require_code_owner_reviews: true
 
-  govuk-cli: {}
+  govuk-cli:
+    can_be_deployed: true
 
   terraform-govuk-infrastructure-sensitive:
     visibility: private


### PR DESCRIPTION
This repo needs the govuk-ci PAT, and this is the easiest way to make that available

https://github.com/alphagov/govuk-infrastructure/issues/4169