### PR TITLE
Add rego policy to block missing request review annotations

### DIFF
--- a/terraform/deployments/cluster-services/gatekeeper.tf
+++ b/terraform/deployments/cluster-services/gatekeeper.tf
@@ -2,8 +2,9 @@ module "gatekeeper" {
   source = "./modules/gatekeeper"
 
   dryrun_map = {
-    immutable_configmap        = true
-    validate_jobrequestreviews = false
+    immutable_configmap                    = true
+    validate_jobrequestreviews             = false
+    jobrequestoperator_requiredannotations = false
   }
 
   constraint_violations_max_to_display = 25

--- a/terraform/deployments/cluster-services/modules/gatekeeper/constraints/locals.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/constraints/locals.tf
@@ -1,11 +1,13 @@
 locals {
-  constraint_path            = "${path.module}/../resources/constraints"
-  immutable_configmap_yaml   = yamldecode(file("${local.constraint_path}/immutable_configmap.yaml"))
-  validate_jobrequestreviews = yamldecode(file("${local.constraint_path}/validate_jobrequestreviews.yaml"))
+  constraint_path                        = "${path.module}/../resources/constraints"
+  immutable_configmap_yaml               = yamldecode(file("${local.constraint_path}/immutable_configmap.yaml"))
+  validate_jobrequestreviews             = yamldecode(file("${local.constraint_path}/validate_jobrequestreviews.yaml"))
+  jobrequestoperator_requiredannotations = yamldecode(file("${local.constraint_path}/jobrequestoperator_requiredannotations.yaml"))
 
   # For each constraint, a value needs to be in the constraint map. This bloc allows us to set values on constraints which enables us to toggle the configuration of the constraints. -- we merge in the spec separately to avoid overwriting entire spec key
   constraint_map = {
-    immutable_configmap        = merge(local.immutable_configmap_yaml, { "spec" : merge(local.immutable_configmap_yaml, { "enforcementAction" : var.dryrun_map.immutable_configmap ? "dryrun" : "deny" }) })
-    validate_jobrequestreviews = merge(local.validate_jobrequestreviews, { "spec" : merge(local.validate_jobrequestreviews, { "enforcementAction" : var.dryrun_map.validate_jobrequestreviews ? "dryrun" : "deny" }) })
+    immutable_configmap                    = merge(local.immutable_configmap_yaml, { "spec" : merge(local.immutable_configmap_yaml, { "enforcementAction" : var.dryrun_map.immutable_configmap ? "dryrun" : "deny" }) })
+    validate_jobrequestreviews             = merge(local.validate_jobrequestreviews, { "spec" : merge(local.validate_jobrequestreviews, { "enforcementAction" : var.dryrun_map.validate_jobrequestreviews ? "dryrun" : "deny" }) })
+    jobrequestoperator_requiredannotations = merge(local.jobrequestoperator_requiredannotations, { "spec" : merge(local.jobrequestoperator_requiredannotations, { "enforcementAction" : var.dryrun_map.jobrequestoperator_requiredannotations ? "dryrun" : "deny" }) })
   }
 }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/constraints/variables.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/constraints/variables.tf
@@ -1,8 +1,9 @@
 variable "dryrun_map" {
   description = "run constraints in dryrun mode"
   type = object({
-    immutable_configmap        = bool
-    validate_jobrequestreviews = bool
+    immutable_configmap                    = bool
+    validate_jobrequestreviews             = bool
+    jobrequestoperator_requiredannotations = bool
   })
 }
 

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/jobrequestoperator_requiredannotations.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/jobrequestoperator_requiredannotations.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: jobrequestoperatorrequiredannotations
+  annotations:
+    metadata.gatekeeper.sh/title: Validate a JobRequest has a requested-by annotation
+    description: This constraint ensures a JobRequest has the requested-by annotation
+spec:
+  crd:
+    spec:
+      names:
+        kind: JobRequestOperatorRequiredAnnotations
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package jobrequestoperatorrequiredannotations
+
+        annotation_keys := {
+          "JobRequest": "platform.publishing.service.gov.uk/requested-by",
+          "JobRequestReview": "platform.publishing.service.gov.uk/reviewed-by"
+        }
+
+        violation[{"msg": msg}] {
+          input.review.operation != "DELETE"
+
+          annotation_key := annotation_keys[input.review.kind.kind]
+
+          annotation_value := object.get(
+            input.review.object,
+            ["metadata", "annotations", annotation_key],
+            ""
+          )
+          annotation_value == ""
+
+          msg := sprintf(
+            "The %s (%s) does not include the required annotation (%s)",
+            [input.review.kind.kind, input.review.name, annotation_key]
+          )
+        }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraints/jobrequestoperator_requiredannotations.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraints/jobrequestoperator_requiredannotations.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: JobRequestOperatorRequiredAnnotations
+metadata:
+  name: jobrequest-operator-required-annotations
+spec:
+  match:
+    kinds:
+      - apiGroups: ["platform.publishing.service.gov.uk"]
+        kinds:
+          - "JobRequest"
+          - "JobRequestReview"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/jobrequestoperator_requiredannotations.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/jobrequestoperator_requiredannotations.yaml
@@ -1,0 +1,36 @@
+---
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+tests:
+  - name: ValidateJobRequestReviews
+    template: ../../resources/constraint_templates/jobrequestoperator_requiredannotations.yaml
+    constraint: ../../resources/constraints/jobrequestoperator_requiredannotations.yaml
+    cases:
+      - name: allow a JobRequest with the correct annotation
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_correct_annotation/case.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequestReview with the correct annotation
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_correct_annotation/case.yaml
+        assertions:
+          - violations: no
+      - name: deny a JobRequest without the correct annotation
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequest_without_correct_annotation/case.yaml
+        assertions:
+          - violations: yes
+            message: "The JobRequest \\(test-jr-no-annotation\\) does not include the required annotation \\(platform.publishing.service.gov.uk/requested-by\\)"
+      - name: deny a JobRequestReview without the correct annotation
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_without_correct_annotation/case.yaml
+        assertions:
+          - violations: yes
+            message: "The JobRequestReview \\(test-jrr-no-annotation\\) does not include the required annotation \\(platform.publishing.service.gov.uk/reviewed-by\\)"
+      - name: deny a JobRequest with the correct annotation set to an empty string
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_correct_annotation_set_to_empty_string/case.yaml
+        assertions:
+          - violations: yes
+            message: "The JobRequest \\(test-jr-empty-annotation\\) does not include the required annotation \\(platform.publishing.service.gov.uk/requested-by\\)"
+      - name: deny a JobRequestReview with the correct annotation set to an empty string
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_correct_annotation_set_to_empty_string/case.yaml
+        assertions:
+          - violations: yes
+            message: "The JobRequestReview \\(test-jrr-empty-annotation\\) does not include the required annotation \\(platform.publishing.service.gov.uk/reviewed-by\\)"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_correct_annotation/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_correct_annotation/case.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/user.name-platformengineer/environment-platformengineer
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_correct_annotation/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_correct_annotation/case.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/otheruser.name-platformengineer/test-platformengineer
+spec:
+  jobRequestName: test-jobrequest-unreviewed
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_correct_annotation_set_to_empty_string/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_correct_annotation_set_to_empty_string/case.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-empty-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: ""
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequest_without_correct_annotation/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequest_without_correct_annotation/case.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-no-annotation
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_correct_annotation_set_to_empty_string/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_correct_annotation_set_to_empty_string/case.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-empty-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: ""
+spec:
+  jobRequestName: test-jobrequest-unreviewed
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_without_correct_annotation/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_without_correct_annotation/case.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-no-annotation
+  namespace: apps
+spec:
+  jobRequestName: test-jobrequest-unreviewed
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/variables.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/variables.tf
@@ -27,8 +27,9 @@ variable "audit_mem_req" {
 variable "dryrun_map" {
   description = "run constraints in dryrun mode"
   type = object({
-    immutable_configmap        = bool
-    validate_jobrequestreviews = bool
+    immutable_configmap                    = bool
+    validate_jobrequestreviews             = bool
+    jobrequestoperator_requiredannotations = bool
   })
 }
 


### PR DESCRIPTION
* Add new rego constraint to deny creating JobRequests without the requested-by annotation and JobRequestReviews without the reviewed-by annotation