### PR TITLE
Bump Integration EKS to 1.35

### DIFF
--- a/terraform/variables/integration/cluster-infrastructure.tfvars
+++ b/terraform/variables/integration/cluster-infrastructure.tfvars
@@ -1,6 +1,6 @@
 # Variables for the cluster-infrastructure-integration workspace
 
-cluster_version = "1.34"
+cluster_version = "1.35"
 
 enable_container_network_observability = true
 enable_eks_pod_identity_addon          = true


### PR DESCRIPTION
## What?
This bumps Kubernetes to 1.35 in Integration (for now). Will be followed by 1.36.

### Related

* https://github.com/alphagov/govuk-infrastructure/issues/3804