### PR TITLE
feat: 🎸 github custom property add team_other if val not in existing valid values list

### DIFF
--- a/terraform/deployments/github/custom_properties.tf
+++ b/terraform/deployments/github/custom_properties.tf
@@ -20,3 +20,14 @@ resource "github_repository_custom_property" "team_identifier" {
   property_value = [contains(data.github_organization_custom_properties.team_identifier.allowed_values, each.value) ? each.value : "other"]
 }
 
+resource "github_repository_custom_property" "team_other" {
+  for_each = {
+    for k, v in local.repos_yml_teams : k => v
+    if !contains(data.github_organization_custom_properties.team_identifier.allowed_values, v)
+  }
+
+  repository     = each.key
+  property_name  = "team_other"
+  property_type  = "string"
+  property_value = [each.value]
+}


### PR DESCRIPTION
We set the "other" field for EE's custom property on a github repo when a value we want to set the custom property to is not in the existing valid values list set at the organisation level by EE.

- set the "team_other" custom property to the new vustom property value (team name / slack channel) when the "other" field is set