### PR TITLE
Set Licensify DocDB Clone to 3 instances.

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb_clone.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb_clone.tf
@@ -58,10 +58,10 @@ resource "aws_docdb_cluster" "licensify_cluster_clone" {
 }
 
 resource "aws_docdb_cluster_instance" "licensify_cluster_clone_instances" {
-  count              = var.create_licensify_documentdb_clone ? 1 : 0
-  identifier         = "licensify-documentdb-clone-0"
+  count              = var.create_licensify_documentdb_clone ? var.licensify_documentdb_clone_instance_count : 0
+  identifier         = "licensify-documentdb-clone-${count.index}"
   cluster_identifier = aws_docdb_cluster.licensify_cluster_clone[0].id
-  instance_class     = "db.r5.large"
+  instance_class     = lookup(var.licensify_documentdb_clone_instance_types, tostring(count.index), "db.r5.large")
   tags               = aws_docdb_cluster.licensify_cluster_clone[0].tags
 }
 

--- a/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb_clone.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb_clone.tf
@@ -61,7 +61,7 @@ resource "aws_docdb_cluster_instance" "licensify_cluster_clone_instances" {
   count              = var.create_licensify_documentdb_clone ? var.licensify_documentdb_clone_instance_count : 0
   identifier         = "licensify-documentdb-clone-${count.index}"
   cluster_identifier = aws_docdb_cluster.licensify_cluster_clone[0].id
-  instance_class     = lookup(var.licensify_documentdb_clone_instance_types, tostring(count.index), "db.r5.large")
+  instance_class     = lookup(var.licensify_documentdb_clone_instance_types, tostring(count.index), "db.r8g.large")
   tags               = aws_docdb_cluster.licensify_cluster_clone[0].tags
 }
 

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -9,6 +9,21 @@ variable "licensify_documentdb_instance_count" {
   description = "Number of instances to create for the Licensify DocumentDB cluster"
 }
 
+variable "licensify_documentdb_clone_instance_count" {
+  type        = number
+  default     = 3
+  description = "Number of instances to create for the Licensify DocumentDB clone cluster"
+}
+
+variable "licensify_documentdb_clone_instance_types" {
+  type = map(string)
+  default = {
+    "0" = "db.r5.large"
+    "1" = "db.r8g.large"
+    "2" = "db.r8g.large"
+  }
+}
+
 variable "licensify_backup_retention_period" {
   type        = number
   default     = 5

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -18,7 +18,7 @@ variable "licensify_documentdb_clone_instance_count" {
 variable "licensify_documentdb_clone_instance_types" {
   type = map(string)
   default = {
-    "0" = "db.r5.large"
+    "0" = "db.r8g.large"
     "1" = "db.r8g.large"
     "2" = "db.r8g.large"
   }

--- a/terraform/variables/integration/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/integration/govuk-publishing-infrastructure.tfvars
@@ -65,6 +65,7 @@ amazonmq_govuk_chat_retry_message_ttl = 300000
 frontend_memcached_node_type = "cache.t4g.micro"
 
 licensify_documentdb_instance_count       = 1
+licensify_documentdb_clone_instance_count = 3
 licensify_backup_retention_period         = 1
 shared_documentdb_instance_count          = 1
 shared_documentdb_backup_retention_period = 1

--- a/terraform/variables/integration/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/integration/govuk-publishing-infrastructure.tfvars
@@ -70,3 +70,8 @@ licensify_backup_retention_period         = 1
 shared_documentdb_instance_count          = 1
 shared_documentdb_backup_retention_period = 1
 create_licensify_documentdb_clone         = true
+licensify_documentdb_clone_instance_types = {
+  "0" = "db.r5.large"
+  "1" = "db.r8g.large"
+  "2" = "db.r8g.large"
+}

--- a/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
@@ -62,6 +62,7 @@ amazonmq_govuk_chat_retry_message_ttl = 300000
 frontend_memcached_node_type = "cache.t4g.medium"
 
 licensify_documentdb_instance_count       = 1
+licensify_documentdb_clone_instance_count = 3
 licensify_backup_retention_period         = 1
 shared_documentdb_instance_count          = 1
 shared_documentdb_backup_retention_period = 1

--- a/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
@@ -66,3 +66,4 @@ licensify_documentdb_clone_instance_count = 3
 licensify_backup_retention_period         = 1
 shared_documentdb_instance_count          = 1
 shared_documentdb_backup_retention_period = 1
+create_licensify_documentdb_clone         = true


### PR DESCRIPTION
## What?
This allows us to run three nodes on the Licensify DocumentDB Cluster in Integration and Staging.

Changes:

* Set the Clone Cluster in Integration to use 3 nodes
* Set up a Clone Cluster in Staging with the same number of 3 nodes
* Optionally support a map of instance types
* Switch the default for Graviton instance types as these are cheaper and more performant.