### PR TITLE
New github repo (private) for storing the ontology work the GOV.UK Inforamtion Architects are working on

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1105,3 +1105,8 @@ repos:
       - "alphagov/gov-uk-ai-accelerator-alpha-team"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"
+
+  govuk-information-model:
+    # standard security checks are disabled as not configured for a private repo
+    can_be_deployed: false
+    visibility: private


### PR DESCRIPTION
Not a deployable application.

Used for version control on the various ontology artefacts that will be shared between the IA community.