### PR TITLE
Address permanent drift in search-api-v2

### DIFF
--- a/terraform/deployments/search-api-v2/README.md
+++ b/terraform/deployments/search-api-v2/README.md
@@ -34,7 +34,9 @@ This module provisions the following resources into the Google Cloud Platform pr
 
 > **Note**
 > The Discovery Engine resources are managed through the [RestAPI provider][restapi_provider_docs]
-> due to the Google provider not offering first party Terraform resources yet (as of October 2023).
+> due to the Google provider not offering sufficient first party Terraform resources yet (as of August 2026).
+> The Google provider does offer a [first party resource for serving controls][control_resource],
+> but this doesn't support multiple control points for boost actions at this point, so doesn't meet our needs.
 
 > **Warning**
 > As of October 2023, the Google Discovery Engine API has a _manual_ enabling step that can only be
@@ -44,6 +46,7 @@ This module provisions the following resources into the Google Cloud Platform pr
 
 [enable-de]: https://console.cloud.google.com/gen-app-builder/start
 [restapi_provider_docs]: https://registry.terraform.io/providers/Mastercard/restapi/latest
+[control_resource]: https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/discovery_engine_control
 [search-api-v2-repo]: https://github.com/alphagov/search-api-v2
 [terraform-cloud]: https://app.terraform.io/
 [api-gateway]: ../govuk-publishing-infrastructure/search_api_gateway.tf

--- a/terraform/deployments/search-api-v2/serving_config_global_variant.tf
+++ b/terraform/deployments/search-api-v2/serving_config_global_variant.tf
@@ -44,8 +44,8 @@ module "control_global_boost_freshness_general" {
         interpolationType = "LINEAR",
         # Control points explained
         # 0.2 (decaying to 0.05), for the first 7 days
-        # 0.05 (decaying to 0), for 8 days to 90 days
-        # 0 (decaying to -0.5) for 91 days to 365 days
+        # 0.05 (decaying to ~0), for 8 days to 90 days
+        # ~0 (decaying to -0.5) for 91 days to 365 days
         # -0.5 (decaying to -0.75) for 366 days to 1460 days
         controlPoints = [
           {
@@ -58,7 +58,10 @@ module "control_global_boost_freshness_general" {
           },
           {
             attributeValue = "90D",
-            boostAmount    = 0.0
+            boostAmount    = 0.00000001
+            # Ideally we'd like to set this boostAmount to 0, but when we do this the boostAmount is stripped out of
+            # the API response, causing a permanent drift in our Terraform configuration. We are therefore setting this
+            # to a very small value instead.
           },
           {
             attributeValue = "365D",


### PR DESCRIPTION
Adjust boostAmount of 0
    
This is to avoid permanent drift in the Terraform configuration, which is caused by explicitly setting the boostAmount to 0. When the boostAmount is set to 0, it is removed from the response by the Discovery Engine API, causing a permanent drift.
    
One way to remove the drift would be to remove the set boostAmount so that our Terraform configuration matches what's in the API response. However, if we do that, we have no way of confirming what the boostAmount actually is, since it is not visible in the GCP console (UI), or the API response. To remove this uncertainty as well as the drift, we are setting the boostAmount to a near-zero value instead.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1949
