### PR TITLE
Mark EKS as Upgraded to 1.35 in Staging

### DIFF
--- a/terraform/variables/staging/cluster-infrastructure.tfvars
+++ b/terraform/variables/staging/cluster-infrastructure.tfvars
@@ -1,6 +1,6 @@
 # Variables for the cluster-infrastructure-staging workspace
 
-cluster_version = "1.34"
+cluster_version = "1.35"
 
 enable_arm_workers_blue  = false
 enable_arm_workers_green = true


### PR DESCRIPTION
## What?

This sets the cluster version to 1.35 in staging (to match the upgrade in the AWS Console).

### Related

* https://github.com/alphagov/govuk-infrastructure/issues/3804