### PR TITLE
Allow only Platform Engineering team to push to govuk-job-request-operator main

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -437,6 +437,7 @@ repos:
   govuk-job-request-operator:
     up_to_date_branches: true
     homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk-job-request-operator.html"
+    push_allowances: ["alphagov/gov-uk-platform-engineering"]
     required_status_checks:
       standard_contexts: *standard_security_checks
     required_pull_request_reviews:


### PR DESCRIPTION
## What

Prevents anyone but this team from pushing to the `main` branch of the `govuk-job-request-operator` repo.