### PR TITLE
Add Cosign to image builds.

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -63,6 +63,7 @@ jobs:
             type=raw,priority=400,value=${{ steps.local-head.outputs.sha }},enable=${{ !startsWith(inputs.gitRef, 'v') }}
 
       - name: Build and push
+        id: build-image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: ${{ inputs.dockerfilepath }}
@@ -72,3 +73,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Sign Image
+        env:
+          TAG: "ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}:${{ steps.meta.outputs.version }}"
+          DIGEST: ${{ steps.build-image.outputs.digest }}
+        run: |
+          cosign sign --yes "${TAG}@${DIGEST}"

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -75,7 +75,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
 
       - name: Sign Image
         env:

--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Create Manifest Lists
         env:
-          IMAGEREF_PREFIX: 'ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}'
+          IMAGEREF_PREFIX: "ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}"
         working-directory: /tmp/digests
         run: |
           tag_args=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
@@ -179,8 +179,23 @@ jobs:
           # shellcheck disable=SC2086 # Intentional word-splitting on $tag_args and $sources.
           docker buildx imagetools create $tag_args $sources
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Sign Images
+        env:
+          # We sign the specific version tag outputted by the metadata action
+          TAG: "ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}:${{ steps.meta.outputs.version }}"
+        run: |
+          # Get digest of newly created manifest list
+          # Fetch it from registry because `imagetools create` pushes it directly
+          DIGEST=$(docker buildx imagetools inspect --raw "${TAG}" | sha256sum | awk '{print $1}')
+
+          # Sign the manifest list digest
+          cosign sign --yes "${TAG}@sha256:${DIGEST}"
+
       - name: Inspect Images
         env:
-          IMAGEREF: 'ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}:${{ steps.meta.outputs.version }}'
+          IMAGEREF: "ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}:${{ steps.meta.outputs.version }}"
         run: |
           docker buildx imagetools inspect "$IMAGEREF"

--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -180,7 +180,7 @@ jobs:
           docker buildx imagetools create $tag_args $sources
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
 
       - name: Sign Images
         env:


### PR DESCRIPTION
## What?
This adds Cosign image signing to our multi-arch (and single-arch) build workflows so we can start selectively testing Cosign enforcement on Integration.

### Relates to

* https://github.com/alphagov/govuk-infrastructure/issues/4258