### PR TITLE
Adding custom domain for the architecture diagrams github pages site

### DIFF
--- a/terraform/variables/production/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/production/govuk-publishing-infrastructure.tfvars
@@ -80,6 +80,7 @@ subdomain_dns_records = [
   { type = "CNAME", name = "guidance", ttl = 300, value = ["alphagov.github.io."] },
   { type = "CNAME", name = "whitehall-admin", ttl = 300, value = ["whitehall-admin.eks.production.govuk.digital."] },
   { type = "CNAME", name = "www-origin", ttl = 300, value = ["www-origin.eks.production.govuk.digital."] },
+  { type = "TXT", name = "_github-pages-challenge-alphagov.architecture", ttl = 300, value = ["8048c0a9324627acf3cad6e91cb0d8"] }, // pragma: allowlist secret
 ]
 
 amazonmq_engine_version                       = "3.13"


### PR DESCRIPTION
We've been working on an architecture diagramming tool in publishing, this is built as a github site, from the private repo: https://github.com/alphagov/govuk-publishing-documentation repo. 

I'm looking to add a custom domain - architecture.publishing.service.gov.uk - to front this, to run alongside the docs.publishing.service.gov.uk site. 

This PR adds the TXT record to enable domain verification. the domain has been requested in Github.

