### PR TITLE
IA-3009: allow google-s3-mirror role to decrypt rds-parquet-exporter files

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_iam.tf
@@ -110,3 +110,35 @@ data "aws_iam_policy_document" "allow_rds_exporter_access" {
     }
   }
 }
+
+resource "aws_iam_policy" "google_s3_mirror_kms_key_access" {
+  count = var.create_google_s3_mirror_role ? 1 : 0
+
+  name        = "google_s3_mirror_kms_key_access"
+  description = "Permissions for decrypting parquet files in s3."
+  policy      = data.aws_iam_policy_document.google_s3_mirror_kms_key_access[0].json
+}
+
+data "aws_iam_policy_document" "google_s3_mirror_kms_key_access" {
+  count = var.create_google_s3_mirror_role ? 1 : 0
+
+  statement {
+    sid = "AllowDecryptionAccessToKMSKey"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+
+    resources = [
+      "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "google_s3_mirror_kms_key_access" {
+  count = var.create_google_s3_mirror_role ? 1 : 0
+
+  role       = aws_iam_role.google-s3-mirror[0].name
+  policy_arn = aws_iam_policy.google_s3_mirror_kms_key_access[0].arn
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_kms.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/rds_parquet_exporter_kms.tf
@@ -118,4 +118,24 @@ data "aws_iam_policy_document" "rds_parquet_exporter_kms" {
 
     resources = ["*"]
   }
+
+  dynamic "statement" {
+    for_each = var.create_google_s3_mirror_role ? [1] : []
+
+    content {
+      sid = "AllowGCPTransferRoleToDecrypt"
+
+      principals {
+        type        = "AWS"
+        identifiers = [aws_iam_role.google-s3-mirror[0].arn]
+      }
+
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey"
+      ]
+
+      resources = ["*"]
+    }
+  }
 }


### PR DESCRIPTION
> There is an existing role `google-s3-mirror` which is used to mirror database backups to GCP. It doesn't appear to have been defined in terraform and only seems to exist in the integration and staging environments.
> 
> The role doesn't have access to the KMS key used to encrypt parquet files output by `rds-parquet-exporter`. This PR adds a policy to allow access and attaches it to that role.
> 
> The production plan is failing as the role doesn't exist there. Not sure how to address that... Do we maybe import the `google-s3-mirror` role and existing policy?

☝️ resolved by https://github.com/alphagov/govuk-infrastructure/pull/4494

---

The aim of this PR is now to allow the `google-s3-mirror` role decrypt the files output by `rds-parquet-exporter`.

It must only create the required resources in the envs that the `google-s3-mirror` role exists in (i.e. integration and staging).