### PR TITLE
[PP-7931] Turn off read replica for Publishing API in integration

### DIFF
--- a/terraform/variables/integration/rds.tfvars
+++ b/terraform/variables/integration/rds.tfvars
@@ -434,7 +434,6 @@ databases = {
     instance_class               = "db.m6g.large"
     performance_insights_enabled = true
     project                      = "GOV.UK - Publishing"
-    has_read_replica             = true
     tags = {
       "used_by" = "publishing-api"
     }


### PR DESCRIPTION
Defaults to false: https://github.com/alphagov/govuk-infrastructure/blob/4bd09a0cf0e958703f890931613a4fdb276e49f8/terraform/deployments/rds/variables.tf#L37

Depends on: 

- https://github.com/alphagov/govuk-helm-charts/pull/4426
- https://github.com/alphagov/govuk-helm-charts/pull/4428