### PR TITLE
Remove govuk-data-engineering team from repos.yml

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -349,7 +349,6 @@ repos:
     teams:
       govuk: "maintain"
       govuk-platform-engineering: "admin"
-      govuk-data-engineering: "admin"
 
   govuk-data-science-workshop:
       archived: true


### PR DESCRIPTION
Removed 'govuk-data-engineering' team from permissions as I'm not sture that exists as a terraform resource