### PR TITLE
revert govuk-data-engineering project deletion

### DIFF
--- a/terraform/deployments/tfc-configuration/gov-graph.tf
+++ b/terraform/deployments/tfc-configuration/gov-graph.tf
@@ -1,3 +1,7 @@
+resource "tfe_project" "data-engineering-project" {
+  name = "govuk-data-engineering"
+}
+
 resource "tfe_project" "data-infrastructure-project" {
   name = "govuk-data-infrastructure"
 }


### PR DESCRIPTION
I can't delete this until all workspaces are reassigned to the new project. Restoring it for now.