### PR TITLE
Dismiss stale PR reviews on govuk-helm-charts

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1086,6 +1086,7 @@ repos:
       pull_request_bypassers:
         - "/govuk-ci"
       require_code_owner_reviews: true
+      dismiss_stale_reviews: true
 
   govuk-knowledge-graph-search:
     homepage_url: "https://docs.data-community.publishing.service.gov.uk/tools/govsearch/"


### PR DESCRIPTION
This was missed when the rest of PE's repos had the option set