### PR TITLE
Rename content-block-editor to content-block-picker in github

### DIFF
--- a/terraform/deployments/github/content_block_picker.tf
+++ b/terraform/deployments/github/content_block_picker.tf
@@ -1,0 +1,44 @@
+moved {
+  from = github_repository.govuk_repos["content-block-editor"]
+  to   = github_repository.govuk_repos["content-block-picker"]
+}
+
+moved {
+  from = aws_codecommit_repository.govuk_repos["alphagov/content-block-editor"]
+  to   = aws_codecommit_repository.govuk_repos["alphagov/content-block-picker"]
+}
+
+moved {
+  from = github_team_repository.govuk_ci_bots_repos["content-block-editor"]
+  to   = github_team_repository.govuk_ci_bots_repos["content-block-picker"]
+}
+
+moved {
+  from = github_team_repository.govuk_production_admin_repos["content-block-editor"]
+  to   = github_team_repository.govuk_production_admin_repos["content-block-picker"]
+}
+
+moved {
+  from = github_team_repository.govuk_production_deploy_repos["content-block-editor"]
+  to   = github_team_repository.govuk_production_deploy_repos["content-block-picker"]
+}
+
+moved {
+  from = github_team_repository.govuk_repos["content-block-editor"]
+  to   = github_team_repository.govuk_repos["content-block-picker"]
+}
+
+moved {
+  from = github_branch_protection.govuk_repos["content-block-editor"]
+  to   = github_branch_protection.govuk_repos["content-block-picker"]
+}
+
+moved {
+  from = github_repository_dependabot_security_updates.govuk_repos["content-block-editor"]
+  to   = github_repository_dependabot_security_updates.govuk_repos["content-block-picker"]
+}
+
+moved {
+  from = github_repository_vulnerability_alerts.govuk_repos["content-block-editor"]
+  to   = github_repository_vulnerability_alerts.govuk_repos["content-block-picker"]
+}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -87,13 +87,6 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test Ruby / Run RSpec
 
-  content-block-editor:
-    required_status_checks:
-      standard_contexts: *standard_security_checks
-      additional_contexts:
-        - Playwright / Run Tests
-        - Vitest / Run Tests
-
   content-block-manager:
     can_be_deployed: true
     homepage_url: "https://docs.publishing.service.gov.uk/repos/content-block-manager.html"
@@ -103,6 +96,13 @@ repos:
         - Test Ruby / Run Rspec
         - Test features / Run Cucumber
         - Check coverage / Combine coverage
+
+  content-block-picker:
+    required_status_checks:
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - Playwright / Run Tests
+        - Vitest / Run Tests
 
   content-data-admin:
     can_be_deployed: true


### PR DESCRIPTION
This repo was renamed in the GitHub UI