### PR TITLE
Update kube-state-metrics addon

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -42,7 +42,7 @@ locals {
   default_cluster_addons = {
     coredns            = { addon_version = "v1.13.2-eksbuild.3", resolve_conflicts_on_create = "OVERWRITE" }
     kube-proxy         = { addon_version = "v1.34.5-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE" }
-    kube-state-metrics = { addon_version = "v2.18.0-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
+    kube-state-metrics = { addon_version = "v2.19.1-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
     metrics-server     = { addon_version = "v0.8.1-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE" }
     vpc-cni = {
       addon_version               = "v1.21.1-eksbuild.5",


### PR DESCRIPTION
## What?
This updates the kube-state-metrics addon to 2.19.1 as it is blocking the upgrade to EKS 1.36