### PR TITLE
chore: 🤖 migrate publishing asset bucket to module

### DIFF
--- a/terraform/deployments/govuk-publishing-infrastructure/asset_manager_s3.tf
+++ b/terraform/deployments/govuk-publishing-infrastructure/asset_manager_s3.tf
@@ -1,22 +1,36 @@
-resource "aws_s3_bucket" "assets" {
-  bucket = "govuk-assets-${var.govuk_environment}"
+locals {
+  assets_bucket_name = "govuk-assets-${var.govuk_environment}"
+  assets_bucket_arn  = "arn:aws:s3:::${local.assets_bucket_name}"
 }
 
-resource "aws_s3_bucket_versioning" "assets" {
-  bucket = aws_s3_bucket.assets.id
-  versioning_configuration { status = "Enabled" }
-}
+module "assets" {
+  source = "../../shared-modules/s3"
 
-resource "aws_s3_bucket_logging" "assets" {
-  bucket        = aws_s3_bucket.assets.id
-  target_bucket = "govuk-${var.govuk_environment}-aws-logging"
-  target_prefix = "s3/govuk-assets-${var.govuk_environment}/"
+  govuk_environment = var.govuk_environment
+  name              = local.assets_bucket_name
+
+  versioning_enabled         = true
+  enable_public_access_block = false
+
+  disable_bucket_logging = startswith(var.govuk_environment, "eph-") ? true : false
+  access_logging_config = {
+    target_bucket = "govuk-${var.govuk_environment}-aws-logging"
+    target_prefix = "s3/govuk-assets-${var.govuk_environment}/"
+  }
+
+  ownership_controls = {
+    rules = [
+      {
+        object_ownership = "ObjectWriter"
+      },
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "asset_manager_s3" {
   statement {
     actions   = ["s3:GetBucketLocation", "s3:ListBucket"]
-    resources = [aws_s3_bucket.assets.arn]
+    resources = [local.assets_bucket_arn]
   }
 
   statement {
@@ -27,10 +41,11 @@ data "aws_iam_policy_document" "asset_manager_s3" {
       "s3:*ObjectVersion",
       "s3:GetObject*Attributes"
     ]
-    resources = ["${aws_s3_bucket.assets.arn}/*"]
+    resources = ["${local.assets_bucket_arn}/*"]
 
   }
 }
+
 
 resource "aws_iam_policy" "asset_manager_s3" {
   name        = "asset_manager_s3"
@@ -41,4 +56,24 @@ resource "aws_iam_policy" "asset_manager_s3" {
 resource "aws_iam_role_policy_attachment" "asset_manager_s3" {
   role       = data.tfe_outputs.cluster_infrastructure.nonsensitive_values.worker_iam_role_name
   policy_arn = aws_iam_policy.asset_manager_s3.arn
+}
+
+moved {
+  from = aws_s3_bucket.assets
+  to   = module.assets.aws_s3_bucket.this
+}
+
+moved {
+  from = aws_s3_bucket_lifecycle_configuration.assets
+  to   = module.assets.aws_s3_bucket_lifecycle_configuration.this[0]
+}
+
+moved {
+  from = aws_s3_bucket_logging.assets
+  to   = module.assets.aws_s3_bucket_logging.this[0]
+}
+
+moved {
+  from = aws_s3_bucket_versioning.assets
+  to   = module.assets.aws_s3_bucket_versioning.this
 }


### PR DESCRIPTION
3 to create:

> \+ ownership controls (same as before ObjectWriter)
> \+ bucket policy (https only for s3 actions)
> \+ server side encryption (same as before default)

1 to change:

> ~ adds "Name" tag to bucket

closes: https://github.com/alphagov/govuk-infrastructure/issues/3890