### PR TITLE
[SCH-2126] Increase throughput provisioning - second attempt

### DIFF
--- a/terraform/variables/integration/elasticsearch-green.tfvars
+++ b/terraform/variables/integration/elasticsearch-green.tfvars
@@ -1,7 +1,7 @@
 ebs = {
   volume_size      = 314
   volume_type      = "gp3"
-  throughput       = 300
+  throughput       = 350
   provisioned_iops = 3000
 }
 engine_version         = "6.8"

--- a/terraform/variables/production/elasticsearch-green.tfvars
+++ b/terraform/variables/production/elasticsearch-green.tfvars
@@ -1,7 +1,7 @@
 ebs = {
   volume_size      = 314
   volume_type      = "gp3"
-  throughput       = 300
+  throughput       = 350
   provisioned_iops = 3000
 }
 engine_version         = "6.8"

--- a/terraform/variables/staging/elasticsearch-green.tfvars
+++ b/terraform/variables/staging/elasticsearch-green.tfvars
@@ -1,7 +1,7 @@
 ebs = {
   volume_size      = 314
   volume_type      = "gp3"
-  throughput       = 300
+  throughput       = 350
   provisioned_iops = 3000
 }
 engine_version         = "6.8"


### PR DESCRIPTION
Despite last week's increase to provisioned throughput we're still getting Disk Throughput Throttle warnings on all three environments, coinciding with the [search-index-env-sync](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/search-index-env-sync/values.yaml) jobs running. 

Increasing provisioning by a further 50 MBps, to see if this reduces the warnings. We're well within the maximum throughput possible for the instances - see [Amazon's EBS specifications for EC2 instances](https://docs.aws.amazon.com/ec2/latest/instancetypes/mo.html#mo_storage-ebs). According to the Terraform plans there is no additional AWS cost associated with this change.

See [Jira ticket SCH-2126](https://gov-uk.atlassian.net/browse/SCH-2126) for context and more useful links.