### PR TITLE
Temporarily remove standardx JS lint as a requirement from email-alert-frontend

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -191,7 +191,6 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Lint SCSS / Run Stylelint
-        - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
 


### PR DESCRIPTION
## What

Temporarily remove standardx JS lint as a requirement from email-alert-frontend

## Why

We want to move over to standard (which has fewer dependency issues), in order to do that we need to remove the standardx requirement.

Once we're okay with standard, we'll put this line back in, pointing to Standard.

Jira card: https://gov-uk.atlassian.net/browse/NAV-19054

Blocks: https://github.com/alphagov/email-alert-frontend/pull/2382
