### PR TITLE
Add discoveryengine.documents.get/delete to search_admin role

### DIFF
--- a/terraform/deployments/search-api-v2/service_accounts.tf
+++ b/terraform/deployments/search-api-v2/service_accounts.tf
@@ -83,6 +83,8 @@ resource "google_project_iam_custom_role" "search_admin" {
     "discoveryengine.controls.get",
     "discoveryengine.controls.list",
     "discoveryengine.controls.update",
+    "discoveryengine.documents.get",
+    "discoveryengine.documents.delete",
     "discoveryengine.operations.get",
     "discoveryengine.servingConfigs.get",
     "discoveryengine.servingConfigs.list",


### PR DESCRIPTION
This is needed so that the search-admin get can get and delete documents from Google Vertex

It allows us to run the rake tasks documented in
https://docs.publishing.service.gov.uk/manual/get-or-delete-a-document-from-VAIS.html