### PR TITLE
Import google s3 mirror role

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/google_s3_mirror.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/google_s3_mirror.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "google-s3-mirror" {
   count = var.create_google_s3_mirror_role ? 1 : 0
-  name  = "google-s3-mirror"
+  name  = "google-s3-mirror" # This is an historic role name and doesn't contain an environment name because it's in use elsewhere
 
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -51,4 +51,25 @@ data "aws_iam_policy_document" "google_s3_mirror" {
       "arn:aws:s3:::govuk-${var.govuk_environment}-database-backups/*",
     ]
   }
+}
+
+import {
+  for_each = var.create_google_s3_mirror_role ? [1] : []
+
+  to = aws_iam_role.google-s3-mirror[0]
+  id = "google-s3-mirror"
+}
+
+import {
+  for_each = var.create_google_s3_mirror_role ? [1] : []
+
+  to = aws_iam_policy.google-s3-mirror[0]
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/google-s3-mirror"
+}
+
+import {
+  for_each = var.create_google_s3_mirror_role ? [1] : []
+
+  to = aws_iam_role_policy_attachment.google-s3-mirror-access[0]
+  id = "google-s3-mirror/arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/google-s3-mirror"
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/google_s3_mirror.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/google_s3_mirror.tf
@@ -1,0 +1,54 @@
+resource "aws_iam_role" "google-s3-mirror" {
+  count = var.create_google_s3_mirror_role ? 1 : 0
+  name  = "google-s3-mirror"
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : "accounts.google.com"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "accounts.google.com:sub" : "107768730699967087212"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "google-s3-mirror" {
+  count       = var.create_google_s3_mirror_role ? 1 : 0
+  name        = "google-s3-mirror"
+  description = "Allows a Google Cloud Platform project to mirror S3 buckets."
+  policy      = data.aws_iam_policy_document.google_s3_mirror[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "google-s3-mirror-access" {
+  count      = var.create_google_s3_mirror_role ? 1 : 0
+  role       = aws_iam_role.google-s3-mirror[0].name
+  policy_arn = aws_iam_policy.google-s3-mirror[0].arn
+}
+
+data "aws_iam_policy_document" "google_s3_mirror" {
+  count = var.create_google_s3_mirror_role ? 1 : 0
+
+  statement {
+    sid = "GoogleReadBucket"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    # Need access to the top level of the tree.
+    resources = [
+      "arn:aws:s3:::govuk-${var.govuk_environment}-database-backups",
+      "arn:aws:s3:::govuk-${var.govuk_environment}-database-backups/*",
+    ]
+  }
+}

--- a/terraform/deployments/govuk-publishing-infrastructure/variables.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/variables.tf
@@ -254,3 +254,10 @@ variable "create_licensify_documentdb_clone" {
   default     = false
   description = "Whether to create a v5 clone of the Licensify DocumentDB cluster."
 }
+
+
+variable "create_google_s3_mirror_role" {
+  type        = bool
+  default     = false
+  description = "Whether to create an IAM role for GCP to mirror a number of S3 buckets to Google Cloud Storage"
+}

--- a/terraform/variables/integration/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/integration/govuk-publishing-infrastructure.tfvars
@@ -76,3 +76,5 @@ licensify_documentdb_clone_instance_types = {
   "1" = "db.r8g.large"
   "2" = "db.r8g.large"
 }
+
+create_google_s3_mirror_role = true

--- a/terraform/variables/production/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/production/govuk-publishing-infrastructure.tfvars
@@ -93,3 +93,5 @@ amazonmq_govuk_chat_retry_message_ttl = 300000
 frontend_memcached_node_type = "cache.r6g.large"
 
 shared_documentdb_identifier_suffix = "-1"
+
+create_google_s3_mirror_role = false

--- a/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/staging/govuk-publishing-infrastructure.tfvars
@@ -75,3 +75,5 @@ licensify_documentdb_clone_instance_types = {
   "1" = "db.r8g.large"
   "2" = "db.r8g.large"
 }
+
+create_google_s3_mirror_role = true


### PR DESCRIPTION
##  What

Defines and imports an IAM role called `google-s3-mirror` which already exists, but in a different, older Terraform state. We define it here to bring it under proper management 

## How to review

1. Check nothing happens in prod
2. Check the plan imports everything in staging and integration. 

> [!NOTE]
> In integration, the plan is showing an additional change where somebody has changed the policy by hand at some point, and because we weren't managing it in Terraform it has never been changed back.