### PR TITLE
Convert all our gatekeeper rules to rego v1

### DIFF
--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/immutable_configmap.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/immutable_configmap.yaml
@@ -22,55 +22,59 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
-      rego: |
-        package k8simmutableconfigmap
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            rego: |
+              package k8simmutableconfigmap
 
-        operations = {"UPDATE"}
+              operations = {"UPDATE"}
 
-        # we need to define the excluded namespaces here and in the constraint yaml because we need to use them in logic
-        excludedNamespaces = {
-            "gatekeeper-system",
-            "kube-system",
-            "kube-node-lease",
-            "kube-public",
-            "default",
-            "logging",
-            "monitoring",
-          }
+              # we need to define the excluded namespaces here and in the constraint yaml because we need to use them in logic
+              excludedNamespaces = {
+                  "gatekeeper-system",
+                  "kube-system",
+                  "kube-node-lease",
+                  "kube-public",
+                  "default",
+                  "logging",
+                  "monitoring",
+                }
 
-        privileged(userInfo, allowedGroups) {
-          # Allow if the user's groups intersect allowedGroups.
-          # Use object.get so omitted parameters can't cause policy bypass by
-          # evaluating to undefined.
-          userGroups := object.get(userInfo, "groups", [])
-          groups := {g | g := userGroups[_]}
-          allowed := {g | g := allowedGroups[_]}
-          intersection := groups & allowed
-          count(intersection) > 0
-        }
+              privileged(userInfo, allowedGroups) if {
+                # Allow if the user's groups intersect allowedGroups.
+                # Use object.get so omitted parameters can't cause policy bypass by
+                # evaluating to undefined.
+                userGroups := object.get(userInfo, "groups", [])
+                groups := {g | g := userGroups[_]}
+                allowed := {g | g := allowedGroups[_]}
+                intersection := groups & allowed
+                count(intersection) > 0
+              }
 
 
-        violation[{"msg": msg}] {
-          input.review.kind.kind == "ConfigMap"
+              violation contains {"msg": msg} if {
+                input.review.kind.kind == "ConfigMap"
 
-          params := object.get(input, "parameters", {})
-          allowedGroups := object.get(params, "allowedGroups", [])
+                params := object.get(input, "parameters", {})
+                allowedGroups := object.get(params, "allowedGroups", [])
 
-          not privileged(input.review.userInfo, allowedGroups)
+                not privileged(input.review.userInfo, allowedGroups)
 
-          operations[input.review.operation]
-          msg := sprintf("\nUsers cannot edit configmap resources %v %v", [input.review.userInfo.username, input.review.userInfo.groups])
-        }
+                operations[input.review.operation]
+                msg := sprintf("\nUsers cannot edit configmap resources %v %v", [input.review.userInfo.username, input.review.userInfo.groups])
+              }
 
-        violation[{"msg": msg}] {
-          input.review.kind.kind == "ConfigMap"
+              violation contains {"msg": msg} if {
+                input.review.kind.kind == "ConfigMap"
 
-          params := object.get(input, "parameters", {})
-          allowedGroups := object.get(params, "allowedGroups", [])
-          not privileged(input.review.userInfo, allowedGroups)
+                params := object.get(input, "parameters", {})
+                allowedGroups := object.get(params, "allowedGroups", [])
+                not privileged(input.review.userInfo, allowedGroups)
 
-          excludedNamespaces[input.review.namespace]
+                excludedNamespaces[input.review.namespace]
 
-          operations[input.review.operation]
-          msg := sprintf("\nUsers cannot edit configmap resources in non-user namespaces %v %v", [input.review.userInfo.username, input.review.userInfo.groups])
-        }
+                operations[input.review.operation]
+                msg := sprintf("\nUsers cannot edit configmap resources in non-user namespaces %v %v", [input.review.userInfo.username, input.review.userInfo.groups])
+              }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/jobrequestoperator_requiredannotations.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/jobrequestoperator_requiredannotations.yaml
@@ -14,105 +14,109 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
-      rego: |
-        package jobrequestoperatorrequiredannotations
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            rego: |
+              package jobrequestoperatorrequiredannotations
 
-        valid_operation {
-          input.review.operation != "DELETE"
-        }
+              valid_operation if {
+                input.review.operation != "DELETE"
+              }
 
-        annotation_keys := {
-          "JobRequest": "platform.publishing.service.gov.uk/requested-by",
-          "JobRequestReview": "platform.publishing.service.gov.uk/reviewed-by"
-        }
+              annotation_keys := {
+                "JobRequest": "platform.publishing.service.gov.uk/requested-by",
+                "JobRequestReview": "platform.publishing.service.gov.uk/reviewed-by"
+              }
 
-        violation[{"msg": msg}] {
-          valid_operation
+              violation contains {"msg": msg} if {
+                valid_operation
 
-          annotation_key := annotation_keys[input.review.kind.kind]
+                annotation_key := annotation_keys[input.review.kind.kind]
 
-          annotation_value := object.get(
-            input.review.object,
-            ["metadata", "annotations", annotation_key],
-            ""
-          )
-          annotation_value == ""
+                annotation_value := object.get(
+                  input.review.object,
+                  ["metadata", "annotations", annotation_key],
+                  ""
+                )
+                annotation_value == ""
 
-          msg := sprintf(
-            "The %s (%s) does not include the required annotation (%s)",
-            [input.review.kind.kind, input.review.name, annotation_key]
-          )
-        }
+                msg := sprintf(
+                  "The %s (%s) does not include the required annotation (%s)",
+                  [input.review.kind.kind, input.review.name, annotation_key]
+                )
+              }
 
-        default parse_gds_username(gds_users_part) := ""
+              default parse_gds_username(gds_users_part) := ""
 
-        parse_gds_username(gds_users_part) := username {
-          strings.any_suffix_match(gds_users_part, [
-            "-fulladmin",
-            "-tempadmin",
-            "-platformengineer",
-            "-developer",
-            "-readonly",
-            "-ithctester",
-          ])
-          user_parts := split(gds_users_part, "-")
-          username = concat("-", array.slice(user_parts, 0, count(user_parts) - 1))
-        }
+              parse_gds_username(gds_users_part) := username if {
+                strings.any_suffix_match(gds_users_part, [
+                  "-fulladmin",
+                  "-tempadmin",
+                  "-platformengineer",
+                  "-developer",
+                  "-readonly",
+                  "-ithctester",
+                ])
+                user_parts := split(gds_users_part, "-")
+                username = concat("-", array.slice(user_parts, 0, count(user_parts) - 1))
+              }
 
-        parse_entraid_username(entra_id_part, gds_username) := entra_id_part {
-          contains(entra_id_part, "@")
-        } else := gds_username
+              parse_entraid_username(entra_id_part, gds_username) := entra_id_part if {
+                contains(entra_id_part, "@")
+              } else := gds_username
 
-        default parse_username_from_arn(arn) := ""
+              default parse_username_from_arn(arn) := ""
 
-        parse_username_from_arn(arn) := username {
-          arn_parts := split(arn, "/")
-          arn_parts_length := count(arn_parts)
-          arn_parts_length == 3
+              parse_username_from_arn(arn) := username if {
+                arn_parts := split(arn, "/")
+                arn_parts_length := count(arn_parts)
+                arn_parts_length == 3
 
-          arn_prefix := arn_parts[0]
+                arn_prefix := arn_parts[0]
 
-          endswith(arn_prefix, "assumed-role")
+                endswith(arn_prefix, "assumed-role")
 
-          gds_username := parse_gds_username(arn_parts[1])
-          username := parse_entraid_username(arn_parts[2], gds_username)
-        }
+                gds_username := parse_gds_username(arn_parts[1])
+                username := parse_entraid_username(arn_parts[2], gds_username)
+              }
 
-        violation[{"msg": msg}] {
-          valid_operation
+              violation contains {"msg": msg} if {
+                valid_operation
 
-          annotation_key := annotation_keys[input.review.kind.kind]
-          arn := input.review.object.metadata.annotations[annotation_key]
+                annotation_key := annotation_keys[input.review.kind.kind]
+                arn := input.review.object.metadata.annotations[annotation_key]
 
-          username := parse_username_from_arn(arn)
+                username := parse_username_from_arn(arn)
 
-          username == ""
+                username == ""
 
-          msg := sprintf(
-            "%s (%s) has a %s annotation (%s) which cannot be parsed to a username",
-            [input.review.kind.kind, input.review.name, split(annotation_key, "/")[1], arn]
-          )
-        }
+                msg := sprintf(
+                  "%s (%s) has a %s annotation (%s) which cannot be parsed to a username",
+                  [input.review.kind.kind, input.review.name, split(annotation_key, "/")[1], arn]
+                )
+              }
 
-        violation[{"msg": msg}] {
-          valid_operation
-          input.review.kind.kind == "JobRequestReview"
+              violation contains {"msg": msg} if {
+                valid_operation
+                input.review.kind.kind == "JobRequestReview"
 
-          namespace := input.review.namespace
-          job_request_name := input.review.object.spec.jobRequestName
+                namespace := input.review.namespace
+                job_request_name := input.review.object.spec.jobRequestName
 
-          job_request := data.inventory.namespace[namespace]["platform.publishing.service.gov.uk/v1"]["JobRequest"][job_request_name]
+                job_request := data.inventory.namespace[namespace]["platform.publishing.service.gov.uk/v1"]["JobRequest"][job_request_name]
 
-          requested_by_arn := input.review.object.metadata.annotations[annotation_keys["JobRequestReview"]]
-          reviewed_by_arn := job_request.metadata.annotations[annotation_keys["JobRequest"]]
+                requested_by_arn := input.review.object.metadata.annotations[annotation_keys["JobRequestReview"]]
+                reviewed_by_arn := job_request.metadata.annotations[annotation_keys["JobRequest"]]
 
-          requested_by_username := parse_username_from_arn(requested_by_arn)
-          reviewed_by_username := parse_username_from_arn(reviewed_by_arn)
+                requested_by_username := parse_username_from_arn(requested_by_arn)
+                reviewed_by_username := parse_username_from_arn(reviewed_by_arn)
 
-          requested_by_username == reviewed_by_username
+                requested_by_username == reviewed_by_username
 
-          msg := sprintf(
-            "JobRequestReview (%s) cannot review JobRequest (%s) since the reviewer and requester are the same user (%s)",
-            [input.review.name, job_request_name, reviewed_by_username]
-          )
-        }
+                msg := sprintf(
+                  "JobRequestReview (%s) cannot review JobRequest (%s) since the reviewer and requester are the same user (%s)",
+                  [input.review.name, job_request_name, reviewed_by_username]
+                )
+              }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/validate_jobrequestreviews.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/validate_jobrequestreviews.yaml
@@ -14,43 +14,47 @@ spec:
 
   targets:
     - target: admission.k8s.gatekeeper.sh
-      rego: |
-        package validatejobrequestreview
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            rego: |
+              package validatejobrequestreview
 
-        valid_resource_and_operation {
-          input.review.kind.kind == "JobRequestReview"
-          input.review.operation != "DELETE"
-        }
+              valid_resource_and_operation if {
+                input.review.kind.kind == "JobRequestReview"
+                input.review.operation != "DELETE"
+              }
 
-        # jobRequestName is a required field, so defensive lookup not needed
-        job_request_name := input.review.object.spec.jobRequestName
-        job_request_review_namespace := input.review.namespace
+              # jobRequestName is a required field, so defensive lookup not needed
+              job_request_name := input.review.object.spec.jobRequestName
+              job_request_review_namespace := input.review.namespace
 
-        violation[{"msg": msg}] {
-          valid_resource_and_operation
+              violation contains {"msg": msg} if {
+                valid_resource_and_operation
 
-          job_request := object.get(
-            data.inventory,
-            ["namespace", job_request_review_namespace, "platform.publishing.service.gov.uk/v1", "JobRequest", job_request_name],
-            {}
-          )
-          job_request == {}
+                job_request := object.get(
+                  data.inventory,
+                  ["namespace", job_request_review_namespace, "platform.publishing.service.gov.uk/v1", "JobRequest", job_request_name],
+                  {}
+                )
+                job_request == {}
 
-          msg := sprintf(
-            "The JobRequestReview references JobRequest (%s) but that JobRequest cannot be found in the namespace of the JobRequestReview (%s)",
-            [job_request_name, job_request_review_namespace]
-          )
-        }
+                msg := sprintf(
+                  "The JobRequestReview references JobRequest (%s) but that JobRequest cannot be found in the namespace of the JobRequestReview (%s)",
+                  [job_request_name, job_request_review_namespace]
+                )
+              }
 
-        violation[{"msg": msg}] {
-          valid_resource_and_operation
+              violation contains {"msg": msg} if {
+                valid_resource_and_operation
 
-          job_request := data.inventory.namespace[namespace]["platform.publishing.service.gov.uk/v1"]["JobRequest"][job_request_name]
-          review_name := object.get(job_request, ["status", "reviewName"], "")
-          review_name != ""
+                job_request := data.inventory.namespace[namespace]["platform.publishing.service.gov.uk/v1"]["JobRequest"][job_request_name]
+                review_name := object.get(job_request, ["status", "reviewName"], "")
+                review_name != ""
 
-          msg := sprintf(
-            "JobRequest (%s) has already been reviewed by JobRequestReview (%s) and is now in state (%s)",
-            [job_request_name, job_request.status.reviewName, job_request.status.state]
-          )
-        }
+                msg := sprintf(
+                  "JobRequest (%s) has already been reviewed by JobRequestReview (%s) and is now in state (%s)",
+                  [job_request_name, job_request.status.reviewName, job_request.status.state]
+                )
+              }


### PR DESCRIPTION
NOTE: This PR has a huge amount of extra indentation, you should [view it with whitespace ignored](https://github.com/alphagov/govuk-infrastructure/pull/4651/changes?w=1)

* Convert all our existing gatekeeper rego rules to rego v1

rego v0 is long deprecated, all the docs are now for rego v1, and the rego playground defaults to v0, it's supported in gatekeeper, so lets convert while we have hardly any rules

Note if you are using regols as an LSP for rego, you should switch to regal which defaults to v1. I believe regols has no v1 support.
