### PR TITLE
Add govuk-chat-monitoring to repos.yml

### DIFF
--- a/terraform/deployments/github/import.tf
+++ b/terraform/deployments/github/import.tf
@@ -1,4 +1,4 @@
 import {
-  to = github_repository.govuk_repos["search-analytics-ga4"]
-  id = "search-analytics-ga4"
+  to = github_repository.govuk_repos["govuk-chat-monitoring"]
+  id = "govuk-chat-monitoring"
 }

--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -350,6 +350,9 @@ repos:
 
   govuk-chat-opensearch: {}
 
+  govuk-chat-monitoring:
+    visibility: private
+
   govuk-content-api-docs:
     homepage_url: "https://content-api.publishing.service.gov.uk"
     required_status_checks:


### PR DESCRIPTION
I've followed prior art for govuk-chat-opensearch since that also doesn't have required_status_checks or branch_protection_rules.[1]

This is a repo that is maintained by the PA on the GOV.UK Chat team, and is also utilised by some PA colleagues in Products and Services.

The repo already exists in GitHub, so I've followed the documentation and added an import in the import.tf file.

[1]: https://github.com/alphagov/govuk-infrastructure/pull/3319