### PR TITLE
fix: 🐛 missing role for perms for subresource and pod/log typo

### DIFF
--- a/terraform/deployments/cluster-access/eks_access.tf
+++ b/terraform/deployments/cluster-access/eks_access.tf
@@ -61,7 +61,7 @@ module "developer" {
   cluster_role_rules = [
     {
       api_groups = [""]
-      resources  = ["namespaces", "pods", "pods/logs", "services", "configmaps", "secrets", "endpoints", "events"]
+      resources  = ["namespaces", "pods", "pods/log", "services", "configmaps", "secrets", "endpoints", "events"]
       verbs      = ["get", "list", "watch"]
     },
     {
@@ -79,7 +79,7 @@ module "developer" {
   namespace_role_rules = [
     {
       api_groups = ["", "apps"]
-      resources  = ["pods", "pods/logs", "deployments", "replicasets", "statefulsets"]
+      resources  = ["pods", "pods/log", "deployments", "replicasets", "statefulsets"]
       verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
     },
     {


### PR DESCRIPTION
- This surfaced when running integration tests in the gov-cli

```
 2026/08/28 13:19:51 ERRO Error following job request error="pods \"follow-pod-logs-x7k2p-9fh3s\" is forbidden: User \"arn:aws:sts::123456789012:assumed-role/job.req-developer/e2e\" cannot get resource \"pods/log\" in API group \"\" in the namespace \"apps\""
```
https://github.com/alphagov/govuk-cli/actions/runs/33174745533/job/98860332410

~~and~~


~~2026/08/28 13:04:54 WARN Error getting JobRequestReview resource error="jobrequestreviews.platform.publishing.service.gov.uk \"review-invalid-arn-review\" is forbidden: User \"arn:aws:sts::123456789012:assumed-role/job.req-developer/e2e\" cannot get resource \"jobrequestreviews/status\" in API group \"platform.publishing.service.gov.uk\" in the namespace \"apps\"" jobRequestReviewName=review-invalid-arn-review~~

~~https://github.com/alphagov/govuk-cli/actions/runs/33173601462/job/98856494649~~