### PR TITLE
Update Release TF Vars to MySQL 8.4

### DIFF
--- a/terraform/variables/production/rds.tfvars
+++ b/terraform/variables/production/rds.tfvars
@@ -339,11 +339,11 @@ databases = {
 
   release = {
     engine         = "mysql"
-    engine_version = "8.0"
+    engine_version = "8.4"
     engine_params = {
       max_allowed_packet = { value = 1073741824 }
     }
-    engine_params_family         = "mysql8.0"
+    engine_params_family         = "mysql8.4"
     name                         = "release"
     allocated_storage            = 100
     instance_class               = "db.t4g.small"


### PR DESCRIPTION
## What?
This updates the Terraform for the Release MySQL RDS to reflect that it is now running on MySQL 8.4

### Related

* https://github.com/alphagov/govuk-infrastructure/issues/4225
* https://github.com/alphagov/govuk-infrastructure/issues/4025