### PR TITLE
Sch 2011 Remove quota overrides for search

### DIFF
--- a/terraform/deployments/gcp-search-api-v2/README.md
+++ b/terraform/deployments/gcp-search-api-v2/README.md
@@ -21,8 +21,9 @@ Before you can use this module, you must:
   `terraform` or through a (gitignored) `local.auto.tfvars` file
 
 ## Additional information
-### Adding additional GCP quota overrides
-Quota overrides on GCP are somewhat complex to set up and use inconsistent terminology between the
+### Adding GCP quota overrides
+Quota overrides are used to cap limits under values that have been set by default or by admin/producer overrides.
+On GCP, these are somewhat complex to set up and use inconsistent terminology between the
 console UI, the REST API, and the (beta) Terraform provider. In particular, it can be somewhat
 confusing to figure out the `limit` value for the `google_service_usage_consumer_quota_override`
 resource (which actually corresponds to the `unit` field in the API but with different syntax), and
@@ -42,3 +43,8 @@ curl -H "Authorization: Bearer $(gcloud auth print-access-token)" \
 
 This returns a list of available quotas by display name, complete with the necessary `metric` and
 `unit` values.
+
+There are limits on the Google side on how high we are permitted to set quotas. If
+you attempt to increase them beyond the ceiling, a `COMMON_QUOTA_CONSUMER_OVERRIDE_TOO_HIGH`
+error will be raised (including some metadata that should tell you what the current ceiling is). 
+You will need to manually request a quota increase from Google through the console first.

--- a/terraform/deployments/gcp-search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/main.tf
@@ -54,13 +54,4 @@ module "environment_production" {
   tfc_project_name             = var.tfe_project_name
   environment_workspace_name   = "search-api-v2-production"
   access_group_name            = "govuk-gcp-access"
-
-
-  # NOTE: There are limits on the Google side on how high we are permitted to set these quotas. If
-  # you attempt to increase these beyond the ceiling, a `COMMON_QUOTA_CONSUMER_OVERRIDE_TOO_HIGH`
-  # error will be raised (including some metadata that should tell you what the current ceiling is)
-  # and you will need to manually request a quota increase from Google through the console first
-  # (see the environment module for the exact quota names you need to request increases for).
-  discovery_engine_quota_search_requests_per_minute = 5000
-  discovery_engine_quota_documents                  = 2000000
 }

--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
@@ -51,34 +51,6 @@ resource "google_project_service" "api_service" {
   disable_dependent_services = true
 }
 
-resource "google_service_usage_consumer_quota_override" "discoveryengine_search_requests" {
-  provider = google-beta
-  project  = google_project.environment_project.project_id
-
-  service = "discoveryengine.googleapis.com"
-  metric  = urlencode("discoveryengine.googleapis.com/search_requests")
-  force   = true
-
-  # limit is equivalent to `unit` field when making a GET request against the metric, but without
-  # leading `1/` and without curly braces
-  limit          = urlencode("/min/project")
-  override_value = var.discovery_engine_quota_search_requests_per_minute
-}
-
-resource "google_service_usage_consumer_quota_override" "discoveryengine_documents" {
-  provider = google-beta
-  project  = google_project.environment_project.project_id
-
-  service = "discoveryengine.googleapis.com"
-  metric  = urlencode("discoveryengine.googleapis.com/documents")
-  force   = true
-
-  # limit is equivalent to `unit` field when making a GET request against the metric, but without
-  # leading `1/` and without curly braces
-  limit          = urlencode("/project")
-  override_value = var.discovery_engine_quota_documents
-}
-
 # Set up Workload Identity Federation between Terraform Cloud and GCP
 # see https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples
 resource "google_iam_workload_identity_pool" "tfc_pool" {

--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
@@ -8,11 +8,6 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 7.0"
     }
-    # required for `google_service_usage_consumer_quota_override` resources
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 7.0"
-    }
   }
 
   required_version = "~> 1.15"

--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/variables.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/variables.tf
@@ -40,18 +40,6 @@ variable "google_cloud_apis" {
   ]
 }
 
-variable "discovery_engine_quota_search_requests_per_minute" {
-  type        = number
-  description = "The maximum number of search requests per minute for the Discovery Engine"
-  default     = 250
-}
-
-variable "discovery_engine_quota_documents" {
-  type        = number
-  description = "The maximum number of documents across Discovery Engine datastores"
-  default     = 1000000
-}
-
 variable "upstream_environment_name" {
   type        = string
   description = "The name of the upstream environment, if any (used to wait for a successful apply on a 'lower' environment before applying this one)"


### PR DESCRIPTION
These quota overrides do not reflect our current project setup, and we don't want to change the current setup with respect to overrides, so these should be removed.
    
The overrides for discoveryengine.googleapis.com/documents and for discoveryengine.googleapis.com/search_requests are no longer listed under the [consumerQuotaMetrics endpoint](https://docs.cloud.google.com/service-usage/docs/reference/rest/v1beta1/services.consumerQuotaMetrics/list). They seem to have been replaced with regional equivalents. Our current settings for the regional equivalents match either the default values, or in some cases have been set higher than the default, so capping the quotas via overrides is not part of the desired setup.
    
However, we still want to keep the documentation for overrides in the README, in case it is useful at a later date.
    
The `terraform plan` before these changes used to show 6 resources related to quota overrides being added. After this change, there are none.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2011