### PR TITLE
Update collections-publisher tfvars to MySQL 8.4 for production

### DIFF
--- a/terraform/variables/production/rds.tfvars
+++ b/terraform/variables/production/rds.tfvars
@@ -88,11 +88,11 @@ databases = {
 
   collections_publisher = {
     engine         = "mysql"
-    engine_version = "8.0"
+    engine_version = "8.4"
     engine_params = {
       max_allowed_packet = { value = 1073741824 }
     }
-    engine_params_family         = "mysql8.0"
+    engine_params_family         = "mysql8.4"
     name                         = "collections-publisher"
     allocated_storage            = 100
     instance_class               = "db.t4g.medium"


### PR DESCRIPTION
[Jira ticket](https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-7484)

### What?
This updates the Terraform for the collections-publisher MySQL RDS to reflect that it is now running on MySQL 8.4 for production