### PR TITLE
Enable CloudWatch network flow and EKS service map in prod

### DIFF
--- a/terraform/variables/production/cluster-infrastructure.tfvars
+++ b/terraform/variables/production/cluster-infrastructure.tfvars
@@ -2,6 +2,10 @@
 
 cluster_version = "1.36" # Don't forget to change this in variables-test.tf too
 
+enable_container_network_observability = true
+enable_eks_pod_identity_addon          = true
+enable_network_flow_addon              = true
+
 enable_arm_workers_blue  = false
 enable_arm_workers_green = true
 enable_x86_workers       = false


### PR DESCRIPTION
Description:
- Enable EKS service map and CloudWatch Network Flow in production
- https://github.com/alphagov/govuk-infrastructure/issues/4082