### PR TITLE
Don't pin github actions to SHAs if the package is alphagov/govuk-infrastructure

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -52,6 +52,11 @@
             "rangeStrategy": "bump",
             "groupName": "Terraform required_version",
             "minimumReleaseAge": "10 days"
+        },
+        {
+          "matchPackageNames": ["alphagov/govuk-infrastructure"],
+          "matchDepTypes": ["action"],
+          "enabled": false
         }
     ],
     "customManagers": [


### PR DESCRIPTION
We agreed not to pin to the SHA for github actions which are in our own infra repo. Lots of other repos extend these rules (e.g. govuk-user-reviewer) and will autoamtically benefit from this change being done centrally