### PR TITLE
Start clone on 3.6.0 to upgrade Snapshot

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb_clone.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb_clone.tf
@@ -35,11 +35,15 @@ resource "aws_docdb_cluster_parameter_group" "licensify_clone_parameter_group" {
   }
 }
 
+locals {
+  db_clone_cluster_parameter_group_name = var.licensify_documentdb_clone_engine_version == "3.6.0" ? aws_docdb_cluster_parameter_group.licensify_parameter_group.name : aws_docdb_cluster_parameter_group.licensify_clone_parameter_group[0].name
+}
+
 resource "aws_docdb_cluster" "licensify_cluster_clone" {
   count                           = var.create_licensify_documentdb_clone ? 1 : 0
   cluster_identifier              = "licensify-documentdb-clone-${var.govuk_environment}"
   db_subnet_group_name            = aws_docdb_subnet_group.licensify_cluster_subnet.name
-  db_cluster_parameter_group_name = aws_docdb_cluster_parameter_group.licensify_clone_parameter_group[0].name
+  db_cluster_parameter_group_name = local.db_clone_cluster_parameter_group_name
   master_username                 = "master"
   master_password                 = random_password.licensify_documentdb_master.result
   storage_encrypted               = true
@@ -48,7 +52,9 @@ resource "aws_docdb_cluster" "licensify_cluster_clone" {
   enabled_cloudwatch_logs_exports = ["profiler"]
   backup_retention_period         = 1
   snapshot_identifier             = data.aws_db_cluster_snapshot.licensify_cluster_snapshot.id
-  engine_version                  = "5.0.0"
+  engine_version                  = var.licensify_documentdb_clone_engine_version
+
+  allow_major_version_upgrade = var.licensify_documentdb_clone_allow_major_upgrade
 
   lifecycle {
     ignore_changes = [

--- a/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb_clone.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/licensify_documentdb_clone.tf
@@ -36,7 +36,7 @@ resource "aws_docdb_cluster_parameter_group" "licensify_clone_parameter_group" {
 }
 
 locals {
-  db_clone_cluster_parameter_group_name = var.licensify_documentdb_clone_engine_version == "3.6.0" ? aws_docdb_cluster_parameter_group.licensify_parameter_group.name : aws_docdb_cluster_parameter_group.licensify_clone_parameter_group[0].name
+  db_clone_cluster_parameter_group_name = var.licensify_documentdb_clone_engine_version == "3.6.0" ? aws_docdb_cluster_parameter_group.licensify_parameter_group.name : try(aws_docdb_cluster_parameter_group.licensify_clone_parameter_group[0].name, null)
 }
 
 resource "aws_docdb_cluster" "licensify_cluster_clone" {

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -9,6 +9,12 @@ variable "licensify_documentdb_instance_count" {
   description = "Number of instances to create for the Licensify DocumentDB cluster"
 }
 
+variable "licensify_documentdb_clone_engine_version" {
+  type        = string
+  default     = "5.0.0"
+  description = "Engine version for the Licensify DocumentDB clone cluster"
+}
+
 variable "licensify_documentdb_clone_instance_count" {
   type        = number
   default     = 3
@@ -22,6 +28,12 @@ variable "licensify_documentdb_clone_instance_types" {
     "1" = "db.r8g.large"
     "2" = "db.r8g.large"
   }
+}
+
+variable "licensify_documentdb_clone_allow_major_upgrade" {
+  type        = bool
+  default     = false
+  description = "Allow major version upgrade for the Licensify DocumentDB clone cluster"
 }
 
 variable "licensify_backup_retention_period" {

--- a/terraform/variables/integration/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/integration/govuk-publishing-infrastructure.tfvars
@@ -64,12 +64,13 @@ amazonmq_govuk_chat_retry_message_ttl = 300000
 
 frontend_memcached_node_type = "cache.t4g.micro"
 
-licensify_documentdb_instance_count       = 1
-licensify_documentdb_clone_instance_count = 3
-licensify_backup_retention_period         = 1
-shared_documentdb_instance_count          = 1
-shared_documentdb_backup_retention_period = 1
-create_licensify_documentdb_clone         = true
+licensify_documentdb_instance_count            = 1
+licensify_documentdb_clone_instance_count      = 3
+licensify_backup_retention_period              = 1
+shared_documentdb_instance_count               = 1
+shared_documentdb_backup_retention_period      = 1
+create_licensify_documentdb_clone              = true
+licensify_documentdb_clone_allow_major_upgrade = false
 licensify_documentdb_clone_instance_types = {
   "0" = "db.r5.large"
   "1" = "db.r8g.large"

--- a/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
@@ -61,9 +61,17 @@ amazonmq_govuk_chat_retry_message_ttl = 300000
 
 frontend_memcached_node_type = "cache.t4g.medium"
 
-licensify_documentdb_instance_count       = 1
-licensify_documentdb_clone_instance_count = 3
-licensify_backup_retention_period         = 1
-shared_documentdb_instance_count          = 1
-shared_documentdb_backup_retention_period = 1
-create_licensify_documentdb_clone         = true
+licensify_documentdb_instance_count            = 1
+licensify_documentdb_clone_instance_count      = 3
+licensify_documentdb_clone_engine_version      = "3.6.0"
+licensify_backup_retention_period              = 1
+shared_documentdb_instance_count               = 1
+shared_documentdb_backup_retention_period      = 1
+create_licensify_documentdb_clone              = true
+licensify_documentdb_clone_allow_major_upgrade = true
+
+licensify_documentdb_clone_instance_types = {
+  "0" = "db.r5.large"
+  "1" = "db.r5.large"
+  "2" = "db.r5.large"
+}


### PR DESCRIPTION
## What?
This allows us to launch the Staging Cluster on 3.6.0 as we have to import the existing 3.6.0 snapshot before it can be upgraded - we can't just import it straight into a 5.0 cluster.

This also adds some additional variables to allow us to shift the version and cluster configs per-environment without breaking what we've done in Integration.