### PR TITLE
Add gatekeeper rules to prevent updating jobrequests and reviews

### DIFF
--- a/terraform/deployments/cluster-services/gatekeeper.tf
+++ b/terraform/deployments/cluster-services/gatekeeper.tf
@@ -2,7 +2,8 @@ module "gatekeeper" {
   source = "./modules/gatekeeper"
 
   dryrun_map = {
-    immutable_configmap = true
+    immutable_configmap        = true
+    validate_jobrequestreviews = false
   }
 
   constraint_violations_max_to_display = 25

--- a/terraform/deployments/cluster-services/modules/gatekeeper/constraints/locals.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/constraints/locals.tf
@@ -1,9 +1,11 @@
 locals {
-  constraint_path          = "${path.module}/../resources/constraints"
-  immutable_configmap_yaml = yamldecode(file("${local.constraint_path}/immutable_configmap.yaml"))
+  constraint_path            = "${path.module}/../resources/constraints"
+  immutable_configmap_yaml   = yamldecode(file("${local.constraint_path}/immutable_configmap.yaml"))
+  validate_jobrequestreviews = yamldecode(file("${local.constraint_path}/validate_jobrequestreviews.yaml"))
 
   # For each constraint, a value needs to be in the constraint map. This bloc allows us to set values on constraints which enables us to toggle the configuration of the constraints. -- we merge in the spec separately to avoid overwriting entire spec key
   constraint_map = {
-    immutable_configmap = merge(local.immutable_configmap_yaml, { "spec" : merge(local.immutable_configmap_yaml, { "enforcementAction" : var.dryrun_map.immutable_configmap ? "dryrun" : "deny" }) })
+    immutable_configmap        = merge(local.immutable_configmap_yaml, { "spec" : merge(local.immutable_configmap_yaml, { "enforcementAction" : var.dryrun_map.immutable_configmap ? "dryrun" : "deny" }) })
+    validate_jobrequestreviews = merge(local.validate_jobrequestreviews, { "spec" : merge(local.validate_jobrequestreviews, { "enforcementAction" : var.dryrun_map.validate_jobrequestreviews ? "dryrun" : "deny" }) })
   }
 }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/constraints/variables.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/constraints/variables.tf
@@ -1,7 +1,8 @@
 variable "dryrun_map" {
   description = "run constraints in dryrun mode"
   type = object({
-    immutable_configmap = bool
+    immutable_configmap        = bool
+    validate_jobrequestreviews = bool
   })
 }
 

--- a/terraform/deployments/cluster-services/modules/gatekeeper/main.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/main.tf
@@ -86,6 +86,12 @@ spec:
       - group: ""
         version: "v1"
         kind: "Service"
+      - group: "platform.publishing.service.gov.uk"
+        version: "v1"
+        kind: "JobRequest"
+      - group: "platform.publishing.service.gov.uk"
+        version: "v1"
+        kind: "JobRequestReview"
 YAML
 }
 

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/validate_jobrequestreviews.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/validate_jobrequestreviews.yaml
@@ -19,6 +19,7 @@ spec:
 
         violation[{"msg": msg}] {
           input.review.kind.kind == "JobRequestReview"
+          input.review.operation != "DELETE"
 
           # jobRequestName is a required field, so defensive lookup not needed
           job_request_name := input.review.object.spec.jobRequestName
@@ -39,6 +40,7 @@ spec:
 
         violation[{"msg": msg}] {
           input.review.kind.kind == "JobRequestReview"
+          input.review.operation != "DELETE"
 
           # jobRequestName is a required field, so defensive lookup not needed
           job_request_name := input.review.object.spec.jobRequestName

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/validate_jobrequestreviews.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/validate_jobrequestreviews.yaml
@@ -17,13 +17,17 @@ spec:
       rego: |
         package validatejobrequestreview
 
-        violation[{"msg": msg}] {
+        valid_resource_and_operation {
           input.review.kind.kind == "JobRequestReview"
           input.review.operation != "DELETE"
+        }
 
-          # jobRequestName is a required field, so defensive lookup not needed
-          job_request_name := input.review.object.spec.jobRequestName
-          job_request_review_namespace := input.review.namespace
+        # jobRequestName is a required field, so defensive lookup not needed
+        job_request_name := input.review.object.spec.jobRequestName
+        job_request_review_namespace := input.review.namespace
+
+        violation[{"msg": msg}] {
+          valid_resource_and_operation
 
           job_request := object.get(
             data.inventory,
@@ -39,12 +43,7 @@ spec:
         }
 
         violation[{"msg": msg}] {
-          input.review.kind.kind == "JobRequestReview"
-          input.review.operation != "DELETE"
-
-          # jobRequestName is a required field, so defensive lookup not needed
-          job_request_name := input.review.object.spec.jobRequestName
-          namespace := input.review.namespace
+          valid_resource_and_operation
 
           job_request := data.inventory.namespace[namespace]["platform.publishing.service.gov.uk/v1"]["JobRequest"][job_request_name]
           review_name := object.get(job_request, ["status", "reviewName"], "")

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/validate_jobrequestreviews.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/validate_jobrequestreviews.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: validatejobrequestreview
+  annotations:
+    metadata.gatekeeper.sh/title: Validate a JobRequestReview targets a valid JobRequest
+    description: This constraint ensures a JobRequestReview targets an existing, unreviewed JobRequest in the same namespace
+spec:
+  crd:
+    spec:
+      names:
+        kind: validatejobrequestreview
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package validatejobrequestreview
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "JobRequestReview"
+
+          # jobRequestName is a required field, so defensive lookup not needed
+          job_request_name := input.review.object.spec.jobRequestName
+          job_request_review_namespace := input.review.namespace
+
+          job_request := object.get(
+            data.inventory,
+            ["namespace", job_request_review_namespace, "platform.publishing.service.gov.uk/v1", "JobRequest", job_request_name],
+            {}
+          )
+          job_request == {}
+
+          msg := sprintf(
+            "The JobRequestReview references JobRequest (%s) but that JobRequest cannot be found in the namespace of the JobRequestReview (%s)",
+            [job_request_name, job_request_review_namespace]
+          )
+        }
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "JobRequestReview"
+
+          # jobRequestName is a required field, so defensive lookup not needed
+          job_request_name := input.review.object.spec.jobRequestName
+          namespace := input.review.namespace
+
+          job_request := data.inventory.namespace[namespace]["platform.publishing.service.gov.uk/v1"]["JobRequest"][job_request_name]
+          review_name := object.get(job_request, ["status", "reviewName"], "")
+          review_name != ""
+
+          msg := sprintf(
+            "JobRequest (%s) has already been reviewed by JobRequestReview (%s) and is now in state (%s)",
+            [job_request_name, job_request.status.reviewName, job_request.status.state]
+          )
+        }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraints/validate_jobrequestreviews.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraints/validate_jobrequestreviews.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: validatejobrequestreview
+metadata:
+  name: validatejobrequestreview
+spec:
+  match:
+    kinds:
+      - apiGroups: ["platform.publishing.service.gov.uk"]
+        kinds: ["JobRequestReview"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/allow_deleting_jobrequestreviews_when_jobrequest_exists/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/allow_deleting_jobrequestreviews_when_jobrequest_exists/case.yaml
@@ -1,0 +1,26 @@
+---
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    kind: JobRequestReview
+    group: platform.publishing.service.gov.uk
+    version: v1
+
+  operation: DELETE
+
+  name: test-jobrequestreview-delete-jobrequest-found
+  namespace: apps
+
+  oldObject:
+    apiVersion: platform.publishing.service.gov.uk/v1
+    kind: JobRequestReview
+    metadata:
+      name: test-jobrequestreview-delete-jobrequest-found
+      namespace: apps
+      annotations:
+        platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/otheruser.name-platformengineer/test-platformengineer
+    spec:
+      jobRequestName: test-jobrequest
+      decision: Approved
+      description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/allow_deleting_jobrequestreviews_when_jobrequest_exists/inventory.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/allow_deleting_jobrequestreviews_when_jobrequest_exists/inventory.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jobrequest
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789012:assumed-role/jonathan.harden-platformengineer/test-platformengineer
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]
+status:
+  state: "Started"
+  reviewName: previous-jobrequestreview

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/allow_deleting_jobrequestreviews_when_jobrequest_notfound/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/allow_deleting_jobrequestreviews_when_jobrequest_notfound/case.yaml
@@ -1,0 +1,26 @@
+---
+kind: AdmissionReview
+apiVersion: admission.k8s.io/v1beta1
+request:
+  kind:
+    kind: JobRequestReview
+    group: platform.publishing.service.gov.uk
+    version: v1
+
+  operation: DELETE
+
+  name: test-jobrequestreview-delete-jobrequest-not-found
+  namespace: apps
+
+  oldObject:
+    apiVersion: platform.publishing.service.gov.uk/v1
+    kind: JobRequestReview
+    metadata:
+      name: test-jobrequestreview-delete-jobrequest-not-found
+      namespace: apps
+      annotations:
+        platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/otheruser.name-platformengineer/test-platformengineer
+    spec:
+      jobRequestName: test-jobrequest-notfound
+      decision: Approved
+      description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/allow_reviewing_unreviewed_jobrequest/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/allow_reviewing_unreviewed_jobrequest/case.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jobrequestreview-unreviewed
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/otheruser.name-platformengineer/test-platformengineer
+spec:
+  jobRequestName: test-jobrequest-unreviewed
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/allow_reviewing_unreviewed_jobrequest/inventory.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/allow_reviewing_unreviewed_jobrequest/inventory.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jobrequest-unreviewed
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789012:assumed-role/jonathan.harden-platformengineer/test-platformengineer
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/deny_referencing_jobrequest_in_another_namespace/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/deny_referencing_jobrequest_in_another_namespace/case.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jobrequestreview-another-namespace
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/otheruser.name-platformengineer/test-platformengineer
+spec:
+  jobRequestName: test-jobrequest-another-namespace
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/deny_referencing_jobrequest_in_another_namespace/inventory.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/deny_referencing_jobrequest_in_another_namespace/inventory.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jobrequest-another-namespace
+  namespace: datagovuk
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789012:assumed-role/jonathan.harden-platformengineer/test-platformengineer
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/deny_referencing_nonexisting_jobrequest/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/deny_referencing_nonexisting_jobrequest/case.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jobrequestreview-notfound
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/otheruser.name-platformengineer/test-platformengineer
+spec:
+  jobRequestName: test-jobrequest-notfound
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/deny_reviewing_already_reviewed_jobrequest/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/deny_reviewing_already_reviewed_jobrequest/case.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jobrequestreview-reviewed
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/otheruser.name-platformengineer/test-platformengineer
+spec:
+  jobRequestName: test-jobrequest-reviewed
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/deny_reviewing_already_reviewed_jobrequest/inventory.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/validate_jobrequestreviews/deny_reviewing_already_reviewed_jobrequest/inventory.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jobrequest-reviewed
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789012:assumed-role/jonathan.harden-platformengineer/test-platformengineer
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]
+status:
+  state: "Started"
+  reviewName: previous-jobrequestreview

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/validate_jobrequestreviews.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/validate_jobrequestreviews.yaml
@@ -12,7 +12,7 @@ tests:
         object: samples/validate_jobrequestreviews/allow_reviewing_unreviewed_jobrequest/case.yaml
         assertions:
           - violations: no
-      - name: deny a JobRequestReview which attempts to review and already reviewed JobRequest
+      - name: deny a JobRequestReview which attempts to review an already reviewed JobRequest
         inventory:
           - samples/validate_jobrequestreviews/deny_reviewing_already_reviewed_jobrequest/inventory.yaml
         object: samples/validate_jobrequestreviews/deny_reviewing_already_reviewed_jobrequest/case.yaml

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/validate_jobrequestreviews.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/validate_jobrequestreviews.yaml
@@ -1,0 +1,33 @@
+---
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+tests:
+  - name: ValidateJobRequestReviews
+    template: ../../resources/constraint_templates/validate_jobrequestreviews.yaml
+    constraint: ../../resources/constraints/validate_jobrequestreviews.yaml
+    cases:
+      - name: allow a JobRequestReview to review an unreviewed JobRequest
+        inventory:
+          - samples/validate_jobrequestreviews/allow_reviewing_unreviewed_jobrequest/inventory.yaml
+        object: samples/validate_jobrequestreviews/allow_reviewing_unreviewed_jobrequest/case.yaml
+        assertions:
+          - violations: no
+      - name: deny a JobRequestReview which attempts to review and already reviewed JobRequest
+        inventory:
+          - samples/validate_jobrequestreviews/deny_reviewing_already_reviewed_jobrequest/inventory.yaml
+        object: samples/validate_jobrequestreviews/deny_reviewing_already_reviewed_jobrequest/case.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequest \\(test-jobrequest-reviewed\\) has already been reviewed by JobRequestReview \\(previous-jobrequestreview\\) and is now in state \\(Started\\)"
+      - name: deny a JobRequestReview which references a non-existant JobRequest
+        object: samples/validate_jobrequestreviews/deny_referencing_nonexisting_jobrequest/case.yaml
+        assertions:
+          - violations: yes
+            message: "The JobRequestReview references JobRequest \\(test-jobrequest-notfound\\) but that JobRequest cannot be found in the namespace of the JobRequestReview \\(apps\\)"
+      - name: deny a JobRequestReview which references a JobRequest in a different namespace
+        object: samples/validate_jobrequestreviews/deny_referencing_jobrequest_in_another_namespace/case.yaml
+        inventory:
+          - samples/validate_jobrequestreviews/deny_referencing_jobrequest_in_another_namespace/inventory.yaml
+        assertions:
+          - violations: yes
+            message: "The JobRequestReview references JobRequest \\(test-jobrequest-another-namespace\\) but that JobRequest cannot be found in the namespace of the JobRequestReview \\(apps\\)"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/validate_jobrequestreviews.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/validate_jobrequestreviews.yaml
@@ -31,3 +31,13 @@ tests:
         assertions:
           - violations: yes
             message: "The JobRequestReview references JobRequest \\(test-jobrequest-another-namespace\\) but that JobRequest cannot be found in the namespace of the JobRequestReview \\(apps\\)"
+      - name: allow deleting a JobRequestReview when the JobRequest it references no longer exists
+        object: samples/validate_jobrequestreviews/allow_deleting_jobrequestreviews_when_jobrequest_notfound/case.yaml
+        assertions:
+          - violations: no
+      - name: allow deleting a JobRequestReview when the JobRequest still exists
+        object: samples/validate_jobrequestreviews/allow_deleting_jobrequestreviews_when_jobrequest_exists/case.yaml
+        inventory:
+          - samples/validate_jobrequestreviews/allow_deleting_jobrequestreviews_when_jobrequest_exists/inventory.yaml
+        assertions:
+          - violations: no

--- a/terraform/deployments/cluster-services/modules/gatekeeper/variables.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/variables.tf
@@ -27,7 +27,8 @@ variable "audit_mem_req" {
 variable "dryrun_map" {
   description = "run constraints in dryrun mode"
   type = object({
-    immutable_configmap = bool
+    immutable_configmap        = bool
+    validate_jobrequestreviews = bool
   })
 }
 


### PR DESCRIPTION
## What
NOTE: There's a fair bit of whitespace change so you might want to [view this PR with whitespace changes ignored](https://github.com/alphagov/govuk-infrastructure/pull/4610/changes?w=1)

* Add JobRequest and JobRequestReviews into the gatekeeper inventory sync policy
* Add a gatekeeper rule which disallows reviewing an already reviewed JobRequest

## How to review

I have a running ephemeral cluster with everything installed in, and enough stuff going so a job can actually run to completion. If you want a demo, or to test in that cluster let me know and I can hook you up :)

If you want to test this you can run the gator tests first (you'll need to `brew install gator` first probably):

### Gator tests

```
$ cd terraform/deployments/cluster-services/modules/gatekeeper
$ gator verify test/suite/ --verbose
```

<details><summary>Expected test suite output</summary>

```
=== RUN   immutable_configmaps
    === RUN   allow updating in an allowed namespace by an allowed group
    --- PASS: allow updating in an allowed namespace by an allowed group	(0.003s)
    === RUN   allow updating from an allowed group in a user's namespace
    --- PASS: allow updating from an allowed group in a user's namespace	(0.002s)
    === RUN   deny updating from a user's group in an excluded namespace
    --- PASS: deny updating from a user's group in an excluded namespace	(0.003s)
    === RUN   deny updating from a user's group in a user's namepsace
    --- PASS: deny updating from a user's group in a user's namepsace	(0.002s)
--- PASS: immutable_configmaps	(0.015s)
ok	test/suite/immutable_configmaps.yaml	0.015s
=== RUN   ValidateJobRequestReviews
    === RUN   allow a JobRequestReview to review an unreviewed JobRequest
    --- PASS: allow a JobRequestReview to review an unreviewed JobRequest	(0.002s)
    === RUN   deny a JobRequestReview which attempts to review and already reviewed JobRequest
    --- PASS: deny a JobRequestReview which attempts to review and already reviewed JobRequest	(0.003s)
    === RUN   deny a JobRequestReview which references a non-existant JobRequest
    --- PASS: deny a JobRequestReview which references a non-existant JobRequest	(0.002s)
    === RUN   deny a JobRequestReview which references a JobRequest in a different namespace
    --- PASS: deny a JobRequestReview which references a JobRequest in a different namespace	(0.002s)
    === RUN   allow deleting a JobRequestReview when the JobRequest it references no longer exists
    --- PASS: allow deleting a JobRequestReview when the JobRequest it references no longer exists	(0.001s)
    === RUN   allow deleting a JobRequestReview when the JobRequest still exists
    --- PASS: allow deleting a JobRequestReview when the JobRequest still exists	(0.003s)
--- PASS: ValidateJobRequestReviews	(0.016s)
ok	test/suite/validate_jobrequestreviews.yaml	0.016s
PASS
```
</details>

### Running against a real cluster

You could also run up an ephemeral cluster, deploy the operator and try and create some JobRequests and JobRequestReviews. But to save you all the pain here's some output:

#### Kubernetes manifests required for testing

<details><summary>File: jobRequestForSuccessfulJob.yaml</summary>

```yaml
---
apiVersion: platform.publishing.service.gov.uk/v1
kind: JobRequest
metadata:
  name: jfharden-jr-success-1
  annotations:
    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::430354129336:assumed-role/jonathan.harden-platformengineer/test-platformengineer
spec:
  containerFrom:
    podSpecFrom:
      group: apps/v1
      kind: Deployment
      name: govuk-replatform-test-app
    containerName: app
  command: rake
  args: ["hello"]
```
</details>

<details><summary>File: jobRequestReviewRejected.yaml</summary>

```yaml
---
apiVersion: platform.publishing.service.gov.uk/v1
kind: JobRequestReview
metadata:
  name: jfharden-jrr-reject-1
  annotations:
    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::430354129336:assumed-role/joe.blogs-platformengineer/test-platformengineer
spec:
  jobRequestName: jfharden-jr-success-1
  decision: Rejected
  description: "Not suitable to run"
```
</details>

<details><summary>File: jobRequestReviewApproved.yaml</summary>

```yaml
---
apiVersion: platform.publishing.service.gov.uk/v1
kind: JobRequestReview
metadata:
  name: jfharden-jrr-approve-1
  annotations:
    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::430354129336:assumed-role/joe.blogs-platformengineer/test-platformengineer
spec:
  jobRequestName: jfharden-jr-success-1
  decision: Approved
  description: "LGTM"
```
</details>

#### The tests

<details><summary>1. Try and create a review when the JobRequest it refers to does not exist:</summary>

```
$ kubectl get jobrequests
No resources found in apps namespace.
$ kubectl apply -f jobRequestReviewRejected.yaml
Error from server (Forbidden): error when creating "jobRequestReviewRejected.yaml": admission webhook "validation.gatekeeper.sh" denied the request: [validatejobrequestreview] The JobRequestReview references JobRequest (jfharden-jr-success-1) but that JobRequest cannot be found in the namespace of the JobRequestReview (apps)
```
</details>

<details><summary>2. Create a JobRequest, then reject it, then try and approve it</summary>

```
$ kubectl apply -f jobRequestForSuccessfulJob.yaml
jobrequest.platform.publishing.service.gov.uk/jfharden-jr-success-1 created
$ kubectl apply -f jobRequestReviewRejected.yaml
jobrequestreview.platform.publishing.service.gov.uk/jfharden-jrr-reject-1 created
$ kubectl get jr
NAME                    COMMAND   ARGUMENTS   STATE      JOB NAME   AGE
jfharden-jr-success-1   rake      ["hello"]   Rejected              19s
$ kubectl apply -f jobRequestReviewApproved.yaml
Error from server (Forbidden): error when creating "jobRequestReviewApproved.yaml": admission webhook "validation.gatekeeper.sh" denied the request: [validatejobrequestreview] JobRequest (jfharden-jr-success-1) has already been reviewed by JobRequestReview (jfharden-jrr-reject-1) and is now in state (Rejected)
```
</details>

<details><summary>3. Delete a JobRequestReview when the JobRequest no longer exists</summary>

```
$ kubectl delete jr jfharden-jr-success-1
jobrequest.platform.publishing.service.gov.uk "jfharden-jr-success-1" deleted from apps namespace
$ kubectl delete jrr jfharden-jrr-reject-1
jobrequestreview.platform.publishing.service.gov.uk "jfharden-jrr-reject-1" deleted from apps namespace
```
</details>

<details><summary>4. Create a JobRequest, then approve it, then try and reject it</summary>

```
$ kubectl apply -f jobRequestForSuccessfulJob.yaml
jobrequest.platform.publishing.service.gov.uk/jfharden-jr-success-1 created
$ kubectl apply -f jobRequestReviewApproved.yaml
jobrequestreview.platform.publishing.service.gov.uk/jfharden-jrr-approve-1 created
$ kubectl get jr
NAME                    COMMAND   ARGUMENTS   STATE     JOB NAME                AGE
jfharden-jr-success-1   rake      ["hello"]   Started   jfharden-jr-success-1   11s
$ kubectl apply -f jobRequestReviewRejected.yaml
Error from server (Forbidden): error when creating "jobRequestReviewRejected.yaml": admission webhook "validation.gatekeeper.sh" denied the request: [validatejobrequestreview] JobRequest (jfharden-jr-success-1) has already been reviewed by JobRequestReview (jfharden-jrr-approve-1) and is now in state (Started)
```
</details>

<details><summary>5. Delete a JobRequestReview while the JobRequest still exists</summary>

```
$ kubectl get jr
NAME                    COMMAND   ARGUMENTS   STATE      JOB NAME                AGE
jfharden-jr-success-1   rake      ["hello"]   Complete   jfharden-jr-success-1   61s
$ kubectl delete jrr jfharden-jrr-approve-1
jobrequestreview.platform.publishing.service.gov.uk "jfharden-jrr-approve-1" deleted from apps namespace
$ kubectl get jr
NAME                    COMMAND   ARGUMENTS   STATE      JOB NAME                AGE
jfharden-jr-success-1   rake      ["hello"]   Complete   jfharden-jr-success-1   74s
$ kubectl get jrr
No resources found in apps namespace.
```
</details>