### PR TITLE
Set the Opensearch live domain to 'blue' in all three environments

### DIFF
--- a/terraform/variables/integration/search-opensearch.tfvars
+++ b/terraform/variables/integration/search-opensearch.tfvars
@@ -1,4 +1,4 @@
-current_live_domain = "green"
+current_live_domain = "blue"
 
 attach_snapshot_policy_with_role_policy_attachment = true
 

--- a/terraform/variables/production/search-opensearch.tfvars
+++ b/terraform/variables/production/search-opensearch.tfvars
@@ -1,4 +1,4 @@
-current_live_domain = "green"
+current_live_domain = "blue"
 
 attach_snapshot_policy_with_role_policy_attachment = true
 

--- a/terraform/variables/staging/search-opensearch.tfvars
+++ b/terraform/variables/staging/search-opensearch.tfvars
@@ -1,4 +1,4 @@
-current_live_domain = "green"
+current_live_domain = "blue"
 
 attach_snapshot_policy_with_role_policy_attachment = true
 


### PR DESCRIPTION
so that all DNS entries point at the blue clusters