### PR TITLE
Archive the govuk-dns-ui repo (step 1)

### DIFF
--- a/terraform/deployments/github/README.md
+++ b/terraform/deployments/github/README.md
@@ -139,12 +139,16 @@ After the repository is created, you will need to manually trigger a new run and
 
 ## Archiving repositories
 
-To archive a repository, you will need to raise **two** Pull Requests to update the repository's configuration in the [repos.yml](/terraform/deployments/github/repos.yml) file.
+To archive a repository, you will need to raise **two** Pull Requests to update the repository's configuration in the 
+[repos.yml](/terraform/deployments/github/repos.yml) file. It is important to do this in two steps, because Terraform will destroy a number of resources 
+when some properties are removed from configuration. If you do this in one step, Terraform will archive the repository
+(making it readonly) before it can delete the other resources, which depends on the repository being writeable.
 
 1. Remove all properties
 
 Remove all properties such as `required_status_checks` or `homepage_url`.
-You may want to keep the `visibility` property if you want to create a private or internal archive.
+If the repository is internal or private, you must keep the `visibility` property, otherwise the visibility will default
+to `public`.
 
 ```diff
 - my-repo:
@@ -161,7 +165,7 @@ You may want to keep the `visibility` property if you want to create a private o
 
 Raise a Pull Request and review the Terraform plan carefully. Once approved, merge the PR. Remember to apply the Terraform changes after reviewing the plan output again in [Terraform Cloud GitHub workspace](https://app.terraform.io/app/govuk/workspaces/GitHub/runs).
 
-2. Add the `archived: true` property
+2. Add the `archived: true` property, and preserve the `visibility` property if the repository is internal or private.
 
 ```diff
 -  my-repo: {}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1014,7 +1014,8 @@ repos:
   govuk-crd-library:
     homepage_url: "https://alphagov.github.io/govuk-crd-library/"
 
-  govuk-dns-ui: {}
+  govuk-dns-ui:
+    visibility: private
 
   govuk-helm-charts:
     can_be_deployed: true

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1073,11 +1073,7 @@ repos:
     required_pull_request_reviews:
       dismiss_stale_reviews: true
 
-  govuk-dns-ui:
-    visibility: private
-    homepage_url: "https://dns.publishing.service.gov.uk"
-    required_pull_request_reviews:
-      dismiss_stale_reviews: true
+  govuk-dns-ui: {}
 
   govuk-helm-charts:
     can_be_deployed: true


### PR DESCRIPTION
Following steps at https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/README.md#archiving-repositories (keeping the `visibility` tag)

(Part of https://github.com/alphagov/govuk-infrastructure/issues/2827)