### PR TITLE
Revert "Test adding a new repo, we think this will fail"

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -1144,7 +1144,4 @@ repos:
       - "alphagov/gov-uk-information-architects"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"
-
-  govuk-test-newrepo:
-    # standard security checks are disabled as not configured for a private repo
-    can_be_deployed: false
+    


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#4768

As expected, this does error:

```
Error: POST https://api.github.com/orgs/alphagov/repos: 422 Property 'team_identifier' requires an explicit value to be set []
with github_repository.govuk_repos["govuk-test-newrepo"]
on main.tf line 213, in resource "github_repository" "govuk_repos":
resource "github_repository" "govuk_repos" {
```