### PR TITLE
BAU: Enable Bedrock Endpoints in Integration/Staging

### DIFF
--- a/terraform/deployments/cluster-infrastructure/variables.tf
+++ b/terraform/deployments/cluster-infrastructure/variables.tf
@@ -200,6 +200,13 @@ variable "authentication_mode" {
   description = "Authentication mode to use for the cluster"
 }
 
+variable "use_bedrock_endpoints" {
+  type        = bool
+  description = "If true, create VPC endpoints for Bedrock Runtime, to avoid using the NAT gateway for this traffic."
+  default     = false
+}
+
+
 variable "use_ecr_vpc_endpoints" {
   type        = bool
   description = "If true, create VPC endpoints for ECR and ECR Docker, to avoid using the NAT gateway for this traffic."

--- a/terraform/deployments/cluster-infrastructure/vpc_endpoints.tf
+++ b/terraform/deployments/cluster-infrastructure/vpc_endpoints.tf
@@ -20,6 +20,20 @@ resource "aws_security_group" "vpc_endpoints" {
   }
 }
 
+resource "aws_vpc_endpoint" "bedrock_runtime" {
+  count               = var.use_bedrock_endpoints ? 1 : 0
+  vpc_id              = data.tfe_outputs.vpc.nonsensitive_values.id
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.bedrock-runtime"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  subnet_ids          = [for subnet in aws_subnet.eks_private : subnet.id]
+
+  tags = {
+    Name = "bedrock-runtime-endpoint-${var.govuk_environment}"
+  }
+}
+
 resource "aws_vpc_endpoint" "ecr_api" {
   count               = var.use_ecr_vpc_endpoints ? 1 : 0
   vpc_id              = data.tfe_outputs.vpc.nonsensitive_values.id

--- a/terraform/variables/integration/cluster-infrastructure.tfvars
+++ b/terraform/variables/integration/cluster-infrastructure.tfvars
@@ -15,4 +15,6 @@ rds_apply_immediately       = true
 rds_backup_retention_period = 1
 rds_skip_final_snapshot     = true
 
+use_bedrock_endpoints = true
+
 secrets_recovery_window_in_days = 0

--- a/terraform/variables/staging/cluster-infrastructure.tfvars
+++ b/terraform/variables/staging/cluster-infrastructure.tfvars
@@ -6,4 +6,6 @@ enable_arm_workers_blue  = false
 enable_arm_workers_green = true
 enable_x86_workers       = false
 
+use_bedrock_endpoints = true
+
 rds_backup_retention_period = 1


### PR DESCRIPTION
## What?
This creates a VPC Endpoint in Integration and Staging for the `bedrock-runtime` endpoint that is used by GOV.UK Chat. This aims to:

* Reduce latency
* Improve security
* Reduce NAT Gateway costs