### PR TITLE
SPIKE: create "backstage" user in ArgoCD

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -33,6 +33,7 @@ locals {
     g, ${var.github_national_data_library_team}, role:readonly
     g, ${var.github_read_only_team}, role:readonly
     g, ${var.github_read_write_team}, role:admin
+    g, backstage, role:readonly
     p, role:nationaldatalibrary, applications, update, datagovuk/*, allow
     p, role:nationaldatalibrary, applications, update, default/dgu-app-of-apps, allow
     p, role:nationaldatalibrary, applications, create, datagovuk/*, allow
@@ -88,6 +89,7 @@ resource "helm_release" "argo_cd" {
           clientID     = "$dex-client-argocd:clientID"
           clientSecret = "$dex-client-argocd:clientSecret"
         })
+        "accounts.backstage" = "apiKey"
       }
 
       # We terminate TLS at the ALB (L7 LB inside the VPC network), so tell


### PR DESCRIPTION
## What
This is used for a spike and will be removed later. The user will have an API key created for it, to be used by Backstage to communicate with ArgoCD.

## Review

See https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/ for user creation
See https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/#local-usersaccounts for RBAC config