### PR TITLE
Match up ITHC role cluster permissions with those of readonly

### DIFF
--- a/terraform/deployments/cluster-access/eks_access.tf
+++ b/terraform/deployments/cluster-access/eks_access.tf
@@ -146,6 +146,21 @@ module "ithctester" {
       api_groups = ["argoproj.io", "external-secrets.io"]
       resources  = ["*"]
       verbs      = ["get", "list", "watch"]
+    },
+    {
+      api_groups = [""]
+      resources  = ["namespaces", "pods", "pods/logs", "services", "configmaps", "endpoints", "events"]
+      verbs      = ["get", "list", "watch"]
+    },
+    {
+      api_groups = ["apps", "batch"]
+      resources  = ["deployments", "replicasets", "statefulsets", "jobs", "cronjobs"]
+      verbs      = ["get", "list", "watch"]
+    },
+    {
+      api_groups = ["networking.k8s.io"]
+      resources  = ["ingresses"]
+      verbs      = ["get", "list", "watch"]
     }
   ]
 


### PR DESCRIPTION
The ITHC role has slightly elevated permissions in AWS, but its cluster permissions should match readonly.