### PR TITLE
Update configuration for `govuk-content-api-docs`

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -336,8 +336,8 @@ repos:
 
   govuk-content-api-docs:
     homepage_url: "https://content-api.publishing.service.gov.uk"
-    need_production_access_to_merge: false
-    push_allowances: []
+    required_status_checks:
+      standard_contexts: *standard_govuk_rails_checks
 
   govuk-cookie-consent:
     topics:


### PR DESCRIPTION
The configuration previously did not allow anyone except owners to merge PRs. It also had no required status checks.

This updates the configuration to allow anyone with production access to merge PRs and requires the standard Rails checks.