### PR TITLE
Allow ckan-db-backup-xaccount-sync-* role sufficient permissions for s3 sync

### DIFF
--- a/terraform/deployments/datagovuk-infrastructure/ckan_db_cross_account_backup_iam.tf
+++ b/terraform/deployments/datagovuk-infrastructure/ckan_db_cross_account_backup_iam.tf
@@ -33,11 +33,16 @@ data "aws_iam_policy_document" "ckan_db_backup_xaccount_sync" {
   statement {
     sid     = "AllowReadingFromSource"
     effect  = "Allow"
-    actions = ["s3:GetObject", "s3:HeadObject", "s3:ListObjects"]
+    actions = ["s3:CopyObject", "s3:GetObject", "s3:HeadObject", "s3:ListObjects"]
 
-    resources = [
-      "${data.tfe_outputs.rds.nonsensitive_values.database_dump_bucket_arn}:ckan-postgres/*"
-    ]
+    resources = ["${data.tfe_outputs.rds.nonsensitive_values.database_dump_bucket_arn}:ckan-postgres/*"]
+  }
+
+  statement {
+    sid       = "AllowActingOnSourceBucket"
+    effect    = "Allow"
+    actions   = ["s3:GetBucketLocation", "s3:ListBucket"]
+    resources = [data.tfe_outputs.rds.nonsensitive_values.database_dump_bucket_arn]
   }
 
   statement {
@@ -47,5 +52,12 @@ data "aws_iam_policy_document" "ckan_db_backup_xaccount_sync" {
     resources = [
       "${var.cross_account_database_backup_sync_target_s3_bucket_arn}:ckan-postgres/*"
     ]
+  }
+
+  statement {
+    sid       = "AllowActingOnDestinationBucket"
+    effect    = "Allow"
+    actions   = ["s3:GetBucketLocation", "s3:ListBucket"]
+    resources = [var.cross_account_database_backup_sync_target_s3_bucket_arn]
   }
 }


### PR DESCRIPTION
## What

This role will be used to perform an `aws s3 sync` (without recursive or delete flags), and I missed some permissions for it.

## How to review

1. Do a bit of research of your own to see what permissions are actually required and whether I've missed any