### PR TITLE
Revert "Remove the Green cluster in integration"

### DIFF
--- a/terraform/deployments/search-opensearch/elasticsearch.tf
+++ b/terraform/deployments/search-opensearch/elasticsearch.tf
@@ -23,4 +23,17 @@ module "opensearch" {
 
   create_remote_connection_to_import_to_blue_from_green = var.create_remote_connection_to_import_to_blue_from_green
   create_remote_connection_to_import_to_green_from_blue = var.create_remote_connection_to_import_to_green_from_blue
+
+
+  // WARNING: The following option must be removed once the existing elasticsearch 6 green cluster has been destroyed
+  use_aws_elasticsearch_domain_resource_for_green_cluster    = var.use_aws_elasticsearch_domain_resource_for_green_cluster
+  override_aws_elasticsearch_domain_name_for_green_cluster   = "green-elasticsearch6-domain"
+  log_resource_policy_name_suffix_override_for_green_cluster = "-domain_log_write"
+  disable_node_to_node_encryption_for_green_cluster          = true
+  disable_enforced_https_for_green_cluster                   = true
+  override_security_group_ids_for_green_cluster              = [data.tfe_outputs.security.nonsensitive_values.govuk_elasticsearch6_access_sg_id]
+  override_custom_domain_endpoint_for_green_cluster          = "green-elasticsearch6.${var.govuk_environment}.govuk-internal.digital"
+  create_additional_manual_snapshot_role_name                = "green-elasticsearch6-manual-snapshot-role"
+  override_old_snapshot_bucket_name                          = "govuk-${var.govuk_environment}-elasticsearch6-manual-snapshots"
+  create_original_snapshot_bucket                            = true
 }

--- a/terraform/deployments/search-opensearch/main.tf
+++ b/terraform/deployments/search-opensearch/main.tf
@@ -30,3 +30,11 @@ data "tfe_outputs" "root_dns" {
   organization = "govuk"
   workspace    = "root-dns-${var.govuk_environment}"
 }
+
+resource "aws_route53_record" "service_record" {
+  zone_id = data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_id
+  name    = "elasticsearch6.green.${data.tfe_outputs.root_dns.nonsensitive_values.internal_root_zone_name}"
+  type    = "CNAME"
+  ttl     = 300
+  records = [module.opensearch.green_elasticsearch_endpoint]
+}

--- a/terraform/shared-modules/opensearch-blue-green-deployment/USAGE.md
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/USAGE.md
@@ -40,6 +40,7 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_elasticsearch_iam_role_arn"></a> [elasticsearch\_iam\_role\_arn](#output\_elasticsearch\_iam\_role\_arn) | The endpoint of the green elasticsearch domain |
+| <a name="output_green_elasticsearch_endpoint"></a> [green\_elasticsearch\_endpoint](#output\_green\_elasticsearch\_endpoint) | The endpoint of the green elasticsearch domain |
 | <a name="output_old_s3_snapshot_bucket_arn"></a> [old\_s3\_snapshot\_bucket\_arn](#output\_old\_s3\_snapshot\_bucket\_arn) | ARN of the S3 bucket used for snapshots |
 | <a name="output_old_s3_snapshot_bucket_name"></a> [old\_s3\_snapshot\_bucket\_name](#output\_old\_s3\_snapshot\_bucket\_name) | Name of the S3 bucket used for snapshots |
 | <a name="output_opensearch_cname"></a> [opensearch\_cname](#output\_opensearch\_cname) | The fully qualified domain name of the route53 record which points to the live OpenSearch domain |

--- a/terraform/shared-modules/opensearch-blue-green-deployment/outputs.tf
+++ b/terraform/shared-modules/opensearch-blue-green-deployment/outputs.tf
@@ -62,6 +62,12 @@ output "secrets_manager_secret_name" {                                          
   value       = aws_secretsmanager_secret.opensearch_passwords.name                                        # pragma: allowlist secret
 }
 
+output "green_elasticsearch_endpoint" {
+  description = "The endpoint of the green elasticsearch domain"
+  deprecated  = "Do not set this option except when importing the existing Search ElasticSearch cluster"
+  value       = var.launch_green_domain && var.use_aws_elasticsearch_domain_resource_for_green_cluster ? module.green_domain[0].opensearch_endpoint : null
+}
+
 output "elasticsearch_iam_role_arn" {
   description = "The endpoint of the green elasticsearch domain"
   deprecated  = "Do not set this option except when importing the existing Search ElasticSearch cluster"

--- a/terraform/variables/integration/search-opensearch.tfvars
+++ b/terraform/variables/integration/search-opensearch.tfvars
@@ -1,8 +1,8 @@
-current_live_domain = "blue"
+current_live_domain = "green"
 
 attach_snapshot_policy_with_role_policy_attachment = true
 
-create_remote_connection_to_import_to_blue_from_green = false
+create_remote_connection_to_import_to_blue_from_green = true
 
 launch_blue_domain = true
 blue_cluster_options = {
@@ -31,8 +31,44 @@ blue_cluster_options = {
   }
 }
 
-launch_green_domain   = false
-green_cluster_options = null
+launch_green_domain = true
+green_cluster_options = {
+  engine         = "Elasticsearch"
+  engine_version = "6.8"
+
+  dedicated_master = {
+    instance_count = 3
+    instance_type  = "c7i.xlarge.elasticsearch"
+  }
+
+  instance_count = 3
+  instance_type  = "r7i.xlarge.elasticsearch"
+
+  zone_awareness_enabled        = true
+  multi_az_with_standby_enabled = false
+
+  advanced_security_options = null
+
+  endpoint_tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  ebs_options = {
+    volume_size = 314
+    volume_type = "gp3"
+    throughput  = 350
+    iops        = 3000
+  }
+
+  // WARNING: All the following options are purely to allow importing the existing ES6 cluster,
+  //          when creating the next blue deployment remove these options and use the defaults
+  prefix_colour_instead_of_suffix = true
+  log_group_name_overrides = {
+    error_logs       = "es6-application-logs"
+    index_slow_logs  = "es6-index-logs"
+    search_slow_logs = "es6-search-logs"
+  }
+  log_retention_in_days            = 3
+  log_group_prefix_override        = "/aws/aes/domains/green-elasticsearch6-domain"
+  inline_access_policy_declaration = true
+}
 
 read_snapshots_from_environments = [
   "staging",
@@ -46,4 +82,4 @@ account_ids_allowed_to_read_domain_snapshots = [
 ]
 
 // WARNING: This _must_ be removed once the existing Search elasticsearch 6.8 green cluster has been destroyed
-use_aws_elasticsearch_domain_resource_for_green_cluster = false
+use_aws_elasticsearch_domain_resource_for_green_cluster = true


### PR DESCRIPTION
Reverts alphagov/govuk-infrastructure#4749

This accidentally causes infrastructure to be removed across all environments. Reverting until we find a better solution