### PR TITLE
Update instance name in Elasticsearch cluster

### DIFF
--- a/terraform/variables/integration/search-opensearch.tfvars
+++ b/terraform/variables/integration/search-opensearch.tfvars
@@ -9,11 +9,11 @@ blue_cluster_options = {
 
   dedicated_master = {
     instance_count = 3
-    instance_type  = "c7i.xlarge.elasticsearch"
+    instance_type  = "c7i.xlarge.search"
   }
 
   instance_count = 3
-  instance_type  = "r7i.xlarge.elasticsearch"
+  instance_type  = "r7i.xlarge.search"
 
   zone_awareness_enabled = true
 


### PR DESCRIPTION
AWS recently renamed the c7i.xlarge.elasticsearch instance to c7i.xlarge.search and so we have to update the name accordingly