### PR TITLE
Bump kubectl provider to 3.0.0-beta3

### DIFF
--- a/terraform/deployments/cluster-services/main.tf
+++ b/terraform/deployments/cluster-services/main.tf
@@ -36,7 +36,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "2.1.3"
+      version = "3.0.0-beta3"
     }
   }
 }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/constraint_templates/versions.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/constraint_templates/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     kubectl = {
       source  = "alekc/kubectl"
-      version = "2.1.3"
+      version = "3.0.0-beta3"
     }
   }
 }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/constraints/versions.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/constraints/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     kubectl = {
       source  = "alekc/kubectl"
-      version = "2.1.3"
+      version = "3.0.0-beta3"
     }
   }
 }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/versions.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     kubectl = {
       source  = "alekc/kubectl"
-      version = "2.1.3"
+      version = "3.0.0-beta3"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
kubectl provider less than 3 has a serious bug where if the apply errors the state is updated anyway and now it thinks the change has been applied and will never apply it.

This is fixed in the beta for 3.0, given we are actively hitting the bug in 2 so it's broken for us, I'm taking the unusual step to use the beta version of the provider