### PR TITLE
Migrate publishing athena

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/athena_query_results_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/athena_query_results_s3.tf
@@ -1,16 +1,38 @@
-resource "aws_s3_bucket" "athena_query_results" {
-  bucket = "govuk-${var.govuk_environment}-athena-query-results"
+module "athena_query_results" {
+  source = "../../shared-modules/s3"
+
+  govuk_environment = var.govuk_environment
+  name              = "govuk-${var.govuk_environment}-athena-query-results"
+
+  versioning_enabled         = false
+  enable_public_access_block = true
+
+  ownership_controls = {
+    rules = [
+      {
+        object_ownership = "ObjectWriter"
+      },
+    ]
+  }
+
+  lifecycle_rules = [
+    {
+      id     = "govuk-${var.govuk_environment}-csp-reports-lifecycle"
+      status = "Enabled"
+
+      expiration = {
+        days = 7
+      }
+    }
+  ]
 }
 
-resource "aws_s3_bucket_lifecycle_configuration" "athena_query_results" {
-  bucket = aws_s3_bucket.athena_query_results.id
+moved {
+  from = aws_s3_bucket.athena_query_results
+  to   = module.athena_query_results.aws_s3_bucket.this
+}
 
-  rule {
-    id     = "govuk-${var.govuk_environment}-csp-reports-lifecycle"
-    status = "Enabled"
-
-    expiration {
-      days = 7
-    }
-  }
+moved {
+  from = aws_s3_bucket_lifecycle_configuration.athena_query_results
+  to   = module.athena_query_results.aws_s3_bucket_lifecycle_configuration.this[0]
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/govuk_mirror_sync.tf
@@ -408,8 +408,8 @@ data "aws_iam_policy_document" "govuk_mirror_sync" {
       "s3:*Object"
     ]
     resources = [
-      aws_s3_bucket.athena_query_results.arn,
-      "${aws_s3_bucket.athena_query_results.arn}/*",
+      module.athena_query_results.arn,
+      "${module.athena_query_results.arn}/*",
     ]
     condition {
       test     = "ForAnyValue:StringEquals"
@@ -463,7 +463,7 @@ data "aws_iam_policy_document" "govuk_mirror_sync" {
       "s3:GetObject"
     ]
     resources = [
-      "${aws_s3_bucket.athena_query_results.arn}/*",
+      "${module.athena_query_results.arn}/*",
     ]
   }
 }


### PR DESCRIPTION
6 to create:

> \+ access logging
> \+ bucket ownership (already exists)
> \+ bucket policy (https only)
> \+ public access (already blocked)
> \+ server side encryption (already default)
> \+ versioning (already disabled)

1 to change:

> ~ add "Name" tag to bucket

closes: https://github.com/alphagov/govuk-infrastructure/issues/3892