### PR TITLE
Allow ES & OS clusters to talk to themselves

### DIFF
--- a/terraform/shared-modules/opensearch-blue-green-deployment/security_groups.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/security_groups.tf
@@ -13,3 +13,61 @@ resource "aws_security_group_rule" "opensearch_cluster_from_eks" {
   security_group_id        = aws_security_group.opensearch.id
   source_security_group_id = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.node_security_group_id
 }
+
+resource "aws_security_group_rule" "opensearch_cluster_from_self" {
+  description       = "OpenSearch accepts OpenSearch requests from itself"
+  type              = "ingress"
+  from_port         = 9200
+  to_port           = 9200
+  protocol          = "tcp"
+  security_group_id = aws_security_group.opensearch.id
+  self              = true
+}
+
+resource "aws_security_group_rule" "opensearch_cluster_from_old_elasticsearch_cluster" {
+  for_each = var.override_security_group_ids_for_green_cluster == null ? [] : toset(var.override_security_group_ids_for_green_cluster)
+
+  description              = "OpenSearch accepts OpenSearch requests from old Elasticsearch cluster"
+  type                     = "ingress"
+  from_port                = 9200
+  to_port                  = 9200
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.opensearch.id
+  source_security_group_id = each.value
+}
+
+resource "aws_security_group_rule" "old_elasticsearch_cluster_from_opensearch_cluster" {
+  for_each = var.override_security_group_ids_for_green_cluster == null ? [] : toset(var.override_security_group_ids_for_green_cluster)
+
+  description              = "Old Elasticsearch cluster accepts Elasticsearch requests from OpenSearch"
+  type                     = "ingress"
+  from_port                = 9200
+  to_port                  = 9200
+  protocol                 = "tcp"
+  security_group_id        = each.value
+  source_security_group_id = aws_security_group.opensearch.id
+}
+
+resource "aws_security_group_rule" "opensearch_cluster_to_old_elasticsearch_cluster" {
+  for_each = var.override_security_group_ids_for_green_cluster == null ? [] : toset(var.override_security_group_ids_for_green_cluster)
+
+  description              = "OpenSearch cluster allows access to Old Elasticsearch cluster"
+  type                     = "egress"
+  from_port                = 9200
+  to_port                  = 9200
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.opensearch.id
+  source_security_group_id = each.value
+}
+
+resource "aws_security_group_rule" "old_elasticsearch_cluster_to_opensearch_cluster" {
+  for_each = var.override_security_group_ids_for_green_cluster == null ? [] : toset(var.override_security_group_ids_for_green_cluster)
+
+  description              = "Old Elasticsearch cluster allows access to OpenSearch cluster"
+  type                     = "egress"
+  from_port                = 9200
+  to_port                  = 9200
+  protocol                 = "tcp"
+  security_group_id        = each.value
+  source_security_group_id = aws_security_group.opensearch.id
+}


### PR DESCRIPTION
The blue and green clusters need to be able to talk to each other, when moving from ES6 to ES7 it cannot be done via the medium of snapshots, so the clusters need to be able to connect to each other.

This PR adds SG rules to allow the security group to talk to itself, and the legacy security group in use for the current green cluster to have full 2 way communications with the new blue cluster.