### PR TITLE
add repo for I&A team docs-improver prototype

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -156,6 +156,22 @@ repos:
     need_production_access_to_merge: false
     push_allowances: []
 
+  docs-improver:
+    visibility: private
+    need_production_access_to_merge: false
+
+    topics:
+      - prototype
+
+    teams:
+      govuk: "maintain"
+      govuk-platform-engineering: "admin"
+      govuk-data-engineering: "admin"
+
+    required_status_checks:
+      standard_contexts: []
+      additional_contexts: []
+
   email-alert-api:
     can_be_deployed: true
     homepage_url: "https://docs.publishing.service.gov.uk/apps/email-alert-api.html"


### PR DESCRIPTION
This adds a repo for development of an internal prototype within I&A.