### PR TITLE
Deploy logging workspace to test

### DIFF
--- a/terraform/deployments/logging/google_logging_bucket.tf
+++ b/terraform/deployments/logging/google_logging_bucket.tf
@@ -1,6 +1,10 @@
-data "google_project" "project" {}
+data "google_project" "project" {
+  count = var.create_google_logging ? 1 : 0
+}
 
 resource "google_storage_bucket" "google_logging" {
+  count = var.create_google_logging ? 1 : 0
+
   name          = "govuk-${var.govuk_environment}-gcp-logging"
   location      = "eu"
   storage_class = "MULTI_REGIONAL"
@@ -22,7 +26,7 @@ resource "google_storage_bucket" "google_logging" {
 }
 
 resource "google_storage_bucket_access_control" "google_logging" {
-  bucket = google_storage_bucket.google_logging.name
+  bucket = google_storage_bucket.google_logging[0].name
 
   role   = "WRITER"
   entity = "group-cloud-storage-analytics@google.com"

--- a/terraform/deployments/logging/google_logging_bucket.tf
+++ b/terraform/deployments/logging/google_logging_bucket.tf
@@ -26,6 +26,8 @@ resource "google_storage_bucket" "google_logging" {
 }
 
 resource "google_storage_bucket_access_control" "google_logging" {
+  count = var.create_google_logging ? 1 : 0
+
   bucket = google_storage_bucket.google_logging[0].name
 
   role   = "WRITER"

--- a/terraform/deployments/logging/variables.tf
+++ b/terraform/deployments/logging/variables.tf
@@ -27,3 +27,10 @@ variable "cyber_slunk_aws_account_id" {
   description = "Account ID which holds the Splunk log bucket"
   default     = "885513274347"
 }
+
+variable "create_google_logging" {
+  type        = bool
+  description = "Create GCP logging storage bucket."
+  default     = true
+  nullable    = false
+}

--- a/terraform/deployments/tfc-configuration/logging.tf
+++ b/terraform/deployments/tfc-configuration/logging.tf
@@ -134,6 +134,9 @@ module "logging-test" {
   working_directory = "/terraform/deployments/logging/"
   trigger_patterns = [
     "/terraform/deployments/logging/**/*",
+    "/terraform/variables/test/common.tfvars",
+    "/terraform/variables/variables-common.tf",
+    "/terraform/variables/test/logging.tfvars",
     "/terraform/shared-modules/s3/**/*",
   ]
   global_remote_state = true
@@ -151,13 +154,13 @@ module "logging-test" {
   }
 
   tfvars_files = [
-    "integration/logging.tfvars"
+    "test/common.tfvars",
+    "test/logging.tfvars",
   ]
 
   variable_set_ids = [
     local.aws_credentials["test"],
     local.gcp_credentials["test"],
-    module.variable-set-test.id,
   ]
 }
 

--- a/terraform/deployments/tfc-configuration/logging.tf
+++ b/terraform/deployments/tfc-configuration/logging.tf
@@ -122,3 +122,42 @@ module "logging-production" {
   ]
 }
 
+module "logging-test" {
+  source = "github.com/alphagov/terraform-govuk-tfe-workspacer"
+
+  organization      = var.organization
+  workspace_name    = "logging-test"
+  workspace_desc    = "This module manages the logging deploymentsthat are required by most other modules (VPC, DNS zones)"
+  workspace_tags    = ["test", "logging", "aws"]
+  terraform_version = var.terraform_version
+  execution_mode    = "remote"
+  working_directory = "/terraform/deployments/logging/"
+  trigger_patterns = [
+    "/terraform/deployments/logging/**/*",
+    "/terraform/shared-modules/s3/**/*",
+  ]
+  global_remote_state = true
+
+  project_name = "govuk-infrastructure"
+  vcs_repo = {
+    identifier     = "alphagov/govuk-infrastructure"
+    branch         = "main"
+    oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
+  }
+
+  team_access = {
+    "GOV.UK Non-Production (r/o)" = "write"
+    "GOV.UK Production"           = "write"
+  }
+
+  tfvars_files = [
+    "integration/logging.tfvars"
+  ]
+
+  variable_set_ids = [
+    local.aws_credentials["test"],
+    local.gcp_credentials["test"],
+    module.variable-set-test.id,
+  ]
+}
+

--- a/terraform/deployments/tfc-configuration/logging.tf
+++ b/terraform/deployments/tfc-configuration/logging.tf
@@ -127,7 +127,7 @@ module "logging-test" {
 
   organization      = var.organization
   workspace_name    = "logging-test"
-  workspace_desc    = "This module manages the logging deploymentsthat are required by most other modules (VPC, DNS zones)"
+  workspace_desc    = "This module manages the logging deployments that are required by most other modules (VPC, DNS zones)"
   workspace_tags    = ["test", "logging", "aws"]
   terraform_version = var.terraform_version
   execution_mode    = "remote"

--- a/terraform/deployments/tfc-configuration/variables-test.tf
+++ b/terraform/deployments/tfc-configuration/variables-test.tf
@@ -1,14 +1,3 @@
-module "variable-set-test" {
-  source = "./variable-set"
-
-  name     = "common-test"
-  priority = false
-  tfvars = {
-    cluster_log_retention_in_days = 7
-    create_google_logging         = false
-  }
-}
-
 module "variable-set-ephemeral" {
   source = "./variable-set"
 

--- a/terraform/deployments/tfc-configuration/variables-test.tf
+++ b/terraform/deployments/tfc-configuration/variables-test.tf
@@ -1,3 +1,14 @@
+module "variable-set-test" {
+  source = "./variable-set"
+
+  name     = "common-test"
+  priority = false
+  tfvars = {
+    cluster_log_retention_in_days = 7
+    create_google_logging         = false
+  }
+}
+
 module "variable-set-ephemeral" {
   source = "./variable-set"
 

--- a/terraform/variables/test/common.tfvars
+++ b/terraform/variables/test/common.tfvars
@@ -1,0 +1,52 @@
+# Common variables for the test environment.
+# Only add variables here if they are shared across multiple workspaces in the test environment.
+# Variables that are only used by a single workspace should be added to that workspace's specific tfvars file.
+
+cluster_log_retention_in_days = 7
+
+vpc_cidr = "10.2.0.0/16"
+
+eks_control_plane_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.2.19.0/28" }
+  b = { az = "eu-west-1b", cidr = "10.2.19.16/28" }
+  c = { az = "eu-west-1c", cidr = "10.2.19.32/28" }
+}
+
+eks_public_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.2.20.0/24" }
+  b = { az = "eu-west-1b", cidr = "10.2.21.0/24" }
+  c = { az = "eu-west-1c", cidr = "10.2.22.0/24" }
+}
+
+eks_private_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.2.24.0/22" }
+  b = { az = "eu-west-1b", cidr = "10.2.28.0/22" }
+  c = { az = "eu-west-1c", cidr = "10.2.32.0/22" }
+}
+
+legacy_private_subnets = {
+  a = { az = "eu-west-1a", cidr = "10.2.4.0/24", nat = true }
+  b = { az = "eu-west-1b", cidr = "10.2.5.0/24", nat = true }
+  c = { az = "eu-west-1c", cidr = "10.2.6.0/24", nat = true }
+
+  rds_a = { az = "eu-west-1a", cidr = "10.2.10.0/24", nat = false }
+  rds_b = { az = "eu-west-1b", cidr = "10.2.11.0/24", nat = false }
+  rds_c = { az = "eu-west-1c", cidr = "10.2.12.0/24", nat = false }
+
+  elasticache_a = { az = "eu-west-1a", cidr = "10.2.7.0/24", nat = false }
+  elasticache_b = { az = "eu-west-1b", cidr = "10.2.8.0/24", nat = false }
+  elasticache_c = { az = "eu-west-1c", cidr = "10.2.9.0/24", nat = false }
+
+  elasticsearch_a = { az = "eu-west-1a", cidr = "10.2.16.0/24", nat = false }
+  elasticsearch_b = { az = "eu-west-1b", cidr = "10.2.17.0/24", nat = false }
+  elasticsearch_c = { az = "eu-west-1c", cidr = "10.2.18.0/24", nat = false }
+
+  neptune_a = { az = "eu-west-1a", cidr = "10.2.36.0/24", nat = false }
+  neptune_b = { az = "eu-west-1b", cidr = "10.2.37.0/24", nat = false }
+  neptune_c = { az = "eu-west-1c", cidr = "10.2.38.0/24", nat = false }
+}
+
+govuk_environment = "test"
+force_destroy     = true
+
+publishing_service_domain = "test.publishing.service.gov.uk"

--- a/terraform/variables/test/logging.tfvars
+++ b/terraform/variables/test/logging.tfvars
@@ -1,0 +1,2 @@
+# Variables for the logging-test workspace
+create_google_logging = false


### PR DESCRIPTION
* Make it possible to deploy the logging bucket with gcp logging bucket creation disabled
* Make a logging deployment for the test account (I've done this with a variable-set, not variables files, because all of the stuff in test is still using this mechanism, so better not to diverge.