### PR TITLE
Update collections-publisher tfvars to MySQL 8.4 for staging

### DIFF
--- a/terraform/variables/staging/rds.tfvars
+++ b/terraform/variables/staging/rds.tfvars
@@ -84,11 +84,11 @@ databases = {
 
   collections_publisher = {
     engine         = "mysql"
-    engine_version = "8.0"
+    engine_version = "8.4"
     engine_params = {
       max_allowed_packet = { value = 1073741824 }
     }
-    engine_params_family         = "mysql8.0"
+    engine_params_family         = "mysql8.4"
     name                         = "collections-publisher"
     allocated_storage            = 100
     instance_class               = "db.t4g.micro"


### PR DESCRIPTION
[Jira ticket](https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-7484)

### What?
This updates the Terraform for the collections-publisher MySQL RDS to reflect that it is now running on MySQL 8.4 for staging