### PR TITLE
Block amazon-Quick and TalonGDP bots in CKAN WAF (DGUK-505)

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/wafs.tf
+++ b/terraform/deployments/datagovuk-infrastructure/wafs.tf
@@ -282,7 +282,7 @@ resource "aws_wafv2_regex_pattern_set" "ckan_hard_block_bots" {
   regular_expression { regex_string = "(?i)(MJ12bot|DotBot)" }
   regular_expression { regex_string = "(?i)(BLEXBot|Clickagy)" }
   regular_expression { regex_string = "(?i)(serpstatbot|DataForSeoBot)" }
-  regular_expression { regex_string = "(?i)amazon-Quick" }                     # Amazon scraper bot
+  regular_expression { regex_string = "(?i)amazon-Quick" }                       # Amazon scraper bot
   regular_expression { regex_string = "(?i)TalonGDPvalAttachmentGroupExplorer" } # unknown crawler
 
   tags = {

--- a/terraform/deployments/datagovuk-infrastructure/wafs.tf
+++ b/terraform/deployments/datagovuk-infrastructure/wafs.tf
@@ -282,6 +282,8 @@ resource "aws_wafv2_regex_pattern_set" "ckan_hard_block_bots" {
   regular_expression { regex_string = "(?i)(MJ12bot|DotBot)" }
   regular_expression { regex_string = "(?i)(BLEXBot|Clickagy)" }
   regular_expression { regex_string = "(?i)(serpstatbot|DataForSeoBot)" }
+  regular_expression { regex_string = "(?i)amazon-Quick" }
+  regular_expression { regex_string = "(?i)TalonGDPvalAttachmentGroupExplorer" }
 
   tags = {
     Name        = "ckan-hard-block-bots-${var.govuk_environment}"

--- a/terraform/deployments/datagovuk-infrastructure/wafs.tf
+++ b/terraform/deployments/datagovuk-infrastructure/wafs.tf
@@ -282,8 +282,8 @@ resource "aws_wafv2_regex_pattern_set" "ckan_hard_block_bots" {
   regular_expression { regex_string = "(?i)(MJ12bot|DotBot)" }
   regular_expression { regex_string = "(?i)(BLEXBot|Clickagy)" }
   regular_expression { regex_string = "(?i)(serpstatbot|DataForSeoBot)" }
-  regular_expression { regex_string = "(?i)amazon-Quick" }
-  regular_expression { regex_string = "(?i)TalonGDPvalAttachmentGroupExplorer" }
+  regular_expression { regex_string = "(?i)amazon-Quick" }                     # Amazon scraper bot
+  regular_expression { regex_string = "(?i)TalonGDPvalAttachmentGroupExplorer" } # unknown crawler
 
   tags = {
     Name        = "ckan-hard-block-bots-${var.govuk_environment}"


### PR DESCRIPTION

This Adds two additional bot User-Agent patterns to the CKAN WAF hard-block rule (priority 0, 403 response), identified during the Wednesday 22 July production outage investigation.

**New patterns added to `ckan_hard_block_bots` regex pattern set:**
- `amazon-Quick-on-behalf-of-*` — an Amazon scraper bot currently generating significant unblocked traffic on CKAN production (observed top UA in nginx logs, 550+ requests per 12-minute window)
- `TalonGDPvalAttachmentGroupExplorer/0.1` — unidentified public attachment discovery crawler observed in logs

Pattern set now uses 8 of the 10 allowed patterns.
