### PR TITLE
[MAIN-7503] Add RDS instance for fact-check-manager in production

### DIFF
--- a/terraform/variables/integration/rds.tfvars
+++ b/terraform/variables/integration/rds.tfvars
@@ -280,6 +280,7 @@ databases = {
     instance_class               = "db.t4g.small"
     performance_insights_enabled = true
     project                      = "GOV.UK - Publishing"
+    snapshot_identifier          = "fact-check-manager-postgres-post-encryption"
     tags = {
       "used_by" = "fact-check-manager"
     }

--- a/terraform/variables/production/rds.tfvars
+++ b/terraform/variables/production/rds.tfvars
@@ -242,6 +242,28 @@ databases = {
     }
   }
 
+  fact_check_manager = {
+    engine         = "postgres"
+    engine_version = "17"
+    engine_params = {
+      log_min_duration_statement = { value = 10000 }
+      log_statement              = { value = "ddl" }
+      deadlock_timeout           = { value = 2500 }
+      log_lock_waits             = { value = 1 }
+    }
+    engine_params_family         = "postgres17"
+    name                         = "fact-check-manager"
+    allocated_storage            = 100
+    instance_class               = "db.t4g.medium"
+    performance_insights_enabled = true
+    project                      = "GOV.UK - Publishing"
+    maintenance_window           = "Mon:00:00-Mon:01:00"
+    snapshot_identifier          = "fact-check-manager-postgres-post-encryption"
+    tags = {
+      "contains_pii" = true
+    }
+  }
+
   link_checker_api = {
     engine         = "postgres"
     engine_version = "14"

--- a/terraform/variables/staging/rds.tfvars
+++ b/terraform/variables/staging/rds.tfvars
@@ -247,6 +247,7 @@ databases = {
     instance_class               = "db.t4g.small"
     performance_insights_enabled = true
     project                      = "GOV.UK - Publishing"
+    snapshot_identifier          = "fact-check-manager-postgres-post-encryption"
     tags = {
       "contains_pii" = true
     }


### PR DESCRIPTION
[Jira ticket](https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-7503)

### Changes
Add an RDS instance for fact-check-manager in production and snapshot identifers to the existing staging and integration tfvars blocks.