### PR TITLE
Bump argo-bootstrap Helm chart version to 0.5.0

### DIFF
--- a/terraform/deployments/cluster-services/argo.tf
+++ b/terraform/deployments/cluster-services/argo.tf
@@ -181,7 +181,7 @@ resource "helm_release" "argo_bootstrap" {
   namespace        = local.services_ns
   create_namespace = true
   repository       = "https://alphagov.github.io/govuk-helm-charts/"
-  version          = "0.4.0"
+  version          = "0.5.0"
   timeout          = var.helm_timeout_seconds
   values = [yamlencode({
     # TODO: This TF module should not need to know the govuk_environment, since


### PR DESCRIPTION
The new version contains a new ArgoCD project we need to deploy