### PR TITLE
[SCH-2261] Remove import block for search-api-v2 quota_preference

### DIFF
--- a/terraform/deployments/search-api-v2/cloud_quotas.tf
+++ b/terraform/deployments/search-api-v2/cloud_quotas.tf
@@ -17,11 +17,3 @@ resource "google_cloud_quotas_quota_preference" "complete_query_requests_prefere
     preferred_value = var.complete_query_requests
   }
 }
-
-# We are importing evaluation_create_requests_preference resource on integration
-# as we'd created it manually when testing
-import {
-  for_each = var.import_quota_preference ? [1] : []
-  id       = "projects/${var.gcp_project_id}/locations/global/quotaPreferences/discoveryengine_evaluation_create_requests"
-  to       = google_cloud_quotas_quota_preference.evaluation_create_requests_preference
-}

--- a/terraform/deployments/search-api-v2/variables.tf
+++ b/terraform/deployments/search-api-v2/variables.tf
@@ -56,7 +56,3 @@ variable "complete_query_requests" {
   description = "The maximum number of complete query requests per minute for Discovery Engine"
   default     = 300
 }
-
-variable "import_quota_preference" {
-  type = bool
-}

--- a/terraform/variables/integration/search-api-v2.tfvars
+++ b/terraform/variables/integration/search-api-v2.tfvars
@@ -1,4 +1,3 @@
-gcp_project_id          = "search-api-v2-integration"
-gcp_project_number      = "780375417592"
-gcp_env                 = "integration"
-import_quota_preference = true
+gcp_project_id     = "search-api-v2-integration"
+gcp_project_number = "780375417592"
+gcp_env            = "integration"

--- a/terraform/variables/production/search-api-v2.tfvars
+++ b/terraform/variables/production/search-api-v2.tfvars
@@ -2,4 +2,3 @@ gcp_project_id          = "search-api-v2-production"
 gcp_project_number      = "931453572747"
 gcp_env                 = "production"
 complete_query_requests = 35000
-import_quota_preference = false

--- a/terraform/variables/staging/search-api-v2.tfvars
+++ b/terraform/variables/staging/search-api-v2.tfvars
@@ -1,4 +1,3 @@
-gcp_project_id          = "search-api-v2-staging"
-gcp_project_number      = "773027887517"
-gcp_env                 = "staging"
-import_quota_preference = false
+gcp_project_id     = "search-api-v2-staging"
+gcp_project_number = "773027887517"
+gcp_env            = "staging"


### PR DESCRIPTION
Remove import block for `evaluation_create_requests_preference` for search-api-v2.

Tidying up the import block & associated variable added in #4773 now that the resource has been correctly imported or created in all envs. 