### PR TITLE
Add role to gcp integration access group

### DIFF
--- a/terraform/deployments/search-api-v2/service_accounts.tf
+++ b/terraform/deployments/search-api-v2/service_accounts.tf
@@ -68,6 +68,17 @@ resource "google_service_account" "search_admin" {
   description  = "Service account to provide access to the search-admin Rails app"
 }
 
+resource "google_service_account_iam_binding" "search_admin_sa_token_creator_iam" {
+  # Only create this resource if the environment is integration.
+  count = terraform.workspace == "search-api-v2-integration" ? 1 : 0
+
+  service_account_id = google_service_account.search_admin.id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  members = [
+    "group:govuk-gcp-access-integration@digital.cabinet-office.gov.uk"
+  ]
+}
+
 resource "google_service_account_key" "search_admin" {
   service_account_id = google_service_account.search_admin.id
 }


### PR DESCRIPTION
Add token creator role to the integration access group to allow service account impersonation of the search_admin service account for local development.

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account_iam#google_service_account_iam_binding https://docs.cloud.google.com/iam/docs/service-account-permissions#token-creator-role

See equivalent PR for search-api-v2: https://github.com/alphagov/govuk-infrastructure/pull/3814

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1968