### PR TITLE
Remove `snapshot_identifier` for `fact-check-manager` in integration, staging and production

### DIFF
--- a/terraform/variables/integration/rds.tfvars
+++ b/terraform/variables/integration/rds.tfvars
@@ -280,7 +280,6 @@ databases = {
     instance_class               = "db.t4g.small"
     performance_insights_enabled = true
     project                      = "GOV.UK - Publishing"
-    snapshot_identifier          = "fact-check-manager-postgres-post-encryption"
     tags = {
       "used_by" = "fact-check-manager"
     }

--- a/terraform/variables/production/rds.tfvars
+++ b/terraform/variables/production/rds.tfvars
@@ -258,7 +258,6 @@ databases = {
     performance_insights_enabled = true
     project                      = "GOV.UK - Publishing"
     maintenance_window           = "Mon:00:00-Mon:01:00"
-    snapshot_identifier          = "fact-check-manager-postgres-post-encryption"
     tags = {
       "contains_pii" = true
     }

--- a/terraform/variables/staging/rds.tfvars
+++ b/terraform/variables/staging/rds.tfvars
@@ -247,7 +247,6 @@ databases = {
     instance_class               = "db.t4g.small"
     performance_insights_enabled = true
     project                      = "GOV.UK - Publishing"
-    snapshot_identifier          = "fact-check-manager-postgres-post-encryption"
     tags = {
       "contains_pii" = true
     }


### PR DESCRIPTION
Description:
- No need to introduce this as these are already created with encryption and we aren't restoring a snapshot