### PR TITLE
Set mysql engine version to 8.4.9 for release in staging

### DIFF
--- a/terraform/variables/staging/rds.tfvars
+++ b/terraform/variables/staging/rds.tfvars
@@ -341,7 +341,7 @@ databases = {
 
   release = {
     engine         = "mysql"
-    engine_version = "8.4"
+    engine_version = "8.4.9"
     engine_params = {
       max_allowed_packet = { value = 1073741824 }
     }


### PR DESCRIPTION
This was meant to be upgraded to the default 8.4 version, but was upgaded to the latest instead by mistake

This has to be set to the current patch version right now, and once 8.4.9 becomes default, this can be set back to 8.4

https://github.com/alphagov/govuk-infrastructure/issues/4025