### PR TITLE
feat: 🎸 add `team_identifier` custom property to repos

### DIFF
--- a/terraform/deployments/github/custom_properties.tf
+++ b/terraform/deployments/github/custom_properties.tf
@@ -1,0 +1,22 @@
+data "github_organization_custom_properties" "team_identifier" {
+  property_name = "team_identifier"
+  value_type    = "single_select"
+}
+
+data "http" "repos_yml" {
+  url = "https://docs.publishing.service.gov.uk/repos.json"
+
+  request_headers = {
+    Accept = "application/json"
+  }
+}
+
+resource "github_repository_custom_property" "team_identifier" {
+  for_each = local.repos_yml_teams
+
+  repository     = each.key
+  property_name  = data.github_organization_custom_properties.team_identifier.property_name
+  property_type  = data.github_organization_custom_properties.team_identifier.value_type
+  property_value = [contains(data.github_organization_custom_properties.team_identifier.allowed_values, each.value) ? each.value : "other"]
+}
+

--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "integrations/github"
       version = "~> 6.10"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.6"
+    }
   }
 }
 
@@ -89,6 +93,10 @@ locals {
     for name, repo in local.repositories : name
     if try(repo.teams.govuk_ithc, "") != ""
   ]
+
+  repos_yml_teams = {
+    for obj in jsondecode(data.http.repos_yml.response_body) : obj.app_name => trimprefix(obj.team, "#")
+  }
 }
 
 resource "github_team" "govuk_ci_bots" {


### PR DESCRIPTION
Discussion context: https://gds.slack.com/archives/C05DC0SJ6UW/p1788874469473189 

+ lookup github_org_custom_properties
+ fetch via http provider `repos.yml` from `https://docs.publishing.service.gov.uk/repos.json`
+ map repo name to slack channel (team_identifier) for each repo add the correct team_identifier as a `custom_property` on the repo (there are no "other" or "not_set" values in the custom properties)

relates: https://github.com/alphagov/govuk-infrastructure/issues/4615

~~blocked: waiting for EE to update the list of team_identifiers so we can correctly set them against the org level custom_properties "enum"~~