### PR TITLE
Install Kyverno Chart in Integration for Sigstore

### DIFF
--- a/terraform/deployments/cluster-services/kyverno.tf
+++ b/terraform/deployments/cluster-services/kyverno.tf
@@ -1,0 +1,20 @@
+resource "helm_release" "kyverno" {
+  # ONLY install if the environment is integration
+  count = var.govuk_environment == "integration" ? 1 : 0
+
+  name             = "kyverno"
+  repository       = "https://kyverno.github.io/kyverno/"
+  chart            = "kyverno"
+  namespace        = "kyverno"
+  create_namespace = true
+
+  version = "3.8.1"
+}
+
+resource "kubernetes_namespace_v1" "sigstore_test" {
+  count = var.govuk_environment == "integration" ? 1 : 0
+
+  metadata {
+    name = "sigstore-test"
+  }
+}


### PR DESCRIPTION
## What?
This installs the Kyverno Helm in Integration so we can test Sigstore in a sandboxed namespace (rather imaginatively called sigstore-test). This won't do anything without us applying Kyverno policies, which will come in a later PR.

### Related

* https://github.com/alphagov/govuk-infrastructure/issues/4258