### PR TITLE
[PNP-10142] Temporarily remove standardx JS lint as a requirement from frontend

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -252,7 +252,6 @@ repos:
     required_status_checks:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
-        - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
@@ -1144,4 +1143,4 @@ repos:
       - "alphagov/gov-uk-information-architects"
       - "alphagov/gov-uk-production-admin"
       - "alphagov/gov-uk-production-deploy"
-    
+


### PR DESCRIPTION
- We want to move over to standard (which has fewer dependency issues). In order to do that we need to remove the standardx requirement. It'll still be run on frontend versions that have standardx, it just won't be a requirement. Once we're okay with standard, we'll put this line back in, pointing to Standard.

Related PR:
- https://github.com/alphagov/frontend/pull/5767

https://gov-uk.atlassian.net/browse/PNP-10142