### PR TITLE
Change release workflow default for autogenerate_release_notes to true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       generate_release_notes:
         required: false
         type: boolean
-        default: false
+        default: true
     secrets:
       GH_TOKEN:
         required: true


### PR DESCRIPTION
Changing the release workflow so it auto generates release descriptions by default (currently it defaults to off, and only content block manager has set it to true)

I asked our developer community in [the #govuk-developers channel in slack](https://gds.slack.com/archives/CAB4Q3QBW/p1788442409842639) and got some agreements and no objections

## More info

Our github release workflow which is called by almost every other repo to do and create github releases defaults to not generating release notes. It means that the description for a release says a single truncated line [like this release v1812 in frontend](https://github.com/alphagov/frontend/releases/tag/v1812)

> Merge pull request #5759 from alphagov/pnp-10125-remove-conditional-c…

Occasionally it will have a full commit message in, but that's very rare.

With it set to true you get release notes with all the commit messages in, links to the PRs that merged them, it @'s the authors, and includes a link to a comparison between old and current version, [like this release v863 in content-block-manager](https://github.com/alphagov/content-block-manager/releases/tag/v863)

> ## What's Changed
> * Bump simplecov from 1.0.3 to 1.1.0 by @dependabot[bot] in https://github.com/alphagov/content-block-manager/pull/851
> * Bump simplecov from 1.1.0 to 1.1.1 by @dependabot[bot] in https://github.com/alphagov/content-block-manager/pull/852
> * Bump globals from 17.9.0 to 17.11.0 by @dependabot[bot] in https://github.com/alphagov/content-block-manager/pull/853
> 
> **Full Changelog**: https://github.com/alphagov/content-block-manager/compare/v858...v863