### PR TITLE
Remove GCP account 'analytics-events-pipeline'

### DIFF
--- a/terraform/deployments/search-api-v2/events_ingestion.tf
+++ b/terraform/deployments/search-api-v2/events_ingestion.tf
@@ -2,31 +2,6 @@
 # BQ dataset and table creation hasn't been migrated to Dataform so remains here
 # Event ingest is orchestrated in Ruby stack not in GCP
 
-
-# custom role for writing ga analytics data to our bq store
-resource "google_project_iam_custom_role" "analytics_write" {
-  role_id     = "analytics_write"
-  title       = "ga4-write-bq-permissions"
-  description = "Write data to vertex schemas in bq"
-  permissions = [
-    "bigquery.tables.update",
-    "bigquery.tables.updateData",
-    "bigquery.jobs.create",
-    "bigquery.datasets.get",
-    "bigquery.tables.get",
-    "bigquery.tables.getData"
-  ]
-}
-
-# binding ga write role to ga write service account
-resource "google_project_iam_binding" "analytics_write" {
-  role    = google_project_iam_custom_role.analytics_write.id
-  project = var.gcp_project_id
-  members = [
-    google_service_account.analytics_events_pipeline.member,
-  ]
-}
-
 # top level dataset to store events for ingestion into Discovery Engine (previously marketed as "Vertex AI Search")
 resource "google_bigquery_dataset" "dataset" {
   dataset_id                 = "analytics_events_vertex"

--- a/terraform/deployments/search-api-v2/service_accounts.tf
+++ b/terraform/deployments/search-api-v2/service_accounts.tf
@@ -114,12 +114,6 @@ resource "google_project_iam_binding" "search_admin" {
   ]
 }
 
-resource "google_service_account" "analytics_events_pipeline" {
-  account_id   = "analytics-events-pipeline"
-  display_name = "analytics-events-pipeline"
-  description  = "Service account for reading GA4 search events data and importing events into our project"
-}
-
 ## Read only service account for local development
 
 resource "google_service_account" "postman" {


### PR DESCRIPTION
This service account was used for the search team’s old data pipelines, which copied GA4 data from the GA4 Analytics GCP project to the search team projects, using Cloud Function and Cloud Scheduler.

This code was removed in an earlier PR: i
https://github.com/alphagov/govuk-infrastructure/pull/2188

Jira: https://gov-uk.atlassian.net/browse/SCH-1962