### PR TITLE
Prepare siteimprove_api_client repo for archiving

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -898,12 +898,7 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
 
-  siteimprove_api_client:
-    publishes_gem: true
-    required_status_checks:
-      standard_contexts: *standard_security_checks
-      additional_contexts:
-        - test
+  siteimprove_api_client: {}
 
   slimmer:
     archived: true


### PR DESCRIPTION
Remove the properties from the siteimprove_api_client gem in preparation for archiving in a subsequent PR.

This repo does not have a `visibility` property set so we can use an empty property set here.

For more information see https://gov-uk.atlassian.net/browse/CR-64 and https://github.com/alphagov/siteimprove_api_client/pull/76