### PR TITLE
[CHAT-671] Add gov-uk-data team to AI repo push allowances

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -307,6 +307,7 @@ repos:
         - Lint
         - Format
         - Type checks
+    push_allowances: ["alphagov/gov-uk-data", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
 
   govuk-chat-gradio-prototype:
     visibility: private
@@ -314,12 +315,12 @@ repos:
 
   govuk-chat-v1-iterations-2026:
     visibility: private
-    need_production_access_to_merge: false
     required_status_checks:
       # standard security checks are disabled as not configured for a private repo
       additional_contexts:
         - Lint
         - Format
+    push_allowances: ["alphagov/gov-uk-data", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
 
   govuk-chat-gradio-user-research:
     visibility: private
@@ -517,6 +518,7 @@ repos:
         - Lint Ruby / Run RuboCop
         - Run RSpec
         - Test GOV.UK Chat / Run RSpec
+    push_allowances: ["alphagov/gov-uk-data", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
 
   govuk_content_item_loader:
     can_be_deployed: true


### PR DESCRIPTION
## Description 

We want the Data Scientists on the team to be able to merge their own PRs into repos that they own. After a steer, we can do this by adding the gov-uk-data team to the push allowances for the relevant repos.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-671