### PR TITLE
IA-3195: grant govgraph ingestion SAs cloud run invoker role

### DIFF
--- a/terraform/deployments/gcp-gov-graph/main-gcp.tf
+++ b/terraform/deployments/gcp-gov-graph/main-gcp.tf
@@ -478,6 +478,12 @@ data "google_iam_policy" "project" {
     role = "roles/workflows.invoker"
     members = [
       google_service_account.eventarc.member,
+    ]
+  }
+
+  binding {
+    role = "roles/run.invoker"
+    members = [
       google_service_account.rds_parquet_bq_loader.member,
       google_service_account.docdb_bq_loader.member,
     ]


### PR DESCRIPTION
This [PR](https://github.com/alphagov/govuk-infrastructure/pull/4654) granted the wrong role to the ingestion SAs. This PR grants the correct role.