### PR TITLE
Update EKS Staging to 1.36

### DIFF
--- a/terraform/variables/staging/cluster-infrastructure.tfvars
+++ b/terraform/variables/staging/cluster-infrastructure.tfvars
@@ -1,6 +1,6 @@
 # Variables for the cluster-infrastructure-staging workspace
 
-cluster_version = "1.35"
+cluster_version = "1.36"
 
 enable_arm_workers_blue  = false
 enable_arm_workers_green = true


### PR DESCRIPTION
## What?
This sets the EKS Staging version in Terraform to 1.36 (matching what is now live in that environment).