### PR TITLE
Set log_statement to 'ddl' for all Postgres databases

### DIFF
--- a/terraform/variables/integration/rds.tfvars
+++ b/terraform/variables/integration/rds.tfvars
@@ -10,7 +10,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -31,7 +31,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
       password_encryption        = { value = "md5" }
@@ -53,7 +53,7 @@ databases = {
     engine_version = "16"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -74,7 +74,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -111,7 +111,7 @@ databases = {
     allow_major_version_upgrade = true
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -132,7 +132,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -159,7 +159,7 @@ databases = {
       "rds.force_autovacuum_logging_level" = { value = "log" }
       log_autovacuum_min_duration          = { value = 10000, apply_method = "pending-reboot" }
       log_min_duration_statement           = { value = "10000" }
-      log_statement                        = { value = "all" }
+      log_statement                        = { value = "ddl" }
       deadlock_timeout                     = { value = 2500 }
       log_lock_waits                       = { value = 1 }
     }
@@ -180,7 +180,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -201,7 +201,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -222,7 +222,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -243,7 +243,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -265,7 +265,7 @@ databases = {
     engine_version = "17"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -285,7 +285,7 @@ databases = {
     engine_version = "17"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -305,7 +305,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -327,7 +327,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -348,7 +348,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -369,7 +369,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
       password_encryption        = { value = "md5" }
@@ -392,7 +392,7 @@ databases = {
     allow_major_version_upgrade = true
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -414,7 +414,7 @@ databases = {
     replica_engine_version = "17"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
       checkpoint_timeout         = { value = 3600 }
@@ -476,7 +476,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -515,7 +515,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -536,7 +536,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }

--- a/terraform/variables/production/rds.tfvars
+++ b/terraform/variables/production/rds.tfvars
@@ -9,7 +9,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -27,7 +27,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
       password_encryption        = { value = "md5" }
@@ -46,7 +46,7 @@ databases = {
     engine_version = "16"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -64,7 +64,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -98,7 +98,7 @@ databases = {
     allow_major_version_upgrade = true
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -116,7 +116,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -139,7 +139,7 @@ databases = {
       "rds.force_autovacuum_logging_level" = { value = "log" }
       log_autovacuum_min_duration          = { value = 10000, apply_method = "pending-reboot" }
       log_min_duration_statement           = { value = "10000" }
-      log_statement                        = { value = "all" }
+      log_statement                        = { value = "ddl" }
       deadlock_timeout                     = { value = 2500 }
       log_lock_waits                       = { value = 1 }
     }
@@ -157,7 +157,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -175,7 +175,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -193,7 +193,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -211,7 +211,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -229,7 +229,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -248,7 +248,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -266,7 +266,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -284,7 +284,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
       password_encryption        = { value = "md5" }
@@ -303,7 +303,7 @@ databases = {
     engine_version = "17"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -322,7 +322,7 @@ databases = {
     replica_engine_version = "17"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -372,7 +372,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -405,7 +405,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -423,7 +423,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "mod" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }

--- a/terraform/variables/staging/rds.tfvars
+++ b/terraform/variables/staging/rds.tfvars
@@ -8,7 +8,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -26,7 +26,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
       password_encryption        = { value = "md5" }
@@ -45,7 +45,7 @@ databases = {
     engine_version = "16"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -63,7 +63,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -97,7 +97,7 @@ databases = {
     allow_major_version_upgrade = true
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -115,7 +115,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -138,7 +138,7 @@ databases = {
       "rds.force_autovacuum_logging_level" = { value = "log" }
       log_autovacuum_min_duration          = { value = 10000, apply_method = "pending-reboot" }
       log_min_duration_statement           = { value = "10000" }
-      log_statement                        = { value = "all" }
+      log_statement                        = { value = "ddl" }
       deadlock_timeout                     = { value = 2500 }
       log_lock_waits                       = { value = 1 }
     }
@@ -156,7 +156,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -174,7 +174,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -192,7 +192,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -210,7 +210,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -228,7 +228,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -247,7 +247,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -265,7 +265,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -283,7 +283,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
       password_encryption        = { value = "md5" }
@@ -302,7 +302,7 @@ databases = {
     engine_version = "17"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -321,7 +321,7 @@ databases = {
     replica_engine_version = "17"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
       checkpoint_timeout         = { value = 3600 }
@@ -373,7 +373,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -406,7 +406,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }
@@ -424,7 +424,7 @@ databases = {
     engine_version = "14"
     engine_params = {
       log_min_duration_statement = { value = 10000 }
-      log_statement              = { value = "all" }
+      log_statement              = { value = "ddl" }
       deadlock_timeout           = { value = 2500 }
       log_lock_waits             = { value = 1 }
     }


### PR DESCRIPTION
## What

Sets the `log_statement` parameter for PostgreSQL databases to `ddl`. `ddl` will log "all data definition statements, such as CREATE, ALTER, and DROP statements". It used to be `all`, which logs every single query statement.

## How to review

1. Did I miss any?