### PR TITLE
Remove the terraform_data imports for search-opensearch

### DIFF
--- a/terraform/deployments/search-opensearch/elasticsearch.tf
+++ b/terraform/deployments/search-opensearch/elasticsearch.tf
@@ -3,21 +3,6 @@ data "tfe_outputs" "security" {
   workspace    = "security-${var.govuk_environment}"
 }
 
-import {
-  to = module.opensearch.terraform_data.blue_domain_replacement
-  id = "vpc-search-domain-blue-7ejykdejkxvqpyoer2gii7gryi.eu-west-1.es.amazonaws.com"
-}
-
-import {
-  to = module.opensearch.terraform_data.green_domain_replacement
-  id = "vpc-green-elasticsearch6-domain-gqsdw3llwygomagfcrzwtjrawy.eu-west-1.es.amazonaws.com"
-}
-
-import {
-  to = module.opensearch.terraform_data.opensearch_domain_replacement
-  id = "vpc-green-elasticsearch6-domain-gqsdw3llwygomagfcrzwtjrawy.eu-west-1.es.amazonaws.com"
-}
-
 module "opensearch" {
   source = "../../shared-modules/opensearch-blue-green-deployment"
 


### PR DESCRIPTION
This PR removes the imports added in https://github.com/alphagov/govuk-infrastructure/pull/4525

This must be merged prior to search-opensearch-staging or search-opensearch-production being applied