### PR TITLE
fix: 🐛 dns failures on fresh cluster for dex

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -233,9 +233,22 @@ resource "helm_release" "argo_bootstrap_ephemeral" {
   })]
 }
 
+resource "terraform_data" "dex_ready" {
+  depends_on = [helm_release.dex]
+
+  provisioner "local-exec" {
+    command = <<EOT
+         until curl -IL "https://${local.dex_host}/.well-known/openid-configuration" | grep "HTTP" | grep -q "200"; do
+           echo "Waiting for dex to be fully ready..."
+           sleep 5
+         done
+       EOT
+  }
+}
+
 resource "helm_release" "argo_workflows" {
   depends_on = [
-    helm_release.dex,
+    terraform_data.dex_ready,
     kubernetes_secret_v1.dex_client,
     module.gatekeeper
   ]


### PR DESCRIPTION
Previously `cluster-services` layer would fail to deploy argo workflows because of dns errors. Wait for dns to be available before trying to deploy dex dependent services.

eg.
```
argo-workflows-server-7d49d77ff5-rzv9t argo-server Error: Get "https://dex.eph-jas-300726-0.ephemeral.govuk.digital/.well-known/openid-configuration": dial tcp: lookup dex.eph-jas-300726-0.ephemeral.govuk.digital on 172.20.0.10:53: no such host
```

`cluster-services` will now deploy without failure.

https://app.terraform.io/app/govuk/workspaces/cluster-services-eph-jas-060826-0/runs/run-Dz6Sa3xZb84bgcXT