### PR TITLE
Bump kube-proxy to stop warning on EKS 1.36

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -41,7 +41,7 @@ locals {
 
   default_cluster_addons = {
     coredns            = { addon_version = "v1.13.2-eksbuild.3", resolve_conflicts_on_create = "OVERWRITE" }
-    kube-proxy         = { addon_version = "v1.34.5-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE" }
+    kube-proxy         = { addon_version = "v1.35.3-eksbuild.13", resolve_conflicts_on_create = "OVERWRITE" }
     kube-state-metrics = { addon_version = "v2.19.1-eksbuild.1", resolve_conflicts_on_create = "OVERWRITE" }
     metrics-server     = { addon_version = "v0.8.1-eksbuild.2", resolve_conflicts_on_create = "OVERWRITE" }
     vpc-cni = {


### PR DESCRIPTION
## What?
The kube-proxy addon has a drift warning which isn't blocking the upgrade to 1.36 but should be addressed before continuing.