### PR TITLE
Config Cosign to recursively sign image manifests

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -82,4 +82,4 @@ jobs:
           TAG: "ghcr.io/${{ github.repository_owner }}/govuk/${{ inputs.imageName }}:${{ steps.meta.outputs.version }}"
           DIGEST: ${{ steps.build-image.outputs.digest }}
         run: |
-          cosign sign --yes "${TAG}@${DIGEST}"
+          cosign sign --recursive --yes "${TAG}@sha256:${DIGEST}"

--- a/.github/workflows/build-and-push-multiarch-image.yml
+++ b/.github/workflows/build-and-push-multiarch-image.yml
@@ -192,7 +192,7 @@ jobs:
           DIGEST=$(docker buildx imagetools inspect --raw "${TAG}" | sha256sum | awk '{print $1}')
 
           # Sign the manifest list digest
-          cosign sign --yes "${TAG}@sha256:${DIGEST}"
+          cosign sign --recursive --yes "${TAG}@sha256:${DIGEST}"
 
       - name: Inspect Images
         env:


### PR DESCRIPTION
## What?
This changes the Cosign command to sign our images recursively so the images that form each manifest are all signed and pass the Kyverno Policy check in Integration.