### PR TITLE
Stop SHA pinning govuk-infrastructure workflows and actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           show-progress: false
-      - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@788b98389ac2003202dc421f4ccd187ad85cda17 # main
+      - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/build-clamav-image.yml
+++ b/.github/workflows/build-clamav-image.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build-and-push-image:
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@788b98389ac2003202dc421f4ccd187ad85cda17 # main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
       imageName: clamav

--- a/.github/workflows/build-mongodb-image.yml
+++ b/.github/workflows/build-mongodb-image.yml
@@ -14,13 +14,13 @@ on:
       - main
     paths:
       - images/mongodb/Dockerfile
-  
+
   schedule:
     - cron: '28 3 * * 1'
 
 jobs:
   build-and-push-image:
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@788b98389ac2003202dc421f4ccd187ad85cda17 # main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref }}
       imageName: mongodb

--- a/.github/workflows/jasmine.yml
+++ b/.github/workflows/jasmine.yml
@@ -32,11 +32,11 @@ jobs:
           BUNDLE_GITHUB__COM: "x-access-token:${{ secrets.BUNDLER_GITHUB_TOKEN }}"
 
       - name: Setup Node
-        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@788b98389ac2003202dc421f4ccd187ad85cda17 # main
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
 
       - name: Precompile Rails assets
         if: inputs.useWithRails
-        uses: alphagov/govuk-infrastructure/.github/actions/precompile-rails-assets@788b98389ac2003202dc421f4ccd187ad85cda17 # main
+        uses: alphagov/govuk-infrastructure/.github/actions/precompile-rails-assets@main
 
       - name: Run Jasmine
         run: yarn run jasmine-browser-runner runSpecs

--- a/.github/workflows/standardx.yml
+++ b/.github/workflows/standardx.yml
@@ -19,7 +19,7 @@ jobs:
           show-progress: false
 
       - name: Setup Node
-        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@788b98389ac2003202dc421f4ccd187ad85cda17 # main
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
 
       - name: Run Standardx
         run: yarn run standardx ${{ inputs.files }}

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -19,7 +19,7 @@ jobs:
           show-progress: false
 
       - name: Setup Node
-        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@788b98389ac2003202dc421f4ccd187ad85cda17 # main
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
 
       - name: Run Stylelint
         run: yarn run stylelint ${{ inputs.files }}


### PR DESCRIPTION
Relates to https://github.com/alphagov/govuk-infrastructure/issues/4474

Stop SHA pinning govuk-infra in github actions and workflows.

Renovate is already configured to not do sha pins for it in this repo.