### PR TITLE
Deny resources in the default Kubernetes namespace

### DIFF
--- a/terraform/deployments/cluster-services/gatekeeper.tf
+++ b/terraform/deployments/cluster-services/gatekeeper.tf
@@ -5,6 +5,7 @@ module "gatekeeper" {
     immutable_configmap                    = true
     validate_jobrequestreviews             = false
     jobrequestoperator_requiredannotations = false
+    deny_default_namespace                 = false
   }
 
   constraint_violations_max_to_display = 25

--- a/terraform/deployments/cluster-services/modules/gatekeeper/constraints/locals.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/constraints/locals.tf
@@ -3,11 +3,13 @@ locals {
   immutable_configmap_yaml               = yamldecode(file("${local.constraint_path}/immutable_configmap.yaml"))
   validate_jobrequestreviews             = yamldecode(file("${local.constraint_path}/validate_jobrequestreviews.yaml"))
   jobrequestoperator_requiredannotations = yamldecode(file("${local.constraint_path}/jobrequestoperator_requiredannotations.yaml"))
+  deny_default_namespace_yaml            = yamldecode(file("${local.constraint_path}/deny_default_namespace.yaml"))
 
   # For each constraint, a value needs to be in the constraint map. This bloc allows us to set values on constraints which enables us to toggle the configuration of the constraints. -- we merge in the spec separately to avoid overwriting entire spec key
   constraint_map = {
     immutable_configmap                    = merge(local.immutable_configmap_yaml, { "spec" : merge(local.immutable_configmap_yaml, { "enforcementAction" : var.dryrun_map.immutable_configmap ? "dryrun" : "deny" }) })
     validate_jobrequestreviews             = merge(local.validate_jobrequestreviews, { "spec" : merge(local.validate_jobrequestreviews, { "enforcementAction" : var.dryrun_map.validate_jobrequestreviews ? "dryrun" : "deny" }) })
     jobrequestoperator_requiredannotations = merge(local.jobrequestoperator_requiredannotations, { "spec" : merge(local.jobrequestoperator_requiredannotations, { "enforcementAction" : var.dryrun_map.jobrequestoperator_requiredannotations ? "dryrun" : "deny" }) })
+    deny_default_namespace                 = merge(local.deny_default_namespace_yaml, { "spec" : merge(local.deny_default_namespace_yaml.spec, { "enforcementAction" : var.dryrun_map.deny_default_namespace ? "dryrun" : "deny" }) })
   }
 }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/constraints/variables.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/constraints/variables.tf
@@ -4,6 +4,7 @@ variable "dryrun_map" {
     immutable_configmap                    = bool
     validate_jobrequestreviews             = bool
     jobrequestoperator_requiredannotations = bool
+    deny_default_namespace                 = bool
   })
 }
 

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/deny_default_namespace.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraint_templates/deny_default_namespace.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdenydefaultnamespace
+  annotations:
+    metadata.gatekeeper.sh/title: Deny resources in the default namespace
+    description: Prevents namespaced resources from being created in the default namespace.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDenyDefaultNamespace
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            rego: |
+              package k8sdenydefaultnamespace
+
+              violation contains {"msg": msg} if {
+                input.review.operation != "DELETE"
+                input.review.namespace == "default"
+
+                msg := "Resources must not be created in the default namespace. Set the current namespace with: kubectl config set-context --current --namespace apps"
+              }

--- a/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraints/deny_default_namespace.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/resources/constraints/deny_default_namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDenyDefaultNamespace
+metadata:
+  name: deny-default-namespace
+spec:
+  match:
+    scope: Namespaced
+    namespaces:
+      - default

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/deny_default_namespace.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/deny_default_namespace.yaml
@@ -1,0 +1,16 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+tests:
+  - name: deny_default_namespace
+    template: ../../resources/constraint_templates/deny_default_namespace.yaml
+    constraint: ../../resources/constraints/deny_default_namespace.yaml
+    cases:
+      - name: deny creating a resource in the default namespace
+        object: samples/deny_default_namespace/default_namespace.yaml
+        assertions:
+          - violations: 1
+            message: "Resources must not be created in the default namespace. Set the current namespace with: kubectl config set-context --current --namespace apps"
+      - name: allow creating a resource outside the default namespace
+        object: samples/deny_default_namespace/apps_namespace.yaml
+        assertions:
+          - violations: no

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/deny_default_namespace/apps_namespace.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/deny_default_namespace/apps_namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example
+  namespace: apps
+data:
+  example: value

--- a/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/deny_default_namespace/default_namespace.yaml
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/test/suite/samples/deny_default_namespace/default_namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example
+  namespace: default
+data:
+  example: value

--- a/terraform/deployments/cluster-services/modules/gatekeeper/variables.tf
+++ b/terraform/deployments/cluster-services/modules/gatekeeper/variables.tf
@@ -30,6 +30,7 @@ variable "dryrun_map" {
     immutable_configmap                    = bool
     validate_jobrequestreviews             = bool
     jobrequestoperator_requiredannotations = bool
+    deny_default_namespace                 = bool
   })
 }
 


### PR DESCRIPTION
Fixes #4629.

## What changed

- add a Gatekeeper ConstraintTemplate that rejects namespaced resources in the `default` namespace
- add the corresponding constraint scoped to `default`
- return actionable guidance to switch the current context to the `apps` namespace
- integrate the constraint with the existing dry-run configuration
- enable the policy in the cluster-services Gatekeeper module
- add Gatekeeper test coverage for both denied `default` namespace resources and allowed `apps` namespace resources

The violation message includes the command requested in the acceptance criteria:

`kubectl config set-context --current --namespace apps`