### PR TITLE
Add Standard workflow parallel to StandardX

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -1,0 +1,25 @@
+name: Run Standard
+
+on:
+  workflow_call:
+    inputs:
+      files:
+        description: 'Files(s) or glob(s) to check'
+        required: false
+        default: "'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'"
+        type: string
+
+jobs:
+  run-standard:
+    name: Run Standard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          show-progress: false
+
+      - name: Setup Node
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
+
+      - name: Run Standard
+        run: yarn run standard ${{ inputs.files }}


### PR DESCRIPTION
- StandardX is a bit of a thorn in our side because it hasn't been updated for years, and feels like it's a bit abandoned. It uses Standard under the hood, but an outdated version. If we could allow apps to use Standard instead of StandardX it might solve a number of dependency issues.
- Added alongside the existing StandardX workflow so that apps can choose which one they want to use. We'll try it out first in Frontend and if it's successful we can roll it out to other apps and remove the StandardX workflow.