### PR TITLE
Temporarily remove standardx JS lint as a requirement from collections

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -67,7 +67,6 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Integration tests
-        - Lint JavaScript / Run Standardx
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec


### PR DESCRIPTION
What
Temporarily remove standardx JS lint as a requirement from collections

Why
We want to move over to standard (which has fewer dependency issues), in order to do that we need to remove the standardx requirement.

Once we're okay with standard, we'll put this line back in, pointing to Standard.

Jira card: https://gov-uk.atlassian.net/browse/NAV-19101

Blocks: https://github.com/alphagov/collections/pull/4661