### PR TITLE
Remove required status checks from govuk-ia-utility

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -414,8 +414,6 @@ repos:
 
   govuk-ia-utility:
     can_be_deployed: false
-    required_status_checks:
-      standard_contexts: *standard_security_checks 
     push_allowances: ["alphagov/gov-uk-data", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
     required_pull_request_reviews:
       pull_request_bypassers:


### PR DESCRIPTION
Removed required status checks for govuk-ia-utility.

This is a temporary measure, as once govuk-engineering is brought into management by user-review we will review what actions we want to perform on our repos and the dependencies. 