### PR TITLE
[PNP-10148] Remove standardx requirement from Finder-Frontend

### DIFF
--- a/terraform/deployments/github/repos.yml
+++ b/terraform/deployments/github/repos.yml
@@ -242,7 +242,6 @@ repos:
       additional_contexts:
         - Integration tests
         - Lint SCSS / Run Stylelint
-        - Lint JavaScript / Run Standardx
         - Test JavaScript / Run Jasmine
         - Test Ruby / Run RSpec
 


### PR DESCRIPTION
- this is being replaced by standard, once that's merged we'll replace the requirement with a standard one

(Similar to https://github.com/alphagov/govuk-infrastructure/pull/4771, but for Finder-Frontend)