### PR TITLE
Set `Tests Go` as a required status check for `govuk-job-request-operator`

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -457,6 +457,8 @@ repos:
       - "alphagov/gov-uk-platform-engineering"
     required_status_checks:
       standard_contexts: *standard_security_checks
+      additional_contexts:
+        - Test Go / Test Go
     required_pull_request_reviews:
       require_code_owner_reviews: true
 


### PR DESCRIPTION
Description:
- Ensures PRs can be merged in only if tests pass