### PR TITLE
Adds push allowances to the IA repo to enable push/merge

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1139,3 +1139,8 @@ repos:
     # standard security checks are disabled as not configured for a private repo
     can_be_deployed: false
     visibility: private
+    push_allowances:
+      - "alphagov/gov-uk-ai-accelerator-alpha-team"
+      - "alphagov/gov-uk-production-admin"
+      - "alphagov/gov-uk-production-deploy"
+    


### PR DESCRIPTION
Added team to push allowances for the IA repo.

This should allow IAs to manage the repo. As part of this it may be better to have a new github team for IAs - as they may not need production deploy access, the AI Accelerator team may need retired in the future and therefore maybe we want to group them seperatly.  May need to be discussed seperatly.

This PR should unblock the immediate need.