### PR TITLE
ecr: add govuk-job-request-operator repository

### DIFF
--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -59,6 +59,7 @@ locals {
   extra_repositories = [
     "clamav",
     "govuk-fastly-diff-generator",
+    "govuk-job-request-operator",
     "govuk-replatform-test-app",
     "imminence",
     "licensify-backend",

--- a/terraform/deployments/ecr/main.tf
+++ b/terraform/deployments/ecr/main.tf
@@ -48,10 +48,10 @@ provider "github" {
 }
 
 locals {
-  repositories = concat(
+  repositories = distinct(concat(
     local.extra_repositories,
     data.tfe_outputs.github.nonsensitive_values.deployable_repo_names
-  )
+  ))
 
   // Populate this with Repos that need to be deleted
   deleted_repositories = []

--- a/terraform/deployments/tfc-configuration/github.tf
+++ b/terraform/deployments/tfc-configuration/github.tf
@@ -25,6 +25,8 @@ module "github" {
   variable_set_ids = [
     local.aws_credentials["tools"],
   ]
+
+  remote_state_consumer_ids = [module.ecr-production.workspace_id]
 }
 
 resource "tfe_project" "github" {


### PR DESCRIPTION
Also includes quick fixes for:
- if a repository name is included in the output from the github workspace and in extra_repositories
- The ecr-production workspace not having access to the github workspace state

https://github.com/alphagov/govuk-infrastructure/issues/4635