### PR TITLE
Fix name of Go test workflow for govuk-cli

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -462,7 +462,7 @@ repos:
     push_allowances: ["alphagov/gov-uk-platform-engineering"]
     required_status_checks:
       additional_contexts:
-        - CI / Test Go
+        - Test Go
         - CodeQL SAST scan / Analyze
         - Dependency Review scan / dependency-review-pr
 


### PR DESCRIPTION
Turns out you only need the job name here if it's for an in-repo workflow

https://github.com/alphagov/govuk-infrastructure/issues/4175