### PR TITLE
IA-3009: attach rds-parquet-exporter policies to roles

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_iam.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "rds_parquet_exporter_job_starter" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = ["export.rds.amazonaws.com"]
+      values   = ["export.rds.amazonaws.com", "rds.amazonaws.com"]
     }
   }
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_iam.tf
@@ -12,15 +12,17 @@ module "rds_parquet_exporter_job_starter_iam_role" {
   description          = "Role for rds-parquet-exporter job to initiate Export. Corresponds to ${local.rds_parquet_exporter_service_account_name} k8s ServiceAccount."
   max_session_duration = 28800
 
-  policies = {
-    "${aws_iam_policy.rds_parquet_exporter_job_starter.name}" = aws_iam_policy.rds_parquet_exporter_job_starter.arn
-  }
   oidc_providers = {
     main = {
       provider_arn               = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.cluster_oidc_provider_arn
       namespace_service_accounts = ["apps:${local.rds_parquet_exporter_service_account_name}"]
     }
   }
+}
+
+resource "aws_iam_role_policy_attachment" "rds_parquet_exporter_job_starter" {
+  role       = module.rds_parquet_exporter_job_starter_iam_role.name
+  policy_arn = aws_iam_policy.rds_parquet_exporter_job_starter.arn
 }
 
 data "aws_iam_policy_document" "rds_parquet_exporter_job_starter" {
@@ -57,6 +59,11 @@ resource "aws_iam_role" "rds_parquet_exporter_export_task" {
   description          = "Role for RDS to use when exporting parquet files to S3"
   assume_role_policy   = data.aws_iam_policy_document.allow_rds_exporter_access.json
   max_session_duration = 28800
+}
+
+resource "aws_iam_role_policy_attachment" "rds_parquet_exporter_export_task" {
+  role       = aws_iam_role.rds_parquet_exporter_export_task.name
+  policy_arn = aws_iam_policy.rds_parquet_exporter_export_task.arn
 }
 
 data "aws_iam_policy_document" "rds_parquet_exporter_export_task" {


### PR DESCRIPTION
Use `aws_iam_role_policy_attachement` to link the roles and policies created in https://github.com/alphagov/govuk-infrastructure/pull/4442.

I wasn't sure if should I also [remove the `policies` in the the IAM module](https://github.com/alphagov/govuk-infrastructure/pull/4480/changes#diff-675df1e3b882f8f3fd575a1eecc5ee178b858e6bd133a47e035d69735430d18dL15) and would appreciate advice there. 