### PR TITLE
Temp Admins need EKS Access Entries

### DIFF
--- a/terraform/deployments/cluster-access/eks_access.tf
+++ b/terraform/deployments/cluster-access/eks_access.tf
@@ -190,6 +190,28 @@ module "readonly" {
   depends_on = [kubernetes_namespace_v1.apps, kubernetes_namespace_v1.datagovuk, kubernetes_namespace_v1.licensify]
 }
 
+module "tempadmin" {
+  source = "./modules/access-entry"
+
+  name = "tempadmin"
+
+  cluster_name = local.cluster_name
+
+  aws_iam_role_arns   = data.aws_iam_roles.tempadmin.arns
+  access_policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+  access_policy_scope = "cluster"
+
+  cluster_role_rules = [
+    {
+      api_groups = ["*"]
+      resources  = ["*"]
+      verbs      = ["*"]
+    }
+  ]
+
+  depends_on = [kubernetes_namespace_v1.apps, kubernetes_namespace_v1.datagovuk, kubernetes_namespace_v1.licensify]
+}
+
 module "dguengineer" {
   source = "./modules/access-entry"
 

--- a/terraform/deployments/cluster-access/main.tf
+++ b/terraform/deployments/cluster-access/main.tf
@@ -64,6 +64,10 @@ data "aws_iam_roles" "readonly" {
   name_regex = "\\..*readonly$"
 }
 
+data "aws_iam_roles" "tempadmin" {
+  name_regex = "\\..*-tempadmin$"
+}
+
 data "aws_iam_roles" "dguengineer" {
   name_regex = "\\..*dguengineer$"
 }


### PR DESCRIPTION
## What?
Temp Admins currently don't have EKS Access Entries so they can't do anything inside the EKS Clusters. Let's fix this.