### PR TITLE
Use opensearch version 2.19 for the blue cluster

### DIFF
--- a/terraform/variables/integration/search-opensearch.tfvars
+++ b/terraform/variables/integration/search-opensearch.tfvars
@@ -7,7 +7,7 @@ create_remote_connection_to_import_to_blue_from_green = true
 launch_blue_domain = true
 blue_cluster_options = {
   engine         = "OpenSearch"
-  engine_version = "1.3"
+  engine_version = "2.19"
 
   dedicated_master = {
     instance_count = 3


### PR DESCRIPTION
We want to try different versions to see if reindexing works. The blue cluster is currently unused.