### PR TITLE
[SCH-2261] Import evaluation_create_requests_preference on integration

### DIFF
--- a/terraform/deployments/search-api-v2/cloud_quotas.tf
+++ b/terraform/deployments/search-api-v2/cloud_quotas.tf
@@ -17,3 +17,11 @@ resource "google_cloud_quotas_quota_preference" "complete_query_requests_prefere
     preferred_value = var.complete_query_requests
   }
 }
+
+# We are importing evaluation_create_requests_preference resource on integration
+# as we'd created it manually when testing
+import {
+  for_each = var.import_quota_preference ? [1] : []
+  id       = "projects/${var.gcp_project_id}/locations/global/quotaPreferences/discoveryengine_evaluation_create_requests"
+  to       = google_cloud_quotas_quota_preference.evaluation_create_requests_preference
+}

--- a/terraform/deployments/search-api-v2/variables.tf
+++ b/terraform/deployments/search-api-v2/variables.tf
@@ -56,3 +56,7 @@ variable "complete_query_requests" {
   description = "The maximum number of complete query requests per minute for Discovery Engine"
   default     = 300
 }
+
+variable "import_quota_preference" {
+  type = bool
+}

--- a/terraform/variables/integration/search-api-v2.tfvars
+++ b/terraform/variables/integration/search-api-v2.tfvars
@@ -1,3 +1,4 @@
-gcp_project_id     = "search-api-v2-integration"
-gcp_project_number = "780375417592"
-gcp_env            = "integration"
+gcp_project_id          = "search-api-v2-integration"
+gcp_project_number      = "780375417592"
+gcp_env                 = "integration"
+import_quota_preference = true

--- a/terraform/variables/production/search-api-v2.tfvars
+++ b/terraform/variables/production/search-api-v2.tfvars
@@ -2,3 +2,4 @@ gcp_project_id          = "search-api-v2-production"
 gcp_project_number      = "931453572747"
 gcp_env                 = "production"
 complete_query_requests = 35000
+import_quota_preference = false

--- a/terraform/variables/staging/search-api-v2.tfvars
+++ b/terraform/variables/staging/search-api-v2.tfvars
@@ -1,3 +1,4 @@
-gcp_project_id     = "search-api-v2-staging"
-gcp_project_number = "773027887517"
-gcp_env            = "staging"
+gcp_project_id          = "search-api-v2-staging"
+gcp_project_number      = "773027887517"
+gcp_env                 = "staging"
+import_quota_preference = false


### PR DESCRIPTION
In #4682 we added the quota_preference resource `evaluation_create_requests_preference`, but the [terraform failed to apply on `integration`](https://app.terraform.io/app/govuk/workspaces/search-api-v2-integration/runs/run-YDKPrUVnzgnnxHvc) as the resource had already been created using an API request.

There isn't a delete endpoint for [QuotaPreference](https://docs.cloud.google.com/docs/quotas/reference/rest/v1/projects.locations.quotaPreferences), so we can't delete the resource using the API before reapplying the terraform. 

Tweaking the terraform so that we import the `evaluation_create_requests_preference` resource on `integration`, but still create it on `staging` & `production`.

I'll remove the import block in a later PR