### PR TITLE
Update Integration EKS to 1.36

### DIFF
--- a/terraform/variables/integration/cluster-infrastructure.tfvars
+++ b/terraform/variables/integration/cluster-infrastructure.tfvars
@@ -1,6 +1,6 @@
 # Variables for the cluster-infrastructure-integration workspace
 
-cluster_version = "1.35"
+cluster_version = "1.36"
 
 enable_container_network_observability = true
 enable_eks_pod_identity_addon          = true


### PR DESCRIPTION
## What?
This updates the Integration EKS Cluster to 1.36 in Terraform, to match the running version.