### PR TITLE
Upgrade Staging Clone DocDB to v5.

### DIFF
--- a/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
@@ -63,7 +63,7 @@ frontend_memcached_node_type = "cache.t4g.medium"
 
 licensify_documentdb_instance_count            = 1
 licensify_documentdb_clone_instance_count      = 3
-licensify_documentdb_clone_engine_version      = "3.6.0"
+licensify_documentdb_clone_engine_version      = "5.0.0"
 licensify_backup_retention_period              = 1
 shared_documentdb_instance_count               = 1
 shared_documentdb_backup_retention_period      = 1


### PR DESCRIPTION
## What?
This changes the licensify DocumentDB Clone Version from 3.6 to 5.0 in the Staging