### PR TITLE
Fix ArgoCD OutOfSync error Re Kyverno Deployment

### DIFF
--- a/terraform/deployments/cluster-services/kyverno.tf
+++ b/terraform/deployments/cluster-services/kyverno.tf
@@ -18,3 +18,32 @@ resource "kubernetes_namespace_v1" "sigstore_test" {
     name = "sigstore-test"
   }
 }
+
+resource "kubernetes_config_map_v1_data" "argocd_kyverno_health_check" {
+  count = var.govuk_environment == "integration" ? 1 : 0
+
+  metadata {
+    name      = "argocd-cm"
+    namespace = local.services_ns
+  }
+
+  data = {
+    "resource.customizations.health.kyverno.io_Policy" = <<-EOT
+      hs = {}
+      hs.status = "Progressing"
+      hs.message = "Waiting for policy to be ready"
+      if obj.status ~= nil and obj.status.ready ~= nil then
+        if obj.status.ready == true then
+          hs.status = "Healthy"
+          hs.message = "Policy is ready"
+        else
+          hs.status = "Degraded"
+          hs.message = "Policy is not ready"
+        end
+      end
+      return hs
+    EOT
+  }
+
+  force = true # Ensures Terraform can overwrite the key if it already exists
+}


### PR DESCRIPTION
## What?
The Argo App for Kyverno is struggling to progress past OutOfSync. According to the internet, Argo needs a custom health rule for Kyverno Policies.