### PR TITLE
Adjust search-api-v2 workspace access

### DIFF
--- a/terraform/deployments/tfc-configuration/search-api-v2.tf
+++ b/terraform/deployments/tfc-configuration/search-api-v2.tf
@@ -90,8 +90,7 @@ module "search-api-v2-staging" {
   }
 
   team_access = {
-    "GOV.UK Non-Production (r/o)" = "write"
-    "GOV.UK Production"           = "write"
+    "GOV.UK Production" = "write"
   }
 
   envvars = {
@@ -146,8 +145,7 @@ module "search-api-v2-production" {
   }
 
   team_access = {
-    "GOV.UK Non-Production (r/o)" = "write"
-    "GOV.UK Production"           = "write"
+    "GOV.UK Production" = "write"
   }
 
   envvars = {


### PR DESCRIPTION
To remove staging and production access for GOV.UK Non-Production Team, to align with [publishing infrastructure permissions](https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/tfc-configuration/govuk-publishing-infrastructure.tf).