### PR TITLE
Launch Blue Opensearch cluster in Production

### DIFF
--- a/terraform/variables/production/search-opensearch.tfvars
+++ b/terraform/variables/production/search-opensearch.tfvars
@@ -2,8 +2,32 @@ current_live_domain = "green"
 
 attach_snapshot_policy_with_role_policy_attachment = true
 
-launch_blue_domain   = false
-blue_cluster_options = null
+launch_blue_domain = true
+blue_cluster_options = {
+  engine         = "OpenSearch"
+  engine_version = "3.7"
+
+  dedicated_master = {
+    instance_count = 3
+    instance_type  = "c7i.xlarge.search"
+  }
+
+  instance_type  = "r7i.4xlarge.search"
+  instance_count = 3
+
+  zone_awareness_enabled        = true
+  multi_az_with_standby_enabled = false
+
+  advanced_security_options = null
+
+  endpoint_tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  ebs_options = {
+    volume_size = 314
+    volume_type = "gp3"
+    throughput  = 350
+    iops        = 3000
+  }
+}
 
 launch_green_domain = true
 green_cluster_options = {


### PR DESCRIPTION
Launch new Opensearch 3.7 cluster in Production so we can seamlessly upgrade