### PR TITLE
Import test logging bucket

### DIFF
--- a/terraform/deployments/logging/aws_logging.tf
+++ b/terraform/deployments/logging/aws_logging.tf
@@ -106,16 +106,6 @@ moved {
   to   = module.aws_logging_bucket.aws_s3_bucket_policy.bucket_policy
 }
 
-import {
-  to = module.aws_logging_bucket.aws_s3_bucket_server_side_encryption_configuration.this
-  id = local.log_bucket_name
-}
-
-import {
-  to = module.aws_logging_bucket.aws_s3_bucket_public_access_block.this[0]
-  id = local.log_bucket_name
-}
-
 # Create a bucket that allows AWS services to write to it
 module "aws_logging_bucket" {
   source = "../../shared-modules/s3"

--- a/terraform/deployments/logging/flow_log.tf
+++ b/terraform/deployments/logging/flow_log.tf
@@ -1,4 +1,6 @@
 data "aws_iam_policy_document" "vpc_flow_logs_policy" {
+  count = var.create_vpc_flow_logs ? 1 : 0
+
   statement {
     actions = [
       "logs:CreateLogGroup",
@@ -13,6 +15,8 @@ data "aws_iam_policy_document" "vpc_flow_logs_policy" {
 }
 
 data "aws_iam_policy_document" "vpc_flow_logs_assume_policy" {
+  count = var.create_vpc_flow_logs ? 1 : 0
+
   statement {
     actions = ["sts:AssumeRole"]
     principals {
@@ -24,29 +28,39 @@ data "aws_iam_policy_document" "vpc_flow_logs_assume_policy" {
 }
 
 resource "aws_cloudwatch_log_group" "log" {
+  count = var.create_vpc_flow_logs ? 1 : 0
+
   name              = "govuk-vpc-flow-log"
   retention_in_days = var.cluster_log_retention_in_days
 }
 
 resource "aws_flow_log" "vpc_flow_log" {
-  log_destination = aws_cloudwatch_log_group.log.arn
-  iam_role_arn    = aws_iam_role.vpc_flow_logs_role.arn
-  vpc_id          = data.tfe_outputs.vpc.nonsensitive_values.id
+  count = var.create_vpc_flow_logs ? 1 : 0
+
+  log_destination = aws_cloudwatch_log_group.log[0].arn
+  iam_role_arn    = aws_iam_role.vpc_flow_logs_role[0].arn
+  vpc_id          = data.tfe_outputs.vpc[0].nonsensitive_values.id
   traffic_type    = var.traffic_type
 }
 
 resource "aws_iam_role" "vpc_flow_logs_role" {
+  count = var.create_vpc_flow_logs ? 1 : 0
+
   name               = "govuk-vpc-flow-logs"
-  assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_assume_policy.json
+  assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_assume_policy[0].json
 }
 
 resource "aws_iam_policy" "vpc_flow_logs_policy" {
+  count = var.create_vpc_flow_logs ? 1 : 0
+
   name   = "govuk-vpc-flow-logs-policy"
   path   = "/"
-  policy = data.aws_iam_policy_document.vpc_flow_logs_policy.json
+  policy = data.aws_iam_policy_document.vpc_flow_logs_policy[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "vpc_flow_logs_policy_attachment" {
-  role       = aws_iam_role.vpc_flow_logs_role.name
-  policy_arn = aws_iam_policy.vpc_flow_logs_policy.arn
+  count = var.create_vpc_flow_logs ? 1 : 0
+
+  role       = aws_iam_role.vpc_flow_logs_role[0].name
+  policy_arn = aws_iam_policy.vpc_flow_logs_policy[0].arn
 }

--- a/terraform/deployments/logging/imports.tf
+++ b/terraform/deployments/logging/imports.tf
@@ -1,0 +1,44 @@
+import {
+  to = module.aws_logging_bucket.aws_s3_bucket.this
+  id = "govuk-test-aws-logging"
+}
+
+import {
+  to = module.aws_logging_bucket.aws_s3_bucket_versioning.this
+  id = "govuk-test-aws-logging"
+}
+
+import {
+  to = module.aws_logging_bucket.aws_s3_bucket_server_side_encryption_configuration.this
+  id = "govuk-test-aws-logging"
+}
+
+import {
+  to = module.aws_logging_bucket.aws_s3_bucket_replication_configuration.this[0]
+  id = "govuk-test-aws-logging"
+}
+
+import {
+  to = module.aws_logging_bucket.aws_s3_bucket_policy.bucket_policy
+  id = "govuk-test-aws-logging"
+}
+
+import {
+  to = module.aws_logging_bucket.aws_s3_bucket_lifecycle_configuration.this[0]
+  id = "govuk-test-aws-logging"
+}
+
+import {
+  to = aws_iam_policy.govuk_aws_logging_replication_policy
+  id = "arn:aws:iam::430354129336:policy/govuk-test-aws-logging-bucket-replication-policy"
+}
+
+import {
+  to = aws_iam_role.rds_enhanced_monitoring
+  id = "rds-monitoring-role"
+}
+
+import {
+  to = aws_iam_role.govuk_aws_logging_replication_role
+  id = "govuk-aws-logging-replication-role"
+}

--- a/terraform/deployments/logging/remote.tf
+++ b/terraform/deployments/logging/remote.tf
@@ -1,4 +1,6 @@
 data "tfe_outputs" "vpc" {
+  count = var.create_vpc_flow_logs ? 1 : 0
+
   organization = "govuk"
   workspace    = "vpc-${var.govuk_environment}"
 }

--- a/terraform/deployments/logging/variables.tf
+++ b/terraform/deployments/logging/variables.tf
@@ -34,3 +34,10 @@ variable "create_google_logging" {
   default     = true
   nullable    = false
 }
+
+variable "create_vpc_flow_logs" {
+  type        = bool
+  description = "Create VPC flowlog logging"
+  default     = true
+  nullable    = false
+}

--- a/terraform/variables/test/logging.tfvars
+++ b/terraform/variables/test/logging.tfvars
@@ -1,2 +1,3 @@
 # Variables for the logging-test workspace
 create_google_logging = false
+create_vpc_flow_logs  = false


### PR DESCRIPTION
Turns out a bunch of the stuff for the logging deployment already exists in test, and some cannot be created. So:

* Make it possible to disable vpc flow logs log creation, and disable for test logging deployment
* Import the exist s3 buckets, some roles and policies

After apply in logging-test I'll need to do a follow on PR to remove the imports which will be unapplyable and unplanable in the non-test workspaces

It's making a few changes to the logging bucket, but they bring it inline with our current standards and setup