### PR TITLE
chore: 🤖 move s3 bucket to shared module

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/static_data_bucket.tf
+++ b/terraform/deployments/datagovuk-infrastructure/static_data_bucket.tf
@@ -1,20 +1,33 @@
-resource "aws_s3_bucket" "datagovuk_static" {
-  bucket = "datagovuk-${var.govuk_environment}-ckan-static-data"
+locals {
+  datagovuk_static_bucket_name = "datagovuk-${var.govuk_environment}-ckan-static-data"
+  datagovuk_static_bucket_arn  = "arn:aws:s3:::${local.datagovuk_static_bucket_name}"
 }
 
-resource "aws_s3_bucket_versioning" "datagovuk_static" {
-  bucket = aws_s3_bucket.datagovuk_static.id
-  versioning_configuration {
-    status = "Enabled"
+module "datagovuk_static" {
+  source = "../../shared-modules/s3"
+
+  govuk_environment = var.govuk_environment
+  name              = local.datagovuk_static_bucket_name
+
+  versioning_enabled         = true
+  enable_public_access_block = false
+  disable_bucket_logging     = startswith(var.govuk_environment, "eph-") ? true : false
+  access_logging_config = {
+    target_bucket = "govuk-${var.govuk_environment}-aws-logging"
+    target_prefix = "s3/datagovuk-${var.govuk_environment}-ckan-static-data/"
   }
-}
 
-resource "aws_s3_bucket_logging" "datagovuk_static" {
-  count = startswith(var.govuk_environment, "eph-") ? 0 : 1
+  ownership_controls = {
+    rules = [
+      {
+        object_ownership = "ObjectWriter"
+      },
+    ]
+  }
 
-  bucket        = aws_s3_bucket.datagovuk_static.id
-  target_bucket = "govuk-${var.govuk_environment}-aws-logging"
-  target_prefix = "s3/datagovuk-${var.govuk_environment}-ckan-static-data/"
+  extra_bucket_policies = [
+    data.aws_iam_policy_document.datagovuk_static.json
+  ]
 }
 
 data "aws_iam_policy_document" "datagovuk_static" {
@@ -23,8 +36,8 @@ data "aws_iam_policy_document" "datagovuk_static" {
     actions = ["s3:GetObject"]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.datagovuk_static.id}",
-      "arn:aws:s3:::${aws_s3_bucket.datagovuk_static.id}/*",
+      local.datagovuk_static_bucket_arn,
+      "${local.datagovuk_static_bucket_arn}/*"
     ]
 
     condition {
@@ -41,7 +54,23 @@ data "aws_iam_policy_document" "datagovuk_static" {
   }
 }
 
-resource "aws_s3_bucket_policy" "govuk_datagovuk_static_read_policy" {
-  bucket = aws_s3_bucket.datagovuk_static.id
-  policy = data.aws_iam_policy_document.datagovuk_static.json
+moved {
+  from = aws_s3_bucket_policy.govuk_datagovuk_static_read_policy
+  to   = module.datagovuk_static.aws_s3_bucket_policy.bucket_policy
 }
+
+moved {
+  from = aws_s3_bucket.datagovuk_static
+  to   = module.datagovuk_static.aws_s3_bucket.this
+}
+
+moved {
+  from = aws_s3_bucket_versioning.datagovuk_static
+  to   = module.datagovuk_static.aws_s3_bucket_versioning.this
+}
+
+moved {
+  from = aws_s3_bucket_logging.datagovuk_static
+  to   = module.datagovuk_static.aws_s3_bucket_logging.this
+}
+


### PR DESCRIPTION
2 to create:

> \+ ownership controls (the owner remains the same as is now ("ObjectWriter")
> \+ server side encryption (set as default already)

2 to change:

> ~ bucket read_policy -> the data block for the fastly ips makes this show as a change
> ~ bucket gets an additional tag `Name: "datagovuk-integration-ckan-static-data"`

closes: https://github.com/alphagov/govuk-infrastructure/issues/3895