### PR TITLE
Block aggressive bot crawlers in CKAN WAF

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/wafs.tf
+++ b/terraform/deployments/datagovuk-infrastructure/wafs.tf
@@ -372,7 +372,7 @@ resource "aws_wafv2_web_acl" "ckan" {
     }
     statement {
       rate_based_statement {
-        limit              = 100
+        limit              = 100 # AWS WAF rate windows are always 5 minutes, so this is 100 requests per 5-minute window per User-Agent string
         aggregate_key_type = "CUSTOM_KEYS"
         custom_key {
           header {

--- a/terraform/deployments/datagovuk-infrastructure/wafs.tf
+++ b/terraform/deployments/datagovuk-infrastructure/wafs.tf
@@ -377,7 +377,7 @@ resource "aws_wafv2_web_acl" "ckan" {
         custom_keys {
           header {
             name = "user-agent"
-            text_transformations {
+            text_transformation {
               priority = 0
               type     = "LOWERCASE"
             }

--- a/terraform/deployments/datagovuk-infrastructure/wafs.tf
+++ b/terraform/deployments/datagovuk-infrastructure/wafs.tf
@@ -269,11 +269,11 @@ resource "aws_wafv2_web_acl_logging_configuration" "find_waf" {
 }
 
 # ===========================================================
-# Bad bot User-Agent patterns for CKAN
+# Bot User-Agent patterns for CKAN
 # ===========================================================
 
-resource "aws_wafv2_regex_pattern_set" "ckan_bad_bots" {
-  name  = "ckan-bad-bots-${var.govuk_environment}"
+resource "aws_wafv2_regex_pattern_set" "ckan_hard_block_bots" {
+  name  = "ckan-hard-block-bots-${var.govuk_environment}"
   scope = "REGIONAL"
 
   regular_expression { regex_string = "(?i)Bytespider" }
@@ -288,18 +288,30 @@ resource "aws_wafv2_regex_pattern_set" "ckan_bad_bots" {
   regular_expression { regex_string = "(?i)Clickagy" }
   regular_expression { regex_string = "(?i)serpstatbot" }
   regular_expression { regex_string = "(?i)DataForSeoBot" }
-  regular_expression { regex_string = "(?i)meta-externalagent" }
+
+  tags = {
+    Name        = "ckan-hard-block-bots-${var.govuk_environment}"
+    Application = "CKAN"
+    Purpose     = "BotBlocking"
+  }
+}
+
+resource "aws_wafv2_regex_pattern_set" "ckan_ai_bots" {
+  name  = "ckan-ai-bots-${var.govuk_environment}"
+  scope = "REGIONAL"
+
   regular_expression { regex_string = "(?i)GPTBot" }
   regular_expression { regex_string = "(?i)ClaudeBot" }
   regular_expression { regex_string = "(?i)Claude-Web" }
   regular_expression { regex_string = "(?i)anthropic-ai" }
   regular_expression { regex_string = "(?i)CCBot" }
   regular_expression { regex_string = "(?i)ChatGPT-User" }
+  regular_expression { regex_string = "(?i)meta-externalagent" }
 
   tags = {
-    Name        = "ckan-bad-bots-${var.govuk_environment}"
+    Name        = "ckan-ai-bots-${var.govuk_environment}"
     Application = "CKAN"
-    Purpose     = "BotBlocking"
+    Purpose     = "BotRateLimiting"
   }
 }
 
@@ -315,7 +327,7 @@ resource "aws_wafv2_web_acl" "ckan" {
     allow {}
   }
   rule {
-    name     = "ckan-bad-bot-block"
+    name     = "ckan-hard-bot-block"
     priority = 0
     action {
       block {
@@ -326,7 +338,7 @@ resource "aws_wafv2_web_acl" "ckan" {
     }
     statement {
       regex_pattern_set_reference_statement {
-        arn = aws_wafv2_regex_pattern_set.ckan_bad_bots.arn
+        arn = aws_wafv2_regex_pattern_set.ckan_hard_block_bots.arn
         field_to_match {
           single_header {
             name = "user-agent"
@@ -340,16 +352,62 @@ resource "aws_wafv2_web_acl" "ckan" {
     }
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "ckan-bad-bot-block"
+      metric_name                = "ckan-hard-bot-block"
       sampled_requests_enabled   = true
     }
   }
-  # Rule 1: Rate limit warning (monitoring only)
-  # This rule counts requests approaching the limit but doesn't block
-  # Useful for monitoring and adjusting limits before blocking occurs
+  rule {
+    name     = "ckan-ai-bot-rate-limit"
+    priority = 1
+    action {
+      block {
+        custom_response {
+          response_code = 429
+          response_header {
+            name  = "Retry-After"
+            value = "300"
+          }
+        }
+      }
+    }
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "CUSTOM_KEYS"
+        custom_keys {
+          header {
+            name = "user-agent"
+            text_transformations {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+        scope_down_statement {
+          regex_pattern_set_reference_statement {
+            arn = aws_wafv2_regex_pattern_set.ckan_ai_bots.arn
+            field_to_match {
+              single_header {
+                name = "user-agent"
+              }
+            }
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "ckan-ai-bot-rate-limit"
+      sampled_requests_enabled   = true
+    }
+  }
   rule {
     name     = "ckan-rate-limit-warning"
-    priority = 1
+    priority = 2
     action {
       count {}
     }
@@ -385,11 +443,9 @@ resource "aws_wafv2_web_acl" "ckan" {
       sampled_requests_enabled   = true
     }
   }
-  # Rule 2: Rate limit blocking
-  # This rule actually blocks requests that exceed the limit
   rule {
     name     = "ckan-rate-limit-block"
-    priority = 2
+    priority = 3
     action {
       block {
         custom_response {

--- a/terraform/deployments/datagovuk-infrastructure/wafs.tf
+++ b/terraform/deployments/datagovuk-infrastructure/wafs.tf
@@ -269,6 +269,41 @@ resource "aws_wafv2_web_acl_logging_configuration" "find_waf" {
 }
 
 # ===========================================================
+# Bad bot User-Agent patterns for CKAN
+# ===========================================================
+
+resource "aws_wafv2_regex_pattern_set" "ckan_bad_bots" {
+  name  = "ckan-bad-bots-${var.govuk_environment}"
+  scope = "REGIONAL"
+
+  regular_expression { regex_string = "(?i)Bytespider" }
+  regular_expression { regex_string = "(?i)Sogou" }
+  regular_expression { regex_string = "(?i)Amazonbot" }
+  regular_expression { regex_string = "(?i)PetalBot" }
+  regular_expression { regex_string = "(?i)SemrushBot" }
+  regular_expression { regex_string = "(?i)AhrefsBot" }
+  regular_expression { regex_string = "(?i)MJ12bot" }
+  regular_expression { regex_string = "(?i)DotBot" }
+  regular_expression { regex_string = "(?i)BLEXBot" }
+  regular_expression { regex_string = "(?i)Clickagy" }
+  regular_expression { regex_string = "(?i)serpstatbot" }
+  regular_expression { regex_string = "(?i)DataForSeoBot" }
+  regular_expression { regex_string = "(?i)meta-externalagent" }
+  regular_expression { regex_string = "(?i)GPTBot" }
+  regular_expression { regex_string = "(?i)ClaudeBot" }
+  regular_expression { regex_string = "(?i)Claude-Web" }
+  regular_expression { regex_string = "(?i)anthropic-ai" }
+  regular_expression { regex_string = "(?i)CCBot" }
+  regular_expression { regex_string = "(?i)ChatGPT-User" }
+
+  tags = {
+    Name        = "ckan-bad-bots-${var.govuk_environment}"
+    Application = "CKAN"
+    Purpose     = "BotBlocking"
+  }
+}
+
+# ===========================================================
 # WAF Web ACL and Rules for CKAN application
 # ===========================================================
 
@@ -278,6 +313,36 @@ resource "aws_wafv2_web_acl" "ckan" {
   scope = "REGIONAL"
   default_action {
     allow {}
+  }
+  rule {
+    name     = "ckan-bad-bot-block"
+    priority = 0
+    action {
+      block {
+        custom_response {
+          response_code = 403
+        }
+      }
+    }
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = aws_wafv2_regex_pattern_set.ckan_bad_bots.arn
+        field_to_match {
+          single_header {
+            name = "user-agent"
+          }
+        }
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "ckan-bad-bot-block"
+      sampled_requests_enabled   = true
+    }
   }
   # Rule 1: Rate limit warning (monitoring only)
   # This rule counts requests approaching the limit but doesn't block

--- a/terraform/deployments/datagovuk-infrastructure/wafs.tf
+++ b/terraform/deployments/datagovuk-infrastructure/wafs.tf
@@ -374,7 +374,7 @@ resource "aws_wafv2_web_acl" "ckan" {
       rate_based_statement {
         limit              = 100
         aggregate_key_type = "CUSTOM_KEYS"
-        custom_keys {
+        custom_key {
           header {
             name = "user-agent"
             text_transformation {


### PR DESCRIPTION
GPTBot and ClaudeBot were not blocked at any level in production and were hitting CKAN at over 100 rps combined. This was exhausting all gunicorn workers and causing liveness probe failures and production outages.

This change blocks bots at the WAF before requests reach the ALB, which removes the load entirely from the cluster. The nginx-level blocking in govuk-dgu-charts remains as a second line of defence but the WAF is the right place to handle this.

I have split the bots into two groups and added two new rules to the existing CKAN WAF Web ACL.
