### PR TITLE
Test adding a new repo, we think this will fail

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1144,4 +1144,7 @@ repos:
       - "alphagov/gov-uk-information-architects"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"
-    
+
+  govuk-test-newrepo:
+    # standard security checks are disabled as not configured for a private repo
+    can_be_deployed: false


### PR DESCRIPTION
We think this will fail since a custom property is now required, and terraform only has a separate resource for it.

There is [this issue in the terraform github provider](https://github.com/integrations/terraform-provider-github/issues/2642) which if solved, I think would solve it, but we want to test to make sure we are actually blocked