### PR TITLE
Make Replatform Test App Deployable for testing.

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -308,11 +308,9 @@ repos:
         - Format
         - Type checks
     push_allowances:
-      [
-        "alphagov/gov-uk-data",
-        "alphagov/gov-uk-production-admin",
-        "alphagov/gov-uk-production-deploy",
-      ]
+      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"
 
   govuk-chat-gradio-prototype:
     visibility: private
@@ -326,11 +324,9 @@ repos:
         - Lint
         - Format
     push_allowances:
-      [
-        "alphagov/gov-uk-data",
-        "alphagov/gov-uk-production-admin",
-        "alphagov/gov-uk-production-deploy",
-      ]
+      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"
 
   govuk-chat-gradio-user-research:
     visibility: private
@@ -424,11 +420,9 @@ repos:
   govuk-ia-utility:
     can_be_deployed: false
     push_allowances:
-      [
-        "alphagov/gov-uk-data",
-        "alphagov/gov-uk-production-admin",
-        "alphagov/gov-uk-production-deploy",
-      ]
+      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"
     required_pull_request_reviews:
       pull_request_bypassers:
         - "alphagov/gov-uk-data"
@@ -450,7 +444,8 @@ repos:
   govuk-job-request-operator:
     up_to_date_branches: true
     homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk-job-request-operator.html"
-    push_allowances: ["alphagov/gov-uk-platform-engineering"]
+    push_allowances:
+      - "alphagov/gov-uk-platform-engineering"
     required_status_checks:
       standard_contexts: *standard_security_checks
     required_pull_request_reviews:
@@ -492,11 +487,9 @@ repos:
     can_be_deployed: false
     visibility: "private"
     push_allowances:
-      [
-        "alphagov/gov-uk-data",
-        "alphagov/gov-uk-production-admin",
-        "alphagov/gov-uk-production-deploy",
-      ]
+      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"
     required_pull_request_reviews:
       pull_request_bypassers:
         - "alphagov/gov-uk-data"
@@ -540,11 +533,9 @@ repos:
         - Run RSpec
         - Test GOV.UK Chat / Run RSpec
     push_allowances:
-      [
-        "alphagov/gov-uk-data",
-        "alphagov/gov-uk-production-admin",
-        "alphagov/gov-uk-production-deploy",
-      ]
+      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"
 
   govuk_content_item_loader:
     can_be_deployed: true
@@ -1076,51 +1067,41 @@ repos:
     can_be_deployed: true
     standard_contexts: *standard_security_checks
     push_allowances:
-      [
-        "alphagov/gov-uk-ai-accelerator-alpha-team",
-        "alphagov/gov-uk-production-admin",
-        "alphagov/gov-uk-production-deploy",
-      ]
+      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"
 
   govuk-ai-accelerator-tooling:
     # standard security checks are disabled as not configured for a private repo
     can_be_deployed: false
     visibility: private
     push_allowances:
-      [
-        "alphagov/gov-uk-ai-accelerator-alpha-team",
-        "alphagov/gov-uk-production-admin",
-        "alphagov/gov-uk-production-deploy",
-      ]
+      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"
 
   govuk-ai-accelerator-tw-accelerator:
     # standard security checks are disabled as not configured for a private repo
     can_be_deployed: false
     visibility: private
     push_allowances:
-      [
-        "alphagov/gov-uk-ai-accelerator-alpha-team",
-        "alphagov/gov-uk-production-admin",
-        "alphagov/gov-uk-production-deploy",
-      ]
+      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"
 
   govuk-ai-accelerator-generator-e2e-testing-framework:
     # standard security checks are disabled as not configured for a private repo
     can_be_deployed: false
     visibility: private
     push_allowances:
-      [
-        "alphagov/gov-uk-ai-accelerator-alpha-team",
-        "alphagov/gov-uk-production-admin",
-        "alphagov/gov-uk-production-deploy",
-      ]
+      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"
 
   govuk-ai-graph-tools:
     can_be_deployed: true
     standard_contexts: *standard_security_checks
     push_allowances:
-      [
-        "alphagov/gov-uk-ai-accelerator-alpha-team",
-        "alphagov/gov-uk-production-admin",
-        "alphagov/gov-uk-production-deploy",
-      ]
+      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -307,7 +307,12 @@ repos:
         - Lint
         - Format
         - Type checks
-    push_allowances: ["alphagov/gov-uk-data", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+    push_allowances:
+      [
+        "alphagov/gov-uk-data",
+        "alphagov/gov-uk-production-admin",
+        "alphagov/gov-uk-production-deploy",
+      ]
 
   govuk-chat-gradio-prototype:
     visibility: private
@@ -320,7 +325,12 @@ repos:
       additional_contexts:
         - Lint
         - Format
-    push_allowances: ["alphagov/gov-uk-data", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+    push_allowances:
+      [
+        "alphagov/gov-uk-data",
+        "alphagov/gov-uk-production-admin",
+        "alphagov/gov-uk-production-deploy",
+      ]
 
   govuk-chat-gradio-user-research:
     visibility: private
@@ -351,7 +361,7 @@ repos:
       govuk-data-engineering: "admin"
 
   govuk-data-science-workshop:
-      archived: true
+    archived: true
 
   govuk-db-sync:
     can_be_deployed: true
@@ -413,7 +423,12 @@ repos:
 
   govuk-ia-utility:
     can_be_deployed: false
-    push_allowances: ["alphagov/gov-uk-data", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+    push_allowances:
+      [
+        "alphagov/gov-uk-data",
+        "alphagov/gov-uk-production-admin",
+        "alphagov/gov-uk-production-deploy",
+      ]
     required_pull_request_reviews:
       pull_request_bypassers:
         - "alphagov/gov-uk-data"
@@ -476,7 +491,12 @@ repos:
   govuk-social-data:
     can_be_deployed: false
     visibility: "private"
-    push_allowances: ["alphagov/gov-uk-data", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+    push_allowances:
+      [
+        "alphagov/gov-uk-data",
+        "alphagov/gov-uk-production-admin",
+        "alphagov/gov-uk-production-deploy",
+      ]
     required_pull_request_reviews:
       pull_request_bypassers:
         - "alphagov/gov-uk-data"
@@ -519,7 +539,12 @@ repos:
         - Lint Ruby / Run RuboCop
         - Run RSpec
         - Test GOV.UK Chat / Run RSpec
-    push_allowances: ["alphagov/gov-uk-data", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+    push_allowances:
+      [
+        "alphagov/gov-uk-data",
+        "alphagov/gov-uk-production-admin",
+        "alphagov/gov-uk-production-deploy",
+      ]
 
   govuk_content_item_loader:
     can_be_deployed: true
@@ -955,6 +980,7 @@ repos:
         - Test Go
 
   govuk-replatform-test-app:
+    can_be_deployed: true
     required_status_checks:
       additional_contexts:
         - Test
@@ -1049,27 +1075,52 @@ repos:
   govuk-ai-accelerator:
     can_be_deployed: true
     standard_contexts: *standard_security_checks
-    push_allowances: ["alphagov/gov-uk-ai-accelerator-alpha-team", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+    push_allowances:
+      [
+        "alphagov/gov-uk-ai-accelerator-alpha-team",
+        "alphagov/gov-uk-production-admin",
+        "alphagov/gov-uk-production-deploy",
+      ]
 
   govuk-ai-accelerator-tooling:
     # standard security checks are disabled as not configured for a private repo
     can_be_deployed: false
     visibility: private
-    push_allowances: ["alphagov/gov-uk-ai-accelerator-alpha-team", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+    push_allowances:
+      [
+        "alphagov/gov-uk-ai-accelerator-alpha-team",
+        "alphagov/gov-uk-production-admin",
+        "alphagov/gov-uk-production-deploy",
+      ]
 
   govuk-ai-accelerator-tw-accelerator:
     # standard security checks are disabled as not configured for a private repo
     can_be_deployed: false
     visibility: private
-    push_allowances: ["alphagov/gov-uk-ai-accelerator-alpha-team", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+    push_allowances:
+      [
+        "alphagov/gov-uk-ai-accelerator-alpha-team",
+        "alphagov/gov-uk-production-admin",
+        "alphagov/gov-uk-production-deploy",
+      ]
 
   govuk-ai-accelerator-generator-e2e-testing-framework:
     # standard security checks are disabled as not configured for a private repo
     can_be_deployed: false
     visibility: private
-    push_allowances: ["alphagov/gov-uk-ai-accelerator-alpha-team", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+    push_allowances:
+      [
+        "alphagov/gov-uk-ai-accelerator-alpha-team",
+        "alphagov/gov-uk-production-admin",
+        "alphagov/gov-uk-production-deploy",
+      ]
 
   govuk-ai-graph-tools:
     can_be_deployed: true
     standard_contexts: *standard_security_checks
-    push_allowances: ["alphagov/gov-uk-ai-accelerator-alpha-team", "alphagov/gov-uk-production-admin", "alphagov/gov-uk-production-deploy"]
+    push_allowances:
+      [
+        "alphagov/gov-uk-ai-accelerator-alpha-team",
+        "alphagov/gov-uk-production-admin",
+        "alphagov/gov-uk-production-deploy",
+      ]


### PR DESCRIPTION
## What?
This sets can_be_deployed to "true" so I can deploy the Replatform Test App into Integration for testing Kyverno and Cosign.

My IDE also auto-formatted the `push_allowances` arrays, which I don't disagree with as it seems to look cleaner.