### PR TITLE
Use separate IAM policy documents for both snapshot buckets

### DIFF
--- a/terraform/shared-modules/opensearch-blue-green-deployment/s3.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/s3.tf
@@ -11,7 +11,7 @@ module "snapshot_bucket" {
   name              = local.snapshot_bucket_name
   govuk_environment = var.govuk_environment
 
-  extra_bucket_policies = [data.aws_iam_policy_document.snapshot_bucket_policy.json]
+  extra_bucket_policies = [data.aws_iam_policy_document.snapshot_bucket_policy[0].json]
 }
 
 module "old_snapshot_bucket" {
@@ -20,10 +20,12 @@ module "old_snapshot_bucket" {
   name              = local.old_snapshot_bucket_name
   govuk_environment = var.govuk_environment
 
-  extra_bucket_policies = [data.aws_iam_policy_document.snapshot_bucket_policy.json]
+  extra_bucket_policies = [data.aws_iam_policy_document.old_snapshot_bucket_policy.json]
 }
 
 data "aws_iam_policy_document" "snapshot_bucket_policy" {
+  count = var.create_original_snapshot_bucket ? 1 : 0
+
   statement {
     sid = "ReadSnapshots"
 
@@ -40,16 +42,10 @@ data "aws_iam_policy_document" "snapshot_bucket_policy" {
       "s3:ListBucket",
     ]
 
-    resources = concat(
-      var.create_original_snapshot_bucket ? [
-        "arn:aws:s3:::${local.snapshot_bucket_name}",
-        "arn:aws:s3:::${local.snapshot_bucket_name}/*",
-      ] : [],
-      [
-        "arn:aws:s3:::${local.old_snapshot_bucket_name}",
-        "arn:aws:s3:::${local.old_snapshot_bucket_name}/*",
-      ]
-    )
+    resources = [
+      "arn:aws:s3:::${local.snapshot_bucket_name}",
+      "arn:aws:s3:::${local.snapshot_bucket_name}/*",
+    ]
   }
 
   statement {
@@ -66,9 +62,47 @@ data "aws_iam_policy_document" "snapshot_bucket_policy" {
       "s3:PutObjectAcl",
     ]
 
-    resources = concat(
-      var.create_original_snapshot_bucket ? ["arn:aws:s3:::${local.snapshot_bucket_name}/*"] : [],
-      ["arn:aws:s3:::${local.old_snapshot_bucket_name}/*"]
-    )
+    resources = ["arn:aws:s3:::${local.snapshot_bucket_name}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "old_snapshot_bucket_policy" {
+  statement {
+    sid = "ReadSnapshots"
+
+    principals {
+      type = "AWS"
+      identifiers = sort(distinct(concat(
+        [data.aws_caller_identity.current.account_id],
+        var.account_ids_allowed_to_read_domain_snapshots
+      )))
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.old_snapshot_bucket_name}",
+      "arn:aws:s3:::${local.old_snapshot_bucket_name}/*",
+    ]
+  }
+
+  statement {
+    sid = "WriteSnapshots"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
+    }
+
+    actions = [
+      "s3:DeleteObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+    ]
+
+    resources = ["arn:aws:s3:::${local.old_snapshot_bucket_name}/*"]
   }
 }


### PR DESCRIPTION
Today I learned an S3 Bucket Policy cannot refer to any resources which are not the bucket the policy is attached to, so I can't resuse the single bucket policy for both old and new snapshot buckets. So this PR:

* Copies and pastes the bucket policy and changes the resources in them to be only the bucket they refer to

In a week or two the entire `old_snapshot_bucket` lot of code will be deleted anyway, so having the copy and paste is fine enough for now, knowing it's a very small bit of tech debt I intend to repay very soon.