### PR TITLE
cloud run job timeout reduced

### DIFF
--- a/terraform/deployments/gcp-gov-graph/docdb-bq-loader.tf
+++ b/terraform/deployments/gcp-gov-graph/docdb-bq-loader.tf
@@ -40,7 +40,7 @@ resource "google_cloud_run_v2_job" "docdb_bq_loader" {
 
     template {
       max_retries           = 0
-      timeout               = "7200s"
+      timeout               = "1800s"
       execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
 
       # Dynamically references the Service Account declared above

--- a/terraform/deployments/gcp-gov-graph/rds-parquet-bq-loader.tf
+++ b/terraform/deployments/gcp-gov-graph/rds-parquet-bq-loader.tf
@@ -41,7 +41,7 @@ resource "google_cloud_run_v2_job" "rds_parquet_bq_loader" {
 
     template {
       max_retries           = 0
-      timeout               = "7200s"
+      timeout               = "1800s"
       execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
 
       # Dynamically references the Service Account declared above

--- a/terraform/deployments/gcp-gov-graph/schemas/monitoring/file_ingestion_audit.json
+++ b/terraform/deployments/gcp-gov-graph/schemas/monitoring/file_ingestion_audit.json
@@ -1,0 +1,64 @@
+[
+  {
+    "name": "audit_id",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "audit_stage",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "bq_dataset",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "bq_table",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "file_type",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "file_path",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "status",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "file_count",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "inserted_rows",
+    "type": "INTEGER",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "error_message",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "start_time",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE",
+    "defaultValueExpression": "CURRENT_TIMESTAMP()"
+  },
+  {
+    "name": "end_time",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE",
+    "defaultValueExpression": "CURRENT_TIMESTAMP()"
+  }
+]


### PR DESCRIPTION
1) The Cloud Run job timeout was reduced from two hours to 30 minutes to prevent long wait times, as the ingestion process usually completes in about 10 minutes
2) Audit table ddl schema included