### PR TITLE
Update EKS to 1.36 in Production.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -68,7 +68,7 @@
             "matchStrings": [
                 "(?<depName>kube-proxy|metrics-server|vpc-cni|coredns|kube-state-metrics)\\s+=\\s+\\{\\s+addon_version\\s+=\\s+\"(?<currentValue>[a-zA-Z0-9-_.]+)\""
             ],
-            "packageNameTemplate": "{\"kubernetesVersion\": \"1.35\", \"addonName\": \"{{depName}}\", \"region\": \"eu-west-1\"}",
+            "packageNameTemplate": "{\"kubernetesVersion\": \"1.36\", \"addonName\": \"{{depName}}\", \"region\": \"eu-west-1\"}",
             "depNameTemplate": "{{depName}}",
             "datasourceTemplate": "aws-eks-addon",
             "versioningTemplate": "aws-eks-addon"

--- a/terraform/deployments/tfc-configuration/variables-test.tf
+++ b/terraform/deployments/tfc-configuration/variables-test.tf
@@ -4,7 +4,7 @@ module "variable-set-ephemeral" {
   name     = "common-ephemeral"
   priority = false
   tfvars = {
-    cluster_version               = "1.35"
+    cluster_version               = "1.36"
     cluster_log_retention_in_days = 7
 
     vpc_cidr = "10.10.0.0/16"

--- a/terraform/variables/production/cluster-infrastructure.tfvars
+++ b/terraform/variables/production/cluster-infrastructure.tfvars
@@ -1,6 +1,6 @@
 # Variables for the cluster-infrastructure-production workspace
 
-cluster_version = "1.35" # Don't forget to change this in variables-test.tf too
+cluster_version = "1.36" # Don't forget to change this in variables-test.tf too
 
 enable_arm_workers_blue  = false
 enable_arm_workers_green = true


### PR DESCRIPTION
## What?
This brings EKS up to 1.36 (the latest version) in Production, bringing all environments into sync.