### PR TITLE
BAU - Add `DescribeEC2InstanceTypes` to EBS CSI Driver IAM Policy

### DIFF
--- a/terraform/deployments/cluster-infrastructure/aws_ebs_csi_iam.tf
+++ b/terraform/deployments/cluster-infrastructure/aws_ebs_csi_iam.tf
@@ -27,6 +27,7 @@ data "aws_iam_policy_document" "aws_ebs_csi_driver" {
       "ec2:ModifyVolume",
       "ec2:DescribeAvailabilityZones",
       "ec2:DescribeInstances",
+      "ec2:DescribeInstanceTypes",
       "ec2:DescribeSnapshots",
       "ec2:DescribeTags",
       "ec2:DescribeVolumes",


### PR DESCRIPTION
Description:
- https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md#v1590 indicates that in the future using `DescribeEC2InstanceTypes` will be mandatory
- Preemptively adding it here to ensure we aren't caught out by a future upgrade