### PR TITLE
Part 2: Actually remove old ECR Repos

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -53,10 +53,8 @@ locals {
     data.tfe_outputs.github.nonsensitive_values.deployable_repo_names
   )
 
-  deleted_repositories = [
-    "govuk-graphql",
-    "govuk-job-request-operator",
-  ]
+  // Populate this with Repos that need to be deleted
+  deleted_repositories = []
 
   extra_repositories = [
     "clamav",

--- a/terraform/deployments/ecr/moved.tf
+++ b/terraform/deployments/ecr/moved.tf
@@ -1,12 +1,2 @@
 # Moves archived or non-deployable Repos to a new Repo to be removable.
 # Delete these after the state change has applied.
-
-moved {
-  from = aws_ecr_repository.github_repositories["govuk-graphql"]
-  to   = aws_ecr_repository.deleted_repositories["govuk-graphql"]
-}
-
-moved {
-  from = aws_ecr_repository.github_repositories["govuk-job-request-operator"]
-  to   = aws_ecr_repository.deleted_repositories["govuk-job-request-operator"]
-}


### PR DESCRIPTION
## What?
This is part 2 to https://github.com/alphagov/govuk-infrastructure/pull/4314

Actually remove the repos and leave the scaffolding in place if anyone else needs to solve this problem in the future.