### PR TITLE
Typo in 'govuk-ai-information-architects'

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1141,7 +1141,7 @@ repos:
     # standard security checks are disabled as not configured for a private repo
     can_be_deployed: false
     push_allowances:
-      - "alphagov/govuk-ai-inforamtion-architects"
+      - "alphagov/govuk-ai-information-architects"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"
     


### PR DESCRIPTION
It was spelled 'govuk-ai-inforamtion-architects'