### PR TITLE
add I&A owners group to GovGraph projects

### DIFF
--- a/terraform/variables/integration/gcp-gov-graph.tfvars
+++ b/terraform/variables/integration/gcp-gov-graph.tfvars
@@ -33,6 +33,7 @@ enable_redis_session_store_instance = true
 project_owner_members = [
   "group:govgraph-developers@digital.cabinet-office.gov.uk",
   "serviceAccount:terraform-cloud-integration@govuk-integration.iam.gserviceaccount.com",
+  "group:gcp-data-infrastructure-owners@digital.cabinet-office.gov.uk",
 ]
 
 iap_govgraphsearch_members = [

--- a/terraform/variables/production/gcp-gov-graph.tfvars
+++ b/terraform/variables/production/gcp-gov-graph.tfvars
@@ -33,6 +33,7 @@ gtm_auth                            = "aWEg5ABBTyIPcsSg1cJWxg"
 project_owner_members = [
   "group:govgraph-developers@digital.cabinet-office.gov.uk",
   "serviceAccount:terraform-cloud-production@govuk-production.iam.gserviceaccount.com",
+  "group:gcp-data-infrastructure-owners@digital.cabinet-office.gov.uk",
 ]
 
 iap_govgraphsearch_members = [

--- a/terraform/variables/staging/gcp-gov-graph.tfvars
+++ b/terraform/variables/staging/gcp-gov-graph.tfvars
@@ -33,6 +33,7 @@ gtm_id                              = "PLACEHOLDER"
 project_owner_members = [
   "group:govgraph-developers@digital.cabinet-office.gov.uk",
   "serviceAccount:terraform-cloud-staging@govuk-staging-160211.iam.gserviceaccount.com",
+  "group:gcp-data-infrastructure-owners@digital.cabinet-office.gov.uk",
 ]
 
 iap_govgraphsearch_members = [


### PR DESCRIPTION
Adds admin group `gcp-data-infrastructure-owners@digital.cabinet-office.gov.uk` to GovGraph projects.