### PR TITLE
[SCH-1625] Archive search-analytics-ga4 repo

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -834,7 +834,8 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test Ruby / Run RSpec
 
-  search-analytics-ga4: {}
+  search-analytics-ga4:
+    archived: true
 
   search-api:
     can_be_deployed: true


### PR DESCRIPTION
This repo is no longer needed. Follows on from #4575 

See [Jira ticket SCH-1625](https://gov-uk.atlassian.net/browse/SCH-1625)