### PR TITLE
Adding CNAME for architecture github pages site

### DIFF
--- a/terraform/variables/production/govuk-publishing-infrastructure.tfvars
+++ b/terraform/variables/production/govuk-publishing-infrastructure.tfvars
@@ -80,6 +80,7 @@ subdomain_dns_records = [
   { type = "CNAME", name = "guidance", ttl = 300, value = ["alphagov.github.io."] },
   { type = "CNAME", name = "whitehall-admin", ttl = 300, value = ["whitehall-admin.eks.production.govuk.digital."] },
   { type = "CNAME", name = "www-origin", ttl = 300, value = ["www-origin.eks.production.govuk.digital."] },
+  { type = "CNAME", name = "architecture", ttl = 3600, value = ["alphagov.github.io."] },
   { type = "TXT", name = "_github-pages-challenge-alphagov.architecture", ttl = 300, value = ["8048c0a9324627acf3cad6e91cb0d8"] }, // pragma: allowlist secret
 ]
 


### PR DESCRIPTION
adds CNAME for architecture diagrams github pages site

(https://architecture.publishing.service.gov.uk)