### PR TITLE
[SCH-1625] Import search-analytics-ga4 repo ahead of archiving it

### DIFF
--- a/terraform/deployments/github/import.tf
+++ b/terraform/deployments/github/import.tf
@@ -1,0 +1,4 @@
+import {
+  to = github_repository.govuk_repos["search-analytics-ga4"]
+  id = "search-analytics-ga4"
+}

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -834,6 +834,8 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test Ruby / Run RSpec
 
+  search-analytics-ga4: {}
+
   search-api:
     can_be_deployed: true
     homepage_url: "https://docs.publishing.service.gov.uk/apps/search-api.html"


### PR DESCRIPTION
The [search-analytics-ga4](https://github.com/alphagov/search-analytics-ga4) repo was created manually for temporary use, and now needs to be archived. It has no resources deployed. Importing the repo in this PR. A subsequent PR will archive it.

I think from the [archive a repo instructions](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/github/README.md#archiving-repositories) that I need to import the repo into govuk-infrastructure first, before I can then archive it.

See [Jira ticket SCH-1625](https://gov-uk.atlassian.net/browse/SCH-1625)