### PR TITLE
(CR-64) Retire siteimprove_api_client gem - part 2

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -898,7 +898,8 @@ repos:
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
 
-  siteimprove_api_client: {}
+  siteimprove_api_client:
+    archived: true
 
   slimmer:
     archived: true


### PR DESCRIPTION
Archive the siteimprove_api_client gem.

This repo does not have a visibility property set so this is not needed.

For more information see https://gov-uk.atlassian.net/browse/CR-64 and alphagov/siteimprove_api_client#76