### PR TITLE
IA-3009: add infra for rds-parquet-exporter job

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_iam.tf
@@ -1,0 +1,105 @@
+locals {
+  rds_parquet_exporter_service_account_name = "rds-parquet-exporter"
+  parquet_files_bucket_prefix               = "parquet"
+}
+
+module "rds_parquet_exporter_job_starter_iam_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "~> 6.0"
+
+  name                 = "${local.rds_parquet_exporter_service_account_name}-job-starter-${data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id}"
+  use_name_prefix      = false
+  description          = "Role for rds-parquet-exporter job to initiate Export. Corresponds to ${local.rds_parquet_exporter_service_account_name} k8s ServiceAccount."
+  max_session_duration = 28800
+
+  policies = {
+    "${aws_iam_policy.rds_parquet_exporter_job_starter.name}" = aws_iam_policy.rds_parquet_exporter_job_starter.arn
+  }
+  oidc_providers = {
+    main = {
+      provider_arn               = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_oidc_provider_arn
+      namespace_service_accounts = ["apps:${local.rds_parquet_exporter_service_account_name}"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "rds_parquet_exporter_job_starter" {
+  statement {
+    sid = "RDSExportPermissions"
+    actions = [
+      "rds:DescribeDBSnapshots",
+      "rds:DescribeExportTasks",
+      "rds:StartExportTask"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = ["iam:PassRole"]
+    resources = [
+      aws_iam_role.rds_parquet_exporter_export_task.arn,
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["export.rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "rds_parquet_exporter_job_starter" {
+  name        = "rds_parquet_exporter_job_starter"
+  description = "Permissions for the RDS parquet exporter job to initiate exports."
+  policy      = data.aws_iam_policy_document.rds_parquet_exporter_job_starter.json
+}
+
+resource "aws_iam_role" "rds_parquet_exporter_export_task" {
+  name                 = "rds-parquet-exporter-export-task-${data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_id}"
+  description          = "Role for RDS to use when exporting parquet files to S3"
+  assume_role_policy   = data.aws_iam_policy_document.allow_rds_exporter_access.json
+  max_session_duration = 28800
+}
+
+data "aws_iam_policy_document" "rds_parquet_exporter_export_task" {
+  statement {
+    sid = "S3AccessForExport"
+    actions = [
+      "s3:PutObject",
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:DeleteObject",
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::govuk-${var.govuk_environment}-database-backups",
+      "arn:aws:s3:::govuk-${var.govuk_environment}-database-backups/${local.parquet_files_bucket_prefix}/*",
+    ]
+  }
+  statement {
+    sid = "AllowAccessToKMSKey"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+    resources = [aws_kms_key.rds_parquet_exporter.arn]
+  }
+}
+
+resource "aws_iam_policy" "rds_parquet_exporter_export_task" {
+  name        = "rds_parquet_exporter_export_task"
+  description = "Permissions for the RDS parquet exporter export task to write to s3."
+  policy      = data.aws_iam_policy_document.rds_parquet_exporter_export_task.json
+}
+
+data "aws_iam_policy_document" "allow_rds_exporter_access" {
+  statement {
+    sid    = "AllowRDSExporterAccess"
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["export.rds.amazonaws.com"]
+    }
+  }
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_kms.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_kms.tf
@@ -1,0 +1,121 @@
+resource "aws_kms_key" "rds_parquet_exporter" {
+  description = "GOV.UK Key for Encrypting RDS parquet exports"
+  key_usage   = "ENCRYPT_DECRYPT"
+  policy      = data.aws_iam_policy_document.rds_parquet_exporter_kms.json
+}
+
+resource "aws_kms_alias" "rds_parquet_exporter" {
+  name          = "alias/govuk/${var.govuk_environment}/rds_parquet_exporter"
+  target_key_id = aws_kms_key.rds_parquet_exporter.key_id
+}
+
+data "aws_iam_policy_document" "rds_parquet_exporter_kms" {
+  statement {
+    sid = "Allow terraform cloud to manage the key"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/terraform-cloud"]
+    }
+
+    actions = [
+      "kms:CancelKeyDeletion",
+      "kms:Create*",
+      "kms:Delete*",
+      "kms:Describe*",
+      "kms:Disable*",
+      "kms:Enable*",
+      "kms:Get*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Revoke*",
+      "kms:ScheduleKeyDeletion",
+      "kms:Update*",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Allow fulladmin roles to manage the key"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "kms:CancelKeyDeletion",
+      "kms:Create*",
+      "kms:Delete*",
+      "kms:Describe*",
+      "kms:Disable*",
+      "kms:Enable*",
+      "kms:Get*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Revoke*",
+      "kms:ScheduleKeyDeletion",
+      "kms:Update*",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*-fulladmin"]
+    }
+  }
+
+  statement {
+    sid = "Allow access through RDS for all principals in the account that are authorized to use RDS"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:CreateGrant",
+      "kms:ListGrants",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:CallerAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["rds.${data.aws_region.current.region}.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid = "Allow direct access to key metadata to the account"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    actions = [
+      "kms:Describe*",
+      "kms:Get*",
+      "kms:List*",
+      "kms:RevokeGrant"
+    ]
+
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
The Insights & Analytics are making a job to export parquet files from RDS - see draft PR https://github.com/alphagov/govuk-helm-charts/pull/4316. We know we need a KMS key and an IAM role but we don't routinely use AWS so hoping to get some feedback on whether this is on the right track given @AP-Hunt 's feedback in that PR.

I've cribbed the KMS from the the [neptune implementation](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/neptune/kms.tf) and the IAM role from the [db-backup](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/govuk-publishing-infrastructure/db_backup_iam.tf). @srinivasadaggu-dotcom has provided the required "actions".

# Requirements

1. dedicated KMS key for the encyrption/decryption of files
2. an IAM role which can kick off the export job and outputs the files to a `parquet/` prefix on the database-backups bucket

# Questions

- Can anyone tell me which kubernetes service accoun the [proposed job](https://github.com/alphagov/govuk-helm-charts/pull/4316/changes) will run as - I need to provide that [here](https://github.com/alphagov/govuk-infrastructure/pull/4442/changes#diff-675df1e3b882f8f3fd575a1eecc5ee178b858e6bd133a47e035d69735430d18dR2) by the looks of it. or do I @srinivasadaggu-dotcom has run the k8s without a dedicated service account and it ran fine - maybe using a default?

# Assumptions
- We only need to run the `rds-parquet-exporter` in gov.uk integration and staging environments.


@srinivasadaggu-dotcom is implementing this so has context. He doesn't have TFC access yet so I'm raising this on his behalf.