### PR TITLE
Remove github_branch_protection resources for archived repos

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -296,7 +296,10 @@ resource "github_repository_dependabot_security_updates" "govuk_repos" {
 }
 
 resource "github_branch_protection" "govuk_repos" {
-  for_each = { for repo_name, repo_details in local.repositories : repo_name => repo_details if try(repo_details["branch_protection"], true) }
+  for_each = { for repo_name, repo_details in local.repositories : repo_name => repo_details if
+    try(repo_details["branch_protection"], true) &&
+    !try(repo_details.archived, false)
+  }
 
   repository_id    = github_repository.govuk_repos[each.key].node_id
   pattern          = "main"


### PR DESCRIPTION
These don't do anything on archived repos, and cause errors if we try to make changes since archived repos are read-only

I'm hoping GitHub lets us delete these branch protection rules. If not, I will remove them from terraform state with `terraform state rm`. If the repos are unarchived for whatever reason, TF will overwrite existing branch protection rules with a new set.

Closes https://github.com/alphagov/govuk-infrastructure/issues/4406