### PR TITLE
Create IAM configuration for data.gov.uk db backups to sync across accounts

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/ckan_db_cross_account_backup_iam.tf
+++ b/terraform/deployments/datagovuk-infrastructure/ckan_db_cross_account_backup_iam.tf
@@ -1,0 +1,51 @@
+locals {
+  ckan_database_cross_account_backup_role_name            = "ckan-db-backup-xaccount-sync-${local.cluster_id}"
+  ckan_database_cross_account_backup_service_account_name = "ckan-db-backup-xaccount-sync"
+}
+
+module "ckan_database_cross_account_backup_role" {
+  count = var.enable_cross_account_database_backup_sync ? 1 : 0
+
+  source             = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version            = "~> 6.0"
+  name               = local.ckan_database_cross_account_backup_role_name
+  use_name_prefix    = false
+  description        = "Role for CKAN S3 access. Corresponds to ${var.ckan_service_account_namespace}/${local.ckan_database_cross_account_backup_service_account_name} k8s ServiceAccount."
+  enable_oidc        = true
+  oidc_provider_urls = [local.oidc_provider]
+  policies = {
+    (aws_iam_policy.ckan_db_backup_xaccount_sync[0].name) = aws_iam_policy.ckan_db_backup_xaccount_sync[0].arn
+  }
+  oidc_subjects = ["system:serviceaccount:${var.ckan_service_account_namespace}:${local.ckan_database_cross_account_backup_service_account_name}"]
+}
+
+resource "aws_iam_policy" "ckan_db_backup_xaccount_sync" {
+  count = var.enable_cross_account_database_backup_sync ? 1 : 0
+
+  name        = "datagovuk-ckan-db-backup-xaccount-sync-${var.govuk_environment}"
+  description = "Allow CKAN database backups to be synced to a new DGU AWS account"
+  policy      = data.aws_iam_policy_document.ckan_db_backup_xaccount_sync[0].json
+}
+
+data "aws_iam_policy_document" "ckan_db_backup_xaccount_sync" {
+  count = var.enable_cross_account_database_backup_sync ? 1 : 0
+
+  statement {
+    sid     = "AllowReadingFromSource"
+    effect  = "Allow"
+    actions = ["s3:GetObject", "s3:HeadObject", "s3:ListObjects"]
+
+    resources = [
+      "${data.tfe_outputs.rds.nonsensitive_values.database_dump_bucket_arn}:ckan-postgres/*"
+    ]
+  }
+
+  statement {
+    sid     = "AllowWritingToDestination"
+    effect  = "Allow"
+    actions = ["s3:HeadObject", "s3:PutObject", "s3:ListObjects"]
+    resources = [
+      "${var.cross_account_database_backup_sync_target_s3_bucket_arn}:ckan-postgres/*"
+    ]
+  }
+}

--- a/terraform/deployments/datagovuk-infrastructure/remote.tf
+++ b/terraform/deployments/datagovuk-infrastructure/remote.tf
@@ -9,3 +9,8 @@ data "tfe_outputs" "vpc" {
   organization = "govuk"
   workspace    = "vpc-${var.govuk_environment}"
 }
+
+data "tfe_outputs" "rds" {
+  organization = "govuk"
+  workspace    = "rds-${var.govuk_environment}"
+}

--- a/terraform/deployments/datagovuk-infrastructure/variables.tf
+++ b/terraform/deployments/datagovuk-infrastructure/variables.tf
@@ -63,3 +63,24 @@ variable "ckan_rate_limit_warning_per_5min" {
   type        = number
   default     = 800
 }
+
+variable "enable_cross_account_database_backup_sync" {
+  description = "Whether this environment should support syncing its database backups to the new NDL AWS account"
+  type        = bool
+  default     = false
+}
+
+variable "cross_account_database_backup_sync_target_s3_bucket_arn" {
+  description = "The ARN of the AWS S3 bucket the backups will be synchronised to. This must be null if enable_cross_account_database_backup_sync is false"
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition = (
+      (!var.enable_cross_account_database_backup_sync && var.cross_account_database_backup_sync_target_s3_bucket_arn == null)
+      || (var.enable_cross_account_database_backup_sync && var.cross_account_database_backup_sync_target_s3_bucket_arn != null)
+    )
+    error_message = "if enable_cross_account_database_backup_sync is true, cross_account_database_backup_sync_target_s3_bucket_arn must be set. Otherwise it must be null."
+  }
+}

--- a/terraform/variables/integration/datagovuk-infrastructure.tfvars
+++ b/terraform/variables/integration/datagovuk-infrastructure.tfvars
@@ -1,1 +1,4 @@
 # Variables for the datagovuk-infrastructure-integration workspace
+
+enable_cross_account_database_backup_sync               = true
+cross_account_database_backup_sync_target_s3_bucket_arn = "arn:aws:s3:::integration-account-ckan-backup"

--- a/terraform/variables/production/datagovuk-infrastructure.tfvars
+++ b/terraform/variables/production/datagovuk-infrastructure.tfvars
@@ -1,1 +1,2 @@
 # Variables for the datagovuk-infrastructure-production workspace
+enable_cross_account_database_backup_sync = false

--- a/terraform/variables/staging/datagovuk-infrastructure.tfvars
+++ b/terraform/variables/staging/datagovuk-infrastructure.tfvars
@@ -1,1 +1,2 @@
 # Variables for the datagovuk-infrastructure-staging workspace
+enable_cross_account_database_backup_sync = false


### PR DESCRIPTION
## What

The new DGU team in the National Data Library want to synchronise their database backups from our account to their new account. For now this is to be done in the integration environment only, but it will expand to other environments later.

## How to reviwe

1. Code review 
2. Check the plans and make sure integration is the only one with changes