### PR TITLE
Mark govuk-rota-generator as private [TECH-29]

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -464,8 +464,9 @@ repos:
     branch_protection: false
 
   govuk-rota-generator:
+    visibility: private
     required_status_checks:
-      standard_contexts: *standard_security_checks
+      # standard security checks are disabled as not configured for a private repo
       additional_contexts:
         - test
 


### PR DESCRIPTION
Set the visibility of govuk-rota-generator to private.

Jira: https://gov-uk.atlassian.net/browse/TECH-29