### PR TITLE
We should trust all the thumbprints of the github OIDC certs, not just the first

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/github_oidc_provider.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/github_oidc_provider.tf
@@ -5,6 +5,6 @@ data "tls_certificate" "github" {
 resource "aws_iam_openid_connect_provider" "github_provider" {
   url             = "https://token.actions.githubusercontent.com"
   client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
+  thumbprint_list = [for certificate in data.tls_certificate.github.certificates : certificate.sha1_fingerprint]
 }
 


### PR DESCRIPTION
We lookup the well known cert thumbprints for github to provide to the oidc connection, but we only trust the first, we should trust all of the thumbprints provided