### PR TITLE
[SCH-2126] Increase throughput provisioning

### DIFF
--- a/terraform/variables/integration/elasticsearch-green.tfvars
+++ b/terraform/variables/integration/elasticsearch-green.tfvars
@@ -1,7 +1,7 @@
 ebs = {
   volume_size      = 314
   volume_type      = "gp3"
-  throughput       = 250
+  throughput       = 300
   provisioned_iops = 3000
 }
 engine_version         = "6.8"

--- a/terraform/variables/production/elasticsearch-green.tfvars
+++ b/terraform/variables/production/elasticsearch-green.tfvars
@@ -1,7 +1,7 @@
 ebs = {
   volume_size      = 314
   volume_type      = "gp3"
-  throughput       = 250
+  throughput       = 300
   provisioned_iops = 3000
 }
 engine_version         = "6.8"

--- a/terraform/variables/staging/elasticsearch-green.tfvars
+++ b/terraform/variables/staging/elasticsearch-green.tfvars
@@ -1,7 +1,7 @@
 ebs = {
   volume_size      = 314
   volume_type      = "gp3"
-  throughput       = 250
+  throughput       = 300
   provisioned_iops = 3000
 }
 engine_version         = "6.8"


### PR DESCRIPTION
We're getting Disk Throughput Throttle warnings for our elasticsearch instances on all three environments, with the timing of the warnings largely coinciding with the [search-index-env-sync jobs](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/search-index-env-sync/values.yaml) running. 

Increasing throughput provisioning by 20% initially, to see if this reduces the warnings. We're well within the maximum throughput possible for the instances - see [Amazon's EBS specifications for EC2 instances](https://docs.aws.amazon.com/ec2/latest/instancetypes/mo.html#mo_storage-ebs). Rough calculations from the AWS calculator suggest that this change will increase monthly costs by about $7 per month for each environment. But checking the terraform runs the costs appear to be unchanged.

See [Jira ticket SCH-2126](https://gov-uk.atlassian.net/browse/SCH-2126) for context and more useful links.