### PR TITLE
IA-2972: add trigger_patterns for workspaces using scheduled-query-monitoring module

### DIFF
--- a/terraform/deployments/tfc-configuration/gcp-projects.tf
+++ b/terraform/deployments/tfc-configuration/gcp-projects.tf
@@ -105,6 +105,7 @@ module "gcp-gds-bq-processing-dev" {
   trigger_patterns = [
     "/gcp-gds-bq-processing-dev/**/*",
     "/modules/gcp-project-init/**/*",
+    "/modules/scheduled-query-monitoring/**/*",
   ]
   global_remote_state = true
   assessments_enabled = true
@@ -547,6 +548,7 @@ module "gcp-gds-bq-reporting" {
   trigger_patterns = [
     "/gcp-gds-bq-reporting/**/*",
     "/modules/gcp-project-init/**/*",
+    "/modules/scheduled-query-monitoring/**/*",
   ]
   global_remote_state = true
   assessments_enabled = true
@@ -683,6 +685,7 @@ module "gcp-govuk-content-data" {
   trigger_patterns = [
     "/gcp-govuk-content-data/**/*",
     "/modules/gcp-project-init/**/*",
+    "/modules/scheduled-query-monitoring/**/*",
   ]
   global_remote_state = true
   assessments_enabled = true


### PR DESCRIPTION
Missed this and have [updated README ](https://github.com/alphagov/govuk-data-infrastructure/pull/18/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23)to hopefully remind people (including myself) to update the `trigger_patterns` when using a module.