### PR TITLE
Enforce standard security checks for govuk-job-request-operator

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -436,6 +436,8 @@ repos:
   govuk-job-request-operator:
     up_to_date_branches: true
     homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk-job-request-operator.html"
+    required_status_checks:
+      standard_contexts: *standard_security_checks
     required_pull_request_reviews:
       require_code_owner_reviews: true
 


### PR DESCRIPTION
## What

Requires CodeQL SAST and dependency checker to run on each PR