### PR TITLE
Revert "Mark govuk-job-request-operator repository as deployable"

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -434,7 +434,6 @@ repos:
 
   govuk-job-request-operator:
     up_to_date_branches: true
-    can_be_deployed: true
     homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk-job-request-operator.html"
     required_pull_request_reviews:
       require_code_owner_reviews: true


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#4214

Turns out it isn't actually needed