### PR TITLE
fix: 🐛 log s3 access to the correct eph bucket

### DIFF
--- a/terraform/shared-modules/s3/main.tf
+++ b/terraform/shared-modules/s3/main.tf
@@ -1,3 +1,9 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  logging_target_bucket_default_val = data.aws_caller_identity.current.account_id == "430354129336" ? "govuk-test-aws-logging" : "govuk-${var.govuk_environment}-aws-logging"
+}
+
 resource "aws_s3_bucket" "this" {
   bucket = var.name
 
@@ -193,7 +199,7 @@ resource "aws_s3_bucket_logging" "this" {
 
   bucket = aws_s3_bucket.this.id
 
-  target_bucket = var.access_logging_config.target_bucket == null ? "govuk-${var.govuk_environment}-aws-logging" : var.access_logging_config.target_bucket
+  target_bucket = var.access_logging_config.target_bucket == null ? local.logging_target_bucket_default_val : var.access_logging_config.target_bucket
   target_prefix = var.access_logging_config.target_prefix == null ? "s3/${aws_s3_bucket.this.bucket}/" : var.access_logging_config.target_prefix
 
   dynamic "target_object_key_format" {


### PR DESCRIPTION
Ephemeral cluster builds fail when deploying buckets using our shared s3 module because the are trying to log to a bucket that doesn't exist

<img width="1463" height="159" alt="Screenshot 2026-07-28 at 10 53 53" src="https://github.com/user-attachments/assets/d7d79e26-c606-405d-8709-b3fe03a4ce5d" />

> var.govuk_environment points to the cluster name and not at "ephemeral"
