### PR TITLE
Update name of Go test workflow in govuk-cli

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -462,9 +462,9 @@ repos:
     push_allowances: ["alphagov/gov-uk-platform-engineering"]
     required_status_checks:
       additional_contexts:
+        - CI / Test Go
         - CodeQL SAST scan / Analyze
         - Dependency Review scan / dependency-review-pr
-        - Test Go / Test Go
 
   govuk-job-request-operator:
     up_to_date_branches: true


### PR DESCRIPTION
This workflow has been moved in-repo, which has changed its name

Example PR: https://github.com/alphagov/govuk-cli/pull/31

https://github.com/alphagov/govuk-infrastructure/issues/4175