### PR TITLE
[CHAT-671] Add govuk_data team to specific AI team repos

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -121,6 +121,10 @@ data "github_team" "co_platform_engineering" {
   slug = "co-platform-engineering"
 }
 
+data "github_team" "govuk_data" {
+  slug = "gov-uk-data"
+}
+
 resource "github_team_repository" "govuk_ai_accelerator_repos" {
   for_each   = toset(var.govuk_ai_accelerator_repo_names)
   repository = each.value
@@ -162,6 +166,13 @@ resource "github_team_repository" "co_platform_engineering_repos" {
   repository = each.key
   team_id    = data.github_team.co_platform_engineering.id
   permission = "pull"
+}
+
+resource "github_team_repository" "govuk_data_repos" {
+  for_each   = toset(["govuk-chat-evaluation", "govuk-chat-v1-iterations-2026", "govuk_chat_private"])
+  repository = each.key
+  team_id    = data.github_team.govuk_data.id
+  permission = "write"
 }
 
 resource "github_team_repository" "ithc_repos" {


### PR DESCRIPTION
## Description 

I recently merged a PR with the intention of allowing Data Science team members to have access to merge PRs in repos they maintain.

However, i hadn't added the govuk_data team to the repos. This PR adds some configuration to main.tf to ensure that the team is added to the repos in question.

## Jira ticket

https://gdsgovukagents.atlassian.net/jira/software/c/projects/CHAT/boards/269?label=Backend_Dev&selectedIssue=CHAT-671