### PR TITLE
Add explicit depends on for remote connections

### DIFF
--- a/terraform/deployments/search-opensearch/elasticsearch.tf
+++ b/terraform/deployments/search-opensearch/elasticsearch.tf
@@ -3,6 +3,21 @@ data "tfe_outputs" "security" {
   workspace    = "security-${var.govuk_environment}"
 }
 
+import {
+  to = module.opensearch.terraform_data.blue_domain_replacement
+  id = "vpc-search-domain-blue-7ejykdejkxvqpyoer2gii7gryi.eu-west-1.es.amazonaws.com"
+}
+
+import {
+  to = module.opensearch.terraform_data.green_domain_replacement
+  id = "vpc-green-elasticsearch6-domain-gqsdw3llwygomagfcrzwtjrawy.eu-west-1.es.amazonaws.com"
+}
+
+import {
+  to = module.opensearch.terraform_data.opensearch_domain_replacement
+  id = "vpc-green-elasticsearch6-domain-gqsdw3llwygomagfcrzwtjrawy.eu-west-1.es.amazonaws.com"
+}
+
 module "opensearch" {
   source = "../../shared-modules/opensearch-blue-green-deployment"
 

--- a/terraform/shared-modules/opensearch-blue-green-deployment/USAGE.md
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/USAGE.md
@@ -5,6 +5,7 @@
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 | <a name="provider_tfe"></a> [tfe](#provider\_tfe) | n/a |
 
 ## Inputs

--- a/terraform/shared-modules/opensearch-blue-green-deployment/opensearch-domain/USAGE.md
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/opensearch-domain/USAGE.md
@@ -42,5 +42,6 @@
 | <a name="output_opensearch_domain_arn"></a> [opensearch\_domain\_arn](#output\_opensearch\_domain\_arn) | n/a |
 | <a name="output_opensearch_domain_name"></a> [opensearch\_domain\_name](#output\_opensearch\_domain\_name) | n/a |
 | <a name="output_opensearch_endpoint"></a> [opensearch\_endpoint](#output\_opensearch\_endpoint) | n/a |
+| <a name="output_opensearch_engine_version"></a> [opensearch\_engine\_version](#output\_opensearch\_engine\_version) | n/a |
 | <a name="output_vpc_endpoint"></a> [vpc\_endpoint](#output\_vpc\_endpoint) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform/shared-modules/opensearch-blue-green-deployment/opensearch-domain/elasticsearch.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/opensearch-domain/elasticsearch.tf
@@ -98,6 +98,12 @@ resource "aws_elasticsearch_domain_policy" "main" {
 
   domain_name     = aws_elasticsearch_domain.elasticsearch[0].domain_name
   access_policies = data.aws_iam_policy_document.elasticsearch_domain.json
+
+  lifecycle {
+    replace_triggered_by = [
+      aws_elasticsearch_domain.elasticsearch[0]
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "elasticsearch_domain" {
@@ -118,5 +124,11 @@ resource "aws_elasticsearch_vpc_endpoint" "elasticsearch" {
   vpc_options {
     subnet_ids         = var.subnet_ids
     security_group_ids = var.security_group_ids
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      aws_elasticsearch_domain.elasticsearch[0]
+    ]
   }
 }

--- a/terraform/shared-modules/opensearch-blue-green-deployment/opensearch-domain/main.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/opensearch-domain/main.tf
@@ -96,6 +96,12 @@ resource "aws_opensearch_domain_policy" "main" {
 
   domain_name     = aws_opensearch_domain.opensearch[0].domain_name
   access_policies = data.aws_iam_policy_document.opensearch_domain.json
+
+  lifecycle {
+    replace_triggered_by = [
+      aws_opensearch_domain.opensearch[0]
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "opensearch_domain" {
@@ -121,5 +127,11 @@ resource "aws_opensearch_vpc_endpoint" "opensearch" {
   vpc_options {
     subnet_ids         = var.subnet_ids
     security_group_ids = var.security_group_ids
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      aws_opensearch_domain.opensearch[0]
+    ]
   }
 }

--- a/terraform/shared-modules/opensearch-blue-green-deployment/opensearch-domain/outputs.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/opensearch-domain/outputs.tf
@@ -10,6 +10,10 @@ output "opensearch_domain_name" {
   value = var.use_aws_elasticsearch_domain_resource ? aws_elasticsearch_domain.elasticsearch[0].domain_name : aws_opensearch_domain.opensearch[0].domain_name
 }
 
+output "opensearch_engine_version" {
+  value = var.use_aws_elasticsearch_domain_resource ? aws_elasticsearch_domain.elasticsearch[0].elasticsearch_version : aws_opensearch_domain.opensearch[0].engine_version
+}
+
 output "vpc_endpoint" {
   value = var.create_vpc_endpoint ? (
     var.use_aws_elasticsearch_domain_resource

--- a/terraform/shared-modules/opensearch-blue-green-deployment/remote_connections.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/remote_connections.tf
@@ -1,4 +1,14 @@
+resource "terraform_data" "blue_domain_replacement" {
+  triggers_replace = var.launch_blue_domain ? module.blue_domain[0].opensearch_endpoint : null
+}
+
+resource "terraform_data" "green_domain_replacement" {
+  triggers_replace = var.launch_green_domain ? module.green_domain[0].opensearch_endpoint : null
+}
+
 resource "aws_opensearch_outbound_connection" "to_green_from_blue" {
+  // The connection for import is done the opposite direction to the direction of the data flow.
+  // So if you are copying to green from blue, the remote connection has to go to blue from green
   count = var.create_remote_connection_to_import_to_blue_from_green ? 1 : 0
 
   connection_alias = "${var.opensearch_domain_name}-connection-to-green-from-blue"
@@ -17,6 +27,13 @@ resource "aws_opensearch_outbound_connection" "to_green_from_blue" {
   }
 
   accept_connection = true
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.blue_domain_replacement,
+      terraform_data.green_domain_replacement,
+    ]
+  }
 }
 
 resource "aws_opensearch_authorize_vpc_endpoint_access" "blue" {
@@ -27,9 +44,17 @@ resource "aws_opensearch_authorize_vpc_endpoint_access" "blue" {
   domain_name = module.blue_domain[0].opensearch_domain_name
   account     = data.aws_caller_identity.current.account_id
   region      = data.aws_region.current.name
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.blue_domain_replacement,
+    ]
+  }
 }
 
 resource "aws_opensearch_outbound_connection" "to_blue_from_green" {
+  // The connection for import is done the opposite direction to the direction of the data flow.
+  // So if you are copying to blue from green, the remote connection has to go to green from blue
   count = var.create_remote_connection_to_import_to_green_from_blue ? 1 : 0
 
   connection_alias = "${var.opensearch_domain_name}-connection-to-blue-from-green"
@@ -48,6 +73,13 @@ resource "aws_opensearch_outbound_connection" "to_blue_from_green" {
   }
 
   accept_connection = true
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.blue_domain_replacement,
+      terraform_data.green_domain_replacement,
+    ]
+  }
 }
 
 resource "aws_opensearch_authorize_vpc_endpoint_access" "green" {
@@ -58,5 +90,11 @@ resource "aws_opensearch_authorize_vpc_endpoint_access" "green" {
   domain_name = module.green_domain[0].opensearch_domain_name
   account     = data.aws_caller_identity.current.account_id
   region      = data.aws_region.current.name
-}
 
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.blue_domain_replacement,
+      terraform_data.green_domain_replacement,
+    ]
+  }
+}

--- a/terraform/shared-modules/opensearch-blue-green-deployment/route53.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/route53.tf
@@ -2,6 +2,10 @@ locals {
   service_record_name = "${var.opensearch_domain_name}-opensearch.${var.govuk_environment}.govuk-internal.digital"
 }
 
+resource "terraform_data" "opensearch_domain_replacement" {
+  triggers_replace = var.current_live_domain == "blue" ? module.blue_domain[0].opensearch_endpoint : module.green_domain[0].opensearch_endpoint
+}
+
 resource "aws_route53_record" "service_record" {
   zone_id = data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_id
   name    = local.service_record_name
@@ -12,4 +16,10 @@ resource "aws_route53_record" "service_record" {
     : var.current_live_domain == "green" ? module.green_domain[0].opensearch_endpoint
     : "IMPOSSIBLE_CONDITION"
   ]
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.opensearch_domain_replacement
+    ]
+  }
 }


### PR DESCRIPTION
NOTE This will need to be applied in search-opensearch-integration ONLY and then the imports removed. https://github.com/alphagov/govuk-infrastructure/pull/4528 is a follow on PR which will remove the imports

For reasons unknown (if I can recreate in a simple example I will open a bug wth the provider) the resources that are dependent on the aws_opensearch_domain are not getting recreated when the opensearch domain is recreated.

This PR adds explicit dependency tree management using the endpoint (which has a random ID in, and so will change on recreation, and not be known until after apply) in a terraform_data and forces other resources to be recreated if it changes.

Within the sub module it can more directly reference the opensearch domain object.

