### PR TITLE
IA-3235: update gcp-ga4-analytics to point to new resource directory path

### DIFF
--- a/terraform/deployments/tfc-configuration/gcp-projects.tf
+++ b/terraform/deployments/tfc-configuration/gcp-projects.tf
@@ -7,8 +7,8 @@ module "gcp-ga4-analytics" {
   workspace_tags      = ["production", "ga4-analytics", "gcp"]
   terraform_version   = var.terraform_version
   execution_mode      = "remote"
-  working_directory   = "/ga4-analytics/"
-  trigger_patterns    = ["/ga4-analytics/**/*"]
+  working_directory   = "/gcp-ga4-analytics/"
+  trigger_patterns    = ["/gcp-ga4-analytics/**/*"]
   global_remote_state = true
   assessments_enabled = true
 


### PR DESCRIPTION
This change needs to happen before I do the actual rename in this [PR](https://github.com/alphagov/govuk-data-infrastructure/pull/26/changes/7444951795a0477950d4749512ab6f38f7bcc4a7) - otherwise TFC won't detect the changes.