### PR TITLE
Remove `go-test` reusuable workflow from `govuk-job-request-operator`

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -435,9 +435,6 @@ repos:
   govuk-job-request-operator:
     up_to_date_branches: true
     homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk-job-request-operator.html"
-    required_status_checks:
-      additional_contexts:
-        - Test Go / Test Go
     required_pull_request_reviews:
       require_code_owner_reviews: true
 


### PR DESCRIPTION
Description:
- Makefile targets required by `Test Go / Test Go` aren't present in this repo at the moment
- https://github.com/alphagov/govuk-infrastructure/issues/4172