### PR TITLE
refactor: 💡 eph shutdown script -> only run application teardown if we have a cluster

### DIFF
--- a/terraform/deployments/ephemeral/shutdown.sh
+++ b/terraform/deployments/ephemeral/shutdown.sh
@@ -231,11 +231,15 @@ read
 # make sure the correct cluster is selected before destroying anything
 aws eks update-kubeconfig --name "${CLUSTER_ID}"
 
-# delete ArgoCD Application resources
-application_shutdown
+if kubectl cluster-info; then
+  # delete ArgoCD Application resources
+  application_shutdown
 
-# uninstall Helm charts
-helm_shutdown
+  # uninstall Helm charts
+  helm_shutdown
+else
+  echo "Skipping application tear down because there is no access to the cluster."
+fi
 
 # do destroy runs on workspaces in the correct order
 retry 2 tfc_do_destroy "datagovuk-infrastructure"


### PR DESCRIPTION
I found when tearing down eph clusters sometimes I would need to comment out the application tear down commands, often because cluster access tear down succeeded but cluster-services failed, on a subsequent run it would fail.

This prevents that because we can skip the cluster specific commands and begin tear down of the terraform. 