### PR TITLE
Add option to dismiss stale PR reviews on GitHub repos

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -300,6 +300,8 @@ resource "github_branch_protection" "govuk_repos" {
     pull_request_bypassers = try(each.value.required_pull_request_reviews.pull_request_bypassers, null)
 
     require_code_owner_reviews = try(each.value.required_pull_request_reviews.require_code_owner_reviews, false)
+
+    dismiss_stale_reviews = try(each.value.required_pull_request_reviews.dismiss_stale_reviews, false)
   }
 
   restrict_pushes {

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1001,6 +1001,8 @@ repos:
   govuk-user-reviewer:
     visibility: private
     homepage_url: "https://github.com/alphagov/govuk-rfcs/pull/75"
+    required_pull_request_reviews:
+      dismiss_stale_reviews: true
     required_status_checks:
       additional_contexts:
         - test

--- a/terraform/deployments/github/schemas/repos.schema.json
+++ b/terraform/deployments/github/schemas/repos.schema.json
@@ -92,6 +92,10 @@
                   "description": "Require an approved review in pull requests including files with a designated code owner. If omitted, defaults to false",
                   "type": "boolean"
                 },
+                "dismiss_stale_reviews": {
+                  "description": "Dismiss approved reviews when new commits are pushed. If omitted, defaults to false",
+                  "type": "boolean"
+                },
                 "pull_request_bypassers": {
                   "description": "The list of actor Names/IDs that are allowed to bypass pull request requirements. If omitted, defaults to null",
                   "type": "array",


### PR DESCRIPTION
Adds an option to automatically dismiss PR reviews when new commits are pushed to a branch. This is disabled by default, but will be enabled for only govuk-user-reviewer to start with.