### PR TITLE
[PP-7559] Mark govuk-graphql as archived

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -409,7 +409,8 @@ repos:
     required_pull_request_reviews:
       require_code_owner_reviews: true
 
-  govuk-graphql: {}
+  govuk-graphql:
+    archived: true
 
   govuk-ia-utility:
     can_be_deployed: false


### PR DESCRIPTION
The application has been retired, so the repo can be archived.

Depends on https://github.com/alphagov/govuk-infrastructure/pull/4228.