### PR TITLE
[PP-7776] Turn off read replica for Publishing API in staging

### DIFF
--- a/terraform/variables/staging/rds.tfvars
+++ b/terraform/variables/staging/rds.tfvars
@@ -336,7 +336,6 @@ databases = {
     instance_class               = "db.m7g.2xlarge"
     performance_insights_enabled = true
     project                      = "GOV.UK - Publishing"
-    has_read_replica             = true
   }
 
   release = {


### PR DESCRIPTION
### Why
We’re removing Publishing API read replica in staging (and shortly in production) to reduce cost as we’re not actively using it at the moment.

#### Notes
The values defaults to false: https://github.com/alphagov/govuk-infrastructure/blob/4bd09a0cf0e958703f890931613a4fdb276e49f8/terraform/deployments/rds/variables.tf#L37

### Depends on:
- https://github.com/alphagov/govuk_content_item_loader/pull/36
- https://github.com/alphagov/frontend/pull/5614
- https://github.com/alphagov/collections/pull/4549
- https://github.com/alphagov/feedback/pull/2482
- https://github.com/alphagov/govuk-helm-charts/pull/4310
- https://github.com/alphagov/govuk-helm-charts/pull/4311