### PR TITLE
Switch Staging Licennsify DocDB types to Graviton

### DIFF
--- a/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
@@ -71,7 +71,7 @@ create_licensify_documentdb_clone              = true
 licensify_documentdb_clone_allow_major_upgrade = true
 
 licensify_documentdb_clone_instance_types = {
-  "0" = "db.r5.large"
-  "1" = "db.r5.large"
-  "2" = "db.r5.large"
+  "0" = "db.r8g.large"
+  "1" = "db.r8g.large"
+  "2" = "db.r8g.large"
 }


### PR DESCRIPTION
## What?
Now we have upgraded to a compatible version of DocDB, we can upgrade to the newer instance types.