### PR TITLE
Update cluster-infra aws provider constraint to >= 6.54.0

### DIFF
--- a/terraform/deployments/cluster-infrastructure/main.tf
+++ b/terraform/deployments/cluster-infrastructure/main.tf
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 6.54.0"
+      version = ">= 6.54.0"
     }
   }
 }


### PR DESCRIPTION
A module used in this workspace now has a >= 6.54.0 requirement and the workspace is currently broken because of it, so update the provider requirement