### PR TITLE
Refactor `logjson` processing in Logstash

### DIFF
--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -5,167 +5,43 @@ filter {
       target => "logjson"
       skip_on_invalid_json => true
     }
-  }
 
-  useragent {
-    source => "[user_agent][original]"
-    target => "ua_tmp"
-    add_field => {
-      "[user_agent][device][name]" => "%{[ua_tmp][device]}"
-      "[user_agent][os][name]" => "%{[ua_tmp][os_name]}"
+    useragent {
+      source => "[logjson][http_user_agent]"
+      ecs_compatibility => "v8"
     }
-  }
 
-  # OS version ECS compatibility
-  if [ua_tmp][os_major] {
     mutate {
-      add_field => {
-        "[user_agent][os][version]" => "%{[ua_tmp][os_major]}"
-      }
+      copy => {"[logjson][upstream_response_time]" => "upstream_response_time_float"}
+      convert => {"upstream_response_time_float" => "float"}
     }
-    if [ua_tmp][os_minor] {
+
+    # Extract Sidekiq message (e.g. "start")
+    if [logjson][message] {
       mutate {
-        replace => {
-          "[user_agent][os][version]" => "%{[user_agent][os][version]}.%{[ua_tmp][os_minor]}"
-        }
+        rename => { "[logjson][message]" => "[logjson_message]" }
       }
-      if [ua_tmp][os_patch] {
+
+      # Detect nested Sidekiq objects and extract to separate field
+      if [logjson_message][queues] {
         mutate {
-          replace => {
-            "[user_agent][os][version]" => "%{[user_agent][os][version]}.%{[ua_tmp][os_patch]}"
-          }
-        }
-        if [ua_tmp][os_build] {
-          mutate {
-            replace => {
-              "[user_agent][os][version]" => "%{[user_agent][os][version]}.%{[ua_tmp][os_build]}"
-            }
-          }
+          rename => { "[logjson_message]" => "[logjson_sidekiq_object]" }
         }
       }
     }
-    mutate {
-      add_field => {
-        "[user_agent][os][full]" => "%{[user_agent][os][name]} %{[user_agent][os][version]}"
-      }
-    }
-  }
-  # User agent version ECS compatibility
-  # Aims to create the following if fields exist: user_agent.version.major.minor.patch.build
-  if [ua_tmp][major] {
-    mutate {
-      add_field => {
-        "[user_agent][version]" => "%{[ua_tmp][major]}"
-      }
-    }
-    if [ua_tmp][minor] {
+
+    # Fix email-alert-frontend errors landing in the DLQ
+    if [logjson][status] and [logjson][status] =~ /[^0-9.-]/ {
       mutate {
-        replace => {
-          "[user_agent][version]" => "%{[user_agent][version]}.%{[ua_tmp][minor]}"
-        }
-      }
-      if [ua_tmp][patch] {
-        mutate {
-          replace => {
-            "[user_agent][version]" => "%{[user_agent][version]}.%{[ua_tmp][patch]}"
-          }
-        }
-        if [ua_tmp][build] {
-          mutate {
-            replace => {
-              "[user_agent][version]" => "%{[user_agent][version]}.%{[ua_tmp][build]}"
-            }
-          }
-        }
+        rename => { "[logjson][status]" => "[logjson][status_text]" }
       }
     }
-  }
-  mutate {
-    remove_field => ["ua_tmp"]
-  }
-  mutate {
-    copy => {"upstream_response_time" => "upstream_response_time_float"}
-    convert => {"upstream_response_time_float" => "float"}
   }
 
   # If error is a string and not an object (fixes mirror?)
   if [error] and ![error][message] and ![error][type] {
     mutate {
       rename => { "error" => "error_message" }
-    }
-  }
-
-  # 1. If message arrives as JSON object, move into logjson
-  if [message] and [message][args] {
-    mutate {
-      rename => { "message" => "logjson" }
-    }
-  }
-
-  # 1B. Convert logjson.ts from string date to float Unix timestamp
-  if [logjson][ts] and [logjson][ts] =~ /[^0-9.]/ {
-    # It's a string date, parse it
-    date {
-      match => [ "[logjson][ts]", "ISO8601", "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss.SSSZ", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "UNIX_MS" ]
-      target => "[@metadata][ts_parsed]"
-      tag_on_failure => ["_dateparsefailure_logjson_ts"]
-    }
-
-    # Convert the parsed timestamp to Unix epoch float
-    if !("_dateparsefailure_logjson_ts" in [tags]) {
-      mutate {
-        add_field => { "[@metadata][ts_epoch]" => "%{+%s.%{+SSS}}" }
-        replace => { "[logjson][ts]" => "%{[@metadata][ts_epoch]}" }
-      }
-      mutate {
-        convert => { "[logjson][ts]" => "float" }
-      }
-    }
-  }
-
-  # 2. Extract human readable message ("Unlocked")
-  if [logjson][message][message] {
-    mutate {
-      add_field => { "message" => "%{[logjson][message][message]}" }
-    }
-  } else if [logjson][message] and [logjson][message] !~ "^{.*}$" {
-    mutate {
-      add_field => { "message" => "%{[logjson][message]}" }
-    }
-  }
-
-  # 3. Move nested JSON payload into object for indexing (no keyword conflict)
-  if [logjson][message] {
-    mutate {
-      rename => { "[logjson][message]" => "[logjson_message]" }
-    }
-  }
-  
-  # 4. Detect Nested Sidekiq Objects and workaround it
-  if [logjson_message] and [logjson_message][queues] {
-    mutate {
-      rename => { "[logjson_message]" => "[logjson_sidekiq_object]" }
-    }
-  }
-
-  # 5. Deduplicate redundant fields
-  mutate {
-    remove_field => [
-      # ECS remains
-      # K8s + container detail remains
-      # FULL message args remain
-
-      # TRUE duplicates:
-      "[logjson][jid]"                 # exists in logjson_message
-      # message already promoted to top-level
-      # tags remain in logjson + can also exist top-level
-    ]
-  }
-
-  # Fix email-alert-frontend errors landing in the DLQ
-  if [logjson][status] and [logjson][status] =~ /[^0-9.-]/ {
-	mutate {
-      rename => { "[logjson][status]" => "[logjson][status_text]" }
     }
   }
 }


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk_sidekiq/blob/c5d2466558fa0e2cad97e5833dd0016f2ad97578/lib/govuk_sidekiq/govuk_json_formatter.rb#L7 doesn't expose `[ts]` so this part can be removed
- Message is already parsed into JSON so `if [message] and [message][args]` can be removed
- `Extract human readable message` is covered by `if [logjosn][message]` so that seciton can be removed
- `[logjson][jid]` doesn't already exist in `logjson_message` so the `remove_field` section can be removed
- Filebeat doesn't annotate `useragent` so the field has to be extracted from nginx logs. This is why the `useragent` filter has to occur after `logjson` transformation happens
- Use [ecs_compatibility](https://www.elastic.co/docs/reference/logstash/plugins/plugins-filters-useragent#plugins-filters-useragent-ecs_compatibility) for `useragent` filter instead of manually creating fields. It will automatically populate and add the `useragent` field
- https://github.com/alphagov/govuk-infrastructure/issues/4063