### PR TITLE
Add `standard` JS linting as a requirement in several apps

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -67,6 +67,7 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Integration tests
+        - Lint JavaScript / Run Standard
         - Lint SCSS / Run Stylelint
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
@@ -190,6 +191,7 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standard
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
 
@@ -251,6 +253,7 @@ repos:
       standard_contexts: *standard_govuk_rails_checks
       additional_contexts:
         - Lint SCSS / Run Stylelint
+        - Lint JavaScript / Run Standard
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
         - CodeQL SAST scan / Analyze


### PR DESCRIPTION
## What

Add `Lint JavaScript / Run Standard` as a requirement in the apps below:

- `frontend`
- `email-alert-frontend`
- `collections`

## Why

These apps previously used standardx as a requirement for linting JavaScript, removed in the PR's below:
  - https://github.com/alphagov/govuk-infrastructure/pull/4771
  - https://github.com/alphagov/govuk-infrastructure/pull/4785
  - https://github.com/alphagov/govuk-infrastructure/pull/4794

Now that these apps are all using standard, we are adding JavaScripting linting back in as a requirement for these apps
