### PR TITLE
Fix opensearch snapshot role permissions to write a snapshot

### DIFF
--- a/terraform/shared-modules/opensearch-blue-green-deployment/iam.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/iam.tf
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "opensearch_snapshot" {
       "s3:DeleteObject",
     ]
 
-    resources = [local.write_snapshot_bucket_arn]
+    resources = ["${local.write_snapshot_bucket_arn}/*"]
   }
 }
 


### PR DESCRIPTION
The new policies as missing /* on the object oriented s3 actions, this fixes it.