### PR TITLE
Migrate content_data_csvs s3 bucket to use the s3 module

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/content_data_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/content_data_s3.tf
@@ -35,11 +35,24 @@ module "content_data_csvs_s3_bucket" {
 
 data "aws_iam_policy_document" "content_data_csvs_s3_bucket_public_read" {
   statement {
-    sid = "AllowPublicRead"
+    sid = "AllowPublicObjectRead"
 
     actions = ["s3:GetObject"]
 
     resources = ["${local.content_data_csvs_s3_bucket_arn}/*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
+    sid = "AllowPublicListBucket"
+
+    actions = ["s3:ListBucket"]
+
+    resources = [local.content_data_csvs_s3_bucket_arn]
 
     principals {
       type        = "*"

--- a/terraform/deployments/govuk-publishing-infrastructure/content_data_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/content_data_s3.tf
@@ -1,29 +1,56 @@
-resource "aws_s3_bucket" "content_data_csvs" {
-  bucket = "govuk-${var.govuk_environment}-content-data-csvs"
+locals {
+  content_data_csvs_s3_bucket_name = "govuk-${var.govuk_environment}-content-data-csvs"
+  content_data_csvs_s3_bucket_arn  = "arn:aws:s3:::${local.content_data_csvs_s3_bucket_name}"
 }
 
-resource "aws_s3_bucket_acl" "content_data_csvs" {
-  bucket = aws_s3_bucket.content_data_csvs.id
-  acl    = "public-read"
-}
+module "content_data_csvs_s3_bucket" {
+  source = "../../shared-modules/s3"
 
-resource "aws_s3_bucket_logging" "content_data_csvs" {
-  bucket        = aws_s3_bucket.content_data_csvs.id
-  target_bucket = "govuk-${var.govuk_environment}-aws-logging"
-  target_prefix = "s3/govuk-${var.govuk_environment}-content-data-csvs/"
-}
+  name              = local.content_data_csvs_s3_bucket_name
+  govuk_environment = var.govuk_environment
 
-resource "aws_s3_bucket_lifecycle_configuration" "content_data_csvs" {
-  bucket = aws_s3_bucket.content_data_csvs.id
+  enable_public_access_block = false
 
-  rule {
+  extra_bucket_policies = [data.aws_iam_policy_document.content_data_csvs_s3_bucket_public_read.json]
+
+  lifecycle_rules = [{
     id     = "all"
     status = "Enabled"
 
-    expiration {
+    expiration = {
       days = 7
     }
+  }]
+}
+
+data "aws_iam_policy_document" "content_data_csvs_s3_bucket_public_read" {
+  statement {
+    sid = "AllowPublicRead"
+
+    actions = ["s3:GetObject"]
+
+    resources = ["${local.content_data_csvs_s3_bucket_arn}/*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
   }
+}
+
+moved {
+  from = aws_s3_bucket.content_data_csvs
+  to   = module.content_data_csvs_s3_bucket.aws_s3_bucket.this
+}
+
+moved {
+  from = aws_s3_bucket_logging.content_data_csvs
+  to   = module.content_data_csvs_s3_bucket.aws_s3_bucket_logging.this[0]
+}
+
+moved {
+  from = aws_s3_bucket_lifecycle_configuration.content_data_csvs
+  to   = module.content_data_csvs_s3_bucket.aws_s3_bucket_lifecycle_configuration.this[0]
 }
 
 # IAM role for content-data-admin
@@ -59,7 +86,7 @@ data "aws_iam_policy_document" "content_data_admin" {
       "s3:ListBucket",
       "s3:GetBucketLocation"
     ]
-    resources = [aws_s3_bucket.content_data_csvs.arn]
+    resources = [local.content_data_csvs_s3_bucket_arn]
   }
   statement {
     effect = "Allow"
@@ -69,7 +96,7 @@ data "aws_iam_policy_document" "content_data_admin" {
       "s3:PutObject",
       "s3:PutObjectAcl"
     ]
-    resources = ["${aws_s3_bucket.content_data_csvs.arn}/*"]
+    resources = ["${local.content_data_csvs_s3_bucket_arn}/*"]
   }
 }
 

--- a/terraform/deployments/govuk-publishing-infrastructure/content_data_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/content_data_s3.tf
@@ -13,14 +13,24 @@ module "content_data_csvs_s3_bucket" {
 
   extra_bucket_policies = [data.aws_iam_policy_document.content_data_csvs_s3_bucket_public_read.json]
 
-  lifecycle_rules = [{
-    id     = "all"
-    status = "Enabled"
+  lifecycle_rules = [
+    {
+      id     = "all"
+      status = "Enabled"
 
-    expiration = {
-      days = 7
-    }
-  }]
+      expiration = {
+        days = 7
+      }
+    },
+    {
+      id     = "all-expired"
+      status = "Enabled"
+
+      noncurrent_version_expiration = {
+        noncurrent_days = 7
+      }
+    },
+  ]
 }
 
 data "aws_iam_policy_document" "content_data_csvs_s3_bucket_public_read" {


### PR DESCRIPTION
This bucket is purposefully public, so I've included a public-read equivalent bucket policy, and set to disable the public access block.

Given we decided to enforce versioning, I've added an additional lifecycle rule to delete the non-current versions 7 days after they become non-current. This means if a second overwrites a first version the non-current will definitely live for the whole time of the lifecycle of the original current version

Deleting the ACL will not actually change the ACL as we uncovered previously, and it will fail to set bucket owner enforcement since the acl is still set. This is good because it means on first apply it will add the bucket policy which also grants get object and list bucket to the world, and then at the cli I can change the canned acl to private before applying the change to bucket owner enforcement.

Note in integration there are other changes happening which are coming from outside this PR, I think perhaps that stuff has been clickopsed for testing, but we have to apply so it will get wiped out, but it should be set via terraform anyway.