### PR TITLE
IA-3087: allow GovGraph ingestion SAs to use data-processed bucket

### DIFF
--- a/terraform/deployments/gcp-gov-graph/storage.tf
+++ b/terraform/deployments/gcp-gov-graph/storage.tf
@@ -109,6 +109,8 @@ data "google_iam_policy" "bucket_data_processed" {
     members = [
       google_service_account.gce_publisher.member,
       google_service_account.gce_asset_manager.member,
+      google_service_account.rds_parquet_bq_loader.member,
+      google_service_account.docdb_bq_loader.member,
     ]
   }
 


### PR DESCRIPTION
Part of https://gov-uk.atlassian.net/browse/IA-3087