### PR TITLE
Sch 2011 document terraform folder for search

### DIFF
--- a/terraform/deployments/gcp-search-api-v2/README.md
+++ b/terraform/deployments/gcp-search-api-v2/README.md
@@ -1,24 +1,50 @@
 # gcp-search-api-v2
-Terraform module to bootstrap GCP projects
+This Terraform module is for bootstrapping the search GCP projects. This lays the initial (minimal) groundwork
+in GCP for the `search-api-v2` projects to run successfully. 
+
+For other parts of the `search-api-v2` setup, see the [search-api-v2 deployment][search-api-v2-deployment], and the
+[tfc-configurations][search-v2-tfc-config] and [variables][variables].
 
 ## Resources
 This module manages the following resources:
-- For every desired environment (dev, integration, staging, prod), through the `modules/environment`
+- For every desired environment (integration, staging, prod), through the `modules/environment`
   child module:
   - A GCP project
 
-## Applying this module
-This module uses Terraform Cloud for remote state storage, but is intended to be run *locally* by a
-user with "interactive" end-user access to both Terraform Cloud and Google Cloud Platform (so as to
-not have a chicken-and-egg problem around having to manually create service accounts to manage
-meta-resources like service accounts or projects).
+This covers initial setup of the GCP projects, including defining the projects and assigning broad access
+roles to access groups and Terraform.
 
-### Authentication & configuration
+## Applying this module
+This module uses Terraform Cloud for remote state storage, but is intended to be manually run *locally* by a
+user with "interactive" end-user access to both Terraform Cloud and Google Cloud Platform. (This is to
+avoid a chicken-and-egg problem around having to manually create service accounts to manage
+meta-resources like service accounts or projects.)
+
+### Authentication
 Before you can use this module, you must:
 - use `terraform login` to authenticate to Terraform Cloud
 - use `gcloud auth application-default login` to authenticate to GCP
-- specify values for `google_cloud_folder` and `google_cloud_billing_account` as parameters to
-  `terraform` or through a (gitignored) `local.auto.tfvars` file
+
+### Using the Terraform cli
+Once you have [authenticated](#authentication), run the module using the Terraform cli. For example:
+
+```bash
+terraform plan
+```
+
+Values for `google_cloud_folder` and `google_cloud_billing_account` will need to be specified:
+- `google_cloud_folder` is a numerical ID for the folder the projects live in, in GCP.
+  For an existing folder, this can be found in the GCP console.
+  Navigate to the 'all' tab in the 'project picker' in GCP to view the folder structure, including the folder IDs.
+- `google_cloud_billing_account` is an ID including alphanumeric characters and hyphens.
+  For an existing project, this can be found in the GCP console under "Billing".
+
+These values can be set interactively in the console when running the cli, or these can be provided through a (gitignored)
+`local.auto.tfvars` file, or they can be provided to the `terraform` command using the `-var` argument:
+
+```bash
+terraform plan -var google_cloud_billing_account=<account-id> -var google_cloud_folder=<folder-id>
+```
 
 ## Additional information
 ### Adding GCP quota overrides
@@ -48,3 +74,7 @@ There are limits on the Google side on how high we are permitted to set quotas. 
 you attempt to increase them beyond the ceiling, a `COMMON_QUOTA_CONSUMER_OVERRIDE_TOO_HIGH`
 error will be raised (including some metadata that should tell you what the current ceiling is). 
 You will need to manually request a quota increase from Google through the console first.
+
+[search-api-v2-deployment]: ../search-api-v2/
+[search-v2-tfc-config]: ../tfc-configuration/search-api-v2.tf
+[variables]: ../../variables

--- a/terraform/deployments/gcp-search-api-v2/variables.tf
+++ b/terraform/deployments/gcp-search-api-v2/variables.tf
@@ -20,11 +20,6 @@ variable "google_cloud_billing_account" {
   description = "The ID of the Google Cloud billing account to associate projects with"
 }
 
-variable "project_id" {
-  type        = string
-  description = "The ID of the overarching terraform cloud project for all workspaces"
-}
-
 variable "tfe_project_name" {
   type        = string
   default     = "govuk-search-api-v2"

--- a/terraform/deployments/search-api-v2/README.md
+++ b/terraform/deployments/search-api-v2/README.md
@@ -1,17 +1,32 @@
-# environment
-Set up Discovery Engine resources, service accounts and keys, and AWS Secrets Manager secrets
-consumed by the Kubernetes platform for an individual environment (e.g. integration, production) for
-[`search-api-v2`][search-api-v2-repo] (applied once per environment through Terraform Cloud)
+# search-api-v2
+This Terraform module is for ongoing maintenance of the search GCP projects. It includes
+set up of Discovery Engine resources, service accounts and keys, and AWS Secrets Manager secrets
+consumed by the Kubernetes platform for an individual environment (integration, staging and production) for
+[`search-api-v2`][search-api-v2-repo].
 
-## Terraform Cloud
-This module will automatically be planned and applied in [Terraform Cloud][terraform-cloud] on
-merges to the `main` branch.
+## Related infrastructure
+
+For initial (bootstrapping) setup of the GCP projects, including broad access roles, see [gcp-search-api-v2][gcp-search-api-v2-deployment].
+
+The setup of the Terraform workspaces for this module is done in the [tfc-configurations][search-v2-tfc-config]. 
+
+## Applying this module
+This module will automatically be **planned** across all environments in [Terraform Cloud][terraform-cloud] on
+merges to the `main` branch. The module will also be automatically **applied** in integration and staging, but
+needs to be manually applied in production.
+
+## Setting variables
+To set variables that change depending on the environment, the variables should be defined in [variables.tf][variables]
+and set in the relevant search-api-v2.tfvars files for each environment in the [variables folder][variables-folder].
 
 ## Resources
 This module provisions the following resources into the Google Cloud Platform project specified:
 - A Discovery Engine datastore and schema
-- Two service accounts with respective roles (read and write) and keys to access Discovery Engine
-  from a consuming application
+- Discovery Engine serving configurations and controls
+- Configuration for Autocomplete
+- BigQuery Dataform pipelines to process data relevant to Discovery Engine
+- Two service accounts with respective roles and keys to access Discovery Engine from a consuming application
+- Read-only service accounts for local development
 - AWS Secrets Manager secrets to be consumed by the API service application in the corresponding
   environment on the Kubernetes platform
 
@@ -29,3 +44,7 @@ This module provisions the following resources into the Google Cloud Platform pr
 [restapi_provider_docs]: https://registry.terraform.io/providers/Mastercard/restapi/latest
 [search-api-v2-repo]: https://github.com/alphagov/search-api-v2
 [terraform-cloud]: https://app.terraform.io/
+[gcp-search-api-v2-deployment]: ../gcp-search-api-v2/
+[search-v2-tfc-config]: ../tfc-configuration/search-api-v2.tf
+[variables]: ./variables.tf
+[variables-folder]: ../../variables


### PR DESCRIPTION
Updates READMEs related to search-api-v2 deployments to provide additional content on Terraform setup.

Also removes project_id from `gcp-search-api-v2` since this variable was unused but was required to be specified
when running Terraform, which was confusing.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2011