### PR TITLE
[PP-7776] Remove Publishing API read replica in production

### DIFF
--- a/terraform/variables/production/rds.tfvars
+++ b/terraform/variables/production/rds.tfvars
@@ -334,7 +334,6 @@ databases = {
     instance_class               = "db.m6g.4xlarge"
     performance_insights_enabled = true
     project                      = "GOV.UK - Publishing"
-    has_read_replica             = true
     snapshot_identifier          = "publishing-api-postgres-post-encryption"
   }
 


### PR DESCRIPTION
To reduce cost as we’re not actively using it at the moment.

The value defaults to false: https://github.com/alphagov/govuk-infrastructure/blob/4bd09a0cf0e958703f890931613a4fdb276e49f8/terraform/deployments/rds/variables.tf#L37

Depends on:
- https://github.com/alphagov/govuk_content_item_loader/pull/36
- https://github.com/alphagov/frontend/pull/5614
- https://github.com/alphagov/collections/pull/4549
- https://github.com/alphagov/feedback/pull/2482
- https://github.com/alphagov/govuk-helm-charts/pull/4312
- https://github.com/alphagov/govuk-helm-charts/pull/4313