### PR TITLE
Edit write permissions in search GCP projects

### DIFF
--- a/terraform/deployments/search-api-v2/events_ingestion.tf
+++ b/terraform/deployments/search-api-v2/events_ingestion.tf
@@ -24,7 +24,6 @@ resource "google_project_iam_binding" "analytics_write" {
   project = var.gcp_project_id
   members = [
     google_service_account.analytics_events_pipeline.member,
-    "serviceAccount:service-${var.gcp_dataform_project_number}@gcp-sa-dataform.iam.gserviceaccount.com"
   ]
 }
 

--- a/terraform/deployments/search-api-v2/variables.tf
+++ b/terraform/deployments/search-api-v2/variables.tf
@@ -19,12 +19,6 @@ variable "gcp_analytics_project_id" {
   default     = "ga4-analytics-352613"
 }
 
-variable "gcp_dataform_project_number" {
-  type        = string
-  description = "GCP project number for the dataform instance orchestrating data movement"
-  default     = "235345844001"
-}
-
 variable "gcp_region" {
   type        = string
   description = "GCP region to create non-global infrastructure in, e.g. europe-west2"


### PR DESCRIPTION
Removes permissions for the default Dataform service account in the search-v2-api-infrastructure GCP project to write to BigQuery in the main search v2 GCP projects (for integration, staging and production).

It seems that search-v2-api-infrastructure was used as a sandbox to set up the Dataform workflows to pull GA4 user event data and store it in BigQuery before importing it into Discovery Engine. These workflows are now run from inside the main search v2 projects, so search-v2-api-infrastructure is no longer needed.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1963