### PR TITLE
Fix gov-uk-ai-accelerator-alpha-team repo permissions

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1067,7 +1067,7 @@ repos:
     can_be_deployed: true
     standard_contexts: *standard_security_checks
     push_allowances:
-      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-ai-accelerator-alpha-team"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"
 
@@ -1076,7 +1076,7 @@ repos:
     can_be_deployed: false
     visibility: private
     push_allowances:
-      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-ai-accelerator-alpha-team"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"
 
@@ -1085,7 +1085,7 @@ repos:
     can_be_deployed: false
     visibility: private
     push_allowances:
-      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-ai-accelerator-alpha-team"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"
 
@@ -1094,7 +1094,7 @@ repos:
     can_be_deployed: false
     visibility: private
     push_allowances:
-      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-ai-accelerator-alpha-team"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"
 
@@ -1102,6 +1102,6 @@ repos:
     can_be_deployed: true
     standard_contexts: *standard_security_checks
     push_allowances:
-      - "alphagov/gov-uk-data"
+      - "alphagov/gov-uk-ai-accelerator-alpha-team"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"


### PR DESCRIPTION
The permissions were accidentally changed in https://github.com/alphagov/govuk-infrastructure/pull/4318