### PR TITLE
chore: 🤖 migrate search_sitemaps bucket to module

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/search_iam.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_iam.tf
@@ -49,8 +49,8 @@ data "aws_iam_policy_document" "sitemaps_bucket_policy" {
       "s3:List*",
     ]
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.search_sitemaps_bucket.id}",
-      "arn:aws:s3:::${aws_s3_bucket.search_sitemaps_bucket.id}/*",
+      module.search_sitemaps_bucket.arn,
+      "${module.search_sitemaps_bucket.arn}/*",
     ]
   }
 }

--- a/terraform/deployments/govuk-publishing-infrastructure/search_sitemaps_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/search_sitemaps_s3.tf
@@ -1,21 +1,49 @@
-resource "aws_s3_bucket" "search_sitemaps_bucket" {
-  bucket = "govuk-${var.govuk_environment}-sitemaps"
-}
+module "search_sitemaps_bucket" {
+  source = "../../shared-modules/s3"
 
-resource "aws_s3_bucket_logging" "search_sitemaps_bucket" {
-  bucket        = aws_s3_bucket.search_sitemaps_bucket.id
-  target_bucket = "govuk-${var.govuk_environment}-aws-logging"
-  target_prefix = "s3/govuk-${var.govuk_environment}-sitemaps/"
-}
+  govuk_environment = var.govuk_environment
+  name              = "govuk-${var.govuk_environment}-sitemaps"
 
-resource "aws_s3_bucket_lifecycle_configuration" "search_sitemaps_bucket" {
-  bucket = aws_s3_bucket.search_sitemaps_bucket.id
+  versioning_enabled         = false
+  enable_public_access_block = false
 
-  rule {
-    id     = "sitemaps_lifecycle_rule"
-    status = "Enabled"
-    expiration {
-      days = 3
-    }
+  disable_bucket_logging = startswith(var.govuk_environment, "eph-") ? true : false
+  access_logging_config = {
+    target_bucket = "govuk-${var.govuk_environment}-aws-logging"
+    target_prefix = "s3/govuk-${var.govuk_environment}-sitemaps/"
   }
+
+  ownership_controls = {
+    rules = [
+      {
+        object_ownership = "ObjectWriter"
+      },
+    ]
+  }
+
+  lifecycle_rules = [
+    {
+      id     = "sitemaps_lifecycle_rule"
+      status = "Enabled"
+
+      expiration = {
+        days = 3
+      }
+    }
+  ]
+}
+
+moved {
+  from = aws_s3_bucket.search_sitemaps_bucket
+  to   = module.search_sitemaps_bucket.aws_s3_bucket.this
+}
+
+moved {
+  from = aws_s3_bucket_lifecycle_configuration.search_sitemaps_bucket
+  to   = module.search_sitemaps_bucket.aws_s3_bucket_lifecycle_configuration.this[0]
+}
+
+moved {
+  from = aws_s3_bucket_logging.search_sitemaps_bucket
+  to   = module.search_sitemaps_bucket.aws_s3_bucket_logging.this[0]
 }


### PR DESCRIPTION
4 to create:

> \+ owenership controls (the same "ObjectWriter")
> \+ bucket policy (adds https only policy)
> \+ server side encryption (stays the same, on by default)
> \+ versioning stays the same (disabled)

1 to change:

> ~ add extra "Name" tag to bucket

closes: https://github.com/alphagov/govuk-infrastructure/issues/3891