### PR TITLE
fix: 🐛 from /repos.json use repo_name not app_name

### DIFF
--- a/terraform/deployments/github/main.tf
+++ b/terraform/deployments/github/main.tf
@@ -95,7 +95,7 @@ locals {
   ]
 
   repos_yml_teams = {
-    for obj in jsondecode(data.http.repos_yml.response_body) : obj.app_name => trimprefix(obj.team, "#")
+    for obj in jsondecode(data.http.repos_yml.response_body) : obj.repo_name => trimprefix(obj.team, "#")
   }
 }
 


### PR DESCRIPTION
context: https://github.com/alphagov/govuk-developer-docs/pull/5663

relates: https://github.com/alphagov/govuk-infrastructure/issues/4615