### PR TITLE
search-api-v2 :restore ÅWS creds

### DIFF
--- a/terraform/deployments/tfc-configuration/search-api-v2.tf
+++ b/terraform/deployments/tfc-configuration/search-api-v2.tf
@@ -48,7 +48,8 @@ module "search-api-v2-integration" {
   ]
 
   variable_set_ids = [
-    local.gcp_credentials["integration"]
+    local.gcp_credentials["integration"],
+    local.aws_credentials["integration"]
   ]
 }
 
@@ -102,7 +103,8 @@ module "search-api-v2-staging" {
   ]
 
   variable_set_ids = [
-    local.gcp_credentials["staging"]
+    local.gcp_credentials["staging"],
+    local.aws_credentials["staging"]
   ]
 }
 
@@ -156,7 +158,8 @@ module "search-api-v2-production" {
   ]
 
   variable_set_ids = [
-    local.gcp_credentials["production"]
+    local.gcp_credentials["production"],
+    local.aws_credentials["production"],
   ]
 }
 

--- a/terraform/deployments/tfc-configuration/search-api-v2.tf
+++ b/terraform/deployments/tfc-configuration/search-api-v2.tf
@@ -22,6 +22,7 @@ module "search-api-v2-integration" {
   working_directory = "/terraform/deployments/search-api-v2/"
   trigger_patterns = [
     "/terraform/deployments/search-api-v2/**/*",
+    "/terraform/deployments/search-api-v2/**/files/**/*",
     "/terraform/variables/integration/search-api-v2.tfvars"
   ]
 
@@ -77,6 +78,7 @@ module "search-api-v2-staging" {
   working_directory = "/terraform/deployments/search-api-v2/"
   trigger_patterns = [
     "/terraform/deployments/search-api-v2/**/*",
+    "/terraform/deployments/search-api-v2/**/files/**/*",
     "/terraform/variables/staging/search-api-v2.tfvars"
   ]
 
@@ -132,6 +134,7 @@ module "search-api-v2-production" {
   working_directory = "/terraform/deployments/search-api-v2/"
   trigger_patterns = [
     "/terraform/deployments/search-api-v2/**/*",
+    "/terraform/deployments/search-api-v2/**/files/**/*",
     "/terraform/variables/production/search-api-v2.tfvars"
   ]
 


### PR DESCRIPTION
## What

In #4505 we refactored the workspaces to use `.tfvars` files, and in doing so we accidentally removed access to AWS credentials, and removed a trigger expression. This PR corrects those things.

## How to review

1. Have another look the code removed in #4505 and see if I've missed anything else