### PR TITLE
Add MySQL databases for Specialist Publisher [WHIT-3578]

### DIFF
--- a/terraform/variables/integration/rds.tfvars
+++ b/terraform/variables/integration/rds.tfvars
@@ -515,6 +515,25 @@ databases = {
     }
   }
 
+  specialist_publisher = {
+    engine                      = "mysql"
+    engine_version              = "8.4"
+    allow_major_version_upgrade = true
+    engine_params = {
+      max_allowed_packet = { value = 1073741824 }
+    }
+    engine_params_family         = "mysql8.4"
+    name                         = "specialist-publisher"
+    allocated_storage            = 20
+    instance_class               = "db.t4g.micro"
+    performance_insights_enabled = true
+    project                      = "GOV.UK - Publishing"
+    snapshot_identifier          = "specialist-publisher-mysql-post-encryption"
+    tags = {
+      "used_by" = "specialist-publisher"
+    }
+  }
+
   support_api = {
     engine         = "postgres"
     engine_version = "14"

--- a/terraform/variables/production/rds.tfvars
+++ b/terraform/variables/production/rds.tfvars
@@ -448,6 +448,25 @@ databases = {
     }
   }
 
+  specialist_publisher = {
+    engine                      = "mysql"
+    engine_version              = "8.4"
+    allow_major_version_upgrade = true
+    engine_params = {
+      max_allowed_packet = { value = 1073741824 }
+    }
+    engine_params_family         = "mysql8.4"
+    name                         = "specialist-publisher"
+    allocated_storage            = 20
+    instance_class               = "db.t4g.micro"
+    performance_insights_enabled = true
+    project                      = "GOV.UK - Publishing"
+    snapshot_identifier          = "specialist-publisher-mysql-post-encryption"
+    tags = {
+      "used_by" = "specialist-publisher"
+    }
+  }
+
   support_api = {
     engine         = "postgres"
     engine_version = "14"

--- a/terraform/variables/staging/rds.tfvars
+++ b/terraform/variables/staging/rds.tfvars
@@ -433,6 +433,25 @@ databases = {
     }
   }
 
+  specialist_publisher = {
+    engine                      = "mysql"
+    engine_version              = "8.4"
+    allow_major_version_upgrade = true
+    engine_params = {
+      max_allowed_packet = { value = 1073741824 }
+    }
+    engine_params_family         = "mysql8.4"
+    name                         = "specialist-publisher"
+    allocated_storage            = 20
+    instance_class               = "db.t4g.micro"
+    performance_insights_enabled = true
+    project                      = "GOV.UK - Publishing"
+    snapshot_identifier          = "specialist-publisher-mysql-post-encryption"
+    tags = {
+      "used_by" = "specialist-publisher"
+    }
+  }
+
   support_api = {
     engine         = "postgres"
     engine_version = "14"


### PR DESCRIPTION
Specialist Publisher is moving from Mongo (shared DocumentDB instance) to MySQL. The vast majority of its data actually lives in Publishing API: Specialist Publisher only requires a database in the first place for Signon integration. The gds-sso gem mandates that there is a database with a Users table.

There are around 200-300 users that visit Specialist Publisher every month, across around 1k unique sessions. The amount of data actually stored is literally bytes.

I've opted for the smallest possible MySQL instance and floor of 20GB storage.

MySQL was chosen over Postgres because our long term plans are to consolidate Specialist Publisher into Whitehall, which itself uses MySQL.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3578