### PR TITLE
Update the Elasticsearch version in the github actions to version 6.8.23

### DIFF
--- a/.github/actions/setup-elasticsearch/action.yml
+++ b/.github/actions/setup-elasticsearch/action.yml
@@ -17,7 +17,7 @@ runs:
 
     - name: Start container
       env:
-        ELASTICSEARCH_IMAGE_TAG: 6.7.2
+        ELASTICSEARCH_IMAGE_TAG: 6.8.23
         ELASTICSEARCH_PORT: 9200
       shell: bash
       run: |


### PR DESCRIPTION
This is in line with the current version of the Elasticsearch instance in production