### PR TITLE
Don't require up to date branches in govuk-job-request-operator

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -470,7 +470,6 @@ repos:
         - Dependency Review scan / dependency-review-pr
 
   govuk-job-request-operator:
-    up_to_date_branches: true
     homepage_url: "https://docs.publishing.service.gov.uk/repos/govuk-job-request-operator.html"
     push_allowances:
       - "alphagov/gov-uk-platform-engineering"


### PR DESCRIPTION
We agreed to disable this setting for this repo