### PR TITLE
Update opensearch module to use s3 bucket by path, not git ref

### DIFF
--- a/terraform/shared-modules/opensearch-blue-green-deployment/s3.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/s3.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "snapshot_bucket" {
-  source = "github.com/alphagov/govuk-infrastructure/terraform/shared-modules/s3?ref=136062481db579d76723705c698c087582cad157"
+  source = "../s3"
 
   name              = local.snapshot_bucket_name
   govuk_environment = var.govuk_environment


### PR DESCRIPTION
This changes the opensearch module to use a path instead of git ref for our shared s3 bucket module, this was the pattern we agreed to change to.

I've brought this into it's own PR since it makes a change to AI Accelerator to change the blocked encryption types to NONE.