### PR TITLE
Add gatekeeper rules to deny reviewing own jobrequest

### DIFF
--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/jobrequestoperator_requiredannotations.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/jobrequestoperator_requiredannotations.yaml
@@ -93,3 +93,26 @@ spec:
             [input.review.kind.kind, input.review.name, split(annotation_key, "/")[1], arn]
           )
         }
+
+        violation[{"msg": msg}] {
+          valid_operation
+          input.review.kind.kind == "JobRequestReview"
+
+          namespace := input.review.namespace
+          job_request_name := input.review.object.spec.jobRequestName
+
+          job_request := data.inventory.namespace[namespace]["platform.publishing.service.gov.uk/v1"]["JobRequest"][job_request_name]
+
+          requested_by_arn := input.review.object.metadata.annotations[annotation_keys["JobRequestReview"]]
+          reviewed_by_arn := job_request.metadata.annotations[annotation_keys["JobRequest"]]
+
+          requested_by_username := parse_username_from_arn(requested_by_arn)
+          reviewed_by_username := parse_username_from_arn(reviewed_by_arn)
+
+          requested_by_username == reviewed_by_username
+
+          msg := sprintf(
+            "JobRequestReview (%s) cannot review JobRequest (%s) since the reviewer and requester are the same user (%s)",
+            [input.review.name, job_request_name, reviewed_by_username]
+          )
+        }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/jobrequestoperator_requiredannotations.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/jobrequestoperator_requiredannotations.yaml
@@ -17,13 +17,17 @@ spec:
       rego: |
         package jobrequestoperatorrequiredannotations
 
+        valid_operation {
+          input.review.operation != "DELETE"
+        }
+
         annotation_keys := {
           "JobRequest": "platform.publishing.service.gov.uk/requested-by",
           "JobRequestReview": "platform.publishing.service.gov.uk/reviewed-by"
         }
 
         violation[{"msg": msg}] {
-          input.review.operation != "DELETE"
+          valid_operation
 
           annotation_key := annotation_keys[input.review.kind.kind]
 
@@ -37,5 +41,55 @@ spec:
           msg := sprintf(
             "The %s (%s) does not include the required annotation (%s)",
             [input.review.kind.kind, input.review.name, annotation_key]
+          )
+        }
+
+        default parse_gds_username(gds_users_part) := ""
+
+        parse_gds_username(gds_users_part) := username {
+          strings.any_suffix_match(gds_users_part, [
+            "-fulladmin",
+            "-tempadmin",
+            "-platformengineer",
+            "-developer",
+            "-readonly",
+            "-ithctester",
+          ])
+          user_parts := split(gds_users_part, "-")
+          username = concat("-", array.slice(user_parts, 0, count(user_parts) - 1))
+        }
+
+        parse_entraid_username(entra_id_part, gds_username) := entra_id_part {
+          contains(entra_id_part, "@")
+        } else := gds_username
+
+        default parse_username_from_arn(arn) := ""
+
+        parse_username_from_arn(arn) := username {
+          arn_parts := split(arn, "/")
+          arn_parts_length := count(arn_parts)
+          arn_parts_length == 3
+
+          arn_prefix := arn_parts[0]
+
+          endswith(arn_prefix, "assumed-role")
+
+          gds_username := parse_gds_username(arn_parts[1])
+          username := parse_entraid_username(arn_parts[2], gds_username)
+        }
+
+        violation[{"msg": msg}] {
+          valid_operation
+
+          annotation_key := annotation_keys[input.review.kind.kind]
+          arn := input.review.object.metadata.annotations[annotation_key]
+
+          username := parse_username_from_arn(arn)
+
+          username == ""
+
+          msg := sprintf(
+            "%s (%s) has a %s annotation (%s) which cannot be parsed to a username",
+            [input.review.kind.kind, input.review.name, split(annotation_key, "/")[1], arn]
           )
         }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/jobrequestoperator_requiredannotations.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/jobrequestoperator_requiredannotations.yaml
@@ -140,3 +140,31 @@ tests:
         assertions:
           - violations: yes
             message: "JobRequestReview \\(test-jrr-with-annotation\\) has a reviewed-by annotation \\(arn:aws:sts::123456789:assumed-role/user.name-unknownrole/test-environment\\) which cannot be parsed to a username"
+      - name: deny a JobRequestReview where the reviewer is the same as the requester and they are both the same gds-users role
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/same-gds-users-role.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequestReview \\(test-jrr-with-annotation\\) cannot review JobRequest \\(test-jr-with-annotation\\) since the reviewer and requester are the same user \\(requesting.user\\)"
+      - name: deny a JobRequestReview where the reviewer is the same as the requester and they have different gds-users roles
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/different-gds-users-role.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequestReview \\(test-jrr-with-annotation\\) cannot review JobRequest \\(test-jr-with-annotation\\) since the reviewer and requester are the same user \\(requesting.user\\)"
+      - name: deny a JobRequestReview where the reviewer is the same as the requester and they are both the same EntraID role
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/same-entra-id-users-role.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_entra_id_user.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequestReview \\(test-jrr-with-annotation\\) cannot review JobRequest \\(test-jr-with-annotation\\) since the reviewer and requester are the same user \\(requesting.user@example.com\\)"
+      - name: deny a JobRequestReview where the reviewer is the same as the requester and they have different EntraID roles
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/different-entra-id-users-role.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_entra_id_user.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequestReview \\(test-jrr-with-annotation\\) cannot review JobRequest \\(test-jr-with-annotation\\) since the reviewer and requester are the same user \\(requesting.user@example.com\\)"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/jobrequestoperator_requiredannotations.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/jobrequestoperator_requiredannotations.yaml
@@ -34,3 +34,109 @@ tests:
         assertions:
           - violations: yes
             message: "The JobRequestReview \\(test-jrr-empty-annotation\\) does not include the required annotation \\(platform.publishing.service.gov.uk/reviewed-by\\)"
+      - name: allow a JobRequest where the annotation is a gds-users fulladmin arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/fulladmin.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequest where the annotation is a gds-users tempadmin arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/tempadmin.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequest where the annotation is a gds-users platformengineer arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/platformengineer.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequest where the annotation is a gds-users developer arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/developer.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequest where the annotation is a gds-users readonly arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/readonly.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequest where the annotation is a gds-users ithctester arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/ithctester.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequest where the annotation is an EntraID arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_entra_id_arn/case.yaml
+        assertions:
+          - violations: no
+      - name: deny a JobRequest where the annotation is an arn that is not an assumed-role arn
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_not_assumed_role_arn/case.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequest \\(test-jr-with-annotation\\) has a requested-by annotation \\(arn:aws:sts::123456789:role/SomeRole\\) which cannot be parsed to a username"
+      - name: deny a JobRequest where the annotation is not an arn
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_not_an_arn/case.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequest \\(test-jr-with-annotation\\) has a requested-by annotation \\(wibble\\) which cannot be parsed to a username"
+      - name: deny a JobRequest where the annotation is an assumed-role arn that cannot be parsed as either gds-users or EntraID
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_not_gds_users_or_entra_id_arn/case.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequest \\(test-jr-with-annotation\\) has a requested-by annotation \\(arn:aws:sts::123456789:assumed-role/user.name-unknownrole/test-environment\\) which cannot be parsed to a username"
+      - name: allow a JobRequestReview where the annotation is a gds-users fulladmin arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/fulladmin.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequestReview where the annotation is a gds-users tempadmin arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/tempadmin.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequestReview where the annotation is a gds-users platformengineer arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/platformengineer.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequestReview where the annotation is a gds-users developer arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/developer.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequestReview where the annotation is a gds-users readonly arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/readonly.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequestReview where the annotation is a gds-users ithctester arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/ithctester.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: no
+      - name: allow a JobRequestReview where the annotation is an EntraID arn
+        object: samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_entra_id_arn/case.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: no
+      - name: deny a JobRequestReview where the annotation is an arn that is not an assumed-role arn
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_not_assumed_role_arn/case.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequestReview \\(test-jrr-with-annotation\\) has a reviewed-by annotation \\(arn:aws:sts::123456789:role/SomeRole\\) which cannot be parsed to a username"
+      - name: deny a JobRequestReview where the annotation is not an arn
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_not_an_arn/case.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequestReview \\(test-jrr-with-annotation\\) has a reviewed-by annotation \\(wibble\\) which cannot be parsed to a username"
+      - name: deny a JobRequestReview where the annotation is an assumed-role arn that cannot be parsed as either gds-users or EntraID
+        object: samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_not_gds_users_or_entra_id_arn/case.yaml
+        inventory:
+          - samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+        assertions:
+          - violations: yes
+            message: "JobRequestReview \\(test-jrr-with-annotation\\) has a reviewed-by annotation \\(arn:aws:sts::123456789:assumed-role/user.name-unknownrole/test-environment\\) which cannot be parsed to a username"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_entra_id_arn/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_entra_id_arn/case.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/SomeRole/user.name@example.com
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/developer.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/developer.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/user.name-developer/test-environment
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/fulladmin.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/fulladmin.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/user.name-fulladmin/test-environment
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/ithctester.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/ithctester.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/user.name-ithctester/test-environment
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/platformengineer.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/platformengineer.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/user.name-platformengineer/test-environment
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/readonly.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/readonly.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/user.name-readonly/test-environment
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/tempadmin.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequest_with_gds_users_arn/tempadmin.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/user.name-tempadmin/test-environment
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_entra_id_arn/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_entra_id_arn/case.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/SomeRole/user.name@example.com
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/developer.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/developer.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/user.name-developer/test-environment
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/fulladmin.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/fulladmin.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/user.name-fulladmin/test-environment
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/ithctester.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/ithctester.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/user.name-ithctester/test-environment
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/platformengineer.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/platformengineer.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/user.name-platformengineer/test-environment
+
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/readonly.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/readonly.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/user.name-readonly/test-environment
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/tempadmin.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/allow_jobrequestreview_with_gds_users_arn/tempadmin.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/user.name-tempadmin/test-environment
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_not_an_arn/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_not_an_arn/case.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: wibble
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_not_assumed_role_arn/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_not_assumed_role_arn/case.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:role/SomeRole
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_not_gds_users_or_entra_id_arn/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequest_with_not_gds_users_or_entra_id_arn/case.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/user.name-unknownrole/test-environment
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_not_an_arn/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_not_an_arn/case.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: wibble
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_not_assumed_role_arn/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_not_assumed_role_arn/case.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:role/SomeRole
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_not_gds_users_or_entra_id_arn/case.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_not_gds_users_or_entra_id_arn/case.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/user.name-unknownrole/test-environment
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/different-entra-id-users-role.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/different-entra-id-users-role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/Administrator/requesting.user@example.com
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/different-gds-users-role.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/different-gds-users-role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/requesting.user-fulladmin/test-environment
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/same-entra-id-users-role.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/same-entra-id-users-role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/Developer/requesting.user@example.com
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/same-gds-users-role.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/deny_jobrequestreview_with_same_reviewer_as_jobrequest_requester/same-gds-users-role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequestReview
+metadata:
+  name: test-jrr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/reviewed-by: arn:aws:sts::123456789:assumed-role/requesting.user-developer/whatever-environment
+spec:
+  jobRequestName: test-jr-with-annotation
+  decision: Approved
+  description: "LGTM"

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_entra_id_user.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_entra_id_user.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/Developer/requesting.user@example.com
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/jobrequestoperator_requiredannotations/shared-inventory/jobrequest_with_gds_users_user.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: platform.publishing.service.gov.uk/v1
+kind: JobRequest
+metadata:
+  name: test-jr-with-annotation
+  namespace: apps
+  annotations:
+    platform.publishing.service.gov.uk/requested-by: arn:aws:sts::123456789:assumed-role/requesting.user-developer/test-environment
+spec:
+  containerFrom:
+    podSpecFrom:
+      group: apps/v1
+      kind: Deployment
+      name: govuk-replatform-test-app
+    containerName: app
+  command: rake
+  args: ["hello"]


### PR DESCRIPTION
NOTE: This PR looks massive, but it's almost entirely yaml fixture files, the actual rego to review is not that big

Add gatekeeper rules to:

* Parse the requested-by and reviewed-by ARNs to usernames, and fail the rule if they cannot be parsed as expected
* Deny creating a JobRequestReview which tries to review a JobRequest created by the same user

I've written it as a rego v0 rule in this PR, in [this follow on PR I will convert all the rules in a single PR to rego v1](https://github.com/alphagov/govuk-infrastructure/pull/4651/changes?w=1)