### PR TITLE
Update standard_contexts for govuk-social-data

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -471,7 +471,8 @@ repos:
   govuk-social-data:
     can_be_deployed: false
     visibility: "private"
-    standard_contexts: *standard_security_checks
+    standard_contexts:
+    # standard security checks are disabled as not configured for a private repo
     push_allowances: ["alphagov/gov-uk-data", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
     required_pull_request_reviews:
       pull_request_bypassers:


### PR DESCRIPTION
Comment added to indicate that standard security checks are disabled for private repositories and the indenting has been corrected in the repos.yaml