### PR TITLE
[SCH-2261] Add search v2 quota preferences

### DIFF
--- a/terraform/deployments/gcp-search-api-v2/README.md
+++ b/terraform/deployments/gcp-search-api-v2/README.md
@@ -45,33 +45,4 @@ These values can be set interactively in the console when running the cli, or th
 terraform plan -var google_cloud_billing_account=<account-id> -var google_cloud_folder=<folder-id>
 ```
 
-## Additional information
-### Adding GCP quota overrides
-Quota overrides are used to cap limits under values that have been set by default or by admin/producer overrides.
-On GCP, these are somewhat complex to set up and use inconsistent terminology between the
-console UI, the REST API, and the (beta) Terraform provider. In particular, it can be somewhat
-confusing to figure out the `limit` value for the `google_service_usage_consumer_quota_override`
-resource (which actually corresponds to the `unit` field in the API but with different syntax), and
-to find the internal (not display) name of quotas.
-
-If you need to set up a new `google_service_usage_consumer_quota_override` resource for a Discovery
-Engine project, the best way of finding out these values is to make a GET request to the
-`consumerQuotaMetrics` endpoint like so:
-
-```bash
-curl -H "Authorization: Bearer $(gcloud auth print-access-token)" \
--H "Content-Type: application/json" \
-"https://serviceusage.googleapis.com/v1beta1/projects/${GCP_PROJECT}/services/discoveryengine.googleapis.com/consumerQuotaMetrics" \
-| jq -r '.metrics[] | "\(.displayName): \(.consumerQuotaLimits[0].metric) (\(.consumerQuotaLimits[0].unit | gsub("[1\\{\\}]";"")))"' \
-| sort
-```
-
-This returns a list of available quotas by display name, complete with the necessary `metric` and
-`unit` values.
-
-There are limits on the Google side on how high we are permitted to set quotas. If
-you attempt to increase them beyond the ceiling, a `COMMON_QUOTA_CONSUMER_OVERRIDE_TOO_HIGH`
-error will be raised (including some metadata that should tell you what the current ceiling is). 
-You will need to manually request a quota increase from Google through the console first.
-
 [search-api-v2-deployment]: ../search-api-v2/README.md

--- a/terraform/deployments/search-api-v2/README.md
+++ b/terraform/deployments/search-api-v2/README.md
@@ -32,6 +32,10 @@ This module provisions the following resources into the Google Cloud Platform pr
 - AWS Secrets Manager secrets to be consumed by the API service application in the corresponding
   environment on the Kubernetes platform
 
+## Additional information
+### GCP quota preferences
+[Quota preferences][quota_preference] are used to request changes to quota values and to document changes already agreed with Google. Note that they cannot be used to alter system limits. See [Quotas and system limits][quotas-and-system-limits] for more information.
+
 > **Note**
 > The Discovery Engine resources are managed through the [RestAPI provider][restapi_provider_docs]
 > due to the Google provider not offering first party Terraform resources yet (as of October 2023).
@@ -52,3 +56,5 @@ This module provisions the following resources into the Google Cloud Platform pr
 [publishing-deployment]: ../govuk-publishing-infrastructure/README.md
 [variables]: ./variables.tf
 [variables-folder]: ../../variables
+[quota_preference]: https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/cloud_quotas_quota_preference
+[quotas-and-system-limits]: https://docs.cloud.google.com/docs/quotas/quotas

--- a/terraform/deployments/search-api-v2/README.md
+++ b/terraform/deployments/search-api-v2/README.md
@@ -33,8 +33,41 @@ This module provisions the following resources into the Google Cloud Platform pr
   environment on the Kubernetes platform
 
 ## Additional information
-### GCP quota preferences
-[Quota preferences][quota_preference] are used to request changes to quota values and to document changes already agreed with Google. Note that they cannot be used to alter system limits. See [Quotas and system limits][quotas-and-system-limits] for more information.
+### Quotas and system limits
+Our usage of the various Google APIs is controlled through [quotas and system limits][quotas-and-system-limits]. Quota changes can be agreed with Google through [quota preferences](#quota-preferences) or capped using [quota overrides](#quota-overrides), while system limits are fixed. 
+
+Despite its fixed nature we have agreed an increase to the system limit `SearchRequestsPerMinutePerProjectPerRegion` on `production`. Quotas and system limits can be found in the GCP console under "IAM and Admin > Quotas and system limits".
+
+### Quota preferences
+[Quota preferences][quota_preference] are used to request changes to quota values and to document changes already agreed with Google. Note that they cannot be used to alter system limits.
+
+### Quota overrides
+Quota overrides are used to cap limits below values that have been set by default or by admin/producer overrides.
+On GCP, these are somewhat complex to set up and use inconsistent terminology between the
+console UI, the REST API, and the (beta) Terraform provider. In particular, it can be somewhat
+confusing to figure out the `limit` value for the `google_service_usage_consumer_quota_override`
+resource (which actually corresponds to the `unit` field in the API but with different syntax), and
+to find the internal (not display) name of quotas.
+
+If you need to set up a new `google_service_usage_consumer_quota_override` resource for a Discovery
+Engine project, the best way of finding out these values is to make a GET request to the
+`consumerQuotaMetrics` endpoint like so:
+
+```bash
+curl -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+-H "Content-Type: application/json" \
+"https://serviceusage.googleapis.com/v1beta1/projects/${GCP_PROJECT}/services/discoveryengine.googleapis.com/consumerQuotaMetrics" \
+| jq -r '.metrics[] | "\(.displayName): \(.consumerQuotaLimits[0].metric) (\(.consumerQuotaLimits[0].unit | gsub("[1\\{\\}]";"")))"' \
+| sort
+```
+
+This returns a list of available quotas by display name, complete with the necessary `metric` and
+`unit` values.
+
+There are limits on the Google side on how high we are permitted to set quotas. If
+you attempt to increase them beyond the ceiling, a `COMMON_QUOTA_CONSUMER_OVERRIDE_TOO_HIGH`
+error will be raised (including some metadata that should tell you what the current ceiling is).
+You will need to request a quota increase from Google via the Cloud Quotas API using [quota_preferences](#quota-preferences) first.
 
 > **Note**
 > The Discovery Engine resources are managed through the [RestAPI provider][restapi_provider_docs]

--- a/terraform/deployments/search-api-v2/cloud_quotas.tf
+++ b/terraform/deployments/search-api-v2/cloud_quotas.tf
@@ -1,0 +1,9 @@
+resource "google_cloud_quotas_quota_preference" "evaluation_create_requests_preference" {
+  parent   = "projects/${var.gcp_project_id}"
+  name     = "discoveryengine_evaluation_create_requests"
+  service  = "discoveryengine.googleapis.com"
+  quota_id = "EvaluationCreateRequestsPerDayPerProject"
+  quota_config {
+    preferred_value = var.evaluation_create_requests
+  }
+}

--- a/terraform/deployments/search-api-v2/cloud_quotas.tf
+++ b/terraform/deployments/search-api-v2/cloud_quotas.tf
@@ -7,3 +7,13 @@ resource "google_cloud_quotas_quota_preference" "evaluation_create_requests_pref
     preferred_value = var.evaluation_create_requests
   }
 }
+
+resource "google_cloud_quotas_quota_preference" "complete_query_requests_preference" {
+  parent   = "projects/${var.gcp_project_id}"
+  name     = "discoveryengine_complete_query_requests"
+  service  = "discoveryengine.googleapis.com"
+  quota_id = "CompleteQueryRequestsPerMinutePerProject"
+  quota_config {
+    preferred_value = var.complete_query_requests
+  }
+}

--- a/terraform/deployments/search-api-v2/variables.tf
+++ b/terraform/deployments/search-api-v2/variables.tf
@@ -44,3 +44,9 @@ variable "discovery_engine_location" {
   description = "GCP location to create Discovery Engine Datastore instance in, e.g. global"
   default     = "global"
 }
+
+variable "evaluation_create_requests" {
+  type        = number
+  description = "The maximum number of evaluation create requests per day for Discovery Engine"
+  default     = 100
+}

--- a/terraform/deployments/search-api-v2/variables.tf
+++ b/terraform/deployments/search-api-v2/variables.tf
@@ -50,3 +50,9 @@ variable "evaluation_create_requests" {
   description = "The maximum number of evaluation create requests per day for Discovery Engine"
   default     = 100
 }
+
+variable "complete_query_requests" {
+  type        = number
+  description = "The maximum number of complete query requests per minute for Discovery Engine"
+  default     = 300
+}

--- a/terraform/variables/production/search-api-v2.tfvars
+++ b/terraform/variables/production/search-api-v2.tfvars
@@ -1,3 +1,4 @@
-gcp_project_id     = "search-api-v2-production"
-gcp_project_number = "931453572747"
-gcp_env            = "production"
+gcp_project_id          = "search-api-v2-production"
+gcp_project_number      = "931453572747"
+gcp_env                 = "production"
+complete_query_requests = 35000


### PR DESCRIPTION
We've agreed certain quota overrides with Google via the console. Adding them to the terraform deployment to document the agreed quotas.

See [Jira ticket SCH-2261](https://gov-uk.atlassian.net/browse/SCH-2261)

N.B. Do not merge until PR #4737 has been merged and the terraform manually applied. Marking as draft for now.
