### PR TITLE
Remove DGU from ephemeral cluster creation by default

### DIFF
--- a/terraform/deployments/ephemeral/tfe.tf
+++ b/terraform/deployments/ephemeral/tfe.tf
@@ -115,6 +115,10 @@ module "rds" {
 }
 */
 
+/*
+ * Commented out because DGU no longer belongs to us and we very rarely need
+ * to test DGU changes in ephemeral clusters
+ *
 module "datagovuk_infrastructure" {
   source = "./ws"
 
@@ -125,3 +129,4 @@ module "datagovuk_infrastructure" {
 
   depends_on = [module.cluster_services, tfe_project.project]
 }
+*/


### PR DESCRIPTION
Comment out DGU creation in ephemeral workspaces because DGU no longer belongs to us and we very rarely need to test DGU changes in ephemeral clusters, and it extends cluster startup and shutdown a fair bit