### PR TITLE
Only build arm64 images on PRs

### DIFF
--- a/.github/workflows/build-image-from-pr.yml
+++ b/.github/workflows/build-image-from-pr.yml
@@ -26,6 +26,8 @@ on:
         required: false
         type: string
         default: ubuntu-24.04-arm
+      # amd64_runner_name This is only kept to maintain compatibility,
+      # once all callers are not passing in this param we can remove it.
       amd64_runner_name:
         required: false
         type: string
@@ -33,18 +35,8 @@ on:
 
 jobs:
   build-image-from-PR:
-    name: Build ${{ inputs.imageName }}-${{ matrix.arch }} image from branch ${{ inputs.gitRef }}
-    strategy:
-      matrix:
-        arch:
-          - amd64
-          - arm64
-        include:
-          - arch: amd64
-            runner: ${{ inputs.amd64_runner_name }}
-          - arch: arm64
-            runner: ${{ inputs.arm64_runner_name }}
-    runs-on: ${{ matrix.runner }}
+    name: Build ${{ inputs.imageName }}-arm64 image from branch ${{ inputs.gitRef }}
+    runs-on: ${{ inputs.arm64_runner_name }}
     permissions:
       contents: read
     steps:
@@ -56,7 +48,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
-          platforms: "linux/${{ matrix.arch }}"
+          platforms: "linux/arm64"
 
       - run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         id: local-head
@@ -78,7 +70,7 @@ jobs:
         with:
           file: ${{ inputs.dockerfilepath }}
           context: ${{ inputs.context }}
-          platforms: "linux/${{ matrix.arch }}"
+          platforms: "linux/arm64"
           build-args: ${{ inputs.buildArgs }}
           labels: ${{ steps.meta.outputs.labels }}
           push: false


### PR DESCRIPTION
All PR builds are broken for a lot of projects because we no longer have amd64 base images, it is intentional not to have them anymore, but on PRs we are still trying to build for both architectures.

This PR takes a big bang approach and changes the existing workflow so we unblock everyone, we can always restore this from git history if we need to.