### PR TITLE
Add MySQL readiness check before setting up DB [WHIT-3921]

### DIFF
--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -27,6 +27,23 @@ runs:
          --performance-schema=off --innodb_buffer_pool_size=32M \
          --innodb-log-buffer-size=8M --key_buffer_size=4M
 
+    - name: Wait for MySQL
+      shell: bash
+      run: |
+        for i in {1..30}; do
+          if docker exec mysql mysqladmin ping -h 127.0.0.1 -uroot -proot --silent; then
+            echo "MySQL is ready"
+            exit 0
+          fi
+
+          echo "Waiting for MySQL..."
+          sleep 2
+        done
+
+        echo "MySQL did not become ready"
+        docker logs mysql
+        exit 1
+
     - name: Generate database URL
       id: generate-url
       env:


### PR DESCRIPTION
The MySQL container is started in detached mode, but this does not guarantee that the MySQL server is ready to accept connections.

This can cause subsequent database setup to fail intermittently with "Lost connection to MySQL server at 'reading initial communication packet'" errors. This happens often enough to be a frustration, requiring developers to manually re-run failed jobs. Examples:

- https://github.com/alphagov/whitehall/actions/runs/33637086835/job/100270556457?pr=11757
- https://github.com/alphagov/whitehall/actions/runs/31373195574/job/93406541566

To fix, we wait for MySQL to respond to `mysqladmin ping` before allowing the workflow to continue, with a timeout and diagnostic container logs if MySQL fails to become ready.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3921