### PR TITLE
[PP-7834] Remove Brakeman requirement from Content API docs

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -337,7 +337,9 @@ repos:
   govuk-content-api-docs:
     homepage_url: "https://content-api.publishing.service.gov.uk"
     required_status_checks:
-      standard_contexts: *standard_govuk_rails_checks
+      standard_contexts: *standard_security_checks
+      additional_contexts:
+        - Lint Ruby / Run RuboCop
 
   govuk-cookie-consent:
     topics:


### PR DESCRIPTION
In 34172aa0c9a920d54266bb59b638ca0e76bb1808, we added some required status checks to the govuk-content-api-docs repo. We added the standard Rails checks, but this isn't a Rails app. The required Rails checks include Brakeman, which is specifically for Rails apps and won't run on on non-Rails repositories

A smaller shared list of checks is available in this file, so we switch to that and add in the one additional check from the Rails set that we are able to run, only omitting Brakeman