### PR TITLE
Fix moved block resource addresses for attachements s3 bucket versioning

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/attachments_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/attachments_s3.tf
@@ -26,7 +26,7 @@ moved {
 }
 
 moved {
-  from = aws_s3_bucket_versioning.attachments
+  from = aws_s3_bucket_versioning.attachments[0]
   to   = module.secure_s3_bucket_attachments.aws_s3_bucket_versioning.this
 }
 

--- a/terraform/deployments/govuk-publishing-infrastructure/attachments_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/attachments_s3.tf
@@ -16,8 +16,7 @@ module "secure_s3_bucket_attachments" {
 
   name = "govuk-attachments-${var.govuk_environment}"
 
-  lifecycle_rules    = var.govuk_environment == "integration" ? local.lifecycle_rules_integration : null
-  versioning_enabled = var.govuk_environment == "production" ? true : false
+  lifecycle_rules = var.govuk_environment == "integration" ? local.lifecycle_rules_integration : null
 }
 
 moved {


### PR DESCRIPTION
When about to apply prod I noticed the plan was going to destroy and recreate the versioning, so this PR fixes the moved block resource addresses so the state moves instead of recreating.

Unfortunately the lower envs were already applied which enabled bucket versioning, and once on you cannot disable, so this PR also makes it on in all envs. Given it isn't used anymore it doesn't really matter