### PR TITLE
Add variable block for encryption_at_rest

### DIFF
--- a/terraform/deployments/elasticsearch-green/main.tf
+++ b/terraform/deployments/elasticsearch-green/main.tf
@@ -98,7 +98,7 @@ resource "aws_elasticsearch_domain" "opensearch" {
   }
 
   encrypt_at_rest {
-    enabled = true
+    enabled = var.encryption_at_rest
   }
 
   domain_endpoint_options {

--- a/terraform/deployments/elasticsearch-green/variables.tf
+++ b/terraform/deployments/elasticsearch-green/variables.tf
@@ -42,6 +42,11 @@ variable "ebs" {
   default     = null
 }
 
+variable "encryption_at_rest" {
+  type        = bool
+  description = "Enable encryption at rest in the opensearch cluster"
+}
+
 variable "tls_security_policy" {
   type        = string
   description = "The pre-canned AWS security policy to enforce for connections to opensearch"


### PR DESCRIPTION
We were getting warnings in terraform for undeclared variable for elasticsearch-green terraform plans. Defining the variable `encryption_at_rest` to address these warnings.

Warning message:
<img width="1483" height="157" alt="20260617 terraform undeclared variable warning" src="https://github.com/user-attachments/assets/76a31ec2-dd6e-46ce-802c-10daae1e0073" />
