### PR TITLE
Add national-data-library team as codeowners of the datagovuk-infrastructure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,15 @@
 # Platform Engineering review required
 # Reusable GitHub Actions workflows and repo config
 /.github/ @alphagov/gov-uk-platform-engineering
+
 # Terraform code
 /terraform/deployments/ @alphagov/gov-uk-platform-engineering
 /terraform/shared-modules/ @alphagov/gov-uk-platform-engineering
+
 # Data Engineering
 /terraform/deployments/gcp-gov-graph/ @alphagov/gov-uk-platform-engineering @alphagov/govuk-data-engineering
 /terraform/variables/**/gcp-gov-graph.tfvars @alphagov/gov-uk-platform-engineering @alphagov/govuk-data-engineering
+
+# National Data Library
+/terraform/deployments/datagovuk-infrastructure/ @alphagov/gov-uk-platform-engineering @alphagov/national-data-library
+/terraform/variables/**/datagovuk-infrastructure.tfvars @alphagov/gov-uk-platform-engineering @alphagov/national-data-library


### PR DESCRIPTION
This adds the NDL team as codeowners of the DGU infra workspace and variables files.

I also added a little whitespace to separate the sections now we have several