### PR TITLE
Set minimum TLS version to 1.2 for all Elastichsearch clusters

### DIFF
--- a/terraform/variables/integration/elasticsearch-green.tfvars
+++ b/terraform/variables/integration/elasticsearch-green.tfvars
@@ -15,7 +15,7 @@ dedicated_master = {
   instance_type  = "c7i.xlarge.elasticsearch"
 }
 
-tls_security_policy = "Policy-Min-TLS-1-0-2019-07"
+tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
 
 stackname = "green"
 

--- a/terraform/variables/integration/elasticsearch.tfvars
+++ b/terraform/variables/integration/elasticsearch.tfvars
@@ -16,7 +16,7 @@ dedicated_master = {
   instance_type  = "c7i.xlarge.elasticsearch"
 }
 
-tls_security_policy = "Policy-Min-TLS-1-0-2019-07"
+tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
 
 stackname = "blue"
 

--- a/terraform/variables/production/elasticsearch-green.tfvars
+++ b/terraform/variables/production/elasticsearch-green.tfvars
@@ -15,7 +15,7 @@ dedicated_master = {
   instance_type  = "c7i.xlarge.elasticsearch"
 }
 
-tls_security_policy = "Policy-Min-TLS-1-0-2019-07"
+tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
 
 stackname = "green"
 

--- a/terraform/variables/production/elasticsearch.tfvars
+++ b/terraform/variables/production/elasticsearch.tfvars
@@ -17,7 +17,7 @@ dedicated_master = {
   instance_type  = "c5.xlarge.elasticsearch"
 }
 
-tls_security_policy = "Policy-Min-TLS-1-0-2019-07"
+tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
 
 stackname = "blue"
 

--- a/terraform/variables/staging/elasticsearch-green.tfvars
+++ b/terraform/variables/staging/elasticsearch-green.tfvars
@@ -15,7 +15,7 @@ dedicated_master = {
   instance_type  = "c7i.large.elasticsearch"
 }
 
-tls_security_policy = "Policy-Min-TLS-1-0-2019-07"
+tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
 
 stackname = "green"
 

--- a/terraform/variables/staging/elasticsearch.tfvars
+++ b/terraform/variables/staging/elasticsearch.tfvars
@@ -18,7 +18,7 @@ dedicated_master = {
   instance_type  = "c5.large.elasticsearch"
 }
 
-tls_security_policy = "Policy-Min-TLS-1-0-2019-07"
+tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
 
 stackname = "blue"
 


### PR DESCRIPTION
## What

The clusters are currently configured to require TLS 1.2 as a minimum. This commit bring the code in line with reality.

## How to review

Check the Terraform plan is no longer changing the TLS version