### PR TITLE
Revert govuk-cli CI workflow name change

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -465,7 +465,7 @@ repos:
     push_allowances: ["alphagov/gov-uk-platform-engineering"]
     required_status_checks:
       additional_contexts:
-        - Test Go
+        - Test Go / Test Go
         - CodeQL SAST scan / Analyze
         - Dependency Review scan / dependency-review-pr
 


### PR DESCRIPTION
We're no longer using a forked version of the Go CI workflow, so we need to change the required check back to the standard one

https://github.com/alphagov/govuk-infrastructure/issues/4175