### PR TITLE
Sch 1426 clean up terraform for gcp search api v2 deployment

### DIFF
--- a/terraform/deployments/gcp-search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/main.tf
@@ -55,3 +55,10 @@ module "environment_production" {
   environment_workspace_name   = "search-api-v2-production"
   access_group_name            = "govuk-gcp-access"
 }
+
+removed {
+  from = google_dataform_repository.search_v2_api
+  lifecycle {
+    destroy = false
+  }
+}

--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
@@ -8,6 +8,11 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 7.0"
     }
+    # required for `google_service_usage_consumer_quota_override` resources
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 7.0"
+    }
   }
 
   required_version = "~> 1.15"

--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
@@ -43,6 +43,7 @@ resource "google_project_service" "api_service" {
 
   project                    = google_project.environment_project.project_id
   service                    = each.value
+  disable_on_destroy         = true
   disable_dependent_services = true
 }
 


### PR DESCRIPTION
The main change here is adding the `disable_on_destroy` argument to the configuration of Google APIs that are enabled within the Search GCP projects, to remove drift within Terraform. The setting is currently true in GCP, but since it's not set in Terraform, this is showing drift in the plan.
    
Setting disable_on_destroy to true means that the services will be disabled when the Terraform resource is destroyed. [Terraform docs](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_project_service#argument-reference) point out that this should generally only be true in configurations that manage the google_project resource itself, but that is true in this case.

Other changes (to add back the google beta provider and to remove the dataform repo) are to correct errors and warnings in the plan, and can be removed from the code once the Terraform has been applied.

See new plan: 
<img width="1068" height="301" alt="Screenshot 2026-09-03 at 16 15 19" src="https://github.com/user-attachments/assets/8ae02b84-5866-4779-84d4-a8d2ac95166c" />

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1426