### PR TITLE
Fix typo in gov-uk-information-architects team name

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1141,7 +1141,7 @@ repos:
     # standard security checks are disabled as not configured for a private repo
     can_be_deployed: false
     push_allowances:
-      - "alphagov/govuk-ai-information-architects"
+      - "alphagov/gov-uk-information-architects"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"
     


### PR DESCRIPTION
In the end this was intended to reference https://github.com/orgs/alphagov/teams/gov-uk-information-architects so I'm reasonably confident this is now the right value