### PR TITLE
Allow only PE team to push to govuk-cli main branch

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -427,6 +427,7 @@ repos:
 
   govuk-cli:
     can_be_deployed: true
+    push_allowances: ["alphagov/gov-uk-platform-engineering"]
     required_status_checks:
       additional_contexts:
         - CodeQL SAST scan / Analyze


### PR DESCRIPTION
This means only platform engineering can merge PRs for this repository. This allows us to ensure the release process is followed correctly when changes are merged in.

https://github.com/alphagov/govuk-infrastructure/issues/4204