### PR TITLE
Sch 1426 tidy gcp search api v2 deployment

### DIFF
--- a/terraform/deployments/gcp-search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/main.tf
@@ -55,10 +55,3 @@ module "environment_production" {
   environment_workspace_name   = "search-api-v2-production"
   access_group_name            = "govuk-gcp-access"
 }
-
-removed {
-  from = google_dataform_repository.search_v2_api
-  lifecycle {
-    destroy = false
-  }
-}

--- a/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
+++ b/terraform/deployments/gcp-search-api-v2/modules/search-api-v2/main.tf
@@ -8,11 +8,6 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 7.0"
     }
-    # required for `google_service_usage_consumer_quota_override` resources
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 7.0"
-    }
   }
 
   required_version = "~> 1.15"


### PR DESCRIPTION
Removal of some temporary additions from https://github.com/alphagov/govuk-infrastructure/pull/4738 that were needed to clean up the Terraform plan.

Plan now showing:
<img width="895" height="51" alt="Screenshot 2026-09-04 at 12 41 55" src="https://github.com/user-attachments/assets/59233998-cc30-4410-bd18-f8cc1ec3a616" />

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1426