### PR TITLE
Add output bucket to store check links reports

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/output-bucket.tf
+++ b/terraform/deployments/datagovuk-infrastructure/output-bucket.tf
@@ -12,7 +12,7 @@ module "s3_bucket_datagovuk_bucket" {
   versioning_enabled   = true
   versioning_suspended = true
 
-  enable_public_access_block = false
+  enable_public_access_block = true
   extra_bucket_policies      = [data.aws_iam_policy_document.datagovuk_bucket.json]
 
   tags = {
@@ -24,15 +24,6 @@ module "s3_bucket_datagovuk_bucket" {
 # TODO: instead of granting write access to nodes, use IRSA (IAM Roles for
 # Service Accounts aka pod identity) so that only Argo CD can write.
 data "aws_iam_policy_document" "datagovuk_bucket" {
-  statement {
-    sid = "PublicCanReadButNotList"
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-    actions   = ["s3:GetObject"]
-    resources = ["${local.s3_bucket_datagovuk_bucket_arn}/*"]
-  }
   statement {
     sid = "EKSNodesCanList"
     principals {

--- a/terraform/deployments/datagovuk-infrastructure/output-bucket.tf
+++ b/terraform/deployments/datagovuk-infrastructure/output-bucket.tf
@@ -1,0 +1,68 @@
+data "aws_iam_policy_document" "s3_fastly_read_policy_doc_ckan_output" {
+  statement {
+    sid     = "S3FastlyReadBucket"
+    actions = ["s3:GetObject"]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.ckan-output.id}",
+      "arn:aws:s3:::${aws_s3_bucket.ckan-output.id}/*",
+    ]
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = data.fastly_ip_ranges.fastly.cidr_blocks
+    }
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "ckan-output" {
+  bucket = "datagovuk-${var.govuk_environment}-ckan-output"
+  tags   = { Name = "datagovuk-${var.govuk_environment}-ckan-output" }
+}
+
+resource "aws_s3_bucket_versioning" "ckan_output" {
+
+  bucket = aws_s3_bucket.ckan-output.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_logging" "ckan_output" {
+  count = startswith(var.govuk_environment, "eph-") ? 0 : 1
+
+  bucket        = aws_s3_bucket.ckan-output.id
+  target_bucket = "govuk-${var.govuk_environment}-aws-logging"
+  target_prefix = "s3/datagovuk-${var.govuk_environment}-ckan-output/"
+}
+
+resource "aws_s3_bucket_cors_configuration" "ckan_output" {
+  bucket = aws_s3_bucket.ckan-output.id
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = var.output_bucket_cors_origins
+  }
+}
+
+resource "aws_s3_bucket_policy" "govuk_ckan_output_read_policy" {
+  bucket = aws_s3_bucket.ckan-output.id
+  policy = data.aws_iam_policy_document.s3_fastly_read_policy_doc.json
+}
+
+resource "aws_s3_bucket_public_access_block" "ckan_output" {
+  bucket = aws_s3_bucket.ckan-output.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "ckan_output" {
+  bucket = aws_s3_bucket.ckan-output.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}

--- a/terraform/deployments/datagovuk-infrastructure/output-bucket.tf
+++ b/terraform/deployments/datagovuk-infrastructure/output-bucket.tf
@@ -1,68 +1,54 @@
-data "aws_iam_policy_document" "s3_fastly_read_policy_doc_ckan_output" {
+locals {
+  s3_bucket_datagovuk_bucket_name = "datagovuk-ckan-output-${var.govuk_environment}"
+  s3_bucket_datagovuk_bucket_arn  = "arn:aws:s3:::${local.s3_bucket_datagovuk_bucket_name}"
+}
+
+module "s3_bucket_datagovuk_bucket" {
+  source = "../../shared-modules/s3"
+
+  govuk_environment = var.govuk_environment
+  name              = local.s3_bucket_datagovuk_bucket_name
+
+  versioning_enabled   = true
+  versioning_suspended = true
+
+  enable_public_access_block = false
+  extra_bucket_policies      = [data.aws_iam_policy_document.datagovuk_bucket.json]
+
+  tags = {
+    System = "Data.gov.uk CKAN outputs"
+    Name   = "CKAN Output Bucket for ${var.govuk_environment}"
+  }
+}
+
+# TODO: instead of granting write access to nodes, use IRSA (IAM Roles for
+# Service Accounts aka pod identity) so that only Argo CD can write.
+data "aws_iam_policy_document" "datagovuk_bucket" {
   statement {
-    sid     = "S3FastlyReadBucket"
-    actions = ["s3:GetObject"]
-    resources = [
-      "arn:aws:s3:::${aws_s3_bucket.ckan-output.id}",
-      "arn:aws:s3:::${aws_s3_bucket.ckan-output.id}/*",
-    ]
-    condition {
-      test     = "IpAddress"
-      variable = "aws:SourceIp"
-      values   = data.fastly_ip_ranges.fastly.cidr_blocks
-    }
+    sid = "PublicCanReadButNotList"
     principals {
-      type        = "AWS"
+      type        = "*"
       identifiers = ["*"]
     }
+    actions   = ["s3:GetObject"]
+    resources = ["${local.s3_bucket_datagovuk_bucket_arn}/*"]
   }
-}
-
-resource "aws_s3_bucket" "ckan-output" {
-  bucket = "datagovuk-${var.govuk_environment}-ckan-output"
-  tags   = { Name = "datagovuk-${var.govuk_environment}-ckan-output" }
-}
-
-resource "aws_s3_bucket_versioning" "ckan_output" {
-
-  bucket = aws_s3_bucket.ckan-output.id
-  versioning_configuration { status = "Enabled" }
-}
-
-resource "aws_s3_bucket_logging" "ckan_output" {
-  count = startswith(var.govuk_environment, "eph-") ? 0 : 1
-
-  bucket        = aws_s3_bucket.ckan-output.id
-  target_bucket = "govuk-${var.govuk_environment}-aws-logging"
-  target_prefix = "s3/datagovuk-${var.govuk_environment}-ckan-output/"
-}
-
-resource "aws_s3_bucket_cors_configuration" "ckan_output" {
-  bucket = aws_s3_bucket.ckan-output.id
-  cors_rule {
-    allowed_methods = ["GET"]
-    allowed_origins = var.output_bucket_cors_origins
+  statement {
+    sid = "EKSNodesCanList"
+    principals {
+      type        = "AWS"
+      identifiers = [data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_arn]
+    }
+    actions   = ["s3:ListBucket"]
+    resources = [local.s3_bucket_datagovuk_bucket_arn]
   }
-}
-
-resource "aws_s3_bucket_policy" "govuk_ckan_output_read_policy" {
-  bucket = aws_s3_bucket.ckan-output.id
-  policy = data.aws_iam_policy_document.s3_fastly_read_policy_doc.json
-}
-
-resource "aws_s3_bucket_public_access_block" "ckan_output" {
-  bucket = aws_s3_bucket.ckan-output.id
-
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
-}
-
-resource "aws_s3_bucket_ownership_controls" "ckan_output" {
-  bucket = aws_s3_bucket.ckan-output.id
-
-  rule {
-    object_ownership = "ObjectWriter"
+  statement {
+    sid = "EKSNodesCanWrite"
+    principals {
+      type        = "AWS"
+      identifiers = [data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_arn]
+    }
+    actions   = ["s3:GetObject", "s3:PutObject"]
+    resources = ["${local.s3_bucket_datagovuk_bucket_arn}/*"]
   }
 }

--- a/terraform/deployments/datagovuk-infrastructure/output-bucket.tf
+++ b/terraform/deployments/datagovuk-infrastructure/output-bucket.tf
@@ -1,5 +1,5 @@
 locals {
-  s3_bucket_datagovuk_bucket_name = "datagovuk-ckan-output-${var.govuk_environment}"
+  s3_bucket_datagovuk_bucket_name = "govuk-ckan-output-${var.govuk_environment}"
   s3_bucket_datagovuk_bucket_arn  = "arn:aws:s3:::${local.s3_bucket_datagovuk_bucket_name}"
 }
 

--- a/terraform/deployments/datagovuk-infrastructure/variables.tf
+++ b/terraform/deployments/datagovuk-infrastructure/variables.tf
@@ -28,8 +28,23 @@ variable "organogram_bucket_cors_origins" {
     "https://www.integration.data.gov.uk",
     "https://find.eks.production.govuk.digital",
     "https://find.eks.integration.govuk.digital",
-    "https://find.eks.staging.govuk.digital",
-    "https://find.eph-aaa113.ephemeral.govuk.digital"
+    "https://find.eks.staging.govuk.digital"
+  ]
+}
+
+variable "output_bucket_cors_origins" {
+  type        = list(string)
+  description = "List of allowed origins for CORS for output bucket"
+  default = [
+    "https://data.gov.uk",
+    "https://www.data.gov.uk",
+    "https://staging.data.gov.uk",
+    "https://www.staging.data.gov.uk",
+    "https://integration.data.gov.uk",
+    "https://www.integration.data.gov.uk",
+    "https://find.eks.production.govuk.digital",
+    "https://find.eks.integration.govuk.digital",
+    "https://find.eks.staging.govuk.digital"
   ]
 }
 

--- a/terraform/deployments/datagovuk-infrastructure/variables.tf
+++ b/terraform/deployments/datagovuk-infrastructure/variables.tf
@@ -32,22 +32,6 @@ variable "organogram_bucket_cors_origins" {
   ]
 }
 
-variable "output_bucket_cors_origins" {
-  type        = list(string)
-  description = "List of allowed origins for CORS for output bucket"
-  default = [
-    "https://data.gov.uk",
-    "https://www.data.gov.uk",
-    "https://staging.data.gov.uk",
-    "https://www.staging.data.gov.uk",
-    "https://integration.data.gov.uk",
-    "https://www.integration.data.gov.uk",
-    "https://find.eks.production.govuk.digital",
-    "https://find.eks.integration.govuk.digital",
-    "https://find.eks.staging.govuk.digital"
-  ]
-}
-
 # Variables for rate limiting configuration
 variable "find_rate_limit_per_5min" {
   description = "Rate limit for Find app per IP per 5 minutes"


### PR DESCRIPTION
Output bucket for the check-links reports but might also be used for other outputs.

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/527?selectedIssue=DGUK-527