### PR TITLE
Grant readonly access to cluster roles to ITHC testers

### DIFF
--- a/terraform/deployments/cluster-access/eks_access.tf
+++ b/terraform/deployments/cluster-access/eks_access.tf
@@ -161,6 +161,11 @@ module "ithctester" {
       api_groups = ["networking.k8s.io"]
       resources  = ["ingresses"]
       verbs      = ["get", "list", "watch"]
+    },
+    {
+      api_groups = ["rbac.authorization.k8s.io"]
+      resources  = ["clusterroles"]
+      verbs      = ["get", "list"]
     }
   ]
 


### PR DESCRIPTION
ITHC testers are likely to audit this kind of thing, so having readonly access is necessary.